### PR TITLE
Optimizing nc_data_cluster_wl integration

### DIFF
--- a/numcosmo/data/nc_data_cluster_wl.c
+++ b/numcosmo/data/nc_data_cluster_wl.c
@@ -462,34 +462,25 @@ static void
 nc_data_cluster_wl_integ (NcmIntegralND *intnd, NcmVector *x, guint dim, guint npoints, guint fdim, NcmVector *fval)
 {
   NcDataClusterWLInt *lh_int = NC_DATA_CLUSTER_WL_INT (intnd);
-  GArray *zarr               = ncm_vector_dup_array (x);
-  GArray *rarr               = g_array_new_take (&lh_int->data.r, 1, FALSE, sizeof (gdouble));
-  GArray *Psinteg            = nc_galaxy_sd_shape_integ (lh_int->data.s_dist,
-                                                         lh_int->data.cosmo,
-                                                         lh_int->data.dp,
-                                                         lh_int->data.smd,
-                                                         lh_int->data.z_cluster,
-                                                         rarr,
-                                                         zarr,
-                                                         lh_int->data.et,
-                                                         lh_int->data.ex);
   guint i;
-
-
 
   for (i = 0; i < npoints; i++)
   {
     const gdouble z = ncm_vector_get (x, i);
     gdouble res     = nc_galaxy_sd_position_integ (lh_int->data.rz_dist, lh_int->data.r, z) *
                       nc_galaxy_sd_z_proxy_integ (lh_int->data.zp_dist, z, lh_int->data.zp) *
-                      g_array_index (Psinteg, gdouble, i);
+                      nc_galaxy_sd_shape_integ (lh_int->data.s_dist,
+                                                lh_int->data.cosmo,
+                                                lh_int->data.dp,
+                                                lh_int->data.smd,
+                                                lh_int->data.z_cluster,
+                                                lh_int->data.r,
+                                                z,
+                                                lh_int->data.et,
+                                                lh_int->data.ex);
 
     ncm_vector_set (fval, i, res);
   }
-
-  g_array_free (zarr, TRUE);
-  g_array_free (rarr, FALSE);
-  g_array_free (Psinteg, TRUE);
 }
 
 static void

--- a/numcosmo/data/nc_data_cluster_wl.c
+++ b/numcosmo/data/nc_data_cluster_wl.c
@@ -464,6 +464,8 @@ nc_data_cluster_wl_integ (NcmIntegralND *intnd, NcmVector *x, guint dim, guint n
   NcDataClusterWLInt *lh_int = NC_DATA_CLUSTER_WL_INT (intnd);
   guint i;
 
+  nc_galaxy_sd_shape_integ_prep (lh_int->data.s_dist, lh_int->data.cosmo, lh_int->data.dp, lh_int->data.smd, lh_int->data.z_cluster, lh_int->data.r);
+
   for (i = 0; i < npoints; i++)
   {
     const gdouble z = ncm_vector_get (x, i);
@@ -474,7 +476,6 @@ nc_data_cluster_wl_integ (NcmIntegralND *intnd, NcmVector *x, guint dim, guint n
                                                 lh_int->data.dp,
                                                 lh_int->data.smd,
                                                 lh_int->data.z_cluster,
-                                                lh_int->data.r,
                                                 z,
                                                 lh_int->data.et,
                                                 lh_int->data.ex);

--- a/numcosmo/galaxy/nc_galaxy_sd_position_lsst_srd.c
+++ b/numcosmo/galaxy/nc_galaxy_sd_position_lsst_srd.c
@@ -63,6 +63,7 @@ typedef struct _NcGalaxySDPositionLSSTSRDPrivate
   gdouble r_ub;
   gdouble r_lb2;
   gdouble r_ub2;
+  gdouble y0;
 } NcGalaxySDPositionLSSTSRDPrivate;
 
 struct _NcGalaxySDPositionLSSTSRD
@@ -90,6 +91,7 @@ nc_galaxy_sd_position_lsst_srd_init (NcGalaxySDPositionLSSTSRD *gsdplsst)
   self->r_ub   = 0.0;
   self->r_lb2  = 0.0;
   self->r_ub2  = 0.0;
+  self->y0     = 0.0;
 }
 
 static void
@@ -216,11 +218,10 @@ _nc_galaxy_sd_position_lsst_srd_integ (NcGalaxySDPosition *gsdp, const gdouble r
   const gdouble alpha                           = ALPHA;
   const gdouble beta                            = BETA;
   const gdouble z0                              = Z0;
-  const gdouble y0                              = pow (z0, alpha);
-  const gdouble gamma_a                         = (1.0 + beta) / alpha;
   const gdouble y                               = pow (z, alpha);
 
-  return gsl_ran_gamma_pdf (y, gamma_a, y0) * alpha * y / z * r * self->r_norm;
+  return pow (z, beta) * exp (-(y / self->y0)) * r * self->r_norm;
+  // return gsl_ran_gamma_pdf (y, gamma_a, y0) * alpha * y / z * r * self->r_norm;
 }
 
 static void
@@ -228,11 +229,13 @@ _nc_galaxy_sd_position_lsst_srd_set_z_lim (NcGalaxySDPosition *gsdp, gdouble z_m
 {
   NcGalaxySDPositionLSSTSRD *gsdplsst           = NC_GALAXY_SD_POSITION_LSST_SRD (gsdp);
   NcGalaxySDPositionLSSTSRDPrivate * const self = nc_galaxy_sd_position_lsst_srd_get_instance_private (gsdplsst);
+  const gdouble alpha = ALPHA;
 
   g_assert_cmpfloat (z_min, <, z_max);
 
   self->z_lb = z_min;
   self->z_ub = z_max;
+  self->y0   = pow (Z0, alpha);
 }
 
 static void

--- a/numcosmo/galaxy/nc_galaxy_sd_shape.c
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape.c
@@ -72,8 +72,14 @@ _nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityP
   g_error ("_nc_galaxy_sd_shape_gen: method not implemented.");
 }
 
+void
+_nc_galaxy_sd_shape_integ_prep (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble R)
+{
+  g_error ("_nc_galaxy_sd_shape_integ_prep: method not implemented.");
+}
+
 static gdouble
-_nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
+_nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble z_source, const gdouble et, const gdouble ex)
 {
   g_error ("_nc_galaxy_sd_shape_integ: method not implemented.");
 
@@ -155,14 +161,32 @@ nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityPr
 }
 
 /**
+ * nc_galaxy_sd_shape_integ_prep: (virtual integ_prep)
+ * @gsds: a #NcGalaxySDShape
+ * @cosmo: a #NcHICosmo
+ * @dp: a #NcHaloDensityProfile
+ * @smd: a #NcWLSurfaceMassDensity
+ * @z_cluster: cluster redshift $z_\mathrm{cl}$
+ * @R: the projected radius $R$
+ *
+ *
+ * Prepares $gsds$ to compute the probability density of the observable shape given the position.
+ *
+ */
+void
+nc_galaxy_sd_shape_integ_prep (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble R)
+{
+  NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ_prep (gsds, cosmo, dp, smd, z_cluster, R);
+}
+
+/**
  * nc_galaxy_sd_shape_integ: (virtual integ)
  * @gsds: a #NcGalaxySDShape
  * @cosmo: a #NcHICosmo
  * @dp: a #NcHaloDensityProfile
  * @smd: a #NcWLSurfaceMassDensity
  * @z_cluster: cluster redshift $z_\mathrm{cl}$
- * @r: the projected radius $r$
- * @z: the redshift $z$
+ * @z_source: the redshift $z$
  * @et: the tangential ellipticity component $e_\mathrm{t}$
  * @ex: the cross ellipticity component $e_\mathrm{x}$
  *
@@ -173,8 +197,8 @@ nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityPr
  * Returns: the probability density of observable shape, $P(s)$.
  */
 gdouble
-nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
+nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble z_source, const gdouble et, const gdouble ex)
 {
-  return NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ (gsds, cosmo, dp, smd, z_cluster, r, z, et, ex);
+  return NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ (gsds, cosmo, dp, smd, z_cluster, z_source, et, ex);
 }
 

--- a/numcosmo/galaxy/nc_galaxy_sd_shape.c
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape.c
@@ -72,12 +72,12 @@ _nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityP
   g_error ("_nc_galaxy_sd_shape_gen: method not implemented.");
 }
 
-static GArray *
-_nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex)
+static gdouble
+_nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
 {
   g_error ("_nc_galaxy_sd_shape_integ: method not implemented.");
 
-  return NULL;
+  return 0.0;
 }
 
 static void
@@ -172,9 +172,9 @@ nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityPr
  *
  * Returns: the probability density of observable shape, $P(s)$.
  */
-GArray *
-nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex)
+gdouble
+nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
 {
-  return NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ (gsds, cosmo, dp, smd, z_cluster, rarr, zarr, et, ex);
+  return NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ (gsds, cosmo, dp, smd, z_cluster, r, z, et, ex);
 }
 

--- a/numcosmo/galaxy/nc_galaxy_sd_shape.c
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape.c
@@ -72,12 +72,12 @@ _nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityP
   g_error ("_nc_galaxy_sd_shape_gen: method not implemented.");
 }
 
-static gdouble
-_nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
+static GArray *
+_nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex)
 {
   g_error ("_nc_galaxy_sd_shape_integ: method not implemented.");
 
-  return 0.0;
+  return NULL;
 }
 
 static void
@@ -172,9 +172,9 @@ nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityPr
  *
  * Returns: the probability density of observable shape, $P(s)$.
  */
-gdouble
-nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
+GArray *
+nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex)
 {
-  return NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ (gsds, cosmo, dp, smd, z_cluster, r, z, et, ex);
+  return NC_GALAXY_SD_SHAPE_GET_CLASS (gsds)->integ (gsds, cosmo, dp, smd, z_cluster, rarr, zarr, et, ex);
 }
 

--- a/numcosmo/galaxy/nc_galaxy_sd_shape.h
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape.h
@@ -55,7 +55,7 @@ struct _NcGalaxySDShapeClass
   GObjectClass parent_class;
 
   void (*gen) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, const gdouble r, const gdouble z, gdouble *et, gdouble *ex);
-  GArray *(*integ) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex);
+  gdouble (*integ) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
 };
 
 struct _NcGalaxySDShape
@@ -73,7 +73,7 @@ void nc_galaxy_sd_shape_free (NcGalaxySDShape *gsds);
 void nc_galaxy_sd_shape_clear (NcGalaxySDShape **gsds);
 
 void nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, gdouble r, gdouble z, gdouble *et, gdouble *ex);
-GArray *nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex);
+gdouble nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
 
 G_END_DECLS
 

--- a/numcosmo/galaxy/nc_galaxy_sd_shape.h
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape.h
@@ -55,7 +55,8 @@ struct _NcGalaxySDShapeClass
   GObjectClass parent_class;
 
   void (*gen) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, const gdouble r, const gdouble z, gdouble *et, gdouble *ex);
-  gdouble (*integ) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
+  void (*integ_prep) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble R);
+  gdouble (*integ) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble z_source, const gdouble et, const gdouble ex);
 };
 
 struct _NcGalaxySDShape
@@ -73,7 +74,8 @@ void nc_galaxy_sd_shape_free (NcGalaxySDShape *gsds);
 void nc_galaxy_sd_shape_clear (NcGalaxySDShape **gsds);
 
 void nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, gdouble r, gdouble z, gdouble *et, gdouble *ex);
-gdouble nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
+void nc_galaxy_sd_shape_integ_prep (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble R);
+gdouble nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble z_source, const gdouble et, const gdouble ex);
 
 G_END_DECLS
 

--- a/numcosmo/galaxy/nc_galaxy_sd_shape.h
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape.h
@@ -55,7 +55,7 @@ struct _NcGalaxySDShapeClass
   GObjectClass parent_class;
 
   void (*gen) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, const gdouble r, const gdouble z, gdouble *et, gdouble *ex);
-  gdouble (*integ) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
+  GArray *(*integ) (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex);
 };
 
 struct _NcGalaxySDShape
@@ -73,7 +73,7 @@ void nc_galaxy_sd_shape_free (NcGalaxySDShape *gsds);
 void nc_galaxy_sd_shape_clear (NcGalaxySDShape **gsds);
 
 void nc_galaxy_sd_shape_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, gdouble r, gdouble z, gdouble *et, gdouble *ex);
-gdouble nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
+GArray *nc_galaxy_sd_shape_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex);
 
 G_END_DECLS
 

--- a/numcosmo/galaxy/nc_galaxy_sd_shape_gauss.c
+++ b/numcosmo/galaxy/nc_galaxy_sd_shape_gauss.c
@@ -125,7 +125,7 @@ _nc_galaxy_sd_shape_gauss_finalize (GObject *object)
 }
 
 static void _nc_galaxy_sd_shape_gauss_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, NcmRNG *rng, gdouble r, gdouble z, gdouble *et, gdouble *ex);
-static gdouble _nc_galaxy_sd_shape_gauss_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex);
+static GArray *_nc_galaxy_sd_shape_gauss_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex);
 
 static void
 nc_galaxy_sd_shape_gauss_class_init (NcGalaxySDShapeGaussClass *klass)
@@ -178,22 +178,28 @@ _nc_galaxy_sd_shape_gauss_gen (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDe
   *ex = cimag (e_obs);
 }
 
-static gdouble
-_nc_galaxy_sd_shape_gauss_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, const gdouble r, const gdouble z, const gdouble et, const gdouble ex)
+static GArray *
+_nc_galaxy_sd_shape_gauss_integ (NcGalaxySDShape *gsds, NcHICosmo *cosmo, NcHaloDensityProfile *dp, NcWLSurfaceMassDensity *smd, const gdouble z_cluster, GArray *rarr, GArray *zarr, const gdouble et, const gdouble ex)
 {
   NcGalaxySDShapeGauss *gsdsgauss          = NC_GALAXY_SD_SHAPE_GAUSS (gsds);
   NcGalaxySDShapeGaussPrivate * const self = gsdsgauss->priv;
+  GArray *gtarr                            = nc_wl_surface_mass_density_reduced_shear_array (smd, dp, cosmo, rarr, 1, 1, zarr, z_cluster, z_cluster);
+  GArray *res                              = g_array_sized_new (FALSE, FALSE, sizeof (gdouble), gtarr->len);
   complex double e_obs                     = et + I * ex;
   complex double e_source                  = e_obs;
-  complex double gt                        = 0.0;
+  guint i;
 
-  if (z > z_cluster)
+  for (i = 0; i < gtarr->len; i++)
   {
-    gt       = nc_wl_surface_mass_density_reduced_shear (smd, dp, cosmo, r, z, z_cluster, z_cluster);
+    complex double gt = g_array_index (gtarr, gdouble, i);
     e_source = (e_obs - gt) / (1.0 - conj (gt) * e_obs);
+
+    g_array_index (res, gdouble, i) = exp (-0.5 * gsl_pow_2 (cabs (e_source) / self->sigma)) / (2.0 * M_PI * self->sigma * self->sigma);
   }
 
-  return exp (-0.5 * gsl_pow_2 (cabs (e_source) / self->sigma)) / (2.0 * M_PI * self->sigma * self->sigma);
+  g_array_free (gtarr, TRUE);
+
+  return res;
 }
 
 /**


### PR DESCRIPTION
- Optimized nc_galaxy_sd_position_integ by removing gsl_gamma_ran 
- Optimize nc_galaxy_sd_shape_integ with nc_wl_surface_mass_density_reduced_shear_optzs (this seemingly makes the integration slower?)