### PR TITLE
Selectable knot placement for spline reconstruction models

### DIFF
--- a/numcosmo/nc/background/nc_hicosmo.h
+++ b/numcosmo/nc/background/nc_hicosmo.h
@@ -49,6 +49,25 @@ G_BEGIN_DECLS
 #define NC_HICOSMO_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), NC_TYPE_HICOSMO, NcHICosmoClass))
 
 /**
+ * NcHICosmoSplineKnots:
+ * @NC_HICOSMO_SPLINE_KNOTS_UNIFORM: knots spaced uniformly over the reconstruction interval
+ * @NC_HICOSMO_SPLINE_KNOTS_CHEBYSHEV: knots on a Chebyshev grid (clustered toward both endpoints)
+ *
+ * Knot placement for the spline-based $w(z)$ / $q(z)$ reconstruction models
+ * (#NcHICosmoDEWSpline, #NcHICosmoQSpline). Uniform spreads resolution evenly;
+ * Chebyshev clusters it toward the endpoints (better interpolation conditioning,
+ * but denser where high-$z$ data are sparse).
+ *
+ */
+typedef enum /*< enum,underscore_name=NC_HICOSMO_SPLINE_KNOTS >*/
+{
+  NC_HICOSMO_SPLINE_KNOTS_UNIFORM = 0,
+  NC_HICOSMO_SPLINE_KNOTS_CHEBYSHEV,
+  /* < private > */
+  NC_HICOSMO_SPLINE_KNOTS_LEN, /*< skip >*/
+} NcHICosmoSplineKnots;
+
+/**
  * NcHICosmoImpl:
  * @NC_HICOSMO_IMPL_H0: Hubble constant
  * @NC_HICOSMO_IMPL_Omega_b0: Baryonic density today $\Omega_{b0} = \rho_{b0} / \rho_{\mathrm{crit}0}$

--- a/numcosmo/nc/background/nc_hicosmo_de_wspline.c
+++ b/numcosmo/nc/background/nc_hicosmo_de_wspline.c
@@ -40,6 +40,7 @@
 #include "build_cfg.h"
 
 #include "nc/background/nc_hicosmo_de_wspline.h"
+#include "nc_enum_types.h"
 #include "ncm/spline/ncm_spline_cubic_notaknot.h"
 #include "ncm/spline/ncm_spline_gsl.h"
 #include "ncm/integration/ncm_integrate.h"
@@ -59,6 +60,7 @@ struct _NcHICosmoDEWSplinePrivate
   gdouble alpha_f;
   gdouble w_f;
   gdouble int_f;
+  NcHICosmoSplineKnots knots;
   NcmSpline *w_alpha;
 };
 
@@ -69,6 +71,7 @@ enum
   PROP_0,
   PROP_Z_1,
   PROP_Z_F,
+  PROP_KNOTS,
   PROP_SIZE,
 };
 
@@ -103,6 +106,9 @@ _nc_hicosmo_de_wspline_get_property (GObject *object, guint prop_id, GValue *val
     case PROP_Z_F:
       g_value_set_double (value, self->z_f);
       break;
+    case PROP_KNOTS:
+      g_value_set_enum (value, self->knots);
+      break;
     default:                                                      /* LCOV_EXCL_LINE */
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); /* LCOV_EXCL_LINE */
       break;                                                      /* LCOV_EXCL_LINE */
@@ -124,6 +130,9 @@ _nc_hicosmo_de_wspline_set_property (GObject *object, guint prop_id, const GValu
       break;
     case PROP_Z_F:
       self->z_f = g_value_get_double (value);
+      break;
+    case PROP_KNOTS:
+      self->knots = g_value_get_enum (value);
       break;
     default:                                                      /* LCOV_EXCL_LINE */
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); /* LCOV_EXCL_LINE */
@@ -159,11 +168,27 @@ _nc_hicosmo_de_wspline_constructed (GObject *object)
     wv     = ncm_vector_get_subvector (orig_vec, wvi, wz_size);
 
     {
+      /* Knot placement in alpha = ln(1+z) over [0, alpha_f]. The default
+       * Chebyshev grid clusters knots toward both endpoints (good for
+       * interpolation conditioning), which puts the densest knots at high z
+       * where expansion data are sparsest. The uniform alternative spreads the
+       * resolution evenly, trading endpoint conditioning for a less degenerate
+       * high-z boundary.
+       */
       for (i = 0; i < wz_size; i++)
       {
-        const gdouble alpha = 0.5 * alphaf + 0.5 * alphaf * cos (M_PI * (i * 1.0) / (wz_size - 1.0));
+        if (self->knots == NC_HICOSMO_SPLINE_KNOTS_UNIFORM)
+        {
+          const gdouble alpha = alphaf * i / (wz_size - 1.0);
 
-        ncm_vector_set (alphav, wz_size - 1 - i, alpha);
+          ncm_vector_set (alphav, i, alpha);
+        }
+        else
+        {
+          const gdouble alpha = 0.5 * alphaf + 0.5 * alphaf * cos (M_PI * (i * 1.0) / (wz_size - 1.0));
+
+          ncm_vector_set (alphav, wz_size - 1 - i, alpha);
+        }
       }
     }
 
@@ -241,6 +266,15 @@ nc_hicosmo_de_wspline_class_init (NcHICosmoDEWSplineClass *klass)
                                                         "final redshift",
                                                         1.0, 1.0e10, 2.0,
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME | G_PARAM_STATIC_BLURB));
+
+  g_object_class_install_property (object_class,
+                                   PROP_KNOTS,
+                                   g_param_spec_enum ("knots",
+                                                      NULL,
+                                                      "knot placement in alpha=ln(1+z)",
+                                                      NC_TYPE_HICOSMO_SPLINE_KNOTS,
+                                                      NC_HICOSMO_SPLINE_KNOTS_CHEBYSHEV,
+                                                      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME | G_PARAM_STATIC_BLURB));
 
   /* Set w_0 param info */
   ncm_model_class_set_vparam (model_class, NC_HICOSMO_DE_WSPLINE_W, 6, "w", "w",

--- a/numcosmo/nc/background/nc_hicosmo_qspline.c
+++ b/numcosmo/nc/background/nc_hicosmo_qspline.c
@@ -38,6 +38,7 @@
 #include "build_cfg.h"
 
 #include "nc/background/nc_hicosmo_qspline.h"
+#include "nc_enum_types.h"
 #include "ncm/spline/ncm_spline_cubic_notaknot.h"
 #include "ncm/spline/ncm_spline_gsl.h"
 #include "ncm/model/ncm_mset_func_list.h"
@@ -55,6 +56,7 @@ enum
   PROP_SPLINE,
   PROP_NKNOTS,
   PROP_Z_F,
+  PROP_KNOTS,
   PROP_SIZE,
 };
 
@@ -94,7 +96,11 @@ _nc_hicosmo_qspline_constructed (GObject *object)
 
     for (i = 0; i < qz_size; i++)
     {
-      gdouble zi  = qspline->z_f / (qz_size - 1.0) * i;
+      /* Knot placement in z over [0, z_f]: uniform spreads resolution evenly,
+       * Chebyshev clusters it toward the endpoints. */
+      const gdouble zi = (qspline->knots == NC_HICOSMO_SPLINE_KNOTS_CHEBYSHEV) ?
+                         0.5 * qspline->z_f * (1.0 - cos (M_PI * i / (qz_size - 1.0))) :
+                         qspline->z_f / (qz_size - 1.0) * i;
       gdouble xi  = zi + 1.0;
       gdouble xi2 = xi * xi;
       gdouble xi3 = xi2 * xi;
@@ -147,6 +153,9 @@ _nc_hicosmo_qspline_get_property (GObject *object, guint prop_id, GValue *value,
     case PROP_Z_F:
       g_value_set_double (value, qspline->z_f);
       break;
+    case PROP_KNOTS:
+      g_value_set_enum (value, qspline->knots);
+      break;
     default:                                                      /* LCOV_EXCL_LINE */
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); /* LCOV_EXCL_LINE */
       break;                                                      /* LCOV_EXCL_LINE */
@@ -170,6 +179,9 @@ _nc_hicosmo_qspline_set_property (GObject *object, guint prop_id, const GValue *
       break;
     case PROP_Z_F:
       qspline->z_f = g_value_get_double (value);
+      break;
+    case PROP_KNOTS:
+      qspline->knots = g_value_get_enum (value);
       break;
     default:                                                      /* LCOV_EXCL_LINE */
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec); /* LCOV_EXCL_LINE */
@@ -299,6 +311,15 @@ nc_hicosmo_qspline_class_init (NcHICosmoQSplineClass *klass)
                                                         "final redshift",
                                                         0.0, 100.0, 1.0,
                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME | G_PARAM_STATIC_BLURB));
+
+  g_object_class_install_property (object_class,
+                                   PROP_KNOTS,
+                                   g_param_spec_enum ("knots",
+                                                      NULL,
+                                                      "knot placement in z",
+                                                      NC_TYPE_HICOSMO_SPLINE_KNOTS,
+                                                      NC_HICOSMO_SPLINE_KNOTS_UNIFORM,
+                                                      G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_NAME | G_PARAM_STATIC_BLURB));
 
   nc_hicosmo_set_H0_impl       (parent_class, &_nc_hicosmo_qspline_H0);
   nc_hicosmo_set_E2_impl       (parent_class, &_nc_hicosmo_qspline_E2);

--- a/numcosmo/nc/background/nc_hicosmo_qspline.h
+++ b/numcosmo/nc/background/nc_hicosmo_qspline.h
@@ -102,6 +102,7 @@ struct _NcHICosmoQSpline
   guint nknots;
   guint size;
   gdouble z_f;
+  NcHICosmoSplineKnots knots;
   NcmSpline *q_z;
   NcmOdeSpline *E2_z;
 };

--- a/numcosmo_py/nc.pyi
+++ b/numcosmo_py/nc.pyi
@@ -9305,6 +9305,8 @@ class HICosmoDEWSpline(HICosmoDE):
         second redshift knot
       zf -> gdouble: zf
         final redshift
+      knots -> NcHICosmoSplineKnots: knots
+        knot placement in alpha=ln(1+z)
       w -> NcmVector: w
         w
       w-length -> guint: w-length
@@ -9393,6 +9395,7 @@ class HICosmoDEWSpline(HICosmoDE):
     """
 
     class Props:
+        knots: HICosmoSplineKnots
         w: NumCosmoMath.Vector
         w_fit: GLib.Variant
         w_length: int
@@ -9440,6 +9443,7 @@ class HICosmoDEWSpline(HICosmoDE):
     priv: HICosmoDEWSplinePrivate = ...
     def __init__(
         self,
+        knots: HICosmoSplineKnots = ...,
         w: NumCosmoMath.Vector = ...,
         w_fit: GLib.Variant = ...,
         w_length: int = ...,
@@ -11077,6 +11081,8 @@ class HICosmoQSpline(HICosmo):
         Spline object
       zf -> gdouble: zf
         final redshift
+      knots -> NcHICosmoSplineKnots: knots
+        knot placement in z
       H0 -> gdouble: H0
         H_0
       Omegat -> gdouble: Omegat
@@ -11127,6 +11133,7 @@ class HICosmoQSpline(HICosmo):
         Omegat_fit: bool
         asdrag: float
         asdrag_fit: bool
+        knots: HICosmoSplineKnots
         qparam: NumCosmoMath.Vector
         qparam_fit: GLib.Variant
         qparam_length: int
@@ -11147,6 +11154,7 @@ class HICosmoQSpline(HICosmo):
     nknots: int = ...
     size: int = ...
     z_f: float = ...
+    knots: HICosmoSplineKnots = ...
     q_z: NumCosmoMath.Spline = ...
     E2_z: NumCosmoMath.OdeSpline = ...
     def __init__(
@@ -11157,6 +11165,7 @@ class HICosmoQSpline(HICosmo):
         Omegat_fit: bool = ...,
         asdrag: float = ...,
         asdrag_fit: bool = ...,
+        knots: HICosmoSplineKnots = ...,
         qparam: NumCosmoMath.Vector = ...,
         qparam_fit: GLib.Variant = ...,
         qparam_length: int = ...,
@@ -23372,6 +23381,21 @@ class HICosmoQSplineSParams(GObject.GEnum):
 
 class HICosmoQSplineVParams(GObject.GEnum):
     Q: HICosmoQSplineVParams = ...
+    _generate_next_value_: function = ...
+    _hashable_values_: list = ...
+    _member_map_: dict = ...
+    _member_names_: list = ...
+    _member_type_: type = ...
+    _new_member_: builtin_function_or_method = ...
+    _unhashable_values_: list = ...
+    _unhashable_values_map_: dict = ...
+    _use_args_: bool = ...
+    _value2member_map_: dict = ...
+    _value_repr_: wrapper_descriptor = ...
+
+class HICosmoSplineKnots(GObject.GEnum):
+    CHEBYSHEV: HICosmoSplineKnots = ...
+    UNIFORM: HICosmoSplineKnots = ...
     _generate_next_value_: function = ...
     _hashable_values_: list = ...
     _member_map_: dict = ...

--- a/tests/python/nc/background/test_hicosmo_de_wspline.py
+++ b/tests/python/nc/background/test_hicosmo_de_wspline.py
@@ -143,3 +143,46 @@ def test_wspline_lp_mset_func(cosmo_w: Nc.HICosmoDEWSpline, name: str) -> None:
     norms = [func.eval1(mset, p) for p in (2.0, 8.0, 16.0)]
     assert norms[0] <= norms[1] * (1.0 + 1e-9)
     assert norms[1] <= norms[2] * (1.0 + 1e-9)
+
+
+def test_wspline_knots_default_is_chebyshev() -> None:
+    """The default knot placement is Chebyshev (clustered toward the endpoints)."""
+    cosmo = Nc.HICosmoDEWSpline.new(nknots=8, z_f=2.0)
+    assert cosmo.props.knots == Nc.HICosmoSplineKnots.CHEBYSHEV
+
+    alpha = np.array(cosmo.get_alpha().dup_array())
+    diffs = np.diff(alpha)
+    # Chebyshev clusters at the ends: the central gap exceeds the boundary gaps.
+    assert diffs[len(diffs) // 2] > diffs[0]
+    assert diffs[len(diffs) // 2] > diffs[-1]
+
+
+def test_wspline_knots_uniform_is_evenly_spaced() -> None:
+    """The uniform option spaces knots evenly in alpha and spreads the high-z end."""
+    n = 8
+    cheb = Nc.HICosmoDEWSpline.new(nknots=n, z_f=2.0)
+    uni = Nc.HICosmoDEWSpline(
+        zf=2.0, w_length=n, knots=Nc.HICosmoSplineKnots.UNIFORM
+    )
+    assert uni.props.knots.value_nick == "uniform"
+
+    a_cheb = np.array(cheb.get_alpha().dup_array())
+    a_uni = np.array(uni.get_alpha().dup_array())
+
+    # Uniform: constant spacing in alpha.
+    assert_allclose(np.diff(a_uni), np.diff(a_uni)[0])
+    # Both span the same range; uniform's last gap is wider than Chebyshev's.
+    assert_allclose(a_uni[0], a_cheb[0])
+    assert_allclose(a_uni[-1], a_cheb[-1])
+    assert (a_uni[-1] - a_uni[-2]) > (a_cheb[-1] - a_cheb[-2])
+
+
+def test_wspline_knots_survive_serialization() -> None:
+    """The knot-placement choice round-trips through serialization."""
+    uni = Nc.HICosmoDEWSpline(
+        zf=2.0, w_length=8, knots=Nc.HICosmoSplineKnots.UNIFORM
+    )
+    ser = Ncm.Serialize.new(Ncm.SerializeOpt.CLEAN_DUP)
+    dup = ser.dup_obj(uni)
+    assert dup.props.knots.value_nick == "uniform"
+    assert_allclose(dup.get_alpha().dup_array(), uni.get_alpha().dup_array())

--- a/tests/python/nc/background/test_hicosmo_qspline.py
+++ b/tests/python/nc/background/test_hicosmo_qspline.py
@@ -144,3 +144,35 @@ def test_qspline_band_function_grid(tmp_path: Path) -> None:
     assert_allclose(
         [reloaded.get(i).eval0(mset) for i in range(reloaded.len())], direct
     )
+
+
+def test_qspline_knots_default_is_uniform() -> None:
+    """The default q(z) knot placement is uniform in z."""
+    cosmo = Nc.HICosmoQSpline.new(Ncm.SplineCubicNotaknot.new(), 8, 2.0)
+    assert cosmo.props.knots == Nc.HICosmoSplineKnots.UNIFORM
+
+    z = np.array(cosmo.props.spline.peek_xv().dup_array())
+    assert_allclose(np.diff(z), np.diff(z)[0])  # evenly spaced in z
+
+
+def test_qspline_knots_chebyshev_clusters() -> None:
+    """The Chebyshev option clusters q(z) knots toward the endpoints in z."""
+    n, z_f = 8, 2.0
+    uni = Nc.HICosmoQSpline.new(Ncm.SplineCubicNotaknot.new(), n, z_f)
+    cheb = Nc.HICosmoQSpline(
+        spline=Ncm.SplineCubicNotaknot.new(),
+        qparam_length=n,
+        zf=z_f,
+        knots=Nc.HICosmoSplineKnots.CHEBYSHEV,
+    )
+    assert cheb.props.knots == Nc.HICosmoSplineKnots.CHEBYSHEV
+
+    z_uni = np.array(uni.props.spline.peek_xv().dup_array())
+    z_cheb = np.array(cheb.props.spline.peek_xv().dup_array())
+    assert_allclose(z_cheb[0], z_uni[0])
+    assert_allclose(z_cheb[-1], z_uni[-1])
+    # Chebyshev's high-z gap is tighter than uniform's.
+    assert (z_cheb[-1] - z_cheb[-2]) < (z_uni[-1] - z_uni[-2])
+    # and the central gap exceeds the boundary gaps.
+    d = np.diff(z_cheb)
+    assert d[len(d) // 2] > d[0]


### PR DESCRIPTION
## Summary

Adds a selectable knot distribution to the spline-based `w(z)` / `q(z)`
reconstruction models, so resolution can be placed deliberately rather than
fixed by the model.

- New shared **`NcHICosmoSplineKnots`** enum (`UNIFORM` / `CHEBYSHEV`) in
  `nc_hicosmo.h` (auto-registered GType via mkenums).
- New **`knots`** `CONSTRUCT_ONLY` property on `NcHICosmoDEWSpline` (knots in
  `alpha = ln(1+z)`) and `NcHICosmoQSpline` (knots in `z`).
- **Defaults preserve current behaviour** — no change unless opted in:
  - `NcHICosmoDEWSpline` → `CHEBYSHEV`
  - `NcHICosmoQSpline` → `UNIFORM`

## Motivation

Chebyshev clusters knots toward both endpoints (good interpolation
conditioning) but puts the *densest* knots at high `z`, where SNIa/BAO/H(z)
data are *sparsest*. With the constant-`w` high-`z` tail and the not-a-knot
boundary, the last knot then floats: in reconstruction tests its across-mock
variance runs 3–8× the interior. Uniform spacing spreads resolution evenly,
giving a less degenerate, lower-variance high-`z` boundary. Exposing the choice
lets each study pick the trade-off (and leaves room for an `ADAPTIVE` option
later).

## Tests

Regression tests for both models (default placement, even spacing, high-`z`
spread, serialization round-trip). Full `nc/background` w-spline + q-spline
suites pass (41). Stubs regenerated; uncrustify + black clean.

Sample (8 knots, `z_f = 2.33`): w-spline last gap Δz `0.193` (Cheby) → `0.526`
(uniform); q-spline last gap `0.333` (uniform) → `0.115` (Cheby).

🤖 Generated with [Claude Code](https://claude.com/claude-code)