### PR TITLE
jpas_forecast: make photo-z scatter sigma0 configurable

### DIFF
--- a/numcosmo_py/app/generate.py
+++ b/numcosmo_py/app/generate.py
@@ -228,6 +228,15 @@ class GenerateJpasForecast:
         typer.Option(help="Cluster photoz relation.", show_default=True),
     ] = ClusterRedshiftType.NODIST
 
+    cluster_redshift_sigma0: Annotated[
+        float,
+        typer.Option(
+            help="Photo-z scatter sigma0 in sigma_z(z)=sigma0(1+z) (GAUSS only).",
+            show_default=True,
+            min=0.0,
+        ),
+    ] = 0.1
+
     lnM_obs_min: Annotated[
         float,
         typer.Option(
@@ -300,6 +309,7 @@ class GenerateJpasForecast:
             z_max=self.z_max,
             znknots=self.znknots,
             cluster_redshift_type=self.cluster_redshift_type,
+            cluster_redshift_sigma0=self.cluster_redshift_sigma0,
             lnM_obs_min=self.lnM_obs_min,
             lnM_obs_max=self.lnM_obs_max,
             lnMobsnknots=self.lnMobsnknots,

--- a/numcosmo_py/experiments/jpas_forecast24.py
+++ b/numcosmo_py/experiments/jpas_forecast24.py
@@ -504,11 +504,13 @@ def create_cluster_mass(
 
 def create_cluster_redshift(
     cluster_redshift_type: ClusterRedshiftType,
+    sigma0: float = 0.1,
 ) -> Nc.ClusterRedshift:
     """Create the cluster photometric redshift (photoz) relation model.
 
     :param cluster_redshift_type: The type of photoz relation to use.
-    :param cluster_redshift_type: The type of photoz relation to use.
+    :param sigma0: Photo-z scatter normalization sigma_z(z) = sigma0 (1+z) for the
+        GAUSS relation (ignored by NODIST).
     :raises ValueError: If the cluster redshift type is invalid.
     :return: An initialized NumCosmo ClusterRedshift model.
     """
@@ -520,7 +522,7 @@ def create_cluster_redshift(
         # Gaussian photoz error distribution
         cluster_z = Nc.ClusterPhotozGaussGlobal(pz_min=0.0, pz_max=1.0)
         cluster_z["z-bias"] = 0  # Photoz bias $langle z_{obs} - z_{true} rangle$
-        cluster_z["sigma0"] = 0.1  # Photoz scatter $sigma_z$
+        cluster_z["sigma0"] = sigma0  # Photoz scatter $sigma_z$
     else:
         raise ValueError(f"Invalid cluster redshift type: {cluster_redshift_type}")
 
@@ -568,6 +570,7 @@ def generate_jpas_forecast_2024(
     z_max: float = 0.8,
     znknots: int = 8,
     cluster_redshift_type: ClusterRedshiftType = ClusterRedshiftType.NODIST,
+    cluster_redshift_sigma0: float = 0.1,
     lnM_obs_min: float | None = None,
     lnM_obs_max: float | None = None,
     lnMobsnknots: int = 2,
@@ -651,7 +654,7 @@ def generate_jpas_forecast_2024(
     cluster_m, default_lnM_obs_min, default_lnM_obs_max = create_cluster_mass(
         cluster_mass_type
     )
-    cluster_z = create_cluster_redshift(cluster_redshift_type)
+    cluster_z = create_cluster_redshift(cluster_redshift_type, sigma0=cluster_redshift_sigma0)
     cosmo = create_cosmo()
 
     # Use defaults if not specified

--- a/numcosmo_py/experiments/jpas_forecast24.py
+++ b/numcosmo_py/experiments/jpas_forecast24.py
@@ -654,7 +654,9 @@ def generate_jpas_forecast_2024(
     cluster_m, default_lnM_obs_min, default_lnM_obs_max = create_cluster_mass(
         cluster_mass_type
     )
-    cluster_z = create_cluster_redshift(cluster_redshift_type, sigma0=cluster_redshift_sigma0)
+    cluster_z = create_cluster_redshift(
+        cluster_redshift_type, sigma0=cluster_redshift_sigma0
+    )
     cosmo = create_cosmo()
 
     # Use defaults if not specified


### PR DESCRIPTION
## Summary
- Thread a configurable photo-z scatter normalization (`sigma0`) through the JPAS forecast generation.
- Add a `--cluster-redshift-sigma0` CLI option (default `0.1`, `min=0.0`) that flows into `create_cluster_redshift` for the GAUSS relation; NODIST ignores it.
- Fix a duplicated docstring line in `create_cluster_redshift`.

## Files
- `numcosmo_py/app/generate.py` — new CLI option, passed through to the generator.
- `numcosmo_py/experiments/jpas_forecast24.py` — `create_cluster_redshift` accepts `sigma0`; plumbed through `generate_jpas_forecast_2024`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)