### PR TITLE
Add --bench flag to numcosmo run subcommands (wall time + peak RSS)

### DIFF
--- a/numcosmo_py/app/run_fit.py
+++ b/numcosmo_py/app/run_fit.py
@@ -144,8 +144,7 @@ class RunCommonOptions(LoadExperiment):
         # ru_maxrss is in bytes on macOS, kibibytes on Linux.
         peak_rss_mib = ru_maxrss / (1024 * 1024 if sys.platform == "darwin" else 1024)
         self.console.print(
-            f"[bold]Benchmark:[/bold] wall time {elapsed:.3f}s, "
-            f"peak RSS {peak_rss_mib:.1f} MiB"
+            f"# Benchmark: wall time {elapsed:.3f}s, peak RSS {peak_rss_mib:.1f} MiB"
         )
 
 

--- a/numcosmo_py/app/run_fit.py
+++ b/numcosmo_py/app/run_fit.py
@@ -24,6 +24,9 @@
 """NumCosmo APP subcommand to fit data."""
 
 import dataclasses
+import resource
+import sys
+import time
 from typing import Optional, Annotated, Tuple
 
 import typer
@@ -83,11 +86,22 @@ class RunCommonOptions(LoadExperiment):
         typer.Option(help="Absolute tolerance for -2lnL."),
     ] = None
 
+    bench: Annotated[
+        bool,
+        typer.Option(
+            "--bench",
+            help="Report wall-clock time and peak memory usage (RSS) for this "
+            "run when it finishes.",
+        ),
+    ] = False
+
     def __post_init__(self) -> None:
         """Create common objects for the run command.
 
         Create the fit object and set the logger.
         """
+        self._bench_start = time.perf_counter()
+
         super().__post_init__()
 
         check_runner_algorithm(self.runner, self.algorithm)
@@ -116,6 +130,23 @@ class RunCommonOptions(LoadExperiment):
             fit.set_m2lnL_abstol(self.m2lnl_abstol)
 
         self.fit = fit
+
+    def end_experiment(self) -> None:
+        """End the experiment, reporting benchmark stats first if requested."""
+        if self.bench:
+            self._report_bench()
+        super().end_experiment()
+
+    def _report_bench(self) -> None:
+        """Print wall-clock time and peak RSS since __post_init__ started."""
+        elapsed = time.perf_counter() - self._bench_start
+        ru_maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # ru_maxrss is in bytes on macOS, kibibytes on Linux.
+        peak_rss_mib = ru_maxrss / (1024 * 1024 if sys.platform == "darwin" else 1024)
+        self.console.print(
+            f"[bold]Benchmark:[/bold] wall time {elapsed:.3f}s, "
+            f"peak RSS {peak_rss_mib:.1f} MiB"
+        )
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -177,3 +208,4 @@ class RunTest(RunCommonOptions):
         self.mset.prepare_fparam_map()
         self.fit.log_info()
         self.fit.run(FitRunMessages.SIMPLE.genum)
+        self.end_experiment()

--- a/tests/python/numcosmo_py/app/test_numcosmo_app.py
+++ b/tests/python/numcosmo_py/app/test_numcosmo_app.py
@@ -154,7 +154,7 @@ def test_run_bench(simple_experiment, subcommand):
     result = runner.invoke(app, [*subcommand, filename.as_posix(), "--bench"])
     if result.exit_code != 0:
         raise result.exception
-    assert "Benchmark:" in result.output
+    assert "# Benchmark:" in result.output
     assert "wall time" in result.output
     assert "peak RSS" in result.output
 

--- a/tests/python/numcosmo_py/app/test_numcosmo_app.py
+++ b/tests/python/numcosmo_py/app/test_numcosmo_app.py
@@ -147,6 +147,18 @@ def test_run_fit(simple_experiment):
         raise result.exception
 
 
+@pytest.mark.parametrize("subcommand", [["run", "test"], ["run", "fit"]])
+def test_run_bench(simple_experiment, subcommand):
+    """--bench reports wall-clock time and peak RSS at the end of the run."""
+    filename, _ = simple_experiment
+    result = runner.invoke(app, [*subcommand, filename.as_posix(), "--bench"])
+    if result.exit_code != 0:
+        raise result.exception
+    assert "Benchmark:" in result.output
+    assert "wall time" in result.output
+    assert "peak RSS" in result.output
+
+
 def test_run_fit_runner(simple_experiment, fit_runner):
     """Test run fit."""
     filename, _ = simple_experiment


### PR DESCRIPTION
## Summary
- Add a `--bench` flag to `RunCommonOptions` (`numcosmo_py/app/run_fit.py`), reporting wall-clock time and peak RSS at the end of a run. Shared base class means this covers `run fit`, `run test`, `run mc`, and `run mcmc` (APES/Stretch) for free.
- `run test` previously never called `end_experiment()` at all -- a pre-existing gap where `--output`/`--log-file` were silently ignored for that subcommand. Fixed so `--bench` (and the pre-existing output/logging options) actually work there too.
- Addresses the long-deferred `cli-benchmark-mode-idea`: perf comparisons (thread-count sweeps, `register_shared` anchor wins, etc.) can now go through the real CLI instead of one-off scratch scripts.

## Test plan
- [x] `numcosmo run fit/test/mc/mcmc --bench` exercised end-to-end manually against a minimal experiment, confirmed the `Benchmark: wall time ..., peak RSS ...` line prints correctly for all four
- [x] Added `test_run_bench` (run test + run fit) to `test_numcosmo_app.py`
- [x] Full `test_numcosmo_app.py --run-app` suite green (206 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)