### PR TITLE
CI: duration-aware test slicing for the coverage job's C-tier shards

### DIFF
--- a/.github/actions/setup-miniforge/action.yml
+++ b/.github/actions/setup-miniforge/action.yml
@@ -1,0 +1,65 @@
+name: 'Setup Miniforge conda environment'
+description: >-
+  Sets up Miniforge, restores/updates/saves the cached NumCosmo conda
+  environment, optionally swapping in a specific MPI implementation.
+  Shared by build-miniforge and build-miniforge-coverage in
+  build_check.yml -- extracted so the setup logic only needs to be
+  changed in one place.
+
+inputs:
+  python-version:
+    description: 'Python version for the conda environment'
+    required: true
+  mpi:
+    description: >-
+      If set, swap the conda env to use this MPI implementation (openmpi
+      or mpich) instead of environment.yml's default. Also folded into
+      the cache key so different MPI variants get separate caches.
+    required: false
+    default: ''
+
+outputs:
+  cache-hit:
+    description: 'Whether the conda environment cache was restored'
+    value: ${{ steps.cache.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup miniforge
+      uses: conda-incubator/setup-miniconda@v4
+      with:
+        miniforge-version: latest
+        python-version: ${{ inputs.python-version }}
+        activate-environment: ${{ env.CONDA_ENV }}
+    - name: Cache date
+      id: get-date
+      shell: bash
+      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+    - name: Cache Conda env
+      uses: actions/cache/restore@v4
+      id: cache
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: conda-${{ runner.os }}-${{ runner.arch }}-py${{ inputs.python-version }}-${{ inputs.mpi }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('environment.yml') }}-v${{ env.CACHE_VERSION }}
+    - name: Update environment
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash -el {0}
+      run: |
+        conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
+        if [ -n "${{ inputs.mpi }}" ]; then
+          which python
+          conda list
+          conda remove -q -v -n numcosmo_developer openmpi
+          conda install -q -v -n numcosmo_developer ${{ inputs.mpi }}
+          conda install -q -v -n numcosmo_developer libfabric-devel
+          conda list
+        else
+          conda list
+        fi
+    - name: Save conda-forge cache
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/scripts/test_slicer.py
+++ b/.github/scripts/test_slicer.py
@@ -187,7 +187,7 @@ def main() -> None:
     plan = sub.add_parser("plan", help="compute a duration-balanced test slice")
     plan.add_argument("--build-dir", default="build")
     plan.add_argument("--suite", action="append", required=True)
-    plan.add_argument("--durations", action="append", default=[])
+    plan.add_argument("--durations", nargs="+", default=[])
     plan.add_argument("--num-slices", type=int, required=True)
     plan.add_argument("--slice", type=int, required=True)
     plan.set_defaults(func=cmd_plan)

--- a/.github/scripts/test_slicer.py
+++ b/.github/scripts/test_slicer.py
@@ -25,7 +25,7 @@ floor. This script replaces it: given historical per-test duration data
 (cached from previous CI runs) and today's actual test list, it greedy
 bin-packs the tests into N roughly-equal-wall-time slices.
 
-Two subcommands:
+Three subcommands:
   plan    -- print slice K's test names (one per line), computed from
              today's `meson test --list` output plus 0-or-more merged
              historical duration files. Tests with no historical duration
@@ -35,6 +35,8 @@ Two subcommands:
   extract -- read a meson testlog.json and print a flat {name: duration}
              JSON object, for caching as tomorrow's historical duration
              data (see the `plan` subcommand's --durations).
+  summary -- read a meson testlog.json and print a Markdown top-N slowest
+             durations report (for a CI job summary).
 
 See the `build-miniforge-coverage` job in
 `.github/workflows/build_check.yml` for how these are wired into CI.
@@ -73,6 +75,26 @@ def _current_tests(build_dir: Path, suites: list[str]) -> list[str]:
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _read_testlog(testlog: Path) -> list[tuple[str, float]]:
+    """Read a meson testlog.json (JSON-lines) into (name, duration) pairs.
+
+    Returns an empty list if the file doesn't exist -- meson never writes
+    it if the build itself failed before any test ran.
+    """
+    entries: list[tuple[str, float]] = []
+
+    if testlog.exists():
+        with testlog.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                entries.append((entry["name"], float(entry.get("duration", 0.0))))
+
+    return entries
 
 
 def _selector(name: str) -> str:
@@ -136,20 +158,25 @@ def cmd_plan(args: argparse.Namespace) -> None:
 
 def cmd_extract(args: argparse.Namespace) -> None:
     """Print a flat {name: duration} JSON object from a testlog.json."""
-    testlog = Path(args.testlog)
-    durations: dict[str, float] = {}
-
-    if testlog.exists():
-        with testlog.open(encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                entry = json.loads(line)
-                durations[entry["name"]] = float(entry.get("duration", 0.0))
-
+    durations = dict(_read_testlog(Path(args.testlog)))
     json.dump(durations, sys.stdout)
     print()
+
+
+def cmd_summary(args: argparse.Namespace) -> None:
+    """Print a Markdown top-N slowest-durations report from a testlog.json."""
+    rows = sorted(
+        _read_testlog(Path(args.testlog)), key=lambda row: row[1], reverse=True
+    )
+    total = sum(duration for _, duration in rows)
+
+    print(
+        f"### Test durations — {args.title} (top {args.top} of {len(rows)}, total {total:.1f}s)"
+    )
+    print("```")
+    for name, duration in rows[: args.top]:
+        print(f"{duration:8.2f}s  {name}")
+    print("```")
 
 
 def main() -> None:
@@ -170,6 +197,14 @@ def main() -> None:
     )
     extract.add_argument("--testlog", required=True)
     extract.set_defaults(func=cmd_extract)
+
+    summary = sub.add_parser(
+        "summary", help="print a Markdown slowest-durations report"
+    )
+    summary.add_argument("--testlog", required=True)
+    summary.add_argument("--title", required=True)
+    summary.add_argument("--top", type=int, default=25)
+    summary.set_defaults(func=cmd_summary)
 
     args = parser.parse_args()
     args.func(args)

--- a/.github/scripts/test_slicer.py
+++ b/.github/scripts/test_slicer.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+#
+# test_slicer.py
+#
+# Copyright (C) 2026 Sandro Dias Pinto Vitenti <vitenti@uel.br>
+#
+# numcosmo is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# numcosmo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Duration-aware test slicing for the coverage job's C-tier shards.
+
+meson's own `meson test --slice K/N` balances by test *count*, not wall
+time, which lets one or two heavy tests dominate a shard's wall-clock
+floor. This script replaces it: given historical per-test duration data
+(cached from previous CI runs) and today's actual test list, it greedy
+bin-packs the tests into N roughly-equal-wall-time slices.
+
+Two subcommands:
+  plan    -- print slice K's test names (one per line), computed from
+             today's `meson test --list` output plus 0-or-more merged
+             historical duration files. Tests with no historical duration
+             get the median of known durations as an estimate; if there
+             is no historical data at all, every test gets an equal
+             weight, degrading gracefully to a count-balanced split.
+  extract -- read a meson testlog.json and print a flat {name: duration}
+             JSON object, for caching as tomorrow's historical duration
+             data (see the `plan` subcommand's --durations).
+
+See the `build-miniforge-coverage` job in
+`.github/workflows/build_check.yml` for how these are wired into CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_durations(paths: list[Path]) -> dict[str, float]:
+    """Merge {name: duration} dicts from possibly-missing JSON files."""
+    merged: dict[str, float] = {}
+
+    for path in paths:
+        if not path.exists():
+            continue
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        for name, duration in data.items():
+            merged[name] = float(duration)
+
+    return merged
+
+
+def _current_tests(build_dir: Path, suites: list[str]) -> list[str]:
+    """Return today's actual test names for the given suites, via meson."""
+    cmd = ["meson", "test", "--list", "-C", str(build_dir)]
+    for suite in suites:
+        cmd += ["--suite", suite]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _selector(name: str) -> str:
+    """Convert a `--list`/testlog.json display name to a meson test selector.
+
+    `meson test --list` and testlog.json's "name" field print e.g.
+    "c-statistical+omp - numcosmo:ncm_stats_dist" -- the suite-tag prefix
+    is for human reading only. The actual positional argument meson test
+    accepts to select that specific test is "numcosmo:ncm_stats_dist"
+    (the "subprojname:testname" part after the first " - ").
+    """
+    return name.split(" - ", 1)[-1]
+
+
+def _lpt_partition(
+    tests: list[str], weights: dict[str, float], num_slices: int
+) -> list[list[str]]:
+    """Greedy longest-processing-time-first bin packing.
+
+    Sorts tests by weight descending, then drops each into whichever bin
+    currently has the smallest running total -- within 4/3 of the optimal
+    makespan in the worst case, and exact-balanced (as here) when weights
+    are roughly uniform.
+    """
+    ordered = sorted(tests, key=lambda name: weights[name], reverse=True)
+    bins: list[list[str]] = [[] for _ in range(num_slices)]
+    totals = [0.0] * num_slices
+
+    for name in ordered:
+        i = min(range(num_slices), key=lambda i: totals[i])
+        bins[i].append(name)
+        totals[i] += weights[name]
+
+    return bins
+
+
+def cmd_plan(args: argparse.Namespace) -> None:
+    """Print slice `args.slice`'s test names, one per line."""
+    tests = _current_tests(Path(args.build_dir), args.suite)
+    if not tests:
+        raise SystemExit("no tests found for the given suite(s)")
+
+    durations = _load_durations([Path(p) for p in args.durations])
+    known = [durations[name] for name in tests if name in durations]
+    fallback = statistics.median(known) if known else 1.0
+    weights = {name: durations.get(name, fallback) for name in tests}
+
+    bins = _lpt_partition(tests, weights, args.num_slices)
+
+    # Safety net: the partition must be exhaustive and non-overlapping --
+    # a bug here would silently drop or double-run tests in CI.
+    flat = [name for b in bins for name in b]
+    assert sorted(flat) == sorted(tests), "slice partition lost or duplicated tests"
+
+    if not 1 <= args.slice <= args.num_slices:
+        raise SystemExit(f"--slice must be between 1 and {args.num_slices}")
+
+    for name in bins[args.slice - 1]:
+        print(_selector(name))
+
+
+def cmd_extract(args: argparse.Namespace) -> None:
+    """Print a flat {name: duration} JSON object from a testlog.json."""
+    testlog = Path(args.testlog)
+    durations: dict[str, float] = {}
+
+    if testlog.exists():
+        with testlog.open(encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                durations[entry["name"]] = float(entry.get("duration", 0.0))
+
+    json.dump(durations, sys.stdout)
+    print()
+
+
+def main() -> None:
+    """Parse arguments and dispatch to the requested subcommand."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan", help="compute a duration-balanced test slice")
+    plan.add_argument("--build-dir", default="build")
+    plan.add_argument("--suite", action="append", required=True)
+    plan.add_argument("--durations", action="append", default=[])
+    plan.add_argument("--num-slices", type=int, required=True)
+    plan.add_argument("--slice", type=int, required=True)
+    plan.set_defaults(func=cmd_plan)
+
+    extract = sub.add_parser(
+        "extract", help="extract {name: duration} from a testlog.json"
+    )
+    extract.add_argument("--testlog", required=True)
+    extract.set_defaults(func=cmd_extract)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -337,12 +337,24 @@ jobs:
         # duration-balanced as the test suite changes. Runs even if some tests
         # failed: testlog.json still has valid per-test durations for whichever
         # tests actually ran, and a stale/absent duration estimate is worse for
-        # future balancing than a partial one.
+        # future balancing than a partial one. But if an EARLIER step failed
+        # (e.g. the build itself, or "Compute test slice"), testlog.json may not
+        # exist at all -- extract then produces an empty {}, and caching that
+        # would poison the *next* run's restore (picked up via restore-keys
+        # prefix match regardless of content) with zero real data, silently
+        # degrading it back to a count-balanced split. has_data guards against
+        # that: only cache when there's something real to cache.
+        id: extract_durations
         if: always() && matrix.slice != ''
         run: |
           python3 .github/scripts/test_slicer.py extract --testlog build/meson-logs/testlog.json > durations-slice${{ matrix.slice }}.json
+          if python3 -c "import json, sys; sys.exit(0 if json.load(open('durations-slice${{ matrix.slice }}.json')) else 1)"; then
+            echo "has_data=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_data=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Cache test slice durations
-        if: always() && matrix.slice != ''
+        if: always() && matrix.slice != '' && steps.extract_durations.outputs.has_data == 'true'
         uses: actions/cache/save@v4
         with:
           path: durations-slice${{ matrix.slice }}.json

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -353,24 +353,7 @@ jobs:
         # across slices is visible at a glance. (For c-* legs this is now mostly a sanity
         # check -- the split itself is duration-balanced by test_slicer.py, not meson --slice.)
         run: |
-          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-          import json, pathlib
-          log = pathlib.Path("build/meson-logs/testlog.json")
-          rows = []
-          if log.exists():
-              for line in log.read_text().splitlines():
-                  line = line.strip()
-                  if line:
-                      d = json.loads(line)
-                      rows.append((float(d.get("duration", 0.0)), d.get("name", "?")))
-          rows.sort(reverse=True)
-          total = sum(d for d, _ in rows)
-          print("### Test durations — ${{ matrix.name }} (top 25 of %d, total %.1fs)" % (len(rows), total))
-          print("```")
-          for dur, name in rows[:25]:
-              print("%8.2fs  %s" % (dur, name))
-          print("```")
-          PY
+          python3 .github/scripts/test_slicer.py summary --testlog build/meson-logs/testlog.json --title "${{ matrix.name }}" >> "$GITHUB_STEP_SUMMARY"
       - name: CodeCov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -192,38 +192,10 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup miniforge
-        uses: conda-incubator/setup-miniconda@v4
+      - uses: ./.github/actions/setup-miniforge
         with:
-          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
-          activate-environment: ${{ env.CONDA_ENV }}
-      - name: Cache date
-        id: get-date
-        run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Cache Conda env
-        uses: actions/cache/restore@v4
-        id: cache
-        with:
-          path: ${{ env.CONDA }}/envs
-          key: conda-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ matrix.mpi }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('environment.yml') }}-v${{ env.CACHE_VERSION }}
-      - name: Update environment
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
-          which python
-          conda list
-          conda remove -q -v -n numcosmo_developer openmpi
-          conda install -q -v -n numcosmo_developer ${{ matrix.mpi }}
-          conda install -q -v -n numcosmo_developer libfabric-devel
-          conda list
-      - name: Save conda-forge cache
-        if: steps.cache.outputs.cache-hit != 'true'
-        id: cache-primes-save
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ env.CONDA }}/envs
-          key: ${{ steps.cache.outputs.cache-primary-key }}
+          mpi: ${{ matrix.mpi }}
       - name: Setting up NumCosmo
         run: |
           conda activate numcosmo_developer
@@ -266,10 +238,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       # Shards are DERIVED, not hand-labeled (see TESTING.md): the C tests are split by
-      # `meson test --slice K/N` over the tier suites, so they auto-distribute as tests are
-      # added (no per-test shard suite to curate). The Python `pytest` lane is internally
-      # parallel (xdist), so it stays a single shard; the marker-gated py-* subsets are their
-      # own shards because they are opt-in, not for balancing.
+      # test_slicer.py into 3 duration-balanced groups (see the c-1/c-2/c-3 entries and
+      # steps below), so they auto-distribute -- and stay balanced by wall time, not just
+      # count -- as tests are added/changed/removed (no per-test shard suite to curate).
+      # The Python `pytest` lane is internally parallel (xdist), so it stays a single
+      # shard; the marker-gated py-* subsets are their own shards because they are
+      # opt-in, not for balancing.
       matrix:
         include:
           - { os: ubuntu, python-version: "3.12", name: python, args: "--suite python" }
@@ -281,41 +255,52 @@ jobs:
           - { os: ubuntu, python-version: "3.12", name: py-powspec, args: "--suite py-powspec" }
           - { os: ubuntu, python-version: "3.12", name: py-xcor, args: "--suite py-xcor" }
           - { os: ubuntu, python-version: "3.12", name: py-app, args: "--suite py-app" }
-          - { os: ubuntu, python-version: "3.12", name: c-1, args: "--suite c --suite c-acceptance --suite c-statistical --slice 1/3" }
-          - { os: ubuntu, python-version: "3.12", name: c-2, args: "--suite c --suite c-acceptance --suite c-statistical --slice 2/3" }
-          - { os: ubuntu, python-version: "3.12", name: c-3, args: "--suite c --suite c-acceptance --suite c-statistical --slice 3/3" }
+          # c-1/c-2/c-3 no longer use meson's own --slice K/N (count-balanced, not
+          # time-balanced -- see .github/scripts/test_slicer.py); the `slice` field
+          # here selects which duration-aware slice this leg runs, computed at
+          # runtime from cached historical per-test durations. Legs without a
+          # `slice` field (above) are unaffected -- see the steps below.
+          - { os: ubuntu, python-version: "3.12", name: c-1, slice: 1 }
+          - { os: ubuntu, python-version: "3.12", name: c-2, slice: 2 }
+          - { os: ubuntu, python-version: "3.12", name: c-3, slice: 3 }
     defaults:
       run:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
-      - name: Setup miniforge
-        uses: conda-incubator/setup-miniconda@v4
-        with:
-          miniforge-version: latest
-          python-version: ${{ matrix.python-version }}
-          activate-environment: ${{ env.CONDA_ENV }}
-      - name: Cache date
-        id: get-date
-        run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Cache Conda env
+      # Every c-* leg restores ALL THREE slices' historical durations (not just its
+      # own), so each leg independently computes the same duration-balanced 3-way
+      # partition and only picks out its own slice -- no coordinator/merge job
+      # needed. A cold cache (first run, or all entries evicted) just restores
+      # nothing; test_slicer.py's `plan` subcommand degrades to a count-balanced
+      # split in that case, matching meson --slice's old behavior.
+      - name: Restore test duration history (slice 1)
+        if: matrix.slice != ''
         uses: actions/cache/restore@v4
-        id: cache
         with:
-          path: ${{ env.CONDA }}/envs
-          key: conda-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('environment.yml') }}-v${{ env.CACHE_VERSION }}
-      - name: Update environment
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          conda env update -q -v -n ${{ env.CONDA_ENV }} -f environment.yml
-          conda list
-      - name: Save conda-forge cache
-        if: steps.cache.outputs.cache-hit != 'true'
-        id: cache-primes-save
-        uses: actions/cache/save@v4
+          path: durations-slice1.json
+          key: test-durations-c-slice1-${{ github.run_id }}
+          restore-keys: |
+            test-durations-c-slice1-
+      - name: Restore test duration history (slice 2)
+        if: matrix.slice != ''
+        uses: actions/cache/restore@v4
         with:
-          path: ${{ env.CONDA }}/envs
-          key: ${{ steps.cache.outputs.cache-primary-key }}
+          path: durations-slice2.json
+          key: test-durations-c-slice2-${{ github.run_id }}
+          restore-keys: |
+            test-durations-c-slice2-
+      - name: Restore test duration history (slice 3)
+        if: matrix.slice != ''
+        uses: actions/cache/restore@v4
+        with:
+          path: durations-slice3.json
+          key: test-durations-c-slice3-${{ github.run_id }}
+          restore-keys: |
+            test-durations-c-slice3-
+      - uses: ./.github/actions/setup-miniforge
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Setting up NumCosmo
         run: |
           conda activate numcosmo_developer
@@ -323,20 +308,50 @@ jobs:
       - name: Building NumCosmo
         run: |
           meson compile -C build
+      - name: Compute test slice
+        if: matrix.slice != ''
+        run: |
+          python3 .github/scripts/test_slicer.py plan \
+            --build-dir build \
+            --suite c --suite c-acceptance --suite c-statistical \
+            --durations durations-slice1.json durations-slice2.json durations-slice3.json \
+            --num-slices 3 --slice ${{ matrix.slice }} \
+            > slice-tests.txt
       - name: Check and coverage
         # First run to generate the coverage base
         # Second run to generate the coverage for the tests
         # Third run to merge the coverage base and the coverage for the tests
         run: |
           lcov --config-file .lcovrc --no-external --capture --initial --directory build --directory numcosmo --directory tests --base-directory $(pwd)/build --output-file numcosmo-coverage-base.info
-          meson test -v -C build --timeout-multiplier 0 --num-processes=$(getconf _NPROCESSORS_ONLN) ${{ matrix.args }} || (cat build/meson-logs/testlog.txt && exit 1)
+          if [ -n "${{ matrix.slice }}" ]; then
+            mapfile -t TEST_ARGS < slice-tests.txt
+            meson test -v -C build --timeout-multiplier 0 --num-processes=$(getconf _NPROCESSORS_ONLN) "${TEST_ARGS[@]}" || (cat build/meson-logs/testlog.txt && exit 1)
+          else
+            meson test -v -C build --timeout-multiplier 0 --num-processes=$(getconf _NPROCESSORS_ONLN) ${{ matrix.args }} || (cat build/meson-logs/testlog.txt && exit 1)
+          fi
           lcov --config-file .lcovrc --no-external --capture --directory build --directory numcosmo --directory tests --base-directory $(pwd)/build --output-file numcosmo-coverage-tests.info
           lcov --config-file .lcovrc --add-tracefile numcosmo-coverage-base.info --add-tracefile numcosmo-coverage-tests.info --output-file numcosmo-coverage-full.info
           lcov --config-file .lcovrc --remove numcosmo-coverage-full.info '*/external/*' '*/tools/*' --output-file numcosmo-coverage.info
+      - name: Save test slice durations
+        # Feeds the next run's "Compute test slice" step -- keeps the c-* legs
+        # duration-balanced as the test suite changes. Runs even if some tests
+        # failed: testlog.json still has valid per-test durations for whichever
+        # tests actually ran, and a stale/absent duration estimate is worse for
+        # future balancing than a partial one.
+        if: always() && matrix.slice != ''
+        run: |
+          python3 .github/scripts/test_slicer.py extract --testlog build/meson-logs/testlog.json > durations-slice${{ matrix.slice }}.json
+      - name: Cache test slice durations
+        if: always() && matrix.slice != ''
+        uses: actions/cache/save@v4
+        with:
+          path: durations-slice${{ matrix.slice }}.json
+          key: test-durations-c-slice${{ matrix.slice }}-${{ github.run_id }}
       - name: Test timing summary
         if: always()
         # Surface the slowest tests of this shard in the job summary so wall-time imbalance
-        # across slices is visible at a glance (meson --slice balances by count, not time).
+        # across slices is visible at a glance. (For c-* legs this is now mostly a sanity
+        # check -- the split itself is duration-balanced by test_slicer.py, not meson --slice.)
         run: |
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import json, pathlib


### PR DESCRIPTION
## Summary
This is "PR4" from the WL legacy-removal plan, queued a while back: replace meson's `--slice K/N` (count-balanced, not wall-time-balanced) for the coverage job's C-tier shards with a duration-aware split, so shard imbalance stops silently drifting back every time the test suite's cost landscape shifts.

**Measured before fixing** (76 C-tier tests, fresh local run):

| Shard | Tests | Wall time |
|---|---|---|
| `--slice 1/3` | 26 | **632.0s** |
| `--slice 2/3` | 25 | 80.0s |
| `--slice 3/3` | 25 | 49.3s |

13x spread -- `ncm_fit` (177s) and `nc_powspec_transfer` (157s), the two heaviest tests in the suite, both happen to land in shard 1 by `tests/c/meson.build` declaration order. The original dominant outlier (the legacy `nc_data_cluster_wl` monolith) is long gone, but the imbalance came right back with entirely different tests -- exactly why this needed a self-updating mechanism instead of one more manual rebalance.

**After** (greedy longest-processing-time-first bin-pack): 254.1s / 253.1s / 254.1s -- ~2.5x faster on the slowest shard.

## What changed
- **`.github/scripts/test_slicer.py`** (new): `plan` computes a duration-balanced slice from today's actual test list (`meson test --list`, so added/removed/renamed tests are picked up automatically) plus historical duration data; falls back to a count-balanced split when there's no history yet. `extract` pulls `{name: duration}` from a fresh `testlog.json` for caching as tomorrow's history. `summary` replaces the coverage job's inline Python heredoc for the job-summary durations report.
- **`build_check.yml`**: the `c-1`/`c-2`/`c-3` legs of `build-miniforge-coverage` now compute their test list via `test_slicer.py` instead of `--slice K/N`. Each leg restores all 3 slices' historical duration data via GitHub Actions cache (own key prefix per slice, so the 3 concurrent legs never race), computes the full partition itself, and saves its own fresh fragment back at the end -- no coordinator job needed.
- **`.github/actions/setup-miniforge`** (new composite action): while reviewing the design, spotted that `build-miniforge` and `build-miniforge-coverage` already duplicated the same ~30-line miniforge/conda-cache setup sequence -- extracted it into a shared composite action instead of adding a third near-copy for this PR. Net effect: the workflow file is shorter than before this PR despite the new feature.

## Test plan
- [x] `extract`+`plan` against real local `testlog.json` data reproduces the exact 254.1/253.1/254.1s balance measured by hand
- [x] Cold-cache and missing-file fallback both degrade cleanly to a count-balanced split (today's behavior)
- [x] Synthetic "test with no history" case gets the median-weight fallback without crashing
- [x] **Found and fixed a real bug during verification**: `meson test --list`/`testlog.json`'s display name has a suite-tag prefix (`"c - numcosmo:ncm_dtuple"`) that `meson test` does NOT accept as a selector (needs `"numcosmo:ncm_dtuple"`) -- would have silently broken all 3 C-tier CI legs on the first real run. Fixed and verified all 76 stripped selectors stay unique.
- [x] Real end-to-end run: computed slice 1's 26 selectors via the actual `mapfile` shell logic the workflow uses, ran them for real with `meson test` -- 26/26 passed
- [x] `black`/`flake8`/`mypy` clean on `test_slicer.py`
- [x] Both YAML files validate
- [x] Cannot verify the actual GitHub Actions cache/matrix/composite-action machinery locally -- watching the first real CI run closely (conda setup via the new composite action including the MPI-swap path, and cold-cache behavior since this is the very first run of this mechanism)

🤖 Generated with [Claude Code](https://claude.com/claude-code)