### PR TITLE
New inspect command. Removing tap support in pytest.

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gobject-introspection gir1.2-glib-2.0 gir1.2-glib-2.0-dev libgirepository-2.0-dev gcc gfortran pkg-config libglib2.0-dev libgmp3-dev libmpfr-dev libgsl0-dev libfftw3-dev libopenblas-dev libflint-dev libcfitsio-dev libfyaml-dev libnlopt-dev libhdf5-dev libopenmpi-dev libcairo2-dev uncrustify
-        pip install meson ninja pytest pytest-tap pytest-lazy-fixtures numpy scipy pygobject typer matplotlib --break-system-packages
+        pip install meson ninja pytest pytest-lazy-fixtures numpy scipy pygobject typer matplotlib --break-system-packages
     - name: Ensure clear Jupyter Notebooks
       uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1
     - name: Configure NumCosmo
@@ -93,7 +93,7 @@ jobs:
         brew install python3 gobject-introspection pygobject3 numpy scipy python-matplotlib meson ninja gsl gmp mpfr fftw cfitsio libfyaml nlopt gfortran glib openblas
     - name: Pip install pre-requisites
       run: |
-        python3 -m pip install pytest pytest-tap pytest-lazy-fixtures typer pydantic --break-system-packages
+        python3 -m pip install pytest pytest-lazy-fixtures typer pydantic --break-system-packages
     - name: Ensure clear Jupyter Notebooks
       uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1
     - name: Fix libfyaml.pc
@@ -180,7 +180,7 @@ jobs:
           conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
           which python
           conda list
-          pip install -v pygobject-stubs pytest-tap types-tabulate
+          pip install -v pygobject-stubs types-tabulate
           conda remove -q -v -n numcosmo_developer openmpi
           conda install -q -v -n numcosmo_developer ${{ matrix.mpi }}
           conda install -q -v -n numcosmo_developer libfabric-devel
@@ -256,7 +256,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
-          pip install -v pygobject-stubs pytest-tap types-tabulate
+          pip install -v pygobject-stubs types-tabulate
           conda list
       - name: Save conda-forge cache
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CONDA_ENV: numcosmo_developer
-  CACHE_VERSION: 3
+  CACHE_VERSION: 0
 
 jobs:
 
@@ -180,7 +180,6 @@ jobs:
           conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
           which python
           conda list
-          pip install -v pygobject-stubs
           conda remove -q -v -n numcosmo_developer openmpi
           conda install -q -v -n numcosmo_developer ${{ matrix.mpi }}
           conda install -q -v -n numcosmo_developer libfabric-devel
@@ -256,7 +255,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
-          pip install -v pygobject-stubs
           conda list
       - name: Save conda-forge cache
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -180,7 +180,7 @@ jobs:
           conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
           which python
           conda list
-          pip install -v pygobject-stubs types-tabulate
+          pip install -v pygobject-stubs
           conda remove -q -v -n numcosmo_developer openmpi
           conda install -q -v -n numcosmo_developer ${{ matrix.mpi }}
           conda install -q -v -n numcosmo_developer libfabric-devel
@@ -256,7 +256,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
-          pip install -v pygobject-stubs types-tabulate
+          pip install -v pygobject-stubs
           conda list
       - name: Save conda-forge cache
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -54,7 +54,7 @@ jobs:
         ./example_simple
         ./example_ca
     - name: Check NumCosmo
-      run: meson test -C build --num-processes=2 || (cat build/meson-logs/testlog.txt && exit 1)
+      run: meson test -v -C build --num-processes=2 || (cat build/meson-logs/testlog.txt && exit 1)
     - name: Create a NumCosmo tarball
       run: meson dist -C build --no-tests
     - name: Upload a Build Artifact
@@ -141,7 +141,7 @@ jobs:
         pytest -xvs tests/python --run-sphere-map -m sphere_map
     - name: Check NumCosmo
       run: |
-        meson test -C build --num-processes=2 || (cat build/meson-logs/testlog.txt && exit 1)
+        meson test -v -C build --num-processes=2 || (cat build/meson-logs/testlog.txt && exit 1)
 
   build-miniforge:
     name: (${{ matrix.os }}, py${{ matrix.python-version }}, ${{ matrix.mpi }}, Miniforge)
@@ -222,7 +222,7 @@ jobs:
       #  run: |
       #    pylint --rcfile .pylintrc numcosmo_py
       - name: Check NumCosmo
-        run: meson test -C build --num-processes=2 || (cat build/meson-logs/testlog.txt && exit 1)
+        run: meson test -v -C build --num-processes=2 || (cat build/meson-logs/testlog.txt && exit 1)
 
   build-miniforge-coverage:
     name: Cov-${{ matrix.suites }} (py${{ matrix.python-version }}, openmpi)
@@ -278,7 +278,7 @@ jobs:
         # Third run to merge the coverage base and the coverage for the tests
         run: |
           lcov --config-file .lcovrc --no-external --capture --initial --directory build --directory numcosmo --directory tests --base-directory $(pwd)/build --output-file numcosmo-coverage-base.info
-          meson test -C build --timeout-multiplier 0 --num-processes=2 --suite=${{ matrix.suites }} || (cat build/meson-logs/testlog.txt && exit 1)
+          meson test -v -C build --timeout-multiplier 0 --num-processes=2 --suite=${{ matrix.suites }} || (cat build/meson-logs/testlog.txt && exit 1)
           lcov --config-file .lcovrc --no-external --capture --directory build --directory numcosmo --directory tests --base-directory $(pwd)/build --output-file numcosmo-coverage-tests.info
           lcov --config-file .lcovrc --add-tracefile numcosmo-coverage-base.info --add-tracefile numcosmo-coverage-tests.info --output-file numcosmo-coverage-full.info
           lcov --config-file .lcovrc --remove numcosmo-coverage-full.info '*/class/*' '*/levmar/*' '*/libcuba/*' '*/plc/*' '*/sundials/*' '*/toeplitz/*' '*/tools/*' --output-file numcosmo-coverage.info

--- a/docs/install.qmd
+++ b/docs/install.qmd
@@ -60,7 +60,7 @@ Note: The pip packages provide type stubs for better mypy type checking support 
 
 To test the installation, run the unit tests:
 ```bash
-meson test -C build
+meson test -v -C build
 ```
 
 If you prefer using the library without installation, export specific environment variables. A script is generated in the build directory for easy execution (and optional addition to shell initialization):
@@ -181,7 +181,7 @@ meson compile -C build
 ```
   - Optionally run the library unit testing
 ```bash
-meson test -C build
+meson test -v -C build
 ```
   - Install the library (optional). 
   Note that most developers **don't** want to install the library since they prefer to update/modify the library without installing it.

--- a/environment.yml
+++ b/environment.yml
@@ -42,6 +42,7 @@ dependencies:
   - pyccl >= 3.0.0
   - pydantic
   - pygobject
+  - pygobject-stubs
   - pylint
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -55,4 +55,5 @@ dependencies:
   - tabulate
   - tqdm
   - typer
+  - types-tabulate
   - zlib

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -157,14 +157,3 @@ option(
        value: 'measure',
        description: 'FFTW planner flag',
 )
-
-#######################################################################################
-# pytest tap plugin
-#######################################################################################
-
-option(
-       'pytest_tap',
-       type: 'boolean',
-       value: true,
-       description: 'Enable pytest tap plugin',
-)

--- a/numcosmo_py/app/__init__.py
+++ b/numcosmo_py/app/__init__.py
@@ -50,6 +50,7 @@ from .generate import (
     GenerateDEWSpline,
 )
 from .cluster_richness import RunClusterRichnessAnalysis
+from .inspect import InspectSummary, InspectClusterNCounts
 from .xcor import ViewKernel, ListKernels
 
 # Attempt optional import of the Firecrown-NumCosmo connector.
@@ -71,6 +72,7 @@ app_cat = typer.Typer(
 )
 app_generate = typer.Typer(no_args_is_help=True, help="Generate experiment files.")
 app_analysis = typer.Typer(no_args_is_help=True, help="Data analysis tools.")
+app_inspect = typer.Typer(no_args_is_help=True, help="Inspect generated experiments.")
 app_xcor = typer.Typer(no_args_is_help=True, help="Cross-correlation kernel analysis.")
 app_xcor_kernel = typer.Typer(
     no_args_is_help=True, help="Kernel visualization and analysis."
@@ -81,6 +83,7 @@ app_run.add_typer(app_run_mcmc, name="mcmc")
 app.add_typer(app_cat, name="catalog")
 app.add_typer(app_generate, name="generate")
 app.add_typer(app_analysis, name="analysis")
+app.add_typer(app_inspect, name="inspect")
 app.add_typer(app_xcor, name="xcor")
 app_xcor.add_typer(app_xcor_kernel, name="kernel")
 
@@ -226,6 +229,18 @@ XCOR_KERNEL_LIST_CMD: CMDArg = {
     "help": "List all available kernel types and their parameters.",
 }
 
+INSPECT_SUMMARY_CMD: CMDArg = {
+    "name": "summary",
+    "no_args_is_help": True,
+    "help": "Inspect experiment summary for likelihood and covariance diagnostics.",
+}
+
+INSPECT_CLUSTER_NCOUNTS_CMD: CMDArg = {
+    "name": "cluster-ncounts",
+    "no_args_is_help": True,
+    "help": "Plot data-vector, covariance/correlation, and optional S_ij diagnostics.",
+}
+
 # ------------------------------------------------------------------------------
 # Installing from-cosmosis command if COSMOSIS is installed and
 # all prerequisites are met.
@@ -263,6 +278,9 @@ app_generate.command(**GEN_DEWSPLINE_CMD)(GenerateDEWSpline)
 # ------------------------------------------------------------------------------
 # Installing analysis subcommands
 app_analysis.command(**ANALYSIS_CLUSTER_RICHNESS_CMD)(RunClusterRichnessAnalysis)
+# Installing inspect subcommands
+app_inspect.command(**INSPECT_SUMMARY_CMD)(InspectSummary)
+app_inspect.command(**INSPECT_CLUSTER_NCOUNTS_CMD)(InspectClusterNCounts)
 # Installing xcor kernel subcommands
 app_xcor_kernel.command(**XCOR_KERNEL_VIEW_CMD)(ViewKernel)
 app_xcor_kernel.command(**XCOR_KERNEL_LIST_CMD)(ListKernels)

--- a/numcosmo_py/app/inspect.py
+++ b/numcosmo_py/app/inspect.py
@@ -1,0 +1,341 @@
+#
+# inspect.py
+#
+# Tue May 13 12:00:00 2026
+# Copyright (C) 2026 Sandro Dias Pinto Vitenti <vitenti@uel.br>
+#
+# numcosmo is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# numcosmo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""NumCosmo APP commands for read-only experiment inspection."""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Annotated
+
+import matplotlib.pyplot as plt
+import numpy as np
+import typer
+from rich.table import Table
+
+from numcosmo_py import Ncm, Nc
+from .loading import LoadExperiment
+
+
+@dataclasses.dataclass(kw_only=True)
+class InspectExperiment(LoadExperiment):
+    """Load experiment and helper objects for inspection commands."""
+
+    def __post_init__(self) -> None:
+        """Load experiment objects using the standard app loading order."""
+        super().__post_init__()
+
+        # Keep dataset loading behavior consistent with the rest of the app while
+        # exposing it as an attribute for inspection commands.
+        ser = Ncm.Serialize.new(Ncm.SerializeOpt.CLEAN_DUP)
+        dataset_file = self.experiment.with_suffix(".dataset.gvar")
+        if dataset_file.exists():
+            dataset = ser.from_binfile(dataset_file.absolute().as_posix())
+            if not isinstance(dataset, Ncm.Dataset):
+                raise RuntimeError(f"Invalid dataset file {dataset_file}.")
+            self.dataset = dataset
+        else:
+            self.dataset = self.likelihood.peek_dataset()
+
+    def _find_cluster_ncounts(self) -> Nc.DataClusterNCountsGauss:
+        """Return the first DataClusterNCountsGauss in the dataset."""
+        for i in range(self.dataset.get_length()):
+            data_i = self.dataset.peek_data(i)
+            if isinstance(data_i, Nc.DataClusterNCountsGauss):
+                return data_i
+
+        raise RuntimeError(
+            "No Nc.DataClusterNCountsGauss data object found in dataset."
+        )
+
+
+@dataclasses.dataclass(kw_only=True)
+class InspectSummary(InspectExperiment):
+    """Print a concise and general summary of experiment contents."""
+
+    show_model_params: Annotated[
+        bool,
+        typer.Option(
+            "--show-model-params/--no-show-model-params",
+            help=(
+                "Show detailed model parameter table including values, bounds, "
+                "scale, and fit type."
+            ),
+        ),
+    ] = False
+
+    def __post_init__(self) -> None:
+        """Print high-level dataset and model inventory diagnostics."""
+        super().__post_init__()
+
+        dset = self.dataset
+        m2lnl = self.likelihood.m2lnL_val(self.mset)
+
+        main_table = Table(title="Experiment summary", show_header=False, expand=False)
+        main_table.add_column(style="bold bright_cyan")
+        main_table.add_column(style="bold bright_green")
+        main_table.add_row("Likelihood m2lnL", f"{m2lnl:.8g}")
+        main_table.add_row("Dataset entries", f"{dset.get_length()}")
+        main_table.add_row("Models present", f"{self.mset.nmodels()}")
+        self.console.print(main_table)
+
+        data_table = Table(title="Dataset likelihood terms", expand=False)
+        data_table.add_column("Index", justify="right", style="bold bright_cyan")
+        data_table.add_column("Type", style="bold")
+        data_table.add_column("Length", justify="right")
+        data_table.add_column("Description")
+        for i in range(dset.get_length()):
+            data_i = dset.peek_data(i)
+            data_type = data_i.__class__.__name__
+            data_desc = data_i.get_desc()
+            data_len = data_i.get_length()
+            data_table.add_row(str(i), data_type, str(data_len), data_desc)
+        self.console.print(data_table)
+
+        models_table = Table(title="Model set", expand=False)
+        models_table.add_column("Index", justify="right", style="bold bright_cyan")
+        models_table.add_column("Namespace")
+        models_table.add_column("Name")
+        models_table.add_column("Nick")
+        for i in range(self.mset.nmodels()):
+            model = self.mset.peek_array_pos(i)
+            model_mid = model.id()
+            model_ns = Ncm.MSet.get_ns_by_id(model_mid)
+            models_table.add_row(str(i), model_ns, model.name(), model.nick())
+        self.console.print(models_table)
+
+        if self.show_model_params:
+            for i in range(self.mset.nmodels()):
+                model = self.mset.peek_array_pos(i)
+                model_mid = model.id()
+                model_ns = Ncm.MSet.get_ns_by_id(model_mid)
+
+                param_table = Table(
+                    title=f"Parameters: {model_ns} ({model.nick()})",
+                    expand=False,
+                )
+                param_table.add_column("#", justify="right", style="bold bright_cyan")
+                param_table.add_column("Name")
+                param_table.add_column("Symbol")
+                param_table.add_column("Value", justify="right")
+                param_table.add_column("Lower", justify="right")
+                param_table.add_column("Upper", justify="right")
+                param_table.add_column("Scale", justify="right")
+                param_table.add_column("Fit type")
+
+                for p in range(model.len()):
+                    ftype = model.param_get_ftype(p)
+                    ftype_str = ftype.name if hasattr(ftype, "name") else str(ftype)
+                    param_table.add_row(
+                        str(p),
+                        model.param_name(p),
+                        model.param_symbol(p),
+                        f"{model.param_get(p):.6g}",
+                        f"{model.param_get_lower_bound(p):.6g}",
+                        f"{model.param_get_upper_bound(p):.6g}",
+                        f"{model.param_get_scale(p):.6g}",
+                        ftype_str,
+                    )
+
+                self.console.print(param_table)
+
+        self.close_logging()
+
+
+@dataclasses.dataclass(kw_only=True)
+class InspectClusterNCounts(InspectExperiment):
+    """Plot cluster-count data vector and covariance diagnostics."""
+
+    output_prefix: Annotated[
+        Path | None,
+        typer.Option(
+            "--output-prefix",
+            help=(
+                "Prefix for output image files. "
+                "If set to path/to/foo, figures are saved as "
+                "foo_data_vector.png, foo_covariance.png, and foo_sij.png."
+            ),
+        ),
+    ] = None
+
+    show_plot: Annotated[
+        bool,
+        typer.Option(
+            "--show-plot/--no-show-plot",
+            help="Display figures interactively.",
+        ),
+    ] = True
+
+    cmap: Annotated[
+        str,
+        typer.Option(help="Matplotlib colormap name for heatmaps."),
+    ] = "viridis"
+
+    dpi: Annotated[
+        int,
+        typer.Option(help="Figure DPI when saving files.", min=50),
+    ] = 150
+
+    log_data: Annotated[
+        bool,
+        typer.Option(
+            "--log-data/--linear-data",
+            help="Use log10 scale for data-vector heatmap color values.",
+        ),
+    ] = False
+
+    show_sij: Annotated[
+        bool,
+        typer.Option(
+            "--show-sij/--no-show-sij",
+            help="Plot fitting and resample S_ij matrices when present.",
+        ),
+    ] = True
+
+    def __post_init__(self) -> None:
+        """Generate cluster-count diagnostic plots."""
+        super().__post_init__()
+
+        ncounts = self._find_cluster_ncounts()
+
+        data_vec = ncounts.peek_mean().to_numpy()
+        cov_matrix, _ = ncounts.compute_cov(self.mset)
+        cov = cov_matrix.to_numpy()
+
+        z_obs = ncounts.get_z_obs().to_numpy()
+        lnm_obs = ncounts.get_lnM_obs().to_numpy()
+
+        n_z_bins = max(z_obs.size - 1, 0)
+        n_m_bins = max(lnm_obs.size - 1, 0)
+
+        if n_z_bins * n_m_bins == data_vec.size and n_z_bins > 0 and n_m_bins > 0:
+            data_grid = data_vec.reshape((n_z_bins, n_m_bins))
+        else:
+            self.console.print(
+                "Could not infer (z, lnM) 2D grid from bins; plotting flattened vector."
+            )
+            data_grid = data_vec.reshape((1, data_vec.size))
+
+        self._plot_data_vector(data_grid)
+        self._plot_covariance(cov)
+
+        if self.show_sij:
+            fit_sij = ncounts.get_s_matrix()
+            resample_sij = ncounts.get_resample_s_matrix()
+            if fit_sij is not None or resample_sij is not None:
+                self._plot_sij(fit_sij, resample_sij)
+            else:
+                self.console.print("No S_ij matrices available to plot.")
+
+        if self.show_plot:
+            plt.show()
+
+        self.close_logging()
+
+    def _save_or_note(self, fig: plt.Figure, suffix: str) -> None:
+        """Save a figure when output prefix is provided."""
+        if self.output_prefix is None:
+            return
+
+        out_file = self.output_prefix.parent / f"{self.output_prefix.name}_{suffix}.png"
+        fig.savefig(out_file, dpi=self.dpi, bbox_inches="tight")
+        self.console.print(f"Saved figure: {out_file}")
+
+    def _plot_data_vector(self, data_grid: np.ndarray) -> None:
+        """Plot data-vector heatmap."""
+        plot_data = data_grid
+        if self.log_data:
+            # Clip at tiny positive values to keep finite log colors.
+            plot_data = np.log10(np.clip(data_grid, 1.0e-16, None))
+
+        fig, ax = plt.subplots(figsize=(8.0, 5.5))
+        im = ax.imshow(plot_data, origin="lower", aspect="auto", cmap=self.cmap)
+        cbar = fig.colorbar(im, ax=ax)
+        cbar.set_label("log10(counts)" if self.log_data else "counts")
+        ax.set_xlabel("lnM_obs bin index")
+        ax.set_ylabel("z bin index")
+        ax.set_title("Cluster-count data vector")
+        fig.tight_layout()
+        self._save_or_note(fig, "data_vector")
+
+    def _plot_covariance(self, cov: np.ndarray) -> None:
+        """Plot covariance and correlation heatmaps."""
+        std = np.sqrt(np.clip(np.diag(cov), 1.0e-300, None))
+        corr = cov / np.outer(std, std)
+
+        fig, (ax_cov, ax_corr) = plt.subplots(1, 2, figsize=(12.5, 5.2))
+
+        im_cov = ax_cov.imshow(cov, origin="lower", aspect="auto", cmap=self.cmap)
+        fig.colorbar(im_cov, ax=ax_cov, fraction=0.046, pad=0.04)
+        ax_cov.set_title("Covariance")
+        ax_cov.set_xlabel("bin index")
+        ax_cov.set_ylabel("bin index")
+
+        im_corr = ax_corr.imshow(
+            corr,
+            origin="lower",
+            aspect="auto",
+            cmap="coolwarm",
+            vmin=-1.0,
+            vmax=1.0,
+        )
+        fig.colorbar(im_corr, ax=ax_corr, fraction=0.046, pad=0.04)
+        ax_corr.set_title("Correlation")
+        ax_corr.set_xlabel("bin index")
+        ax_corr.set_ylabel("bin index")
+
+        fig.tight_layout()
+        self._save_or_note(fig, "covariance")
+
+    def _plot_sij(
+        self,
+        fit_sij: Ncm.Matrix | None,
+        resample_sij: Ncm.Matrix | None,
+    ) -> None:
+        """Plot available S_ij matrices."""
+        fit_arr = fit_sij.to_numpy() if fit_sij is not None else None
+        resample_arr = resample_sij.to_numpy() if resample_sij is not None else None
+
+        n_panels = int(fit_arr is not None) + int(resample_arr is not None)
+        fig, axes = plt.subplots(1, n_panels, figsize=(6.0 * n_panels, 5.0))
+
+        if n_panels == 1:
+            axes = [axes]
+
+        i = 0
+        if fit_arr is not None:
+            im = axes[i].imshow(fit_arr, origin="lower", aspect="auto", cmap=self.cmap)
+            fig.colorbar(im, ax=axes[i], fraction=0.046, pad=0.04)
+            axes[i].set_title("Fitting S_ij")
+            axes[i].set_xlabel("z bin j")
+            axes[i].set_ylabel("z bin i")
+            i += 1
+
+        if resample_arr is not None:
+            im = axes[i].imshow(
+                resample_arr, origin="lower", aspect="auto", cmap=self.cmap
+            )
+            fig.colorbar(im, ax=axes[i], fraction=0.046, pad=0.04)
+            axes[i].set_title("Resample S_ij")
+            axes[i].set_xlabel("z bin j")
+            axes[i].set_ylabel("z bin i")
+
+        fig.tight_layout()
+        self._save_or_note(fig, "sij")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ test = [
     "pyccl",
     "pydantic",
     "pytest-lazy-fixtures",
-    "pytest-tap",
     "pytest",
     "rich",
     "sacc",

--- a/tests/python/app/test_inspect_app.py
+++ b/tests/python/app/test_inspect_app.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+#
+# test_inspect_app.py
+#
+# Thu May 14 2026
+# Copyright (C) 2026 Sandro Dias Pinto Vitenti <vitenti@uel.br>
+#
+# numcosmo is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# numcosmo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for inspect CLI commands."""
+
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+from typer.testing import CliRunner
+
+pytest.importorskip("astropy")
+pytest.importorskip("getdist")
+# flake8: noqa: E402
+# pylint: disable=wrong-import-position
+
+from numcosmo_py import Ncm
+from numcosmo_py.app import app
+from numcosmo_py.app import generate as gen
+from numcosmo_py import Nc
+
+pytestmark = pytest.mark.app
+runner = CliRunner()
+
+Ncm.cfg_init()
+
+
+@pytest.fixture(name="simple_experiment")
+def fixture_simple_experiment(tmp_path: Path) -> Tuple[Path, Ncm.ObjDictStr]:
+    """Create a generic simple experiment with one Gaussian data object."""
+    rng = Ncm.RNG.seeded_new(None, 1234)
+    model_mvnd = Ncm.ModelMVND.new(5)
+    mset = Ncm.MSet.new_array([model_mvnd])
+    mset.param_set_all_ftype(Ncm.ParamType.FREE)
+
+    data_mvnd = Ncm.DataGaussCovMVND.new_full(5, 1.0, 2.0, 30.0, 0.0, 0.0, rng)
+    likelihood = Ncm.Likelihood.new(dset=Ncm.Dataset.new_array([data_mvnd]))
+
+    exp_file = tmp_path / "simple_experiment.yaml"
+    ser = Ncm.Serialize.new(Ncm.SerializeOpt.CLEAN_DUP)
+
+    experiment = Ncm.ObjDictStr.new()
+    experiment.add("model-set", mset)
+    experiment.add("likelihood", likelihood)
+
+    ser.dict_str_to_yaml_file(experiment, exp_file.as_posix())
+
+    return exp_file, experiment
+
+
+@pytest.fixture(name="jpas_experiment")
+def fixture_jpas_experiment(tmp_path: Path) -> Path:
+    """Create a small JPAS cluster-count experiment for inspect tests."""
+    exp_file = tmp_path / "jpas_small.yaml"
+
+    _ = gen.GenerateJpasForecast(
+        experiment=exp_file.absolute(),
+        znknots=3,
+        lnMobsnknots=2,
+        fitting_sky_cut=gen.JpasSSCType.NO_SSC,
+        resample_sky_cut=gen.JpasSSCType.NO_SSC,
+    )
+
+    return exp_file
+
+
+def test_inspect_summary_lists_dataset_terms(
+    simple_experiment: Tuple[Path, Ncm.ObjDictStr],
+):
+    """inspect summary should list likelihood terms from dataset."""
+    exp_file, _ = simple_experiment
+
+    result = runner.invoke(app, ["inspect", "summary", exp_file.as_posix()])
+
+    assert result.exit_code == 0, result.output
+    assert "Experiment summary" in result.output
+    assert "Dataset likelihood terms" in result.output
+    assert "DataGaussCovMVND" in result.output
+    assert "Models present" in result.output
+
+
+def test_inspect_summary_show_model_params(
+    simple_experiment: Tuple[Path, Ncm.ObjDictStr],
+):
+    """inspect summary --show-model-params should print parameter table details."""
+    exp_file, _ = simple_experiment
+
+    result = runner.invoke(
+        app,
+        ["inspect", "summary", exp_file.as_posix(), "--show-model-params"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Parameters:" in result.output
+    assert "Fit type" in result.output
+    assert "FREE" in result.output
+    assert "ParamType." not in result.output
+
+
+def test_inspect_cluster_ncounts_creates_plots(jpas_experiment: Path, tmp_path: Path):
+    """inspect cluster-ncounts should generate plot files when output prefix is set."""
+    out_prefix = tmp_path / "inspect_plots"
+
+    result = runner.invoke(
+        app,
+        [
+            "inspect",
+            "cluster-ncounts",
+            jpas_experiment.as_posix(),
+            "--no-show-plot",
+            "--output-prefix",
+            out_prefix.as_posix(),
+            "--no-show-sij",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "inspect_plots_data_vector.png").exists()
+    assert (tmp_path / "inspect_plots_covariance.png").exists()
+
+
+def test_inspect_cluster_ncounts_no_sij_message(jpas_experiment: Path):
+    """inspect cluster-ncounts should report missing S_ij when none is configured."""
+    result = runner.invoke(
+        app,
+        [
+            "inspect",
+            "cluster-ncounts",
+            jpas_experiment.as_posix(),
+            "--no-show-plot",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No S_ij matrices available to plot." in result.output
+
+
+def test_inspect_cluster_ncounts_log_data_and_plot_options(
+    jpas_experiment: Path, tmp_path: Path
+):
+    """inspect cluster-ncounts should accept plot style options and save figures."""
+    out_prefix = tmp_path / "inspect_opts"
+
+    result = runner.invoke(
+        app,
+        [
+            "inspect",
+            "cluster-ncounts",
+            jpas_experiment.as_posix(),
+            "--no-show-plot",
+            "--output-prefix",
+            out_prefix.as_posix(),
+            "--log-data",
+            "--cmap",
+            "plasma",
+            "--dpi",
+            "120",
+            "--no-show-sij",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "inspect_opts_data_vector.png").exists()
+    assert (tmp_path / "inspect_opts_covariance.png").exists()
+
+
+def test_inspect_cluster_ncounts_reshape_fallback(
+    jpas_experiment: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """inspect cluster-ncounts.
+
+    inspect cluster-ncounts should fallback to flattened vector when bin shape
+    mismatches.
+    """
+
+    def fake_get_z_obs(_self):
+        # Force a shape mismatch with the original data-vector length.
+        return Ncm.Vector.new_array([0.1, 0.3, 0.5, 0.7])
+
+    monkeypatch.setattr(Nc.DataClusterNCountsGauss, "get_z_obs", fake_get_z_obs)
+
+    result = runner.invoke(
+        app,
+        [
+            "inspect",
+            "cluster-ncounts",
+            jpas_experiment.as_posix(),
+            "--no-show-plot",
+            "--no-show-sij",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "Could not infer (z, lnM) 2D grid from bins; plotting flattened vector."
+        in result.output
+    )
+
+
+def test_inspect_cluster_ncounts_sij_plot_created(
+    jpas_experiment: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """inspect cluster-ncounts should save S_ij panel when S_ij matrices are present."""
+
+    sij = Ncm.Matrix.new_array([1.0, 0.2, 0.2, 0.5], 2)
+
+    monkeypatch.setattr(Nc.DataClusterNCountsGauss, "get_s_matrix", lambda _self: sij)
+    monkeypatch.setattr(
+        Nc.DataClusterNCountsGauss,
+        "get_resample_s_matrix",
+        lambda _self: sij,
+    )
+
+    out_prefix = tmp_path / "inspect_sij"
+    result = runner.invoke(
+        app,
+        [
+            "inspect",
+            "cluster-ncounts",
+            jpas_experiment.as_posix(),
+            "--no-show-plot",
+            "--output-prefix",
+            out_prefix.as_posix(),
+            "--show-sij",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "inspect_sij_sij.png").exists()
+
+
+def test_inspect_cluster_ncounts_requires_cluster_data(
+    simple_experiment: Tuple[Path, Ncm.ObjDictStr],
+):
+    """inspect cluster-ncounts should fail for experiments without cluster counts."""
+    exp_file, _ = simple_experiment
+
+    result = runner.invoke(
+        app,
+        ["inspect", "cluster-ncounts", exp_file.as_posix(), "--no-show-plot"],
+    )
+
+    assert result.exit_code != 0
+    assert result.exception is not None
+    assert "No Nc.DataClusterNCountsGauss data object found in dataset." in str(
+        result.exception
+    )

--- a/tests/python/meson.build
+++ b/tests/python/meson.build
@@ -45,27 +45,6 @@ if enable_gir and python_for_tests.found()
         pytest_base_args += ['--cov-append']
     endif
 
-    py_tap = python_module.find_installation(
-        'python3',
-        modules: ['pytest_tap'],
-        required: false,
-    )
-    if py_tap.found() and get_option('pytest_tap')
-        r = run_command(
-            python,
-            '-c', 'import importlib.metadata; import sys; sys.stdout.write(importlib.metadata.version("pytest-tap"))',
-            check: true,
-        )
-        message('pytest-tap version: @0@'.format(r.stdout().strip()))
-
-        if r.stdout().version_compare('>= 3.4')
-            pytest_base_args += ['--tap']
-        else
-            pytest_base_args += ['--tap-stream']
-        endif
-        pytest_protocol = 'tap'
-    endif
-
     # If xdist is available, use it for parallel test execution
     py_xdist = python_module.find_installation(
         'python3',


### PR DESCRIPTION
Adds the new `inspect` command, its tests, and docs updates; removes TAP support for Python tests; and makes CI `meson test` output verbose for easier debugging.