### PR TITLE
Make FFTW3/NLopt hard requirements, vendor libfyaml

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install pre-requisites
       run: |
         sudo apt-get update
-        sudo apt-get install gobject-introspection gir1.2-glib-2.0 gir1.2-glib-2.0-dev libgirepository-2.0-dev gcc gfortran pkg-config libglib2.0-dev libgmp3-dev libmpfr-dev libgsl0-dev libfftw3-dev libopenblas-dev libflint-dev libcfitsio-dev libfyaml-dev libnlopt-dev libhdf5-dev libopenmpi-dev libcairo2-dev uncrustify
+        sudo apt-get install gobject-introspection gir1.2-glib-2.0 gir1.2-glib-2.0-dev libgirepository-2.0-dev gcc gfortran pkg-config libglib2.0-dev libgmp3-dev libmpfr-dev libgsl0-dev libfftw3-dev libopenblas-dev libflint-dev libcfitsio-dev libnlopt-dev libhdf5-dev libopenmpi-dev libcairo2-dev uncrustify
         pip install -e ".[test]" meson ninja --break-system-packages
     - name: Ensure clear Jupyter Notebooks
       uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1
@@ -123,17 +123,13 @@ jobs:
     - name: Brew install pre-requisites
       run: |
         brew uninstall --ignore-dependencies --force pkg-config@0.29.2
-        brew install python3 gobject-introspection pygobject3 numpy scipy python-matplotlib meson ninja gsl gmp mpfr fftw cfitsio libfyaml nlopt gfortran glib openblas
+        brew install python3 gobject-introspection pygobject3 numpy scipy python-matplotlib meson ninja gsl gmp mpfr fftw cfitsio nlopt gfortran glib openblas
     - name: Pip install pre-requisites
       run: |
         python3 -m pip install -e ".[test]" --break-system-packages
     - name: Ensure clear Jupyter Notebooks
       uses: ResearchSoftwareActions/EnsureCleanNotebooksAction@1.1
-    - name: Fix libfyaml.pc
-      run: |
-        pc=$(pkg-config --variable=pcfiledir libfyaml)/libfyaml.pc
-        sed -i '' 's/none required//g' "$pc" || true
-    - name: Dump pkg-config info (cfitsio + libfyaml)
+    - name: Dump pkg-config info (cfitsio)
       run: |
         set -x
 
@@ -152,12 +148,6 @@ jobs:
         pkg-config --cflags cfitsio || true
         pkg-config --variable=pcfiledir cfitsio || true
         pkg-config --debug --libs cfitsio || true
-
-        echo "---- libfyaml ----"
-        pkg-config --libs libfyaml || true
-        pkg-config --cflags libfyaml || true
-        pkg-config --variable=pcfiledir libfyaml || true
-        pkg-config --debug --libs libfyaml || true      
     - name: Configure NumCosmo
       run: |
         meson setup build -Dbuildtype=release -Dnumcosmo_py=true -Dfftw-planner=estimate -Dmpi=disabled --prefix=/usr || (cat build/meson-logs/meson-log.txt && exit 1)

--- a/.github/workflows/weekly_flaky.yml
+++ b/.github/workflows/weekly_flaky.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Install pre-requisites
       run: |
         sudo apt-get update
-        sudo apt-get install gobject-introspection gir1.2-glib-2.0 gir1.2-glib-2.0-dev libgirepository-2.0-dev gcc gfortran pkg-config libglib2.0-dev libgmp3-dev libmpfr-dev libgsl0-dev libfftw3-dev libopenblas-dev libflint-dev libcfitsio-dev libfyaml-dev libnlopt-dev libhdf5-dev libopenmpi-dev libcairo2-dev
+        sudo apt-get install gobject-introspection gir1.2-glib-2.0 gir1.2-glib-2.0-dev libgirepository-2.0-dev gcc gfortran pkg-config libglib2.0-dev libgmp3-dev libmpfr-dev libgsl0-dev libfftw3-dev libopenblas-dev libflint-dev libcfitsio-dev libnlopt-dev libhdf5-dev libopenmpi-dev libcairo2-dev
         pip install -e ".[test]" meson ninja --break-system-packages
     - name: Configure NumCosmo (flaky mode)
       run: meson setup build -Dbuildtype=release -Dnumcosmo_py=true -Dfftw-planner=estimate -Ddocumentation=false -Dflaky_tests=true --prefix=/usr || (cat build/meson-logs/meson-log.txt && exit 1)

--- a/docs/install.qmd
+++ b/docs/install.qmd
@@ -105,11 +105,9 @@ The requirements below can be found on most Linux distributions. Click [here](#s
     A library of C and Fortran subroutines for reading and writing data files in FITS (Flexible Image Transport System) data format.
   - [FFTW3](http://www.fftw.org/) >= 3.1.2 --
     Discrete Fourier transform library.
-
-#### Recommended packages
-
   - [NLOpt](http://ab-initio.mit.edu/wiki/index.php/NLopt) -- Several general purpose minimization algorithms.
-  - [libfyaml](https://github.com/pantoniou/libfyaml) -- A fancy 1.2 YAML and JSON parser/writer.
+
+Note: [libfyaml](https://github.com/pantoniou/libfyaml) (used for YAML/JSON (de)serialization) does not need to be installed separately -- NumCosmo bundles the parser/emitter core it needs under `numcosmo/external/libfyaml`.
 
 #### Optional packages
 
@@ -134,7 +132,7 @@ On Debian-like systems, you can install the required packages from the main repo
 ```bash
 sudo apt-get install gobject-introspection gir1.2-glib-2.0 libgirepository1.0-dev gcc \
   gfortran pkg-config libglib2.0-dev libgmp3-dev libmpfr-dev libgsl0-dev libfftw3-dev \
-  libopenblas-dev libflint-dev libcfitsio-dev libfyaml-dev libnlopt-dev \
+  libopenblas-dev libflint-dev libcfitsio-dev libnlopt-dev \
   libhdf5-dev gtk-doc-tools
 ```
 
@@ -145,7 +143,7 @@ Note: in recent Debian and Ubuntu releases, the package name changed from
 
 For Mac OS users, Homebrew simplifies the installation process. Execute the following command to install the required packages:
 ```bash
-brew install gobject-introspection gsl gmp mpfr fftw cfitsio libfyaml nlopt gfortran \
+brew install gobject-introspection gsl gmp mpfr fftw cfitsio nlopt gfortran \
   gtk-doc glib openblas
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - jupyter
   - lcov
   - libflint
-  - libfyaml < 0.9.6
   - matplotlib-base
   - meson
   - mpfr

--- a/meson.build
+++ b/meson.build
@@ -538,14 +538,13 @@ gmp_dep = dependency('gmp')
 mpfr_dep = dependency('mpfr')
 
 #######################################################################################
-# Checking for FFTW (optional):
+# Checking for FFTW:
 #######################################################################################
 message('Checking for FFTW')
 
 fftw3_dep = dependency(
   'fftw3',
   version: fftw_req,
-  required: false,
 )
 
 fftw3f_dep = dependency(
@@ -554,17 +553,13 @@ fftw3f_dep = dependency(
   required: false,
 )
 
-if fftw3_dep.found()
-  numcosmo_conf.set('HAVE_FFTW3', true)
-endif
+numcosmo_conf.set('HAVE_FFTW3', true)
 
 if fftw3f_dep.found()
   numcosmo_conf.set('HAVE_FFTW3F', true)
 endif
 
-if fftw3_dep.found() or fftw3f_dep.found()
-  numcosmo_conf.set_quoted('NUMCOSMO_FFTW_PLAN', get_option('fftw-planner'))
-endif
+numcosmo_conf.set_quoted('NUMCOSMO_FFTW_PLAN', get_option('fftw-planner'))
 
 #######################################################################################
 # Checking for cfitsio (optional):
@@ -582,20 +577,6 @@ if cfitsio_dep.found()
 endif
 
 #######################################################################################
-# Checking for libfyaml
-#######################################################################################
-message('Checking for libfyaml')
-
-libfyaml_dep = dependency(
-  'libfyaml',
-  required: false,
-)
-
-if libfyaml_dep.found()
-  numcosmo_conf.set('HAVE_LIBFYAML', true)
-endif
-
-#######################################################################################
 # Using internal libcuba:
 #######################################################################################
 
@@ -609,19 +590,20 @@ numcosmo_conf.set('HAVE_LIBCUBA_4_0', 1)
 numcosmo_conf.set('HAVE_SUNDIALS_ARKODE', 1)
 
 #######################################################################################
-# Checking for NLopt (optional):
+# Using internal libfyaml:
+#######################################################################################
+
+numcosmo_conf.set('HAVE_LIBFYAML', 1)
+
+#######################################################################################
+# Checking for NLopt:
 #######################################################################################
 message('Checking for NLopt')
 
-nlopt_dep = dependency(
-  'nlopt',
-  required: false,
-)
+nlopt_dep = dependency('nlopt')
 
-if nlopt_dep.found()
-  numcosmo_conf.set('HAVE_NLOPT', true)
-  numcosmo_build_cfg.set('have_nlopt_support', '#define NUMCOSMO_HAVE_NLOPT 1')
-endif
+numcosmo_conf.set('HAVE_NLOPT', true)
+numcosmo_build_cfg.set('have_nlopt_support', '#define NUMCOSMO_HAVE_NLOPT 1')
 
 #######################################################################################
 # Checking for Flint (optional):
@@ -942,7 +924,6 @@ dependencies_summary = {
   'gmp': gmp_dep,
   'gsl': gsl_dep,
   'lapack': lapack_dep,
-  'libfyaml': libfyaml_dep,
   'mpfr': mpfr_dep,
   'mpi': mpi_c_dep,
   'nlopt': nlopt_dep,

--- a/numcosmo/external/libfyaml/LICENSE
+++ b/numcosmo/external/libfyaml/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/numcosmo/external/libfyaml/config.h
+++ b/numcosmo/external/libfyaml/config.h
@@ -1,0 +1,53 @@
+/*
+ * config.h - hand-written configuration header for the vendored libfyaml subset
+ *
+ * NumCosmo only vendors the core parser/emitter library (see meson.build in this
+ * directory), not the upstream CLI tool, reflection/libclang backend, python
+ * bindings, or test harness. This header only defines the macros that the
+ * vendored sources actually branch on, using values that are safe and portable
+ * across the Linux/macOS toolchains NumCosmo supports.
+ */
+#ifndef NUMCOSMO_LIBFYAML_CONFIG_H
+#define NUMCOSMO_LIBFYAML_CONFIG_H
+
+#define VERSION "0.9.6"
+
+/* alloca.h is available on Linux and macOS. */
+#define HAVE_ALLOCA_H 1
+
+/*
+ * byteswap.h is glibc/Linux-specific and absent on macOS. Skip it and rely on
+ * the __builtin_bswap* fallback below instead, which is portable to every
+ * GCC/Clang toolchain this project already requires.
+ */
+/* #undef HAVE_BYTESWAP_H */
+#define HAVE___BUILTIN_BSWAP16 1
+#define HAVE___BUILTIN_BSWAP32 1
+#define HAVE___BUILTIN_BSWAP64 1
+
+/*
+ * qsort_r() has an incompatible argument order between glibc and BSD/macOS.
+ * Rather than probe and branch on it, keep it disabled: the fallback path
+ * (plain qsort() plus a static sort context) is fully correct for NumCosmo's
+ * single-threaded (de)serialization use.
+ */
+#define HAVE_QSORT_R 0
+
+/*
+ * mremap() is a Linux-only syscall (absent on macOS/BSD). The dedup allocator
+ * falls back to a portable alloc+copy path when this is 0.
+ */
+#define HAVE_MREMAP 0
+
+/* No libclang/LLVM reflection backend is vendored or linked. */
+#define HAVE_LIBCLANG 0
+/* #undef HAVE_LLVM_C_CORE_H */
+
+/* Portable BLAKE3 backend only -- see meson.build for the rationale. */
+/* #undef TARGET_HAS_SSE2 */
+/* #undef TARGET_HAS_SSE41 */
+/* #undef TARGET_HAS_AVX2 */
+/* #undef TARGET_HAS_AVX512 */
+/* #undef TARGET_HAS_NEON */
+
+#endif /* NUMCOSMO_LIBFYAML_CONFIG_H */

--- a/numcosmo/external/libfyaml/include/libfyaml.h
+++ b/numcosmo/external/libfyaml/include/libfyaml.h
@@ -1,0 +1,90 @@
+/*
+ * libfyaml.h - Main header file of the public interface
+ *
+ * Copyright (c) 2019-2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBFYAML_H
+#define LIBFYAML_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: libfyaml public API — umbrella header
+ *
+ * This is the single top-level include for the entire libfyaml public API.
+ * Including it pulls in all subsystem headers:
+ *
+ * - Core YAML parser, document tree, emitter, and diagnostics
+ *   (``libfyaml/libfyaml-core.h``)
+ * - General-purpose utilities and portability macros
+ *   (``libfyaml/libfyaml-util.h``)
+ * - YAML path expression parser and executor
+ *   (``libfyaml/libfyaml-path-exec.h``)
+ * - Document builder: event-stream to tree conversion
+ *   (``libfyaml/libfyaml-docbuild.h``)
+ * - Document iterator: tree traversal and event replay
+ *   (``libfyaml/libfyaml-dociter.h``)
+ * - Composer: callback-driven, path-aware event processing
+ *   (``libfyaml/libfyaml-composer.h``)
+ * - Pluggable memory allocators
+ *   (``libfyaml/libfyaml-allocator.h``)
+ * - Thread pool for parallel work
+ *   (``libfyaml/libfyaml-thread.h``)
+ * - BLAKE3 cryptographic hashing
+ *   (``libfyaml/libfyaml-blake3.h``)
+ * - Alignment macros and helpers
+ *   (``libfyaml/libfyaml-align.h``)
+ * - Portable endian detection
+ *   (``libfyaml/libfyaml-endian.h``)
+ * - Portable atomic operations
+ *   (``libfyaml/libfyaml-atomics.h``)
+ * - Variable-length size encoding
+ *   (``libfyaml/libfyaml-vlsize.h``)
+ *
+ * For faster compilation you may include only the subsystem headers you need.
+ * All public symbols are prefixed with ``fy_`` (functions/types) or ``FY_``
+ * (macros and constants).
+ */
+
+#include <libfyaml/libfyaml-util.h>
+#include <libfyaml/libfyaml-core.h>
+#include <libfyaml/libfyaml-path-exec.h>
+#include <libfyaml/libfyaml-docbuild.h>
+#include <libfyaml/libfyaml-dociter.h>
+#include <libfyaml/libfyaml-composer.h>
+#include <libfyaml/libfyaml-allocator.h>
+#include <libfyaml/libfyaml-thread.h>
+#include <libfyaml/libfyaml-blake3.h>
+#include <libfyaml/libfyaml-align.h>
+#include <libfyaml/libfyaml-endian.h>
+#include <libfyaml/libfyaml-atomics.h>
+#include <libfyaml/libfyaml-vlsize.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-align.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-align.h
@@ -1,0 +1,258 @@
+/*
+ * libfyaml-align.h - various align related stuff
+ *
+ * Copyright (c) 2023-2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef LIBFYAML_ALIGN_H
+#define LIBFYAML_ALIGN_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#ifdef _WIN32
+#include <malloc.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: Alignment macros and aligned allocation helpers
+ *
+ * This header provides portable utilities for working with memory alignment
+ * requirements, from compile-time attributes to runtime allocation and
+ * pointer-rounding helpers.  It has no libfyaml dependencies.
+ *
+ * **Compile-time attributes**
+ *
+ * - ``FY_ALIGNED_TO(x)``   — apply an alignment attribute to a variable or
+ *   type; expands to ``__attribute__((aligned(x)))`` on GCC/Clang and
+ *   ``__declspec(align(x))`` on MSVC
+ * - ``FY_CACHELINE_ALIGN`` — shorthand for cache-line (64-byte) alignment,
+ *   useful for preventing false sharing between fields accessed concurrently
+ *   by different threads
+ *
+ * **Value rounding**
+ *
+ * - ``FY_ALIGN(align, x)``         — round an integer up to the next
+ *   multiple of ``align`` (must be a power of two)
+ * - ``FY_CACHELINE_SIZE_ALIGN(x)``  — round up to the next cache-line boundary
+ * - ``fy_ptr_align(p, align)``      — round a pointer up to alignment
+ * - ``fy_size_t_align(sz, align)``  — round a size_t value up to alignment
+ *
+ * **Heap allocation**
+ *
+ * - ``fy_align_alloc(align, size)`` / ``fy_align_free(p)`` — allocate and
+ *   free memory with an explicit alignment (``posix_memalign`` on POSIX,
+ *   ``_aligned_malloc`` on Windows)
+ * - ``fy_cacheline_alloc(size)``    / ``fy_cacheline_free(p)`` — convenience
+ *   wrappers that fix the alignment at ``FY_CACHELINE_SIZE``
+ *
+ * **Stack allocation**
+ *
+ * - ``fy_alloca_align(sz, align)`` — allocate a block on the stack with a
+ *   specified alignment; uses plain ``alloca`` when alignment fits within
+ *   ``max_align_t``, otherwise over-allocates and advances the pointer
+ */
+
+/**
+ * FY_ALIGNED_TO() - Declare that a variable or type has a minimum alignment.
+ *
+ * Expands to the appropriate compiler-specific alignment attribute:
+ * - GCC/Clang: ``__attribute__((aligned(x)))``
+ * - MSVC:      should be ``__declspec(align(x))`` but MSVC does not support trailing alignment...
+ * - Other:     empty (no enforced alignment)
+ *
+ * @x: Required alignment in bytes (must be a power of two).
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define FY_ALIGNED_TO(x) __attribute__ ((aligned(x)))
+#elif defined(_MSC_VER)
+// #define FY_ALIGNED_TO(x) __declspec(align(x))
+#define FY_ALIGNED_TO(x) /* nothing - MSVC doesn't support trailing alignment */
+#else
+#define FY_ALIGNED_TO(x) /* nothing */
+#endif
+
+/**
+ * FY_ALIGN() - Round @_x up to the next multiple of @_align.
+ *
+ * @_align must be a power of two. The result is always >= @_x and
+ * is the smallest multiple of @_align that is >= @_x.
+ *
+ * @_align: Alignment boundary (power of two).
+ * @_x:     Value to round up.
+ *
+ * Returns: @_x rounded up to the nearest multiple of @_align.
+ */
+#define FY_ALIGN(_align, _x) (((_x) + ((_align) - 1)) & ~((_align) - 1))
+
+/**
+ * FY_CACHELINE_SIZE - Size of a CPU cache line in bytes.
+ *
+ * Universally 64 bytes on all currently supported architectures
+ * (x86, x86_64, ARM, ARM64, PowerPC).
+ */
+#define FY_CACHELINE_SIZE 64
+
+/**
+ * FY_CACHELINE_SIZE_ALIGN() - Round @_x up to the next cache-line boundary.
+ *
+ * @_x: Value to round up.
+ *
+ * Returns: @_x rounded up to the nearest multiple of %FY_CACHELINE_SIZE.
+ */
+#define FY_CACHELINE_SIZE_ALIGN(_x) FY_ALIGN(FY_CACHELINE_SIZE, _x)
+
+/**
+ * FY_CACHELINE_ALIGN - Alignment attribute for cache-line-aligned objects.
+ *
+ * Apply to a variable or struct field to ensure it starts on a cache-line
+ * boundary, preventing false sharing between concurrent readers/writers.
+ *
+ * Example::
+ *
+ *   struct my_data {
+ *       FY_CACHELINE_ALIGN int hot_counter;
+ *       int cold_field;
+ *   };
+ */
+#define FY_CACHELINE_ALIGN FY_ALIGNED_TO(FY_CACHELINE_SIZE)
+
+/**
+ * fy_align_alloc() - Allocate memory with a specific alignment.
+ *
+ * Allocates @size bytes rounded up to the nearest multiple of @align, with
+ * the returned pointer guaranteed to be a multiple of @align.
+ *
+ * Uses ``posix_memalign()`` on POSIX systems and ``_aligned_malloc()`` on
+ * Windows. Free the result with fy_align_free().
+ *
+ * @align: Required alignment in bytes (must be a power of two and >= ``sizeof(void *)`` ).
+ * @size:  Number of bytes to allocate.
+ *
+ * Returns: Pointer to the allocated block, or NULL on failure.
+ */
+static inline void *fy_align_alloc(size_t align, size_t size)
+{
+	void *p;
+
+	size = FY_ALIGN(align, size);
+#ifndef _WIN32
+	if (posix_memalign(&p, align, size))
+		return NULL;
+#else
+	p = _aligned_malloc(size, align);
+	if (!p)
+		return NULL;
+#endif
+	return p;
+}
+
+/**
+ * fy_align_free() - Free memory allocated by fy_align_alloc().
+ *
+ * A NULL @p is silently ignored.
+ *
+ * @p: Pointer previously returned by fy_align_alloc(), or NULL.
+ */
+static inline void fy_align_free(void *p)
+{
+	if (!p)
+		return;
+#ifndef _WIN32
+	free(p);
+#else
+	_aligned_free(p);
+#endif
+}
+
+/**
+ * fy_cacheline_alloc() - Allocate cache-line-aligned memory.
+ *
+ * Equivalent to ``fy_align_alloc(FY_CACHELINE_SIZE, size)``.
+ * Free the result with fy_cacheline_free().
+ *
+ * @size: Number of bytes to allocate.
+ *
+ * Returns: Cache-line-aligned pointer, or NULL on failure.
+ */
+static inline void *fy_cacheline_alloc(size_t size)
+{
+	return fy_align_alloc(FY_CACHELINE_SIZE, size);
+}
+
+/**
+ * fy_cacheline_free() - Free memory allocated by fy_cacheline_alloc().
+ *
+ * A NULL @p is silently ignored.
+ *
+ * @p: Pointer previously returned by fy_cacheline_alloc(), or NULL.
+ */
+static inline void fy_cacheline_free(void *p)
+{
+	fy_align_free(p);
+}
+
+/**
+ * fy_ptr_align() - Round a pointer up to the next multiple of @align.
+ *
+ * Does not allocate any memory; the caller is responsible for ensuring
+ * the underlying buffer extends at least (@align - 1) bytes past @p.
+ *
+ * @p:     Pointer to align.
+ * @align: Alignment boundary in bytes (must be a power of two).
+ *
+ * Returns: @p rounded up to the nearest multiple of @align.
+ */
+static inline void *fy_ptr_align(void *p, size_t align)
+{
+	return (void *)(((uintptr_t)p + (align - 1)) & ~(align - 1));
+}
+
+/**
+ * fy_size_t_align() - Round a size_t value up to the next multiple of @align.
+ *
+ * @size:  Value to round up.
+ * @align: Alignment boundary in bytes (must be a power of two).
+ *
+ * Returns: @size rounded up to the nearest multiple of @align.
+ */
+static inline size_t fy_size_t_align(size_t size, size_t align)
+{
+	return (size + (align - 1)) & ~(align - 1);
+}
+
+/**
+ * fy_alloca_align() - Stack-allocate a buffer with a specific alignment.
+ *
+ * Expands to a statement expression (GCC extension) that allocates @_sz bytes
+ * on the stack, aligned to @_align bytes. When @_align <= ``sizeof(max_align_t)``
+ * a plain ``alloca()`` is used; otherwise @_sz + @_align - 1 bytes are allocated
+ * and the pointer is advanced with fy_ptr_align().
+ * This macro does not work on MSVC.
+ *
+ * The result is valid only for the lifetime of the enclosing function; do not
+ * return or store it beyond that scope.
+ *
+ * @_sz:    Number of bytes to allocate.
+ * @_align: Required alignment in bytes (must be a power of two).
+ *
+ * Returns: Stack pointer aligned to @_align.
+ */
+#define fy_alloca_align(_sz, _align) \
+	({ \
+		const size_t __sz = (_sz); \
+		const size_t __align = (_align); \
+		void *__p; \
+		__p = __align <= sizeof(max_align_t) ? alloca(__sz) : fy_ptr_align(alloca(__sz + __align - 1), __align); \
+		__p; \
+	})
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-allocator.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-allocator.h
@@ -1,0 +1,600 @@
+/*
+ * libfyaml-allocator.h - libfyaml allocator API
+ * Copyright (c) 2019-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef LIBFYAML_ALLOCATOR_H
+#define LIBFYAML_ALLOCATOR_H
+
+#include <stddef.h>
+
+/* pull in common definitions and platform abstraction macros */
+#include <libfyaml/libfyaml-util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: Pluggable memory allocator interface
+ *
+ * This header exposes libfyaml's pluggable allocator subsystem.  Rather than
+ * using ``malloc``/``free`` directly, the library routes certain internal
+ * allocations through a ``struct fy_allocator``.
+ * This lets callers trade memory footprint, speed,
+ * and deduplication behaviour to match their workload.
+ *
+ * **Available strategies** (select by name when calling
+ * ``fy_allocator_create()``):
+ *
+ * - ``"linear"`` — bump-pointer arena.  Allocation is O(1) and
+ *   near-zero overhead; individual frees are a no-op.  Ideal for
+ *   parse-and-discard workflows where the entire arena is released at once.
+ *
+ * - ``"malloc"`` — thin wrapper around the system ``malloc``/``free``.
+ *   Familiar semantics; useful when individual node lifetimes vary.
+ *   Should never be used for regular application builds. The presence
+ *   of it is for having a ASAN/valgrind compatible allocator where
+ *   buffer overflows can be detected easily.
+ *
+ * - ``"mremap"`` — growable linear arena backed by ``mremap(2)``.
+ *   Avoids copying when the arena needs to grow.
+ *   While mremap is Linux specific, this allocator can be configured
+ *   to use mmap() or malloc() areas where they work for other platforms.
+ *
+ * - ``"dedup"`` — content-addressed store built on xxhash hashing.
+ *   Stores each unique byte sequence exactly once and returns a shared
+ *   pointer to all callers.  Dramatically reduces memory use when parsing
+ *   documents with many repeated keys or values (e.g. large YAML
+ *   configurations, test-suite corpora).
+ *
+ * - ``"auto"`` — heuristic selection: given a policy. It usually can
+ *   do the right thing and is a safe bet.
+ *
+ * **Tags** partition an allocator's address space.  Obtain a tag with
+ * ``fy_allocator_get_tag()`` and pass it to every ``fy_allocator_alloc()``
+ * / ``fy_allocator_store()`` call; release the whole tag's memory in one
+ * shot with ``fy_allocator_release_tag()``.  This maps naturally to
+ * document lifetimes.
+ *
+ * **In-place variants** (``fy_linear_allocator_create_in_place()``,
+ * ``fy_dedup_allocator_create_in_place()``) initialise the allocator
+ * inside a caller-supplied buffer — zero dynamic setup cost, useful in
+ * stack-allocated or shared-memory contexts.
+ */
+
+/* forward decl of allocator interfaces */
+struct fy_allocator;
+
+/* A tag that represents the default tag */
+#define FY_ALLOC_TAG_DEFAULT	0
+/* A tag that denotes error */
+#define FY_ALLOC_TAG_ERROR	-1
+/* A tag that represents 'none' */
+#define FY_ALLOC_TAG_NONE	-2
+
+/**
+ * fy_allocator_iterate() - Iterate over available allocator names
+ *
+ * This method iterates over all the available allocator names.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @prevp: The previous allocator iterator pointer
+ *
+ * Returns:
+ * The next allocator name in sequence or NULL at the end.
+ */
+const char *
+fy_allocator_iterate(const char **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_is_available() - Check if an allocator is available
+ *
+ * Check if the named allocator is available.
+ *
+ * @name: The name of the allocator to check
+ *
+ * Returns:
+ * true if the allocator is available, false otherwise
+ */
+bool
+fy_allocator_is_available(const char *name)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_create() - Create an allocator.
+ *
+ * Creates an allocator of the given type, using the configuration
+ * argument provided.
+ * The allocator may be destroyed by a corresponding call to
+ * fy_allocator_destroy().
+ *
+ * You can retrieve the names of available allocators
+ * with the fy_allocator_get_names() method.
+ *
+ * @name: The name of the allocator
+ * @cfg: The type specific configuration for the allocator, or NULL
+ *       for the default.
+ *
+ * Returns:
+ * A pointer to the allocator or NULL in case of an error.
+ */
+struct fy_allocator *
+fy_allocator_create(const char *name, const void *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_destroy() - Destroy the given allocator
+ *
+ * Destroy an allocator created earlier via fy_allocator_create().
+ * Tracking allocators will release all memory allocated using them.
+ *
+ * @a: The allocator to destroy
+ */
+void
+fy_allocator_destroy(struct fy_allocator *a)
+	FY_EXPORT;
+
+/** The minimum amount of memory for an inplace linear allocator */
+#define FY_LINEAR_ALLOCATOR_IN_PLACE_MIN_SIZE	256
+
+/**
+ * fy_linear_allocator_create_in_place() - Create a linear allocator in place
+ *
+ * Creates a linear allocator in place, using the buffer provided.
+ * No memory allocations will be performed, so it's safe to embed.
+ * There is no need to call fy_allocator_destroy for this allocator.
+ *
+ * @buffer: The memory buffer to use for both storage and the allocator
+ * @size: The size of the memory buffer
+ *
+ * Returns:
+ * A pointer to the allocator, or NULL if there is no space
+ */
+struct fy_allocator *
+fy_linear_allocator_create_in_place(void *buffer, size_t size)
+	FY_EXPORT;
+
+/** The minimum amount of memory for an inplace dedup allocator */
+#define FY_DEDUP_ALLOCATOR_IN_PLACE_MIN_SIZE	4096
+
+/**
+ * fy_dedup_allocator_create_in_place() - Create a dedup allocator in place
+ *
+ * Creates a dedup allocator in place, using the buffer provided.
+ * No memory allocations will be performed, so it's safe to embed.
+ * There is no need to call fy_allocator_destroy for this allocator.
+ * The parent allocator of this will be a linear allocator.
+ *
+ * @buffer: The memory buffer to use for both storage and the allocator
+ * @size: The size of the memory buffer
+ *
+ * Returns:
+ * A pointer to the allocator, or NULL if there is no space
+ */
+struct fy_allocator *
+fy_dedup_allocator_create_in_place(void *buffer, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_get_tag() - Get a tag from an allocator
+ *
+ * The allocator interface requires all allocation to belong
+ * to a tag. This call creates a tag and returns its value,
+ * or an error if not available.
+ *
+ * If an allocator only provides a single tag (like the linear
+ * allocator for instance), the same tag number, usually 0, is
+ * returned.
+ *
+ * @a: The allocator
+ *
+ * Returns:
+ * The created tag or -1 in case of an error.
+ */
+int
+fy_allocator_get_tag(struct fy_allocator *a)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_release_tag() - Release a tag from an allocator
+ *
+ * Releases a tag from an allocator and frees all memory it
+ * allocated (if such an operation is provided by the allocator).
+ *
+ * @a: The allocator
+ * @tag: The tag to release
+ */
+void
+fy_allocator_release_tag(struct fy_allocator *a, int tag)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_get_tag_count() - Get the maximum number of tags a
+ * 				  allocator supports
+ *
+ * Get the maximum amount of tags an allocator supports.
+ *
+ * If an allocator only provides a single tag (like the linear
+ * allocator for instance), 1 will be returned.
+ *
+ * @a: The allocator
+ *
+ * Returns:
+ * The number of tags, or -1 on error
+ */
+int
+fy_allocator_get_tag_count(struct fy_allocator *a)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_set_tag_count() - Set the maximum number of tags a
+ * 				  allocator supports
+ *
+ * Sets the maximum amount of tags an allocator supports.
+ * If the set allocator tag count is less than the current
+ * the additional tags will be released.
+ *
+ * @a: The allocator
+ * @count: The amount of tags the allocator should support
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_allocator_set_tag_count(struct fy_allocator *a, unsigned int count)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_trim_tag() - Trim a tag
+ *
+ * Trim a tag, that is free any excess memory it allocator, fitting
+ * it to the size of the content it carries.
+ * Allocators that cannot perform this operation treat it as a NOP.
+ *
+ * @a: The allocator
+ * @tag: The tag to trim
+ */
+void
+fy_allocator_trim_tag(struct fy_allocator *a, int tag)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_reset_tag() - Reset a tag
+ *
+ * Reset a tag, that is free any content it carries, but do not
+ * release the tag.
+ *
+ * @a: The allocator
+ * @tag: The tag to reset
+ */
+void
+fy_allocator_reset_tag(struct fy_allocator *a, int tag)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_alloc() - Allocate memory from an allocator
+ *
+ * Allocate memory from the given allocator tag, satisfying the
+ * size and align restrictions.
+ *
+ * @a: The allocator
+ * @tag: The tag to allocate from
+ * @size: The size of the memory to allocate
+ * @align: The alignment of the object
+ *
+ * Returns:
+ * A pointer to the allocated memory or NULL
+ */
+void *
+fy_allocator_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_free() - Free memory allocated from an allocator
+ *
+ * Attempt to free the memory allocated previously by fy_allocator_alloc()
+ * Note that non per object tracking allocators treat this as a NOP
+ *
+ * @a: The allocator
+ * @tag: The tag used to allocate the memory
+ * @ptr: The pointer to the memory to free
+ */
+void
+fy_allocator_free(struct fy_allocator *a, int tag, void *ptr)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_store() - Store an object to an allocator
+ *
+ * Store an object to an allocator and return a pointer to the location
+ * it was stored. When using a deduplicating allocator no new allocation
+ * will take place and a pointer to the object already stored will be
+ * returned.
+ *
+ * The return pointer must not be modified, the objects stored are idempotent.
+ *
+ * @a: The allocator
+ * @tag: The tag used to allocate the memory
+ * @data: The pointer to object to store
+ * @size: The size of the object
+ * @align: The alignment restriction of the object
+ *
+ * Returns:
+ * A constant pointer to the object stored, or NULL in case of an error
+ */
+const void *
+fy_allocator_store(struct fy_allocator *a, int tag, const void *data, size_t size, size_t align)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_storev() - Store an object to an allocator (scatter gather)
+ *
+ * Store an object to an allocator and return a pointer to the location
+ * it was stored. When using a deduplicating allocator no new allocation
+ * will take place and a pointer to the object already stored will be
+ * returned.
+ *
+ * The object is created linearly from the scatter gather io vector provided.
+ *
+ * The return pointer must not be modified, the objects stored are immutable.
+ *
+ * @a: The allocator
+ * @tag: The tag used to allocate the memory from
+ * @iov: The I/O scatter gather vector
+ * @iovcnt: The number of vectors
+ * @align: The alignment restriction of the object
+ *
+ * Returns:
+ * A constant pointer to the object stored, or NULL in case of an error
+ */
+const void *
+fy_allocator_storev(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_lookup() - Lookup for object in an allocator.
+ *
+ * Lookup for the exact contents of an object stored in an allocator
+ * and return a pointer to the location it was stored.
+ * The allocator must have the FYACF_CAN_LOOKUP capability.
+ *
+ * @a: The allocator
+ * @tag: The tag used to locate the memory
+ * @data: The pointer to object to store
+ * @size: The size of the object
+ * @align: The alignment restriction of the object
+ *
+ * Returns:
+ * A constant pointer to the object stored, or NULL if the object does not exist
+ */
+const void *
+fy_allocator_lookup(struct fy_allocator *a, int tag, const void *data, size_t size, size_t align)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_lookupv() - Lookup for object in an allocator (scatter gather)
+ *
+ * Lookup for the exact contents of an object stored in an allocator
+ * and return a pointer to the location it was stored.
+ * The allocator must have the FYACF_CAN_LOOKUP capability.
+ *
+ * The scatter gather vector is used to recreate the object.
+ *
+ * @a: The allocator
+ * @tag: The tag used to search into
+ * @iov: The I/O scatter gather vector
+ * @iovcnt: The number of vectors
+ * @align: The alignment restriction of the object
+ *
+ * Returns:
+ * A constant pointer to the object stored, or NULL in case the object does not exist
+ */
+const void *
+fy_allocator_lookupv(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_dump() - Dump internal allocator state
+ *
+ * @a: The allocator
+ */
+void
+fy_allocator_dump(struct fy_allocator *a)
+	FY_EXPORT;
+
+/**
+ * enum fy_allocator_cap_flags - Allocator capability flags
+ *
+ * @FYACF_CAN_FREE_INDIVIDUAL: Allocator supports freeing individual allocations
+ * @FYACF_CAN_FREE_TAG: Allocator supports releasing entire tags
+ * @FYACF_CAN_DEDUP: Allocator supports deduplication
+ * @FYACF_HAS_CONTAINS: Allocator can report if it contains a pointer (even if inefficiently)
+ * @FYACF_HAS_EFFICIENT_CONTAINS: Allocator can report if it contains a pointer (efficiently)
+ * @FYACF_HAS_TAGS: Allocator has individual tags or not
+ * @FYACF_CAN_LOOKUP: Allocator supports lookup for content
+ *
+ * These flags describe what operations an allocator supports.
+ */
+enum fy_allocator_cap_flags {
+	FYACF_CAN_FREE_INDIVIDUAL		= FY_BIT(0),
+	FYACF_CAN_FREE_TAG			= FY_BIT(1),
+	FYACF_CAN_DEDUP				= FY_BIT(2),
+	FYACF_HAS_CONTAINS			= FY_BIT(3),
+	FYACF_HAS_EFFICIENT_CONTAINS		= FY_BIT(4),
+	FYACF_HAS_TAGS				= FY_BIT(5),
+	FYACF_CAN_LOOKUP			= FY_BIT(6),
+};
+
+/**
+ * fy_allocator_get_caps() - Get allocator capabilities
+ *
+ * Retrieve the capabilities of an allocator.
+ *
+ * @a: The allocator
+ *
+ * Returns:
+ * The capabilities of the allocator
+ */
+enum fy_allocator_cap_flags
+fy_allocator_get_caps(struct fy_allocator *a)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_contains() - Check if a allocator contains a pointer
+ *
+ * Report if an allocator contains the pointer
+ *
+ * @a: The allocator
+ * @tag: Tag to search in, -1 for all
+ * @ptr: The object pointer
+ *
+ * Returns:
+ * true if the pointer ptr is contained in the allocator, false otherwise
+ */
+bool
+fy_allocator_contains(struct fy_allocator *a, int tag, const void *ptr)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_get_tag_linear_size() - Get the linear size of an allocator tag
+ *
+ * Retrieve the linear size of the content of a tag.
+ * That is the size of a buffer if one was to copy the content of the tag in
+ * that buffer in a linear manner.
+ *
+ * @a: The allocator
+ * @tag: The tag
+ *
+ * Returns:
+ * The linear size of the content stored in the tag or -1 in case of an error.
+ */
+ssize_t
+fy_allocator_get_tag_linear_size(struct fy_allocator *a, int tag)
+	FY_EXPORT;
+
+/**
+ * fy_allocator_get_tag_single_linear() - Get the linear extend of a tag
+ *
+ * If a tag stores it's content in a single linear buffer, retrieve it
+ * directly. This is possible only under careful arrangement of allocator
+ * configuration, but it is an important optimization case.
+ *
+ * @a: The allocator
+ * @tag: The tag
+ * @sizep: Pointer to a variable that will be filled with the size.
+ *
+ * Returns:
+ * A pointer to the linear content of the tag, or NULL if othersize.
+ */
+const void *
+fy_allocator_get_tag_single_linear(struct fy_allocator *a, int tag, size_t *sizep)
+	FY_EXPORT;
+
+/**
+ * struct fy_linear_allocator_cfg - linear allocator configuration
+ *
+ * @buf: A pointer to a buffer that will be used, or NULL in order to allocate
+ * @size: Size of the buffer in bytes
+ */
+struct fy_linear_allocator_cfg {
+	void *buf;
+	size_t size;
+};
+
+/**
+ * enum fy_mremap_arena_type - The mremap allocator arena types
+ *
+ * @FYMRAT_DEFAULT: Use what's optimal for this platform
+ * @FYMRAT_MALLOC: Use malloc/realloc arena type (not recommended)
+ * @FYMRAT_MMAP: Use mmap/mremap arena type
+ *
+ */
+enum fy_mremap_arena_type {
+	FYMRAT_DEFAULT,
+	FYMRAT_MALLOC,
+	FYMRAT_MMAP,
+};
+
+/**
+ * struct fy_mremap_allocator_cfg - mremap allocator configuration
+ *
+ * If any of the fields is zero, then the system will provide (somewhat)
+ * reasonable defaults.
+ *
+ * @big_alloc_threshold: Threshold for immediately creating a new arena.
+ * @empty_threshold: The threshold under which an arena is moved to the full list.
+ * @minimum_arena_size: The minimum (and starting size) of an arena.
+ * @grow_ratio: The ratio which an arena will try to grow if full (>1.0)
+ * @balloon_ratio: The multiplier for the vm area first allocation
+ * @arena_type: The arena type
+ */
+struct fy_mremap_allocator_cfg {
+	size_t big_alloc_threshold;
+	size_t empty_threshold;
+	size_t minimum_arena_size;
+	float grow_ratio;
+	float balloon_ratio;
+	enum fy_mremap_arena_type arena_type;
+};
+
+/* malloc allocator has no configuration data, pass NULL */
+
+/**
+ * struct fy_dedup_allocator_cfg - dedup allocator configuration
+ *
+ * @parent_allocator: The parent allocator (required)
+ * @bloom_filter_bits: Number of bits of the bloom filter (or 0 for default)
+ * @bucket_count_bits: Number of bits for the bucket count (or 0 for default)
+ * @dedup_threshold: Number of bytes over which dedup takes place (default 0=always)
+ * @chain_length_grow_trigger: Chain length of a bucket over which a grow takes place (or 0 for auto)
+ * @estimated_content_size: Estimated content size (or 0 for don't know)
+ * @minimum_bucket_occupancy: The minimum amount that a tag bucket must be full before
+ * 			      growth is allowed (default 50%, or 0.0)
+ */
+struct fy_dedup_allocator_cfg {
+	struct fy_allocator *parent_allocator;
+	unsigned int bloom_filter_bits;
+	unsigned int bucket_count_bits;
+	size_t dedup_threshold;
+	unsigned int chain_length_grow_trigger;
+	size_t estimated_content_size;
+	float minimum_bucket_occupancy;
+};
+
+/**
+ * enum fy_auto_allocator_scenario_type - auto allocator scenario type
+ *
+ * @FYAST_PER_TAG_FREE: only per tag freeing, no individual obj free
+ * @FYAST_PER_TAG_FREE_DEDUP: per tag freeing, dedup obj store
+ * @FYAST_PER_OBJ_FREE:	object freeing allowed, tag freeing still works
+ * @FYAST_PER_OBJ_FREE_DEDUP: per obj freeing, dedup obj store
+ * @FYAST_SINGLE_LINEAR_RANGE: just a single linear range, no frees at all
+ * @FYAST_SINGLE_LINEAR_RANGE_DEDUP: single linear range, with dedup
+ */
+enum fy_auto_allocator_scenario_type {
+	FYAST_PER_TAG_FREE,
+	FYAST_PER_TAG_FREE_DEDUP,
+	FYAST_PER_OBJ_FREE,
+	FYAST_PER_OBJ_FREE_DEDUP,
+	FYAST_SINGLE_LINEAR_RANGE,
+	FYAST_SINGLE_LINEAR_RANGE_DEDUP,
+};
+
+/**
+ * struct fy_auto_allocator_cfg - auto allocator configuration
+ *
+ * @scenario: Auto allocator scenario
+ * @estimated_max_size: Estimated max content size (or 0 for don't know)
+ */
+struct fy_auto_allocator_cfg {
+	enum fy_auto_allocator_scenario_type scenario;
+	size_t estimated_max_size;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBFYAML_ALLOCATOR_H */

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-atomics.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-atomics.h
@@ -1,0 +1,450 @@
+/*
+ * libfyaml-atomic.h - libfyaml atomics
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * DOC: Portable atomic operations
+ *
+ * This header provides a thin, portable abstraction over C11 ``<stdatomic.h>``
+ * with graceful fallback for compilers that support ``_Atomic`` as an extension
+ * (GCC without ``-std=c11``, Clang) and a last-resort non-atomic fallback for
+ * toolchains that support neither.
+ *
+ * **Detection macros** (defined by this header, not meant for direct use):
+ *
+ * - ``FY_HAVE_STDATOMIC_H``   — ``<stdatomic.h>`` was successfully included;
+ *                               the standard ``atomic_*`` functions and types
+ *                               are available.
+ * - ``FY_HAVE_C11_ATOMICS``   — the ``_Atomic`` qualifier is available, either
+ *                               from ``<stdatomic.h>`` or as a compiler extension.
+ * - ``FY_HAVE_ATOMICS``       — effective atomics are available (``_Atomic``
+ *                               maps to a real atomic type).  When not defined,
+ *                               ``_Atomic(_x)`` expands to plain ``_x`` and all
+ *                               operations are non-atomic single-threaded stubs.
+ * - ``FY_HAVE_SAFE_ATOMIC_OPS`` — the underlying operations are properly
+ *                               memory-ordered (i.e. ``<stdatomic.h>`` is in
+ *                               use).  Without this, operations are performed
+ *                               as plain loads/stores with no memory barriers.
+ *
+ * **Public API** — all ``fy_atomic_*`` macros delegate to the selected backend:
+ *
+ * - FY_ATOMIC()                     — qualify a type as atomic
+ * - fy_atomic_flag                  — boolean flag type
+ * - fy_atomic_load() / fy_atomic_store()
+ * - fy_atomic_exchange()
+ * - fy_atomic_compare_exchange_strong() / fy_atomic_compare_exchange_weak()
+ * - fy_atomic_fetch_add() / fy_atomic_fetch_sub()
+ * - fy_atomic_fetch_or() / fy_atomic_fetch_xor() / fy_atomic_fetch_and()
+ * - fy_atomic_flag_clear() / fy_atomic_flag_set() / fy_atomic_flag_test_and_set()
+ * - fy_cpu_relax()                  — emit a CPU relaxation hint (PAUSE/YIELD)
+ * - fy_atomic_get_and_clear_counter() — atomically read and subtract a counter
+ */
+
+#ifndef LIBFYAML_ATOMICS_H
+#define LIBFYAML_ATOMICS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Detect standard C11 atomics */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+/*
+ * FY_HAVE_STDATOMIC_H - Defined when ``<stdatomic.h>`` is available.
+ *
+ * When defined, the standard ``atomic_*`` types and functions are in scope
+ * and all ``fy_atomic_*`` macros delegate to them.
+ */
+#define FY_HAVE_STDATOMIC_H
+/*
+ * FY_HAVE_C11_ATOMICS - Defined when the ``_Atomic`` qualifier is usable.
+ *
+ * Set when C11 ``<stdatomic.h>`` is available, or when the compiler supports
+ * ``_Atomic`` as an extension (GCC without ``-std=c11``, Clang).
+ * When not defined, ``_Atomic(_x)`` is a no-op and operations are non-atomic.
+ */
+#define FY_HAVE_C11_ATOMICS
+#endif
+
+/* Detect compiler extensions for _Atomic */
+#if !defined(FY_HAVE_C11_ATOMICS)
+#undef FY_HAVE_STDATOMIC_H
+
+#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#define FY_HAVE_C11_ATOMICS
+#elif defined(__clang__) && defined(__has_extension)
+#if __has_extension(c_atomic)
+#define FY_HAVE_C11_ATOMICS
+#endif
+#endif
+
+#endif
+
+/* Decide macro */
+#ifdef FY_HAVE_C11_ATOMICS
+/*
+ * FY_HAVE_ATOMICS - Defined when real atomic types are available.
+ *
+ * ``FY_ATOMIC(_x)`` expands to ``_Atomic(_x)`` when this is defined.
+ * When not defined, ``FY_ATOMIC(_x)`` is a no-op and all ``fy_atomic_*``
+ * operations degenerate to plain non-atomic loads and stores.
+ */
+#define FY_HAVE_ATOMICS
+#else
+#undef FY_HAVE_ATOMICS
+#define _Atomic(_x) _x
+#endif
+
+#if defined(FY_HAVE_STDATOMIC_H)
+/*
+ * FY_HAVE_SAFE_ATOMIC_OPS - Defined when atomic operations are memory-ordered.
+ *
+ * Set only when ``<stdatomic.h>`` is in use.  Without this, the fallback
+ * implementations perform plain loads/stores with no memory barriers and are
+ * therefore only safe in single-threaded contexts.
+ */
+#define FY_HAVE_SAFE_ATOMIC_OPS
+#else
+
+#undef FY_HAVE_SAFE_ATOMIC_OPS
+
+typedef bool atomic_flag;
+
+#define atomic_load(_ptr) \
+	(*(_ptr))
+
+#define atomic_store(_ptr, _val) \
+	do { \
+		*(_ptr) = (_val); \
+	} while(0)
+
+#define atomic_exchange(_ptr, _v) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		*__ptr = (_v); \
+		__old; \
+	})
+
+#define atomic_compare_exchange_strong(_ptr, _exp, _des) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		bool __res; \
+		if (*__ptr == *(_exp)) { \
+			*__ptr = (_des); \
+			__res = true; \
+		} else \
+			__res = false; \
+		__res; \
+	})
+
+#define atomic_compare_exchange_weak(_ptr, _exp, _des) \
+	atomic_compare_exchange_strong((_ptr), (_exp), (_des))
+
+#define atomic_fetch_add(_ptr, _v) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		*__ptr += (_v); \
+		__old; \
+	})
+
+#define atomic_fetch_sub(_ptr, _v) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		*__ptr -= (_v); \
+		__old; \
+	})
+
+#define atomic_fetch_or(_ptr, _v) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		*__ptr |= (_v); \
+		__old; \
+	})
+
+#define atomic_fetch_xor(_ptr, _v) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		*__ptr ^= (_v); \
+		__old; \
+	})
+
+#define atomic_fetch_and(_ptr, _v) \
+	({ \
+		__typeof__(_ptr) __ptr = (_ptr); \
+		__typeof__(*(_ptr)) __old = *__ptr; \
+		*__ptr &= (_v); \
+		__old; \
+	})
+
+#define atomic_flag_clear(_ptr) \
+	do { \
+		*(_ptr) = false; \
+	} while(0)
+
+#define atomic_flag_set(_ptr) \
+	do { \
+		*(_ptr) = true; \
+	} while(0)
+
+
+#define atomic_flag_test_and_set(_ptr) \
+	({ \
+		volatile atomic_flag *__ptr = (_ptr); \
+		bool __ret; \
+		if (!*__ptr) { \
+			*__ptr = true; \
+			__ret = true; \
+		} else \
+			__ret = false; \
+		__ret; \
+	})
+
+#endif
+
+/**
+ * FY_ATOMIC() - Qualify a type as atomic.
+ *
+ * Expands to ``_Atomic(_x)`` when %FY_HAVE_ATOMICS is defined, or to plain
+ * ``_x`` otherwise (non-atomic fallback).
+ *
+ * Example::
+ *
+ *   FY_ATOMIC(uint64_t) refcount;
+ *
+ * @_x: The underlying C type.
+ */
+#define FY_ATOMIC(_x) _Atomic(_x)
+
+/**
+ * fy_atomic_flag - A boolean flag that can be set/cleared/tested atomically.
+ *
+ * Backed by ``atomic_flag`` from ``<stdatomic.h>`` when available, or a plain
+ * ``bool`` in the fallback path.
+ */
+#define fy_atomic_flag atomic_flag
+
+/**
+ * fy_atomic_load() - Atomically load the value at @_ptr.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified variable.
+ *
+ * Returns: The current value.
+ */
+#define fy_atomic_load(_ptr) \
+	atomic_load((_ptr))
+
+/**
+ * fy_atomic_store() - Atomically store @_v at @_ptr.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified variable.
+ * @_v:   Value to store.
+ */
+#define fy_atomic_store(_ptr, _v) \
+	atomic_store((_ptr), (_v))
+
+/**
+ * fy_atomic_exchange() - Atomically replace the value at @_ptr with @_v.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified variable.
+ * @_v:   New value to store.
+ *
+ * Returns: The old value that was at @_ptr before the exchange.
+ */
+#define fy_atomic_exchange(_ptr, _v) \
+	atomic_exchange((_ptr), (_v))
+
+/**
+ * fy_atomic_compare_exchange_strong() - Strong CAS: replace @_ptr's value if it equals @_e.
+ *
+ * If ``*_ptr == *_e``, stores @_d into @_ptr and returns true.
+ * Otherwise, loads the current value into @_e and returns false.
+ * The strong variant never spuriously fails.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified variable.
+ * @_e:   Pointer to the expected value (updated on failure).
+ * @_d:   Desired value to store on success.
+ *
+ * Returns: true if the exchange succeeded, false otherwise.
+ */
+#define fy_atomic_compare_exchange_strong(_ptr, _e, _d) \
+	atomic_compare_exchange_strong((_ptr), (_e), (_d))
+
+/**
+ * fy_atomic_compare_exchange_weak() - Weak CAS: may spuriously fail.
+ *
+ * Like fy_atomic_compare_exchange_strong() but may fail even when
+ * ``*_ptr == *_e``. Prefer in retry loops where a spurious failure
+ * is harmless and performance matters.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified variable.
+ * @_e:   Pointer to the expected value (updated on failure).
+ * @_d:   Desired value to store on success.
+ *
+ * Returns: true if the exchange succeeded, false otherwise.
+ */
+#define fy_atomic_compare_exchange_weak(_ptr, _e, _d) \
+	atomic_compare_exchange_weak((_ptr), (_e), (_d))
+
+/**
+ * fy_atomic_fetch_add() - Atomically add @_v to @_ptr and return the old value.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified integer variable.
+ * @_v:   Value to add.
+ *
+ * Returns: The value of @_ptr before the addition.
+ */
+#define fy_atomic_fetch_add(_ptr, _v) \
+	atomic_fetch_add((_ptr), (_v))
+
+/**
+ * fy_atomic_fetch_sub() - Atomically subtract @_v from @_ptr and return the old value.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified integer variable.
+ * @_v:   Value to subtract.
+ *
+ * Returns: The value of @_ptr before the subtraction.
+ */
+#define fy_atomic_fetch_sub(_ptr, _v) \
+	atomic_fetch_sub((_ptr), (_v))
+
+/**
+ * fy_atomic_fetch_or() - Atomically OR @_v into @_ptr and return the old value.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified integer variable.
+ * @_v:   Value to OR in.
+ *
+ * Returns: The value of @_ptr before the operation.
+ */
+#define fy_atomic_fetch_or(_ptr, _v) \
+	atomic_fetch_or((_ptr), (_v))
+
+/**
+ * fy_atomic_fetch_xor() - Atomically XOR @_v into @_ptr and return the old value.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified integer variable.
+ * @_v:   Value to XOR in.
+ *
+ * Returns: The value of @_ptr before the operation.
+ */
+#define fy_atomic_fetch_xor(_ptr, _v) \
+	atomic_fetch_xor((_ptr), (_v))
+
+/**
+ * fy_atomic_fetch_and() - Atomically AND @_v into @_ptr and return the old value.
+ *
+ * @_ptr: Pointer to an FY_ATOMIC-qualified integer variable.
+ * @_v:   Value to AND in.
+ *
+ * Returns: The value of @_ptr before the operation.
+ */
+#define fy_atomic_fetch_and(_ptr, _v) \
+	atomic_fetch_and((_ptr), (_v))
+
+/**
+ * fy_atomic_flag_clear() - Atomically clear a flag (set to false).
+ *
+ * @_ptr: Pointer to an fy_atomic_flag.
+ */
+#define fy_atomic_flag_clear(_ptr) \
+	atomic_flag_clear((_ptr))
+
+/**
+ * fy_atomic_flag_set() - Atomically set a flag (set to true).
+ *
+ * Note: this is a libfyaml extension; standard ``<stdatomic.h>`` only
+ * provides ``atomic_flag_test_and_set()``.  In the fallback path this
+ * is implemented as a plain store.
+ *
+ * @_ptr: Pointer to an fy_atomic_flag.
+ */
+#define fy_atomic_flag_set(_ptr) \
+	atomic_flag_set((_ptr))
+
+/**
+ * fy_atomic_flag_test_and_set() - Atomically set a flag and return its old value.
+ *
+ * Sets the flag to true and returns the value it held before the operation.
+ * This is the standard test-and-set primitive.
+ *
+ * @_ptr: Pointer to an fy_atomic_flag.
+ *
+ * Returns: true if the flag was already set, false if it was clear.
+ */
+#define fy_atomic_flag_test_and_set(_ptr) \
+	atomic_flag_test_and_set((_ptr))
+
+/**
+ * fy_cpu_relax() - Emit a CPU relaxation hint inside a spin-wait loop.
+ *
+ * Reduces power consumption and improves hyper-threading performance on
+ * x86/x86_64 (``PAUSE``), signals a yield on AArch64/ARM (``YIELD``),
+ * and emits a low-priority hint on PowerPC (``or 27,27,27``).
+ * Falls back to a compiler memory barrier on unsupported architectures.
+ *
+ * Use inside tight spin loops to avoid memory-ordering penalties and
+ * allow sibling hardware threads to make progress::
+ *
+ *   while (!fy_atomic_load(&ready))
+ *       fy_cpu_relax();
+ */
+static inline void fy_cpu_relax(void)
+{
+#if defined(__x86_64__) || defined(__i386__)
+	__builtin_ia32_pause();
+#elif defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+	_mm_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+	__asm__ volatile ("yield");
+#elif defined(__powerpc__)
+	__asm__ volatile ("or 27,27,27");
+#else
+	__asm__ volatile ("" : : : "memory");
+#endif
+}
+
+/*
+ * fy_atomic_get_and_clear_counter() - Atomically read and drain a counter.
+ *
+ * Reads the current value of @ptr and subtracts that same value from it in
+ * one logical step, effectively resetting the counter to zero while returning
+ * how many units were accumulated since the last drain.
+ *
+ * Note: The read and subtract are two separate atomic operations, so another
+ * thread may increment the counter between them. The returned value therefore
+ * represents a snapshot taken at the moment of the load, not a strict
+ * atomic drain. This is intentional and sufficient for statistics / rate
+ * accounting where approximate values are acceptable.
+ *
+ * @ptr: Pointer to an FY_ATOMIC(uint64_t) counter.
+ *
+ * Returns: The value of the counter at the time of the load.
+ */
+static inline uint64_t
+fy_atomic_get_and_clear_counter(FY_ATOMIC(uint64_t) *ptr)
+{
+	uint64_t v;
+
+	v = fy_atomic_load(ptr);
+	fy_atomic_fetch_sub(ptr, v);
+	return v;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_ATOMICS_H

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-blake3.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-blake3.h
@@ -1,0 +1,215 @@
+/*
+ * libfyaml-blake3.h - libfyaml blake3 API
+ * Copyright (c) 2019-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef LIBFYAML_BLAKE3_H
+#define LIBFYAML_BLAKE3_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* pull in common definitions and platform abstraction macros */
+#include <libfyaml/libfyaml-util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: BLAKE3 cryptographic hashing
+ *
+ * This header exposes libfyaml's embedded BLAKE3 hasher.  BLAKE3 is a
+ * modern, highly parallelisable cryptographic hash function producing
+ * 256-bit (32-byte) output.
+ *
+ * Three hashing modes are supported, selected via
+ * ``struct fy_blake3_hasher_cfg`` at creation time:
+ *
+ * - **Standard**: plain BLAKE3 hash (default when key and context are NULL)
+ * - **Keyed**: MAC-like hash using a 32-byte key
+ * - **Key derivation**: derive a subkey from an application context string
+ *
+ * The hasher can be used in streaming fashion (``update`` / ``finalize``)
+ * or for one-shot hashing of memory regions (``fy_blake3_hash()``) and
+ * files (``fy_blake3_hash_file()``).  File hashing uses ``mmap`` by
+ * default for large files and can be further parallelised via a thread pool.
+ *
+ * Runtime SIMD backend selection is automatic: the best available backend
+ * (SSE2, SSE4.1, AVX2, AVX512 on x86; NEON on ARM; portable C otherwise)
+ * is used unless a specific backend name is requested in the config.
+ * Use ``fy_blake3_backend_iterate()`` to enumerate available backends.
+ *
+ * The hasher object is reusable: call ``fy_blake3_hasher_reset()`` to
+ * start a new hash without reallocating the object.
+ */
+
+/* BLAKE3 key length */
+#define FY_BLAKE3_KEY_LEN 32
+/* BLAKE3 output length */
+#define FY_BLAKE3_OUT_LEN 32
+
+/* opaque BLAKE3 hasher type for the user*/
+struct fy_blake3_hasher;
+
+/**
+ * fy_blake3_backend_iterate() - Iterate over the supported BLAKE3 backends
+ *
+ * This method iterates over the supported BLAKE3 backends.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * The default backend is always the last in sequence, so for
+ * example if the order is [ "portable", "sse2", NULL ] the
+ * default is "sse2".
+ *
+ * @prevp: The previous backend pointer, or NULL at start
+ *
+ * Returns:
+ * The next backend or NULL at the end.
+ */
+const char *
+fy_blake3_backend_iterate(const char **prevp)
+	FY_EXPORT;
+
+/**
+ * struct fy_blake3_hasher_cfg - BLAKE3 hasher configuration
+ *
+ * Argument to the fy_blake3_hasher_create() method which
+ * is the fyaml's user facing BLAKE3 API.
+ * It is very minimal, on purpose, since it's meant to be
+ * exposing a full blown BLAKE3 API.
+ *
+ * @backend: NULL for default, or a specific backend name
+ * @file_buffer: Use this amount of buffer for buffering, zero for default
+ * @mmap_min_chunk: Minimum chunk size for mmap case
+ * @mmap_max_chunk: Maximum chunk size for mmap case
+ * @no_mmap: Disable mmap for file access
+ * @key: pointer to a FY_BLAKE3_KEY_LEN area when in keyed mode.
+ *       NULL otherwise.
+ * @context: pointer to a context when in key derivation mode.
+ *           NULL otherwise.
+ * @context_len: The size of the context when in key derivation mode.
+ *               0 otherwise.
+ * @tp: The thread pool to use, if NULL, create a private one
+ * @num_threads: Number of threads to use
+ *               - 0 means default: NUM_CPUS * 3 / 2
+ *               - > 0 specific number of threads
+ *               - -1 disable threading entirely
+ */
+struct fy_blake3_hasher_cfg {
+	const char *backend;
+	size_t file_buffer;
+	size_t mmap_min_chunk;
+	size_t mmap_max_chunk;
+	bool no_mmap;
+	const uint8_t *key;
+	const void *context;
+	size_t context_len;
+	struct fy_thread_pool *tp;
+	int num_threads;
+};
+
+/**
+ * fy_blake3_hasher_create() - Create a BLAKE3 hasher object.
+ *
+ * Creates a BLAKE3 hasher with its configuration @cfg
+ * The hasher may be destroyed by a corresponding call to
+ * fy_blake3_hasher_destroy().
+ *
+ * @cfg: The configuration for the BLAKE3 hasher
+ *
+ * Returns:
+ * A pointer to the BLAKE3 hasher or NULL in case of an error.
+ */
+struct fy_blake3_hasher *
+fy_blake3_hasher_create(const struct fy_blake3_hasher_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_blake3_hasher_destroy() - Destroy the given BLAKE3 hasher
+ *
+ * Destroy a BLAKE3 hasher created earlier via fy_blake3_hasher_create().
+ *
+ * @fyh: The BLAKE3 hasher to destroy
+ */
+void
+fy_blake3_hasher_destroy(struct fy_blake3_hasher *fyh)
+	FY_EXPORT;
+
+/**
+ * fy_blake3_hasher_update() - Update the BLAKE3 hasher state with the given input
+ *
+ * Updates the BLAKE3 hasher state by hashing the given input.
+ *
+ * @fyh: The BLAKE3 hasher
+ * @input: Pointer to the input
+ * @input_len: Size of the input in bytes
+ */
+void
+fy_blake3_hasher_update(struct fy_blake3_hasher *fyh, const void *input, size_t input_len)
+	FY_EXPORT;
+
+/**
+ * fy_blake3_hasher_finalize() - Finalize the hash and get output
+ *
+ * Finalizes the BLAKE3 hasher and returns the output
+ *
+ * @fyh: The BLAKE3 hasher
+ *
+ * Returns:
+ * A pointer to the BLAKE3 output (sized FY_BLAKE3_OUT_LEN), or NULL
+ * in case of an error.
+ */
+const uint8_t *
+fy_blake3_hasher_finalize(struct fy_blake3_hasher *fyh)
+	FY_EXPORT;
+
+/**
+ * fy_blake3_hasher_reset() - Resets the hasher
+ *
+ * Resets the hasher for re-use
+ *
+ * @fyh: The BLAKE3 hasher
+ */
+void
+fy_blake3_hasher_reset(struct fy_blake3_hasher *fyh)
+	FY_EXPORT;
+
+/**
+ * fy_blake3_hash() - BLAKE3 hash a memory area
+ *
+ * Hash a memory area and return the BLAKE3 output.
+ *
+ * @fyh: The BLAKE3 hasher
+ * @mem: Pointer to the memory to use
+ * @size: The size of the memory in bytes
+ *
+ * Returns:
+ * A pointer to the BLAKE3 output (sized FY_BLAKE3_OUT_LEN), or NULL
+ * in case of an error.
+ */
+const uint8_t *
+fy_blake3_hash(struct fy_blake3_hasher *fyh, const void *mem, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_blake3_hash_file() - BLAKE3 hash a file.
+ *
+ * Hash the given file (possibly using mmap)
+ *
+ * @fyh: The BLAKE3 hasher
+ * @filename: The filename
+ *
+ * Returns:
+ * A pointer to the BLAKE3 output (sized FY_BLAKE3_OUT_LEN), or NULL
+ * in case of an error.
+ */
+const uint8_t *
+fy_blake3_hash_file(struct fy_blake3_hasher *fyh, const char *filename)
+	FY_EXPORT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBFYAML_BLAKE3 */

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-composer.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-composer.h
@@ -1,0 +1,704 @@
+/*
+ * libfyaml-composer.h - libfyaml composer API
+ *
+ * Copyright (c) 2023-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBFYAML_COMPOSER_H
+#define LIBFYAML_COMPOSER_H
+
+#include <libfyaml/libfyaml-core.h>
+#include <libfyaml/libfyaml-path-exec.h>
+#include <libfyaml/libfyaml-docbuild.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: Composer — callback-driven, path-aware event processing
+ *
+ * This header provides two complementary interfaces for processing YAML
+ * event streams with awareness of the current position in the document
+ * hierarchy, without committing to building a full in-memory tree.
+ *
+ * **Simple callback interface** — ``fy_parse_compose()`` calls a user
+ * function for each event, passing both the event and the current
+ * ``struct fy_path`` so the callback can make intelligent decisions
+ * without maintaining its own path stack::
+ *
+ *   enum fy_composer_return my_cb(struct fy_parser *fyp,
+ *                                 struct fy_event *fye,
+ *                                 struct fy_path *path,
+ *                                 void *userdata)
+ *   {
+ *       if (fy_path_depth(path) > 3)
+ *           return FYCR_OK_START_SKIP;
+ *       process(fye);
+ *       return FYCR_OK_CONTINUE;
+ *   }
+ *   fy_parse_compose(fyp, my_cb, ctx);
+ *
+ * **Object-based interface** — ``struct fy_composer`` wraps the same
+ * mechanism in a reusable object with ops callbacks, optional document
+ * builder integration, and helpers for navigating the path hierarchy.
+ *
+ * **Path inspection helpers** — functions such as ``fy_path_in_mapping()``,
+ * ``fy_path_depth()``, ``fy_path_component_is_sequence()``, and the
+ * user-data attach/retrieve pairs let callbacks annotate and query the
+ * live path stack without any external bookkeeping.
+ *
+ * Callbacks control event processing by returning one of:
+ *
+ * - ``FYCR_OK_CONTINUE``    — consume the event and continue
+ * - ``FYCR_OK_STOP``        — consume the event and stop
+ * - ``FYCR_OK_START_SKIP``  — start skipping the current subtree
+ * - ``FYCR_OK_STOP_SKIP``   — stop an active skip and resume processing
+ * - ``FYCR_ERROR``          — abort with an error
+ */
+
+struct fy_composer;
+
+/**
+ * enum fy_composer_return - The returns of the composer callback
+ *
+ * @FYCR_OK_CONTINUE: continue processing, event processed
+ * @FYCR_OK_STOP: stop processing, event processed
+ * @FYCR_OK_START_SKIP: start skip object(s), event processed
+ * @FYCR_OK_STOP_SKIP: stop skipping of objects, event processed
+ * @FYCR_ERROR: error, stop processing
+ */
+enum fy_composer_return {
+	FYCR_OK_CONTINUE = 0,
+	FYCR_OK_STOP = 1,
+	FYCR_OK_START_SKIP = 2,
+	FYCR_OK_STOP_SKIP = 3,
+	FYCR_ERROR = -1,
+};
+
+/**
+ * fy_composer_return_is_ok() - Check if the return code is OK
+ *
+ * Convenience method for checking if it's OK to continue
+ *
+ * @ret: the composer return to check
+ *
+ * Returns:
+ * true if non error or skip condition
+ */
+static inline bool
+fy_composer_return_is_ok(enum fy_composer_return ret)
+{
+	return ret == FYCR_OK_CONTINUE || ret == FYCR_OK_STOP;
+}
+
+/**
+ * typedef fy_parse_composer_cb - composer callback method
+ *
+ * This method is called by the fy_parse_compose() method
+ * when an event must be processed.
+ *
+ * @fyp: The parser
+ * @fye: The event
+ * @path: The path that the parser is processing
+ * @userdata: The user data of the fy_parse_compose() method
+ *
+ * Returns:
+ * fy_composer_return code telling the parser what to do
+ */
+typedef enum fy_composer_return
+(*fy_parse_composer_cb)(struct fy_parser *fyp, struct fy_event *fye,
+			struct fy_path *path, void *userdata);
+
+/**
+ * fy_parse_compose() - Parse using a compose callback
+ *
+ * Alternative parsing method using a composer callback.
+ *
+ * The parser will construct a path argument that is used
+ * by the callback to make intelligent decisions about
+ * creating a document and/or DOM.
+ *
+ * @fyp: The parser
+ * @cb: The callback that will be called
+ * @userdata: user pointer to pass to the callback
+ *
+ * Returns:
+ * 0 if no error occured
+ * -1 on error
+ */
+int
+fy_parse_compose(struct fy_parser *fyp, fy_parse_composer_cb cb,
+		 void *userdata)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_is_mapping() - Check if the component is a mapping
+ *
+ * @fypc: The path component to check
+ *
+ * Returns:
+ * true if the path component is a mapping, false otherwise
+ */
+bool
+fy_path_component_is_mapping(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_is_sequence() - Check if the component is a sequence
+ *
+ * @fypc: The path component to check
+ *
+ * Returns:
+ * true if the path component is a sequence, false otherwise
+ */
+bool
+fy_path_component_is_sequence(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_sequence_get_index() - Get the index of sequence path component
+ *
+ * @fypc: The sequence path component to return it's index value
+ *
+ * Returns:
+ * >= 0 the sequence index
+ * -1 if the component is either not in the proper mode, or not a sequence
+ */
+int
+fy_path_component_sequence_get_index(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_mapping_get_scalar_key() - Get the scalar key of a mapping
+ *
+ * @fypc: The mapping path component to return it's scalar key
+ *
+ * Returns:
+ * a non NULL scalar or alias token if the mapping contains a scalar key
+ * NULL in case of an error, or if the component has a complex key
+ */
+struct fy_token *
+fy_path_component_mapping_get_scalar_key(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_mapping_get_scalar_key_tag() - Get the scalar key's tag of a mapping
+ *
+ * @fypc: The mapping path component to return it's scalar key's tag
+ *
+ * Returns:
+ * a non NULL tag token if the mapping contains a scalar key with a tag or
+ * NULL in case of an error, or if the component has a complex key
+ */
+struct fy_token *
+fy_path_component_mapping_get_scalar_key_tag(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_mapping_get_complex_key() - Get the complex key of a mapping
+ *
+ * @fypc: The mapping path component to return it's complex key
+ *
+ * Returns:
+ * a non NULL document if the mapping contains a complex key
+ * NULL in case of an error, or if the component has a simple key
+ */
+struct fy_document *
+fy_path_component_mapping_get_complex_key(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_get_text() - Get the textual representation of a path component
+ *
+ * Given a path component, return a malloc'ed string which contains
+ * the textual representation of it.
+ *
+ * Note that this method will only return fully completed components and not
+ * ones that are in the building process.
+ *
+ * @fypc: The path component to get it's textual representation
+ *
+ * Returns:
+ * The textual representation of the path component, NULL on error, or
+ * if the component has not been completely built during the composition
+ * of a complex key.
+ * The string must be free'ed using free.
+ */
+char *
+fy_path_component_get_text(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+#define fy_path_component_get_text_alloca(_fypc) \
+	FY_ALLOCA_COPY_FREE(fy_path_component_get_text((_fypc)), FY_NT)
+/**
+ * fy_path_depth() - Get the depth of a path
+ *
+ * @fypp: The path to query
+ *
+ * Returns:
+ * The depth of the path, or -1 on error
+ */
+int
+fy_path_depth(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_parent() - Get the parent of a path
+ *
+ * Paths may contain parents when traversing complex keys.
+ * This method returns the immediate parent.
+ *
+ * @fypp: The path to return it's parent
+ *
+ * Returns:
+ * The path parent or NULL on error, if it doesn't exist
+ */
+struct fy_path *
+fy_path_parent(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_get_text() - Get the textual representation of a path
+ *
+ * Given a path, return a malloc'ed string which contains
+ * the textual representation of it.
+ *
+ * Note that during processing, complex key paths are simply
+ * indicative and not to be used for addressing.
+ *
+ * @fypp: The path to get it's textual representation
+ *
+ * Returns:
+ * The textual representation of the path, NULL on error.
+ * The string must be free'ed using free.
+ */
+char *
+fy_path_get_text(struct fy_path *fypp)
+	FY_EXPORT;
+
+#define fy_path_get_text_alloca(_fypp) \
+	FY_ALLOCA_COPY_FREE(fy_path_get_text((_fypp)), FY_NT)
+
+/**
+ * fy_path_in_root() - Check if the path is in the root of the document
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * true if the path is located within the root of the document
+ */
+bool
+fy_path_in_root(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_in_mapping() - Check if the path is in a mapping
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * true if the path is located within a mapping
+ */
+bool
+fy_path_in_mapping(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_in_sequence() - Check if the path is in a sequence
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * true if the path is located within a sequence
+ */
+bool
+fy_path_in_sequence(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_in_mapping_key() - Check if the path is in a mapping key state
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * true if the path is located within a mapping key state
+ */
+bool
+fy_path_in_mapping_key(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_in_mapping_value() - Check if the path is in a mapping value state
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * true if the path is located within a mapping value state
+ */
+bool
+fy_path_in_mapping_value(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_in_collection_root() - Check if the path is in a collection root
+ *
+ * A collection root state is when the path points to a sequence or mapping
+ * but the state does not allow setting keys, values or adding items.
+ *
+ * This occurs on MAPPING/SEQUENCE START/END events.
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * true if the path is located within a collectin root state
+ */
+bool
+fy_path_in_collection_root(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_get_root_user_data() - Return the userdata associated with the path root
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * The user data associated with the root of the path, or NULL if no path
+ */
+void *
+fy_path_get_root_user_data(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_set_root_user_data() - Set the user data associated with the root
+ *
+ * Note, no error condition if not a path
+ *
+ * @fypp: The path
+ * @data: The data to set as root data
+ */
+void
+fy_path_set_root_user_data(struct fy_path *fypp, void *data)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_get_mapping_user_data() - Return the userdata associated with the mapping
+ *
+ * @fypc: The path component
+ *
+ * Returns:
+ * The user data associated with the mapping, or NULL if not a mapping or the user data are NULL
+ */
+void *
+fy_path_component_get_mapping_user_data(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_get_mapping_key_user_data() - Return the userdata associated with the mapping key
+ *
+ * @fypc: The path component
+ *
+ * Returns:
+ * The user data associated with the mapping key, or NULL if not a mapping or the user data are NULL
+ */
+void *
+fy_path_component_get_mapping_key_user_data(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_get_sequence_user_data() - Return the userdata associated with the sequence
+ *
+ * @fypc: The path component
+ *
+ * Returns:
+ * The user data associated with the sequence, or NULL if not a sequence or the user data are NULL
+ */
+void *
+fy_path_component_get_sequence_user_data(struct fy_path_component *fypc)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_set_mapping_user_data() - Set the user data associated with a mapping
+ *
+ * Note, no error condition if not a mapping
+ *
+ * @fypc: The path component
+ * @data: The data to set as mapping data
+ */
+void
+fy_path_component_set_mapping_user_data(struct fy_path_component *fypc, void *data)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_set_mapping_key_user_data() - Set the user data associated with a mapping key
+ *
+ * Note, no error condition if not in a mapping key state
+ *
+ * @fypc: The path component
+ * @data: The data to set as mapping key data
+ */
+void
+fy_path_component_set_mapping_key_user_data(struct fy_path_component *fypc, void *data)
+	FY_EXPORT;
+
+/**
+ * fy_path_component_set_sequence_user_data() - Set the user data associated with a sequence
+ *
+ * Note, no error condition if not a sequence
+ *
+ * @fypc: The path component
+ * @data: The data to set as sequence data
+ */
+void
+fy_path_component_set_sequence_user_data(struct fy_path_component *fypc, void *data)
+	FY_EXPORT;
+
+/**
+ * fy_path_get_parent_user_data() - Return the userdata of the parent collection
+ *
+ * @path: The path
+ *
+ * Returns:
+ * The user data associated with the parent collection of the path, or NULL if no path
+ */
+void *
+fy_path_get_parent_user_data(struct fy_path *path)
+	FY_EXPORT;
+
+/**
+ * fy_path_set_parent_user_data() - Set the user data associated with the parent collection
+ *
+ * Note, no error condition if not a path
+ *
+ * @path: The path
+ * @data: The data to set as parent collection data
+ */
+void
+fy_path_set_parent_user_data(struct fy_path *path, void *data)
+	FY_EXPORT;
+
+/**
+ * fy_path_get_last_user_data() - Return the userdata of the last collection
+ *
+ * @path: The path
+ *
+ * Returns:
+ * The user data associated with the last collection of the path, or NULL if no path
+ */
+void *
+fy_path_get_last_user_data(struct fy_path *path)
+	FY_EXPORT;
+
+/**
+ * fy_path_set_last_user_data() - Set the user data associated with the last collection
+ *
+ * Note, no error condition if not a path
+ *
+ * @path: The path
+ * @data: The data to set as last collection data
+ */
+void
+fy_path_set_last_user_data(struct fy_path *path, void *data)
+	FY_EXPORT;
+
+/**
+ * fy_path_last_component() - Get the very last component of a path
+ *
+ * Returns the last component of a path.
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * The last path component (which may be a collection root component), or NULL
+ * if it does not exist
+ */
+struct fy_path_component *
+fy_path_last_component(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_last_not_collection_root_component() - Get the last non collection root component of a path
+ *
+ * Returns the last non collection root component of a path. This may not be the
+ * last component that is returned by fy_path_last_component().
+ *
+ * The difference is present on MAPPING/SEQUENCE START/END events where the
+ * last component is present but not usuable as a object parent.
+ *
+ * @fypp: The path
+ *
+ * Returns:
+ * The last non collection root component, or NULL if it does not exist
+ */
+struct fy_path_component *
+fy_path_last_not_collection_root_component(struct fy_path *fypp)
+	FY_EXPORT;
+
+/**
+ * struct fy_composer_ops - Composer operation callbacks
+ *
+ * Callbacks used by the composer to process events and create document builders.
+ *
+ * @process_event: Callback for processing a single YAML event with path context
+ * @create_document_builder: Callback for creating a document builder instance
+ */
+struct fy_composer_ops {
+	/* single process event callback */
+	enum fy_composer_return (*process_event)(struct fy_composer *fyc, struct fy_path *path, struct fy_event *fye);
+	struct fy_document_builder *(*create_document_builder)(struct fy_composer *fyc);
+};
+
+/**
+ * struct fy_composer_cfg - Composer configuration structure
+ *
+ * Configuration structure for creating a composer instance.
+ *
+ * @ops: Pointer to composer operation callbacks
+ * @userdata: Opaque user data pointer passed to callbacks
+ * @diag: Optional diagnostic interface to use, NULL for default
+ */
+struct fy_composer_cfg {
+	const struct fy_composer_ops *ops;
+	void *userdata;
+	struct fy_diag *diag;
+};
+
+/**
+ * fy_composer_create() - Create a composer
+ *
+ * Creates a composer with the given configuration. The composer processes
+ * YAML events using callback methods and maintains path information for
+ * intelligent document composition. The composer may be destroyed by a
+ * corresponding call to fy_composer_destroy().
+ *
+ * @cfg: The configuration for the composer
+ *
+ * Returns:
+ * A pointer to the composer or NULL in case of an error.
+ */
+struct fy_composer *
+fy_composer_create(struct fy_composer_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_composer_destroy() - Destroy the given composer
+ *
+ * Destroy a composer created earlier via fy_composer_create().
+ *
+ * @fyc: The composer to destroy
+ */
+void fy_composer_destroy(struct fy_composer *fyc)
+	FY_EXPORT;
+
+/**
+ * fy_composer_process_event() - Process a YAML event through the composer
+ *
+ * Process a YAML event by calling the configured process_event callback
+ * with path context. The composer maintains the current path and provides
+ * it to the callback for intelligent processing decisions.
+ *
+ * @fyc: The composer
+ * @fye: The event to process
+ *
+ * Returns:
+ * A fy_composer_return code indicating how to proceed (continue, stop, skip, or error)
+ */
+enum fy_composer_return
+fy_composer_process_event(struct fy_composer *fyc, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_composer_get_cfg() - Get the configuration of a composer
+ *
+ * @fyc: The composer
+ *
+ * Returns:
+ * The configuration of the composer
+ */
+struct fy_composer_cfg *
+fy_composer_get_cfg(struct fy_composer *fyc)
+	FY_EXPORT;
+
+/**
+ * fy_composer_get_cfg_userdata() - Get the userdata from composer configuration
+ *
+ * Retrieve the opaque userdata pointer from the composer's configuration.
+ *
+ * @fyc: The composer
+ *
+ * Returns:
+ * The userdata pointer from the configuration
+ */
+void *
+fy_composer_get_cfg_userdata(struct fy_composer *fyc)
+	FY_EXPORT;
+
+/**
+ * fy_composer_get_diag() - Get the diagnostic object of a composer
+ *
+ * Return a pointer to the diagnostic object of a composer object.
+ * Note that the returned diag object has a reference taken so
+ * you should fy_diag_unref() it when you're done with it.
+ *
+ * @fyc: The composer to get the diagnostic object
+ *
+ * Returns:
+ * A pointer to a ref'ed diagnostic object or NULL in case of an error.
+ */
+struct fy_diag *
+fy_composer_get_diag(struct fy_composer *fyc)
+	FY_EXPORT;
+
+/**
+ * fy_composer_get_path() - Get the current path of the composer
+ *
+ * Retrieve the current path being processed by the composer.
+ * The path represents the location in the YAML document structure
+ * where the composer is currently positioned.
+ *
+ * @fyc: The composer
+ *
+ * Returns:
+ * The current path, or NULL if no path is active
+ */
+struct fy_path *
+fy_composer_get_path(struct fy_composer *fyc)
+	FY_EXPORT;
+
+/**
+ * fy_composer_get_root_path() - Get the root path of the composer
+ *
+ * Retrieve the root path of the composer's path hierarchy.
+ *
+ * @fyc: The composer
+ *
+ * Returns:
+ * The root path, or NULL if no root exists
+ */
+struct fy_path *
+fy_composer_get_root_path(struct fy_composer *fyc)
+	FY_EXPORT;
+
+/**
+ * fy_composer_get_next_path() - Get the next path in the composer's path list
+ *
+ * Iterate through the composer's path list. Pass NULL to get the first path,
+ * or pass the previous path to get the next one.
+ *
+ * @fyc: The composer
+ * @fypp: The previous path, or NULL to get the first path
+ *
+ * Returns:
+ * The next path in the list, or NULL if no more paths exist
+ */
+struct fy_path *
+fy_composer_get_next_path(struct fy_composer *fyc, struct fy_path *fypp)
+	FY_EXPORT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_COMPOSER_H

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-core.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-core.h
@@ -1,0 +1,7559 @@
+/*
+ * libfyaml-core.h - libfyaml core API
+ * Copyright (c) 2019-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef LIBFYAML_CORE_H
+#define LIBFYAML_CORE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+
+/* pull in common definitions and platform abstraction macros */
+#include <libfyaml/libfyaml-util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* opaque types for the user */
+struct fy_token;
+struct fy_document_state;
+struct fy_parser;
+struct fy_emitter;
+struct fy_document;
+struct fy_node;
+struct fy_node_pair;
+struct fy_anchor;
+struct fy_node_mapping_sort_ctx;
+struct fy_token_iter;
+struct fy_diag;
+struct fy_parser_checkpoint;
+
+/**
+ * DOC: libfyaml public API
+ *
+ * This header provides the complete YAML 1.2 / JSON parser, document tree,
+ * and emitter API — the core of libfyaml.  It is the largest and most
+ * frequently used part of the public interface.
+ *
+ * **Three complementary APIs** cover the full lifecycle of a YAML document:
+ *
+ * *Event-based parsing* (``fy_parser_*``): A streaming interface similar to
+ * libyaml's.  The parser produces a sequence of typed events
+ * (stream-start, document-start, scalar, sequence-start, …) without
+ * building an in-memory tree.  Ideal for large documents, filters, and
+ * transcoding pipelines.
+ *
+ * *Document tree* (``fy_document_*``, ``fy_node_*``): Builds a fully
+ * navigable in-memory tree from a YAML or JSON source.  Nodes can be
+ * queried, modified, merged, and serialised.  Path-expression helpers
+ * (``fy_document_scanf()``, ``fy_document_insert_at()``, …) provide
+ * XPath-like access into the tree.
+ *
+ * *Emitter* (``fy_emitter_*``): Serialises documents or raw event streams
+ * back to YAML or JSON with full control over formatting style, indentation,
+ * and quoting.  Supports streaming output to files, memory buffers, or
+ * user-supplied callbacks.
+ *
+ * **Diagnostics** (``fy_diag_*``): A structured error-reporting subsystem
+ * that attributes messages to precise source locations and integrates with
+ * IDE/compiler toolchains via a standard ``file:line:col: level: text``
+ * format.
+ *
+ * All types are opaque pointers (``struct fy_parser *``, ``struct
+ * fy_document *``, ``struct fy_node *``, …) so the ABI is stable across
+ * minor releases.
+ */
+
+/**
+ * struct fy_version - The YAML version
+ *
+ * @major: Major version number
+ * @minor: Major version number
+ *
+ * The parser fills it according to the \%YAML directive
+ * found in the document.
+ */
+struct fy_version {
+	int major;
+	int minor;
+};
+
+/* Build a fy_version * from the given major and minor */
+#define fy_version_make(_maj, _min) (&(struct fy_version){ (_maj), (_min) })
+
+/**
+ * fy_version_compare() - Compare two yaml versions
+ *
+ * Compare the versions
+ *
+ * @va: The first version, if NULL use default version
+ * @vb: The second version, if NULL use default version
+ *
+ * Returns:
+ * 0 if versions are equal, > 0 if version va is higher than vb
+ * < 0 if version va is lower than vb
+ */
+int
+fy_version_compare(const struct fy_version *va, const struct fy_version *vb)
+	FY_EXPORT;
+
+/**
+ * fy_version_default() - Get the default version of the library
+ *
+ * Return the default version of the library, i.e. the highest
+ * stable version that is supported.
+ *
+ * Returns:
+ * The default YAML version of this library
+ */
+const struct fy_version *
+fy_version_default(void)
+	FY_EXPORT;
+
+/**
+ * fy_version_is_supported() - Check if supported version
+ *
+ * Check if the given YAML version is supported.
+ *
+ * @vers: The version to check, NULL means default version.
+ *
+ * Returns:
+ * true if version supported, false otherwise.
+ */
+bool
+fy_version_is_supported(const struct fy_version *vers)
+	FY_EXPORT;
+
+/**
+ * fy_version_supported_iterate() - Iterate over the supported YAML versions
+ *
+ * This method iterates over the supported YAML versions of this ibrary.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @prevp: The previous version iterator
+ *
+ * Returns:
+ * The next node in sequence or NULL at the end of the sequence.
+ */
+const struct fy_version *
+fy_version_supported_iterate(void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_shutdown() - Final cleanup before exit
+ *
+ * Some libraries *cough*libclang** need explicit cleanup calls
+ * at the end of program execution, even if you've never called
+ * any of their functions.
+ *
+ * This method will make sure it calls their cleanup functions
+ * so that no memory leaks are reported in valgrind etc.
+ */
+void
+fy_shutdown(void)
+	FY_EXPORT;
+
+/**
+ * struct fy_tag - The YAML tag structure.
+ *
+ * @handle: Handle of the tag (i.e. `"!!"`)
+ * @prefix: The prefix of the tag (i.e. `"tag:yaml.org,2002:"`)
+ * The parser fills it according to the \%TAG directives
+ * encountered during parsing.
+ */
+struct fy_tag {
+	const char *handle;
+	const char *prefix;
+};
+
+/**
+ * struct fy_mark - marker holding information about a location
+ *		    in a &struct fy_input
+ *
+ * @input_pos: Position of the mark (from the start of the current input)
+ * @line: Line position (0 index based)
+ * @column: Column position (0 index based)
+ */
+struct fy_mark {
+	size_t input_pos;
+	int line;
+	int column;
+};
+
+/**
+ * enum fy_error_type - The supported diagnostic/error types
+ *
+ * @FYET_DEBUG: Debug level (disabled if library is not compiled in debug mode)
+ * @FYET_INFO: Informational level
+ * @FYET_NOTICE: Notice level
+ * @FYET_WARNING: Warning level
+ * @FYET_ERROR: Error level - error reporting is using this level
+ * @FYET_MAX: Non inclusive maximum fy_error_type value
+ *
+ */
+enum fy_error_type {
+	FYET_DEBUG,
+	FYET_INFO,
+	FYET_NOTICE,
+	FYET_WARNING,
+	FYET_ERROR,
+	FYET_MAX,
+};
+
+/**
+ * enum fy_error_module - Module which generated the diagnostic/error
+ *
+ * @FYEM_UNKNOWN: Unknown, default if not specific
+ * @FYEM_ATOM: Atom module, used by atom chunking
+ * @FYEM_SCAN: Scanner module
+ * @FYEM_PARSE: Parser module
+ * @FYEM_DOC: Document module
+ * @FYEM_BUILD: Build document module (after tree is constructed)
+ * @FYEM_INTERNAL: Internal error/diagnostic module
+ * @FYEM_SYSTEM: System error/diagnostic module
+ * @FYEM_EMIT: Emitter module
+ * @FYEM_TYPESET: Prepare types module (C reflection)
+ * @FYEM_DECODE: Decode, serialization -> internal form module
+ * @FYEM_ENCODE: Encode, internal form -> serialized form module
+ * @FYEM_REFLECTION: Generic reflection module messages
+ * @FYEM_MAX: Non inclusive maximum fy_error_module value
+ */
+enum fy_error_module {
+	FYEM_UNKNOWN,
+	FYEM_ATOM,
+	FYEM_SCAN,
+	FYEM_PARSE,
+	FYEM_DOC,
+	FYEM_BUILD,
+	FYEM_INTERNAL,
+	FYEM_SYSTEM,
+	FYEM_EMIT,
+	FYEM_TYPESET,
+	FYEM_DECODE,
+	FYEM_ENCODE,
+	FYEM_REFLECTION,
+	FYEM_MAX,
+};
+
+/* Shift amount of the default version */
+#define FYPCF_DEFAULT_VERSION_SHIFT	9
+/* Mask of the default version */
+#define FYPCF_DEFAULT_VERSION_MASK	((1U << 5) - 1)
+/* Build a default version */
+#define FYPCF_DEFAULT_VERSION(x)	(((unsigned int)(x) & FYPCF_DEFAULT_VERSION_MASK) << FYPCF_DEFAULT_VERSION_SHIFT)
+
+/* Shift amount of the JSON input mode */
+#define FYPCF_JSON_SHIFT		16
+/* Mask of the JSON input mode */
+#define FYPCF_JSON_MASK			((1U << 2) - 1)
+/* Build a JSON input mode option */
+#define FYPCF_JSON(x)			(((unsigned int)(x) & FYPCF_JSON_MASK) << FYPCF_JSON_SHIFT)
+
+/* guaranteed minimum depth limit for generated document */
+/* the actual limit is larger depending on the platform */
+#define FYPCF_GUARANTEED_MINIMUM_DEPTH_LIMIT	64
+
+/**
+ * enum fy_parse_cfg_flags - Parse configuration flags
+ *
+ * These flags control the operation of the parse and the debugging
+ * output/error reporting via filling in the &fy_parse_cfg->flags member.
+ *
+ * @FYPCF_QUIET: Quiet, do not output any information messages
+ * @FYPCF_COLLECT_DIAG: Collect diagnostic/error messages
+ * @FYPCF_RESOLVE_DOCUMENT: When producing documents, automatically resolve them
+ * @FYPCF_DISABLE_MMAP_OPT: Disable mmap optimization
+ * @FYPCF_DISABLE_RECYCLING: Disable recycling optimization
+ * @FYPCF_PARSE_COMMENTS: Enable parsing of comments (experimental)
+ * @FYPCF_DISABLE_DEPTH_LIMIT: Disable depth limit check, use with enlarged stack
+ * @FYPCF_DISABLE_ACCELERATORS: Disable use of access accelerators (saves memory)
+ * @FYPCF_DISABLE_BUFFERING: Disable use of buffering where possible
+ * @FYPCF_DEFAULT_VERSION_AUTO: Automatically use the most recent version the library supports
+ * @FYPCF_DEFAULT_VERSION_1_1: Default version is YAML 1.1
+ * @FYPCF_DEFAULT_VERSION_1_2: Default version is YAML 1.2
+ * @FYPCF_DEFAULT_VERSION_1_3: Default version is YAML 1.3 (experimental)
+ * @FYPCF_SLOPPY_FLOW_INDENTATION: Allow sloppy indentation in flow mode
+ * @FYPCF_PREFER_RECURSIVE: Prefer recursive algorighms instead of iterative whenever possible
+ * @FYPCF_JSON_AUTO: Automatically enable JSON mode (when extension is .json)
+ * @FYPCF_JSON_NONE: Never enable JSON input mode
+ * @FYPCF_JSON_FORCE: Force JSON mode always
+ * @FYPCF_YPATH_ALIASES: Enable YPATH aliases mode
+ * @FYPCF_ALLOW_DUPLICATE_KEYS: Allow duplicate keys on mappings
+ */
+enum fy_parse_cfg_flags {
+	FYPCF_QUIET			= FY_BIT(0),
+	FYPCF_COLLECT_DIAG		= FY_BIT(1),
+	FYPCF_RESOLVE_DOCUMENT		= FY_BIT(2),
+	FYPCF_DISABLE_MMAP_OPT		= FY_BIT(3),
+	FYPCF_DISABLE_RECYCLING		= FY_BIT(4),
+	FYPCF_PARSE_COMMENTS		= FY_BIT(5),
+	FYPCF_DISABLE_DEPTH_LIMIT	= FY_BIT(6),
+	FYPCF_DISABLE_ACCELERATORS	= FY_BIT(7),
+	FYPCF_DISABLE_BUFFERING		= FY_BIT(8),
+	FYPCF_DEFAULT_VERSION_AUTO	= FYPCF_DEFAULT_VERSION(0),
+	FYPCF_DEFAULT_VERSION_1_1	= FYPCF_DEFAULT_VERSION(1),
+	FYPCF_DEFAULT_VERSION_1_2	= FYPCF_DEFAULT_VERSION(2),
+	FYPCF_DEFAULT_VERSION_1_3	= FYPCF_DEFAULT_VERSION(3),
+	FYPCF_SLOPPY_FLOW_INDENTATION	= FY_BIT(14),
+	FYPCF_PREFER_RECURSIVE		= FY_BIT(15),
+	FYPCF_JSON_AUTO			= FYPCF_JSON(0),
+	FYPCF_JSON_NONE			= FYPCF_JSON(1),
+	FYPCF_JSON_FORCE		= FYPCF_JSON(2),
+	FYPCF_YPATH_ALIASES		= FY_BIT(18),
+	FYPCF_ALLOW_DUPLICATE_KEYS	= FY_BIT(19),
+};
+
+#define FYPCF_DEFAULT_PARSE	(0)
+
+#define FYPCF_DEFAULT_DOC	(FYPCF_QUIET | FYPCF_DEFAULT_PARSE)
+
+/**
+ * struct fy_parse_cfg - parser configuration structure.
+ *
+ * Argument to the fy_parser_create() method which
+ * perform parsing of YAML files.
+ *
+ * @search_path: Search path when accessing files, seperate with ':'
+ * @flags: Configuration flags
+ * @userdata: Opaque user data pointer
+ * @diag: Optional diagnostic interface to use
+ */
+struct fy_parse_cfg {
+	const char *search_path;
+	enum fy_parse_cfg_flags flags;
+	void *userdata;
+	struct fy_diag *diag;
+};
+
+/**
+ * enum fy_event_type - Event types
+ *
+ * @FYET_NONE: No event
+ * @FYET_STREAM_START: Stream start event
+ * @FYET_STREAM_END: Stream end event
+ * @FYET_DOCUMENT_START: Document start event
+ * @FYET_DOCUMENT_END: Document end event
+ * @FYET_MAPPING_START: YAML mapping start event
+ * @FYET_MAPPING_END: YAML mapping end event
+ * @FYET_SEQUENCE_START: YAML sequence start event
+ * @FYET_SEQUENCE_END: YAML sequence end event
+ * @FYET_SCALAR: YAML scalar event
+ * @FYET_ALIAS: YAML alias event
+ */
+enum fy_event_type {
+	FYET_NONE,
+	FYET_STREAM_START,
+	FYET_STREAM_END,
+	FYET_DOCUMENT_START,
+	FYET_DOCUMENT_END,
+	FYET_MAPPING_START,
+	FYET_MAPPING_END,
+	FYET_SEQUENCE_START,
+	FYET_SEQUENCE_END,
+	FYET_SCALAR,
+	FYET_ALIAS,
+};
+
+/**
+ * fy_event_type_get_text() - Return text of an event type
+ *
+ * @type: The event type to get text from
+ *
+ * Returns:
+ * A pointer to a text, i.e for FYET_SCALAR "=VAL".
+ */
+const char *
+fy_event_type_get_text(enum fy_event_type type)
+	FY_EXPORT;
+
+/**
+ * enum fy_collection_style - Collection styles supported by the parser/emitter
+ *
+ * @FYCS_ANY: Any collection style, not generated by the parser.
+ * 	      Lets the emitter to choose
+ * @FYCS_BLOCK: Block style (not {}[])
+ * @FYCS_FLOW: Flow style {}[]
+ * @FYCS_MAX: marks end of scalar styles
+ */
+enum fy_collection_style {
+	FYCS_ANY = -1,
+	FYCS_BLOCK,
+	FYCS_FLOW,
+	FYCS_MAX,
+};
+
+/**
+ * enum fy_scalar_style - Scalar styles supported by the parser/emitter
+ *
+ * @FYSS_ANY: Any scalar style, not generated by the parser.
+ * 	      Lets the emitter to choose
+ * @FYSS_PLAIN: Plain scalar style
+ * @FYSS_SINGLE_QUOTED: Single quoted style
+ * @FYSS_DOUBLE_QUOTED: Double quoted style
+ * @FYSS_LITERAL: YAML literal block style
+ * @FYSS_FOLDED: YAML folded block style
+ * @FYSS_MAX: marks end of scalar styles
+ */
+enum fy_scalar_style {
+	FYSS_ANY = -1,
+	FYSS_PLAIN,
+	FYSS_SINGLE_QUOTED,
+	FYSS_DOUBLE_QUOTED,
+	FYSS_LITERAL,
+	FYSS_FOLDED,
+	FYSS_MAX,
+};
+
+/**
+ * struct fy_event_stream_start_data - stream start event data
+ *
+ * @stream_start: The token that started the stream
+ */
+struct fy_event_stream_start_data {
+	struct fy_token *stream_start;
+};
+
+/**
+ * struct fy_event_stream_end_data - stream end event data
+ *
+ * @stream_end: The token that ended the stream
+ */
+struct fy_event_stream_end_data {
+	struct fy_token *stream_end;
+};
+
+/**
+ * struct fy_event_document_start_data - doument start event data
+ *
+ * @document_start: The token that started the document, or NULL if
+ * 		    the document was implicitly started.
+ * @document_state: The state of the document (i.e. information about
+ * 		    the YAML version and configured tags)
+ * @implicit: True if the document started implicitly
+ */
+struct fy_event_document_start_data {
+	struct fy_token *document_start;
+	struct fy_document_state *document_state;
+	bool implicit;
+};
+
+/**
+ * struct fy_event_document_end_data - doument end event data
+ *
+ * @document_end: The token that ended the document, or NULL if the
+ * 	          document was implicitly ended
+ * @implicit: True if the document ended implicitly
+ */
+struct fy_event_document_end_data {
+	struct fy_token *document_end;
+	bool implicit;
+};
+
+/**
+ * struct fy_event_alias_data - alias event data
+ *
+ * @anchor: The anchor token definining this alias.
+ */
+struct fy_event_alias_data {
+	struct fy_token *anchor;
+};
+
+/**
+ * struct fy_event_scalar_data - scalar event data
+ *
+ * @anchor: anchor token or NULL
+ * @tag: tag token or NULL
+ * @value: scalar value token (cannot be NULL)
+ * @tag_implicit: true if the tag was implicit or explicit
+ */
+struct fy_event_scalar_data {
+	struct fy_token *anchor;
+	struct fy_token *tag;
+	struct fy_token *value;
+	bool tag_implicit;
+};
+
+/**
+ * struct fy_event_sequence_start_data - sequence start event data
+ *
+ * @anchor: anchor token or NULL
+ * @tag: tag token or NULL
+ * @sequence_start: sequence start value token or NULL if the sequence
+ * 		    was started implicitly
+ */
+struct fy_event_sequence_start_data {
+	struct fy_token *anchor;
+	struct fy_token *tag;
+	struct fy_token *sequence_start;
+};
+
+/**
+ * struct fy_event_sequence_end_data - sequence end event data
+ *
+ * @sequence_end: The token that ended the sequence, or NULL if
+ * 		  the sequence was implicitly ended
+ */
+struct fy_event_sequence_end_data {
+	struct fy_token *sequence_end;
+};
+
+/**
+ * struct fy_event_mapping_start_data - mapping start event data
+ *
+ * @anchor: anchor token or NULL
+ * @tag: tag token or NULL
+ * @mapping_start: mapping start value token or NULL if the mapping
+ * 		    was started implicitly
+ */
+struct fy_event_mapping_start_data {
+	struct fy_token *anchor;
+	struct fy_token *tag;
+	struct fy_token *mapping_start;
+};
+
+/**
+ * struct fy_event_mapping_end_data - mapping end event data
+ *
+ * @mapping_end: The token that ended the mapping, or NULL if
+ * 		  the mapping was implicitly ended
+ */
+struct fy_event_mapping_end_data {
+	struct fy_token *mapping_end;
+};
+
+/**
+ * struct fy_event - Event generated by the parser
+ *
+ * This structure is generated by the parser by each call
+ * to fy_parser_parse() and release by fy_parser_event_free()
+ *
+ * @type: Type of the event, see &enum fy_event_type
+ *
+ * @stream_start: Stream start information, it is valid when
+ *                &fy_event->type is &enum FYET_STREAM_START
+ * @stream_end: Stream end information, it is valid when
+ *                &fy_event->type is &enum FYET_STREAM_END
+ * @document_start: Document start information, it is valid when
+ *                  &fy_event->type is &enum FYET_DOCUMENT_START
+ * @document_end: Document end information, it is valid when
+ *                &fy_event->type is &enum FYET_DOCUMENT_END
+ * @alias: Alias information, it is valid when
+ *         &fy_event->type is &enum FYET_ALIAS
+ * @scalar: Scalar information, it is valid when
+ *          &fy_event->type is &enum FYET_SCALAR
+ * @sequence_start: Sequence start information, it is valid when
+ *                  &fy_event->type is &enum FYET_SEQUENCE_START
+ * @sequence_end: Sequence end information, it is valid when
+ *                &fy_event->type is &enum FYET_SEQUENCE_END
+ * @mapping_start: Mapping start information, it is valid when
+ *                 &fy_event->type is &enum FYET_MAPPING_START
+ * @mapping_end: Mapping end information, it is valid when
+ *               &fy_event->type is &enum FYET_MAPPING_END
+ */
+struct fy_event {
+	enum fy_event_type type;
+	/* anonymous union */
+	union {
+		struct fy_event_stream_start_data stream_start;
+		struct fy_event_stream_end_data stream_end;
+		struct fy_event_document_start_data document_start;
+		struct fy_event_document_end_data document_end;
+		struct fy_event_alias_data alias;
+		struct fy_event_scalar_data scalar;
+		struct fy_event_sequence_start_data sequence_start;
+		struct fy_event_sequence_end_data sequence_end;
+		struct fy_event_mapping_start_data mapping_start;
+		struct fy_event_mapping_end_data mapping_end;
+	};
+};
+
+/**
+ * enum fy_event_part - Select part of the event
+ *
+ * @FYEP_VALUE: The value of the event (the main token)
+ * @FYEP_TAG: The tag of the event
+ * @FYEP_ANCHOR: The anchor of the event
+ */
+enum fy_event_part {
+	FYEP_VALUE,
+	FYEP_TAG,
+	FYEP_ANCHOR,
+};
+
+/**
+ * fy_event_get_type() - Get the event's type
+ *
+ * Return the type of the event
+ *
+ * @fye: The event
+ *
+ * Returns:
+ * The event type, or FYET_NONE when the event is invalid
+ */
+static inline enum fy_event_type
+fy_event_get_type(const struct fy_event *fye)
+{
+	return fye ? fye->type : FYET_NONE;
+}
+
+/**
+ * fy_event_data() - Get a pointer to the event data
+ *
+ * Some languages *cough*golang*cough* really don't like
+ * unions, and anonymous unions in particular.
+ *
+ * You should not have to use this in other language bindings.
+ *
+ * @fye: The event
+ *
+ * Returns:
+ * A pointer to the event data structure, or NULL if the
+ * event is invalid
+ */
+static inline void *
+fy_event_data(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	/* note that the unions should all be laid out
+	 * at the same address, but play it straight and
+	 * hope the optimizer will figure this is all
+	 * the same...
+	 */
+	switch (fye->type) {
+	case FYET_STREAM_START:
+		return &fye->stream_start;
+	case FYET_STREAM_END:
+		return &fye->stream_end;
+	case FYET_DOCUMENT_START:
+		return &fye->document_start;
+	case FYET_DOCUMENT_END:
+		return &fye->document_end;
+	case FYET_ALIAS:
+		return &fye->alias;
+	case FYET_SCALAR:
+		return &fye->scalar;
+	case FYET_SEQUENCE_START:
+		return &fye->sequence_start;
+	case FYET_SEQUENCE_END:
+		return &fye->sequence_end;
+	case FYET_MAPPING_START:
+		return &fye->mapping_start;
+	case FYET_MAPPING_END:
+		return &fye->mapping_end;
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+/**
+ * fy_library_version() - Return the library version string
+ *
+ * Returns:
+ * A pointer to a version string of the form
+ * <MAJOR>.<MINOR>[[.<PATCH>][-EXTRA-VERSION-INFO]]
+ */
+const char *
+fy_library_version(void)
+	FY_EXPORT;
+
+/**
+ * fy_string_to_error_type() - Return the error type from a string
+ *
+ * @str: The string to convert to an error type
+ *
+ * Returns:
+ * The error type if greater or equal to zero, FYET_MAX otherwise
+ */
+enum fy_error_type fy_string_to_error_type(const char *str)
+	FY_EXPORT;
+
+/**
+ * fy_error_type_to_string() - Convert an error type to string
+ *
+ * @type: The error type to convert
+ *
+ * Returns:
+ * The string value of the error type or the empty string "" on error
+ */
+const char *fy_error_type_to_string(enum fy_error_type type)
+	FY_EXPORT;
+
+/**
+ * fy_string_to_error_module() - Return the error module from a string
+ *
+ * @str: The string to convert to an error module
+ *
+ * Returns:
+ * The error type if greater or equal to zero, FYEM_MAX otherwise
+ */
+enum fy_error_module fy_string_to_error_module(const char *str)
+	FY_EXPORT;
+
+/**
+ * fy_error_module_to_string() - Convert an error module to string
+ *
+ * @module: The error module to convert
+ *
+ * Returns:
+ * The string value of the error module or the empty string "" on error
+ */
+const char *fy_error_module_to_string(enum fy_error_module module)
+	FY_EXPORT;
+
+/**
+ * fy_event_is_implicit() - Check whether the given event is an implicit one
+ *
+ * @fye: A pointer to a &struct fy_event to check.
+ *
+ * Returns:
+ * true if the event is an implicit one.
+ */
+bool
+fy_event_is_implicit(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_document_event_is_implicit() - Check whether the given document event is an implicit one
+ *
+ * @fye: A pointer to a &struct fy_event to check.
+ *       It must be either a document start or document end event.
+ *
+ * Returns:
+ * true if the event is an implicit one.
+ */
+bool
+fy_document_event_is_implicit(const struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_parser_create() - Create a parser.
+ *
+ * Creates a parser with its configuration @cfg
+ * The parser may be destroyed by a corresponding call to
+ * fy_parser_destroy().
+ *
+ * @cfg: The configuration for the parser
+ *
+ * Returns:
+ * A pointer to the parser or NULL in case of an error.
+ */
+struct fy_parser *
+fy_parser_create(const struct fy_parse_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_parser_destroy() - Destroy the given parser
+ *
+ * Destroy a parser created earlier via fy_parser_create().
+ *
+ * @fyp: The parser to destroy
+ */
+void
+fy_parser_destroy(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_get_cfg() - Get the configuration of a parser
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The configuration of the parser
+ */
+const struct fy_parse_cfg *
+fy_parser_get_cfg(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_get_diag() - Get the diagnostic object of a parser
+ *
+ * Return a pointer to the diagnostic object of a parser object.
+ * Note that the returned diag object has a reference taken so
+ * you should fy_diag_unref() it when you're done with it.
+ *
+ * @fyp: The parser to get the diagnostic object
+ *
+ * Returns:
+ * A pointer to a ref'ed diagnostic object or NULL in case of an
+ * error.
+ */
+struct fy_diag *
+fy_parser_get_diag(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_diag() - Set the diagnostic object of a parser
+ *
+ * Replace the parser's current diagnostic object with the one
+ * given as an argument. The previous diagnostic object will be
+ * unref'ed (and freed if its reference gets to 0).
+ * Also note that the diag argument shall take a reference too.
+ *
+ * @fyp: The parser to replace the diagnostic object
+ * @diag: The parser's new diagnostic object, NULL for default
+ *
+ * Returns:
+ * 0 if everything OK, -1 otherwise
+ */
+int
+fy_parser_set_diag(struct fy_parser *fyp, struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_parser_reset() - Reset a parser completely
+ *
+ * Completely reset a parser, including after an error
+ * that caused a parser error to be emitted.
+ *
+ * @fyp: The parser to reset
+ *
+ * Returns:
+ * 0 if the reset was successful, -1 otherwise
+ */
+int
+fy_parser_reset(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_input_file() - Set the parser to process the given file
+ *
+ * Point the parser to the given @file for processing. The file
+ * is located by honoring the search path of the configuration set
+ * by the earlier call to fy_parser_create().
+ * While the parser is in use the file will must be available.
+ *
+ * @fyp: The parser
+ * @file: The file to parse.
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int
+fy_parser_set_input_file(struct fy_parser *fyp, const char *file)
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_string() - Set the parser to process the given string.
+ *
+ * Point the parser to the given (NULL terminated) string. Note that
+ * while the parser is active the string must not go out of scope.
+ *
+ * @fyp: The parser
+ * @str: The YAML string to parse.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int
+fy_parser_set_string(struct fy_parser *fyp, const char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_malloc_string() - Set the parser to process the given malloced string.
+ *
+ * Point the parser to the given (possible NULL terminated) string. Note that
+ * the string is expected to be allocated via malloc(3) and ownership is transferred
+ * to the created input. When the input is free'ed the memory will be automatically
+ * freed.
+ *
+ * In case of an error the string is not freed.
+ *
+ * @fyp: The parser
+ * @str: The YAML string to parse (allocated).
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int
+fy_parser_set_malloc_string(struct fy_parser *fyp, char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_input_fp() - Set the parser to process the given file
+ *
+ * Point the parser to use @fp for processing.
+ *
+ * @fyp: The parser
+ * @name: The label of the stream
+ * @fp: The FILE pointer, it must be open in read mode.
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int
+fy_parser_set_input_fp(struct fy_parser *fyp, const char *name, FILE *fp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_input_callback() - Set the parser to process via a callback
+ *
+ * Point the parser to use a callback for input.
+ *
+ * @fyp: The parser
+ * @user: The user data pointer
+ * @callback: The callback method to request data with
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int fy_parser_set_input_callback(struct fy_parser *fyp, void *user,
+		ssize_t (*callback)(void *user, void *buf, size_t count))
+	FY_EXPORT;
+
+/**
+ * fy_parser_set_input_fd() - Set the parser to process the given file descriptor
+ *
+ * Point the parser to use @fd for processing.
+ *
+ * @fyp: The parser
+ * @fd: The file descriptor to use
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int
+fy_parser_set_input_fd(struct fy_parser *fyp, int fd)
+	FY_EXPORT;
+
+/**
+ * fy_parser_parse() - Parse and return the next event.
+ *
+ * Each call to fy_parser_parse() returns the next event from
+ * the configured input of the parser, or NULL at the end of
+ * the stream. The returned event must be released via
+ * a matching call to fy_parser_event_free().
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The next event in the stream or NULL.
+ */
+struct fy_event *
+fy_parser_parse(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_parse_peek() - Parse and peek at the next event.
+ *
+ * It will return the next event that a call to fy_parser_parse
+ * would generate, but as read-only.
+ *
+ * You must not free this event.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * A peek at the next event in the stream or NULL.
+ */
+const struct fy_event *
+fy_parser_parse_peek(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_skip() - Skip the current scalar/collection
+ *
+ * Skips the current scalar or collection.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_parser_skip(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_count_sequence_items() - Count the sequence items
+ *
+ * Counts the number of sequence items. Parser must already
+ * be in a sequence state.
+ * Note that this uses backtracking so it might not be very
+ * efficient.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The number of sequence items on success, -1 on error
+ * Note if the number of items exceeds INT_MAX, INT_MAX will
+ * be returned.
+ */
+int
+fy_parser_count_sequence_items(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_count_mapping_items() - Count the mapping items
+ *
+ * Counts the number of mapping items. Parser must already
+ * be in a mapping state.
+ * Note that this uses backtracking so it might not be very
+ * efficient.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The number of mapping items on success, -1 on error
+ * Note if the number of items exceeds INT_MAX, INT_MAX will
+ * be returned.
+ */
+int
+fy_parser_count_mapping_items(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_event_free() - Free an event
+ *
+ * Free a previously returned event from fy_parser_parse().
+ *
+ * @fyp: The parser
+ * @fye: The event to free (may be NULL)
+ */
+void
+fy_parser_event_free(struct fy_parser *fyp, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_parser_get_stream_error() - Check the parser for stream errors
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * true in case of a stream error, false otherwise.
+ */
+bool
+fy_parser_get_stream_error(struct fy_parser *fyp)
+	FY_EXPORT;
+
+enum fy_parser_mode {
+	fypm_invalid = -1,
+	fypm_none,	/* scanning for mode, not committed yet */
+	fypm_yaml_1_1,
+	fypm_yaml_1_2,
+	fypm_yaml_1_3,	/* experimental */
+	fypm_json,
+};
+
+static inline bool
+fy_parser_mode_is_yaml(enum fy_parser_mode mode)
+{
+	return mode >= fypm_yaml_1_1 && mode <= fypm_yaml_1_3;
+}
+
+/**
+ * fy_parser_get_mode() - Get the parser mode
+ *
+ * Retrieve the current mode of the parser, which indicates the YAML version
+ * or format being parsed (YAML 1.1, 1.2, 1.3, or JSON).
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The parser mode
+ */
+enum fy_parser_mode
+fy_parser_get_mode(struct fy_parser *fyp)
+	FY_EXPORT;
+
+static inline bool
+fy_parser_is_in_yaml_mode(struct fy_parser *fyp)
+{
+	return fy_parser_mode_is_yaml(fy_parser_get_mode(fyp));
+}
+
+static inline bool
+fy_parser_is_in_json_mode(struct fy_parser *fyp)
+{
+	return fy_parser_get_mode(fyp) == fypm_json;
+}
+
+/**
+ * fy_parser_vlog() - Log using the parsers diagnostics printf style (va_arg)
+ *
+ * Output a log on the parser diagnostic output
+ *
+ * @fyp: The parser
+ * @type: The error type
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_parser_vlog(struct fy_parser *fyp, enum fy_error_type type, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_parser_log() - Log using the parsers diagnostics printf style
+ *
+ * Output a report on the parser's diagnostics
+ *
+ * @fyp: The parser
+ * @type: The error type
+ * @fmt: The printf format string
+ * @...: The extra arguments
+ */
+void
+fy_parser_log(struct fy_parser *fyp, enum fy_error_type type, const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4)
+	FY_EXPORT;
+
+#ifndef NDEBUG
+
+#define fy_parser_debug(_fyp, _fmt, ...) \
+	fy_parser_log((_fyp), FYET_DEBUG, (_fmt) , ## __VA_ARGS__)
+#else
+
+#define fy_parser_debug(_fyp, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fy_parser_info(_fyp, _fmt, ...) \
+	fy_parser_log((_fyp), FYET_INFO, (_fmt) , ## __VA_ARGS__)
+#define fy_parser_notice(_fyp, _fmt, ...) \
+	fy_parser_log((_fyp), FYET_NOTICE, (_fmt) , ## __VA_ARGS__)
+#define fy_parser_warning(_fyp, _fmt, ...) \
+	fy_parser_log((_fyp), FYET_WARNING, (_fmt) , ## __VA_ARGS__)
+#define fy_parser_error(_fyp, _fmt, ...) \
+	fy_parser_log((_fyp), FYET_ERROR, (_fmt) , ## __VA_ARGS__)
+
+/**
+ * fy_parser_vreport() - Report using the parsers diagnostics printf style and mark token (va_arg)
+ *
+ * Output a report on the parser and indicate the token's position
+ *
+ * @fyp: The parser
+ * @type: The error type
+ * @fyt: The token
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_parser_vreport(struct fy_parser *fyp, enum fy_error_type type, struct fy_token *fyt,
+		  const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_parser_report() - Report using the parsers diagnostics printf style and mark token
+ *
+ * Output a report on the parser and indicate the token's position
+ *
+ * @fyp: The parser
+ * @type: The error type
+ * @fyt: The token
+ * @fmt: The printf format string
+ * @...: The extra arguments
+ */
+void
+fy_parser_report(struct fy_parser *fyp, enum fy_error_type type, struct fy_token *fyt,
+		 const char *fmt, ...)
+	FY_FORMAT(printf, 4, 5)
+	FY_EXPORT;
+
+#ifndef NDEBUG
+
+#define fy_parser_report_debug(_fyp, _fyt, _fmt, ...) \
+	fy_parser_report((_fyp), FYET_DEBUG, (_fyt), (_fmt) , ## __VA_ARGS__)
+#else
+
+#define fy_parser_report_debug(_fyp, _fyt, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fy_parser_report_info(_fyp, _fyt, _fmt, ...) \
+	fy_parser_report((_fyp), FYET_INFO, (_fyt), (_fmt) , ## __VA_ARGS__)
+#define fy_parser_report_notice(_fyp, _fyt, _fmt, ...) \
+	fy_parser_report((_fyp), FYET_NOTICE, (_fyt), (_fmt) , ## __VA_ARGS__)
+#define fy_parser_report_warning(_fyp, _fyt, _fmt, ...) \
+	fy_parser_report((_fyp), FYET_WARNING, (_fyt), (_fmt) , ## __VA_ARGS__)
+#define fy_parser_report_error(_fyp, _fyt, _fmt, ...) \
+	fy_parser_report((_fyp), FYET_ERROR, (_fyt), (_fmt) , ## __VA_ARGS__)
+
+/**
+ * fy_token_scalar_style() - Get the style of a scalar token
+ *
+ * @fyt: The scalar token to get it's style. Note that a NULL
+ *       token is a &enum FYSS_PLAIN.
+ *
+ * Returns:
+ * The scalar style of the token, or FYSS_PLAIN on each other case
+ */
+enum fy_scalar_style
+fy_token_scalar_style(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_collection_style() - Get the style of a collection token
+ *
+ * @fyt: The collection token to get it's style. Note that a NULL
+ *       token is a &enum FYCS_ANY.
+ *
+ * Returns:
+ * The collection style of the token, or FYCS_ANY
+ */
+enum fy_collection_style
+fy_token_collection_style(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_scalar_is_null() - Test whether the scalar is null (content)
+ *
+ * @fyt: The scalar token to check for NULLity.
+ *
+ * Note that this is different than null of the YAML type system.
+ * It is null as in null content. It is also different than an
+ * empty scalar.
+ *
+ * Returns:
+ * true if is a null scalar, false otherwise
+ */
+bool
+fy_token_scalar_is_null(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_get_text() - Get text (and length of it) of a token
+ *
+ * This method will return a pointer to the text of a token
+ * along with the length of it. Note that this text is *not*
+ * NULL terminated. If you need a NULL terminated pointer
+ * use fy_token_get_text0().
+ *
+ * In case that the token is 'simple' enough (i.e. a plain scalar)
+ * or something similar the returned pointer is a direct pointer
+ * to the space of the input that contains the token.
+ *
+ * That means that the pointer is *not* guaranteed to be valid
+ * after the parser is destroyed.
+ *
+ * If the token is 'complex' enough, then space shall be allocated,
+ * filled and returned.
+ *
+ * Note that the concept of 'simple' and 'complex' is vague, and
+ * that's on purpose.
+ *
+ * @fyt: The token out of which the text pointer will be returned.
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the text representation of the token, while
+ * @lenp will be assigned the character length of said representation.
+ * NULL in case of an error.
+ */
+const char *
+fy_token_get_text(struct fy_token *fyt, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_token_get_text0() - Get zero terminated text of a token
+ *
+ * This method will return a pointer to the text of a token
+ * which is zero terminated. It will allocate memory to hold
+ * it in the token structure so try to use fy_token_get_text()
+ * instead if possible.
+ *
+ * @fyt: The token out of which the text pointer will be returned.
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of the token.
+ * NULL in case of an error.
+ */
+const char *
+fy_token_get_text0(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_get_text_length() - Get length of the text of a token
+ *
+ * This method will return the length of the text representation
+ * of a token.
+ *
+ * @fyt: The token
+ *
+ * Returns:
+ * The size of the text representation of a token, -1 in case of an error.
+ * Note that the NULL token will return a length of zero.
+ */
+size_t
+fy_token_get_text_length(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * enum fy_comment_placement - Comment placement relative to token
+ *
+ * @fycp_top: Comment on top of token
+ * @fycp_right: Comment to the right of the token
+ * @fycp_bottom: Comment to the bottom of the token
+ */
+enum fy_comment_placement {
+	fycp_top,
+	fycp_right,
+	fycp_bottom
+};
+#define fycp_max (fycp_bottom + 1)
+
+/**
+ * fy_token_get_comment() - Get zero terminated comment of a token
+ *
+ * Get the comment that is attached at a token having the given
+ * placement.
+ *
+ * @fyt: The token out of which the comment text will be returned.
+ * @which: The comment placement
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of the token comment.
+ * NULL in case of an error or if the token has no comment.
+ */
+const char *
+fy_token_get_comment(struct fy_token *fyt, enum fy_comment_placement which)
+	FY_EXPORT;
+
+/**
+ * fy_token_get_comments() - Get all comments of a token
+ *
+ * Get all the comments that are attached on a token
+ *
+ * @fyt: The token
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of all the comments.
+ * The comments of all the placements are concatenated and returned as one.
+ * NULL in case of an error or if the event has no comments.
+ */
+const char *
+fy_token_get_comments(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_set_comment() - Attach a comment to a token
+ *
+ * Attach the given comment on the token at the specified placement.
+ * If another comment is already present it will be overriden.
+ * If text is NULL the comment is removed.
+ *
+ * @fyt: The token out of which the comment text will be attached
+ * @which: The placement
+ * @text: The text of the comment
+ * @len: The length of the comment (FY_NT means the length of text)
+ *
+ * Returns:
+ * 0 on success, -1 on failure.
+ */
+int
+fy_token_set_comment(struct fy_token *fyt, enum fy_comment_placement which,
+		     const char *text, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_event_get_comments() - Get all comments of an event
+ *
+ * @fye: The event
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of all the comments.
+ * The comments of all the placements are concatenated and returned as one.
+ * NULL in case of an error or if the event has no comments.
+ * The pointer must be free'ed if it's not NULL via a call to free()
+ */
+const char *
+fy_event_get_comments(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_comment() - Get comment of a node
+ *
+ * @fyn:   The node
+ * @which: The placement of the comment
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of the comment.
+ * NULL in case of an error or if the event has no such comments.
+ */
+const char *
+fy_node_get_comment(struct fy_node *fyn, enum fy_comment_placement which)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_comments() - Get all comments of a node
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of all the comments.
+ * The comments of all the placements are concatenated and returned as one.
+ * NULL in case of an error or if the event has no comments.
+ */
+const char *
+fy_node_get_comments(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * struct fy_iter_chunk - An iteration chunk
+ *
+ * @str: Pointer to the start of the chunk
+ * @len: The size of the chunk
+ *
+ * The iterator produces a stream of chunks which
+ * cover the whole object.
+ */
+struct fy_iter_chunk {
+	const char *str;
+	size_t len;
+};
+
+/**
+ * fy_token_iter_create() - Create a token iterator
+ *
+ * Create an iterator for operating on the given token, or
+ * a generic iterator for use with fy_token_iter_start().
+ * The iterator must be destroyed with a matching call to
+ * fy_token_iter_destroy().
+ *
+ * @fyt: The token to iterate, or NULL.
+ *
+ * Returns:
+ * A pointer to the newly created iterator, or NULL in case of
+ * an error.
+ */
+struct fy_token_iter *
+fy_token_iter_create(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_destroy() - Destroy the iterator
+ *
+ * Destroy the iterator created by fy_token_iter_create().
+ *
+ * @iter: The iterator to destroy.
+ */
+void
+fy_token_iter_destroy(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_start() - Start iterating over the contents of a token
+ *
+ * Prepare an iterator for operating on the given token.
+ * The iterator must be created via a previous call to fy_token_iter_create()
+ * for user level API access.
+ *
+ * @fyt: The token to iterate over
+ * @iter: The iterator to prepare.
+ */
+void
+fy_token_iter_start(struct fy_token *fyt, struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_finish() - Stop iterating over the contents of a token
+ *
+ * Stop the iteration operation.
+ *
+ * @iter: The iterator.
+ */
+void
+fy_token_iter_finish(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_peek_chunk() - Peek at the next iterator chunk
+ *
+ * Peek at the next iterator chunk
+ *
+ * @iter: The iterator.
+ *
+ * Returns:
+ * A pointer to the next iterator chunk, or NULL in case there's
+ * no other.
+ */
+const struct fy_iter_chunk *
+fy_token_iter_peek_chunk(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_chunk_next() - Get next iterator chunk
+ *
+ * Get the next iterator chunk in sequence,
+ *
+ * @iter: The iterator.
+ * @curr: The current chunk, or NULL for the first one.
+ * @errp: Pointer to an error return value or NULL
+ *
+ * Returns:
+ * A pointer to the next iterator chunk, or NULL in case there's
+ * no other. When the return value is NULL, the errp variable
+ * will be filled with 0 for normal end, or -1 in case of an error.
+ */
+const struct fy_iter_chunk *
+fy_token_iter_chunk_next(struct fy_token_iter *iter,
+			 const struct fy_iter_chunk *curr, int *errp)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_advance() - Advance the iterator position
+ *
+ * Advance the read pointer of the iterator.
+ * Note that mixing calls of this with any call of fy_token_iter_ungetc() /
+ * fy_token_iter_utf8_unget() in a single iterator sequence leads
+ * to undefined behavior.
+ *
+ * @iter: The iterator.
+ * @len: Number of bytes to advance the iterator position
+ */
+void
+fy_token_iter_advance(struct fy_token_iter *iter, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_read() - Read a block from an iterator
+ *
+ * Read a block from an iterator. Note than mixing calls of this
+ * and any of the ungetc methods leads to undefined behavior.
+ *
+ * @iter: The iterator.
+ * @buf: Pointer to a block of memory to receive the data. Must be at
+ *       least count bytes long.
+ * @count: Amount of bytes to read.
+ *
+ * Returns:
+ * The amount of data read, or -1 in case of an error.
+ */
+ssize_t
+fy_token_iter_read(struct fy_token_iter *iter, void *buf, size_t count)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_getc() - Get a single character from an iterator
+ *
+ * Reads a single character from an iterator. If the iterator is
+ * finished, it will return -1. If any calls to ungetc have pushed
+ * a character in the iterator it shall return that.
+ *
+ * @iter: The iterator.
+ *
+ * Returns:
+ * The next character in the iterator, or -1 in case of an error, or
+ * end of stream.
+ */
+int
+fy_token_iter_getc(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_ungetc() - Ungets a single character from an iterator
+ *
+ * Pushes back a single character to an iterator stream. It will be
+ * returned in subsequent calls of fy_token_iter_getc(). Currently
+ * only a single character is allowed to be pushed back, and any
+ * further calls to ungetc will return an error.
+ *
+ * @iter: The iterator.
+ * @c: The character to push back, or -1 to reset the pushback buffer.
+ *
+ * Returns:
+ * The pushed back character given as argument, or -1 in case of an error.
+ * If the pushed back character was -1, then 0 will be returned.
+ */
+int
+fy_token_iter_ungetc(struct fy_token_iter *iter, int c)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_peekc() - Peeks at single character from an iterator
+ *
+ * Peeks at the next character to get from an iterator. If the iterator is
+ * finished, it will return -1. If any calls to ungetc have pushed
+ * a character in the iterator it shall return that. The character is not
+ * removed from the iterator stream.
+ *
+ * @iter: The iterator.
+ *
+ * Returns:
+ * The next character in the iterator, or -1 in case of an error, or end
+ * of stream.
+ */
+int
+fy_token_iter_peekc(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_utf8_get() - Get a single utf8 character from an iterator
+ *
+ * Reads a single utf8 character from an iterator. If the iterator is
+ * finished, it will return -1. If any calls to ungetc have pushed
+ * a character in the iterator it shall return that.
+ *
+ * @iter: The iterator.
+ *
+ * Returns:
+ * The next utf8 character in the iterator, or -1 in case of an error, or end
+ * of stream.
+ */
+int
+fy_token_iter_utf8_get(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_utf8_unget() - Ungets a single utf8 character from an iterator
+ *
+ * Pushes back a single utf8 character to an iterator stream. It will be
+ * returned in subsequent calls of fy_token_iter_utf8_getc(). Currently
+ * only a single character is allowed to be pushed back, and any
+ * further calls to ungetc will return an error.
+ *
+ * @iter: The iterator.
+ * @c: The character to push back, or -1 to reset the pushback buffer.
+ *
+ * Returns:
+ * The pushed back utf8 character given as argument, or -1 in case of an error.
+ * If the pushed back utf8 character was -1, then 0 will be returned.
+ */
+int
+fy_token_iter_utf8_unget(struct fy_token_iter *iter, int c)
+	FY_EXPORT;
+
+/**
+ * fy_token_iter_utf8_peek() - Peeks at single utf8 character from an iterator
+ *
+ * Peeks at the next utf8 character to get from an iterator. If the iterator is
+ * finished, it will return -1. If any calls to ungetc have pushed
+ * a character in the iterator it shall return that. The character is not
+ * removed from the iterator stream.
+ *
+ * @iter: The iterator.
+ *
+ * Returns:
+ * The next utf8 character in the iterator, or -1 in case of an error, or end
+ * of stream.
+ */
+int
+fy_token_iter_utf8_peek(struct fy_token_iter *iter)
+	FY_EXPORT;
+
+/**
+ * fy_parse_load_document() - Parse the next document from the parser stream
+ *
+ * This method performs parsing on a parser stream and returns the next
+ * document. This means that for a compound document with multiple
+ * documents, each call will return the next document.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The next document from the parser stream.
+ */
+struct fy_document *
+fy_parse_load_document(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parse_document_destroy() - Destroy a document created by fy_parse_load_document()
+ *
+ * @fyp: The parser
+ * @fyd: The document to destroy
+ */
+void
+fy_parse_document_destroy(struct fy_parser *fyp, struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_resolve() - Resolve anchors and merge keys
+ *
+ * This method performs resolution of the given document,
+ * by replacing references to anchors with their contents
+ * and handling merge keys (<<)
+ *
+ * @fyd: The document to resolve
+ *
+ * Returns:
+ * zero on success, -1 on error
+ */
+int
+fy_document_resolve(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_has_directives() - Document directive check
+ *
+ * Checks whether the given document has any directives, i.e.
+ * %TAG or %VERSION.
+ *
+ * @fyd: The document to check for directives existence
+ *
+ * Returns:
+ * true if directives exist, false if not
+ */
+bool
+fy_document_has_directives(const struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_has_explicit_document_start() - Explicit document start check
+ *
+ * Checks whether the given document has an explicit document start marker,
+ * i.e. ---
+ *
+ * @fyd: The document to check for explicit start marker
+ *
+ * Returns:
+ * true if document has an explicit document start marker, false if not
+ */
+bool
+fy_document_has_explicit_document_start(const struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_has_explicit_document_end() - Explicit document end check
+ *
+ * Checks whether the given document has an explicit document end marker,
+ * i.e. ...
+ *
+ * @fyd: The document to check for explicit end marker
+ *
+ * Returns:
+ * true if document has an explicit document end marker, false if not
+ */
+bool
+fy_document_has_explicit_document_end(const struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_node_document() - Retreive the document the node belong to
+ *
+ * Returns the document of the node; note that while the node may not
+ * be reachable via a path expression, it may still be member of a
+ * document.
+ *
+ * @fyn: The node to retreive it's document
+ *
+ * Returns:
+ * The document of the node, or NULL in case of an error, or
+ * when the node has no document attached.
+ */
+struct fy_document *
+fy_node_document(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * enum fy_emitter_write_type - Type of the emitted output
+ *
+ * Describes the kind of emitted output, which makes it
+ * possible to colorize the output, or do some other content related
+ * filtering.
+ *
+ * @fyewt_document_indicator: Output chunk is a document indicator
+ * @fyewt_tag_directive: Output chunk is a tag directive
+ * @fyewt_version_directive: Output chunk is a version directive
+ * @fyewt_indent: Output chunk is a document indicator
+ * @fyewt_indicator: Output chunk is an indicator
+ * @fyewt_whitespace: Output chunk is white space
+ * @fyewt_plain_scalar: Output chunk is a plain scalar
+ * @fyewt_single_quoted_scalar: Output chunk is a single quoted scalar
+ * @fyewt_double_quoted_scalar: Output chunk is a double quoted scalar
+ * @fyewt_literal_scalar: Output chunk is a literal block scalar
+ * @fyewt_folded_scalar: Output chunk is a folded block scalar
+ * @fyewt_anchor: Output chunk is an anchor
+ * @fyewt_tag: Output chunk is a tag
+ * @fyewt_linebreak: Output chunk is a linebreak
+ * @fyewt_alias: Output chunk is an alias
+ * @fyewt_terminating_zero: Output chunk is a terminating zero
+ * @fyewt_plain_scalar_key: Output chunk is an plain scalar key
+ * @fyewt_single_quoted_scalar_key: Output chunk is an single quoted scalar key
+ * @fyewt_double_quoted_scalar_key: Output chunk is an double quoted scalar key
+ * @fyewt_comment: Output chunk is a comment
+ * @fyewt_indicator_question_mark: ? indicator
+ * @fyewt_indicator_colon: : indicator
+ * @fyewt_indicator_dash: - indicator
+ * @fyewt_indicator_left_bracket: [ indicator
+ * @fyewt_indicator_right_bracket: ] indicator
+ * @fyewt_indicator_left_brace: { indicator
+ * @fyewt_indicator_right_brace: } indicator
+ * @fyewt_indicator_comma: , indicator
+ * @fyewt_indicator_bar: | indicator
+ * @fyewt_indicator_greater: > indicator
+ * @fyewt_indicator_single_quote_start: ' indicator
+ * @fyewt_indicator_single_quote_end: ' indicator
+ * @fyewt_indicator_double_quote_start: " indicator
+ * @fyewt_indicator_double_quote_end: " indicator
+ * @fyewt_indicator_ambersand: & indicator
+ * @fyewt_indicator_star: * indicator
+ * @fyewt_indicator_chomp: chomp indicator (- or +)
+ * @fyewt_indicator_explicit_indent: explicit indent indicator (0-9)
+ */
+enum fy_emitter_write_type {
+	fyewt_document_indicator,
+	fyewt_tag_directive,
+	fyewt_version_directive,
+	fyewt_indent,
+	fyewt_indicator,
+	fyewt_whitespace,
+	fyewt_plain_scalar,
+	fyewt_single_quoted_scalar,
+	fyewt_double_quoted_scalar,
+	fyewt_literal_scalar,
+	fyewt_folded_scalar,
+	fyewt_anchor,
+	fyewt_tag,
+	fyewt_linebreak,
+	fyewt_alias,
+	fyewt_terminating_zero,
+	fyewt_plain_scalar_key,
+	fyewt_single_quoted_scalar_key,
+	fyewt_double_quoted_scalar_key,
+	fyewt_comment,
+	/* extended indicators */
+	fyewt_indicator_question_mark,
+	fyewt_indicator_colon,
+	fyewt_indicator_dash,
+	fyewt_indicator_left_bracket,
+	fyewt_indicator_right_bracket,
+	fyewt_indicator_left_brace,
+	fyewt_indicator_right_brace,
+	fyewt_indicator_comma,
+	fyewt_indicator_bar,
+	fyewt_indicator_greater,
+	fyewt_indicator_single_quote_start,
+	fyewt_indicator_single_quote_end,
+	fyewt_indicator_double_quote_start,
+	fyewt_indicator_double_quote_end,
+	fyewt_indicator_ambersand,
+	fyewt_indicator_star,
+	fyewt_indicator_chomp,
+	fyewt_indicator_explicit_indent,
+};
+#define FYEWT_EXTENDED_INDICATORS_FIRST fyewt_indicator_question_mark
+#define FYEWT_EXTENDED_INDICATORS_LAST 	fyewt_indicator_explicit_indent
+
+#define FYEWT_EXTENDED_START 	fyewt_indicator_question_mark
+#define FYEWT_COUNT 		(fyewt_indicator_explicit_indent + 1)
+
+#define FYECF_INDENT_SHIFT	8
+#define FYECF_INDENT_MASK	0xf
+#define FYECF_INDENT(x)	(((x) & FYECF_INDENT_MASK) << FYECF_INDENT_SHIFT)
+
+#define FYECF_WIDTH_SHIFT	12
+#define FYECF_WIDTH_MASK	0xff
+#define FYECF_WIDTH(x)		(((x) & FYECF_WIDTH_MASK) << FYECF_WIDTH_SHIFT)
+
+#define FYECF_MODE_SHIFT	20
+#define FYECF_MODE_MASK		0xf
+#define FYECF_MODE(x)		(((x) & FYECF_MODE_MASK) << FYECF_MODE_SHIFT)
+
+#define FYECF_DOC_START_MARK_SHIFT	24
+#define FYECF_DOC_START_MARK_MASK	0x3
+#define FYECF_DOC_START_MARK(x)		(((x) & FYECF_DOC_START_MARK_MASK) << FYECF_DOC_START_MARK_SHIFT)
+
+#define FYECF_DOC_END_MARK_SHIFT	26
+#define FYECF_DOC_END_MARK_MASK		0x3
+#define FYECF_DOC_END_MARK(x)		(((x) & FYECF_DOC_END_MARK_MASK) << FYECF_DOC_END_MARK_SHIFT)
+
+#define FYECF_VERSION_DIR_SHIFT		28
+#define FYECF_VERSION_DIR_MASK		0x3
+#define FYECF_VERSION_DIR(x)		(((x) & FYECF_VERSION_DIR_MASK) << FYECF_VERSION_DIR_SHIFT)
+
+#define FYECF_TAG_DIR_SHIFT		30
+#define FYECF_TAG_DIR_MASK		0x3
+#define FYECF_TAG_DIR(x)		(((unsigned int)(x) & FYECF_TAG_DIR_MASK) << FYECF_TAG_DIR_SHIFT)
+
+/**
+ * enum fy_emitter_cfg_flags - Emitter configuration flags
+ *
+ * These flags control the operation of the emitter
+ *
+ * @FYECF_SORT_KEYS: Sort key when emitting
+ * @FYECF_OUTPUT_COMMENTS: Output comments (experimental)
+ * @FYECF_STRIP_LABELS: Strip labels when emitting
+ * @FYECF_STRIP_TAGS: Strip tags when emitting
+ * @FYECF_STRIP_DOC: Strip document tags and markers when emitting
+ * @FYECF_NO_ENDING_NEWLINE: Do not output ending new line (useful for single line mode)
+ * @FYECF_STRIP_EMPTY_KV: Remove all keys with empty values from the output (not available in streaming mode)
+ * @FYECF_EXTENDED_CFG: Extend configuration, this config structure is embedded in a fy_emitter_xcfg.
+ * @FYECF_INDENT_DEFAULT: Default emit output indent
+ * @FYECF_INDENT_1: Output indent is 1
+ * @FYECF_INDENT_2: Output indent is 2
+ * @FYECF_INDENT_3: Output indent is 3
+ * @FYECF_INDENT_4: Output indent is 4
+ * @FYECF_INDENT_5: Output indent is 5
+ * @FYECF_INDENT_6: Output indent is 6
+ * @FYECF_INDENT_7: Output indent is 7
+ * @FYECF_INDENT_8: Output indent is 8
+ * @FYECF_INDENT_9: Output indent is 9
+ * @FYECF_WIDTH_DEFAULT: Default emit output width
+ * @FYECF_WIDTH_80: Output width is 80
+ * @FYECF_WIDTH_132: Output width is 132
+ * @FYECF_WIDTH_INF: Output width is infinite
+ * @FYECF_MODE_ORIGINAL: Emit using the same flow mode as the original
+ * @FYECF_MODE_BLOCK: Emit using only the block mode
+ * @FYECF_MODE_FLOW: Emit using only the flow mode
+ * @FYECF_MODE_FLOW_ONELINE: Emit using only the flow mode (in one line)
+ * @FYECF_MODE_JSON: Emit using JSON mode (non type preserving)
+ * @FYECF_MODE_JSON_TP: Emit using JSON mode (type preserving)
+ * @FYECF_MODE_JSON_ONELINE: Emit using JSON mode (non type preserving, one line)
+ * @FYECF_MODE_DEJSON: Emit YAML trying to pretify JSON
+ * @FYECF_MODE_PRETTY: Emit YAML that tries to look good
+ * @FYECF_MODE_MANUAL: Emit YAML respecting all manual style hints (reformats if needed)
+ * @FYECF_MODE_FLOW_COMPACT: Emit using only the flow mode in as much as possible compact form
+ * @FYECF_MODE_JSON_COMPACT: Emit using JSON compact form
+ * @FYECF_DOC_START_MARK_AUTO: Automatically generate document start markers if required
+ * @FYECF_DOC_START_MARK_OFF: Do not generate document start markers
+ * @FYECF_DOC_START_MARK_ON: Always generate document start markers
+ * @FYECF_DOC_END_MARK_AUTO: Automatically generate document end markers if required
+ * @FYECF_DOC_END_MARK_OFF: Do not generate document end markers
+ * @FYECF_DOC_END_MARK_ON: Always generate document end markers
+ * @FYECF_VERSION_DIR_AUTO: Automatically generate version directive
+ * @FYECF_VERSION_DIR_OFF: Never generate version directive
+ * @FYECF_VERSION_DIR_ON: Always generate version directive
+ * @FYECF_TAG_DIR_AUTO: Automatically generate tag directives
+ * @FYECF_TAG_DIR_OFF: Never generate tag directives
+ * @FYECF_TAG_DIR_ON: Always generate tag directives
+ * @FYECF_DEFAULT: The default emitter configuration
+ */
+enum fy_emitter_cfg_flags {
+	FYECF_SORT_KEYS			= FY_BIT(0),
+	FYECF_OUTPUT_COMMENTS		= FY_BIT(1),
+	FYECF_STRIP_LABELS		= FY_BIT(2),
+	FYECF_STRIP_TAGS		= FY_BIT(3),
+	FYECF_STRIP_DOC			= FY_BIT(4),
+	FYECF_NO_ENDING_NEWLINE		= FY_BIT(5),
+	FYECF_STRIP_EMPTY_KV		= FY_BIT(6),
+	FYECF_EXTENDED_CFG		= FY_BIT(7),
+	FYECF_INDENT_DEFAULT		= FYECF_INDENT(0),
+	FYECF_INDENT_1			= FYECF_INDENT(1),
+	FYECF_INDENT_2			= FYECF_INDENT(2),
+	FYECF_INDENT_3			= FYECF_INDENT(3),
+	FYECF_INDENT_4			= FYECF_INDENT(4),
+	FYECF_INDENT_5			= FYECF_INDENT(5),
+	FYECF_INDENT_6			= FYECF_INDENT(6),
+	FYECF_INDENT_7			= FYECF_INDENT(7),
+	FYECF_INDENT_8			= FYECF_INDENT(8),
+	FYECF_INDENT_9			= FYECF_INDENT(9),
+	FYECF_WIDTH_DEFAULT		= FYECF_WIDTH(80),
+	FYECF_WIDTH_80			= FYECF_WIDTH(80),
+	FYECF_WIDTH_132			= FYECF_WIDTH(132),
+	FYECF_WIDTH_INF			= FYECF_WIDTH(255),
+	FYECF_MODE_ORIGINAL		= FYECF_MODE(0),
+	FYECF_MODE_BLOCK		= FYECF_MODE(1),
+	FYECF_MODE_FLOW			= FYECF_MODE(2),
+	FYECF_MODE_FLOW_ONELINE 	= FYECF_MODE(3),
+	FYECF_MODE_JSON			= FYECF_MODE(4),
+	FYECF_MODE_JSON_TP		= FYECF_MODE(5),
+	FYECF_MODE_JSON_ONELINE 	= FYECF_MODE(6),
+	FYECF_MODE_DEJSON 		= FYECF_MODE(7),
+	FYECF_MODE_PRETTY 		= FYECF_MODE(8),
+	FYECF_MODE_MANUAL 		= FYECF_MODE(9),
+	FYECF_MODE_FLOW_COMPACT		= FYECF_MODE(10),
+	FYECF_MODE_JSON_COMPACT		= FYECF_MODE(11),
+	FYECF_DOC_START_MARK_AUTO	= FYECF_DOC_START_MARK(0),
+	FYECF_DOC_START_MARK_OFF	= FYECF_DOC_START_MARK(1),
+	FYECF_DOC_START_MARK_ON		= FYECF_DOC_START_MARK(2),
+	FYECF_DOC_END_MARK_AUTO		= FYECF_DOC_END_MARK(0),
+	FYECF_DOC_END_MARK_OFF		= FYECF_DOC_END_MARK(1),
+	FYECF_DOC_END_MARK_ON		= FYECF_DOC_END_MARK(2),
+	FYECF_VERSION_DIR_AUTO		= FYECF_VERSION_DIR(0),
+	FYECF_VERSION_DIR_OFF		= FYECF_VERSION_DIR(1),
+	FYECF_VERSION_DIR_ON		= FYECF_VERSION_DIR(2),
+	FYECF_TAG_DIR_AUTO		= FYECF_TAG_DIR(0),
+	FYECF_TAG_DIR_OFF		= FYECF_TAG_DIR(1),
+	FYECF_TAG_DIR_ON		= FYECF_TAG_DIR(2),
+
+	FYECF_DEFAULT			= FYECF_WIDTH_INF |
+					  FYECF_MODE_ORIGINAL |
+					  FYECF_INDENT_DEFAULT,
+};
+
+/**
+ * struct fy_emitter_cfg - emitter configuration structure.
+ *
+ * Argument to the fy_emitter_create() method which
+ * is the way to convert a runtime document structure back to YAML.
+ *
+ * @flags: Configuration flags
+ * @output: Pointer to the method that will perform output.
+ * @userdata: Opaque user data pointer
+ * @diag: Diagnostic interface
+ */
+struct fy_emitter_cfg {
+	enum fy_emitter_cfg_flags flags;
+	int (*output)(struct fy_emitter *emit, enum fy_emitter_write_type type,
+		      const char *str, int len, void *userdata);
+	void *userdata;
+	struct fy_diag *diag;
+};
+
+/* Shift amount of the color settings */
+#define FYEXCF_COLOR_SHIFT	0
+/* Mask of the color */
+#define FYEXCF_COLOR_MASK	((1U << 2) - 1)
+/* Build a color version */
+#define FYEXCF_COLOR(x)	(((unsigned int)(x) & FYEXCF_COLOR_MASK) << FYEXCF_COLOR_SHIFT)
+
+/* Shift amount of the output settings */
+#define FYEXCF_OUTPUT_SHIFT	2
+/* Mask of the output */
+#define FYEXCF_OUTPUT_MASK	((1U << 3) - 1)
+/* Build an output */
+#define FYEXCF_OUTPUT(x)	(((unsigned int)(x) & FYEXCF_OUTPUT_MASK) << FYEXCF_OUTPUT_SHIFT)
+
+/**
+ * enum fy_emitter_xcfg_flags - Emitter extended configuration flags
+ *
+ * These flags control the operation of the emitter.
+ * If no extended configuration mode is enabled all the flags are assumed 0.
+ *
+ * @FYEXCF_COLOR_AUTO: Automatically colorize if on a terminal
+ * @FYEXCF_COLOR_NONE: Do not colorize output
+ * @FYEXCF_COLOR_FORCE: Force color generation
+ * @FYEXCF_VISIBLE_WS: Make white space visible
+ * @FYEXCF_EXTENDED_INDICATORS: Extend the indicators generated
+ * @FYEXCF_INDENTED_SEQ_IN_MAP: Indent block sequences that are mapping values
+ * @FYEXCF_PRESERVE_FLOW_LAYOUT: Preserve oneline flow collections in streaming mode
+ * @FYEXCF_OUTPUT_STDOUT: Output to stdout (default)
+ * @FYEXCF_OUTPUT_STDERR: Output to stderr, instead of stdout
+ * @FYEXCF_OUTPUT_FILE: Output to the fp FILE pointer
+ * @FYEXCF_OUTPUT_FD: Output to the fd file descriptor
+ * @FYEXCF_NULL_OUTPUT: No output
+ * @FYEXCF_OUTPUT_FILENAME: Output to the given filename
+ */
+enum fy_emitter_xcfg_flags {
+	FYEXCF_COLOR_AUTO		= FYEXCF_COLOR(0),
+	FYEXCF_COLOR_NONE		= FYEXCF_COLOR(1),
+	FYEXCF_COLOR_FORCE		= FYEXCF_COLOR(2),
+	FYEXCF_OUTPUT_STDOUT		= FYEXCF_OUTPUT(0),
+	FYEXCF_OUTPUT_STDERR		= FYEXCF_OUTPUT(1),
+	FYEXCF_OUTPUT_FILE		= FYEXCF_OUTPUT(2),
+	FYEXCF_OUTPUT_FD		= FYEXCF_OUTPUT(2),
+	FYEXCF_NULL_OUTPUT		= FYEXCF_OUTPUT(3),
+	FYEXCF_OUTPUT_FILENAME		= FYEXCF_OUTPUT(4),
+	FYEXCF_VISIBLE_WS		= FY_BIT(5),
+	FYEXCF_EXTENDED_INDICATORS	= FY_BIT(6),
+	FYEXCF_INDENTED_SEQ_IN_MAP	= FY_BIT(7),
+	FYEXCF_PRESERVE_FLOW_LAYOUT	= FY_BIT(8),
+};
+
+/**
+ * struct fy_emitter_xcfg - emitter extended configuration structure.
+ *
+ * Argument to the fy_emitter create when FYECF_EXTENDED_CFG bit is
+ * set.
+ *
+ * @cfg: The standard emitter configuration
+ * @xflags: Extra configuration flags
+ * @colors: ANSI color overrides for the default output method
+ * @output_fp: The output FILE \*, FYEXCF\_FILE\_OUTPUT must be set
+ * @output_fd: The output file descriptor, FYEXCF\_FD\_OUTPUT must be set
+ * @output_filename: The output filename, FYEXCF\_FILENAME\_OUTPUT must be set
+ */
+struct fy_emitter_xcfg {
+	struct fy_emitter_cfg cfg;
+	enum fy_emitter_xcfg_flags xflags;
+	const char *colors[FYEWT_COUNT];
+	union {
+		FILE *output_fp;
+		int output_fd;
+		const char *output_filename;
+	};
+};
+
+/**
+ * fy_emitter_create() - Create an emitter
+ *
+ * Creates an emitter using the supplied configuration
+ *
+ * @cfg: The emitter configuration
+ *
+ * Returns:
+ * The newly created emitter or NULL on error.
+ */
+struct fy_emitter *
+fy_emitter_create(const struct fy_emitter_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_emitter_destroy() - Destroy an emitter
+ *
+ * Destroy an emitter previously created by fy_emitter_create()
+ *
+ * @emit: The emitter to destroy
+ */
+void
+fy_emitter_destroy(struct fy_emitter *emit)
+	FY_EXPORT;
+
+/**
+ * fy_emitter_get_cfg() - Get the configuration of an emitter
+ *
+ * @emit: The emitter
+ *
+ * Returns:
+ * The configuration of the emitter
+ */
+const struct fy_emitter_cfg *
+fy_emitter_get_cfg(struct fy_emitter *emit)
+	FY_EXPORT;
+
+/**
+ * fy_emitter_get_diag() - Get the diagnostic object of an emitter
+ *
+ * Return a pointer to the diagnostic object of an emitter object.
+ * Note that the returned diag object has a reference taken so
+ * you should fy_diag_unref() it when you're done with it.
+ *
+ * @emit: The emitter to get the diagnostic object
+ *
+ * Returns:
+ * A pointer to a ref'ed diagnostic object or NULL in case of an
+ * error.
+ */
+struct fy_diag *
+fy_emitter_get_diag(struct fy_emitter *emit)
+	FY_EXPORT;
+
+/**
+ * fy_emitter_set_diag() - Set the diagnostic object of an emitter
+ *
+ * Replace the emitters's current diagnostic object with the one
+ * given as an argument. The previous diagnostic object will be
+ * unref'ed (and freed if its reference gets to 0).
+ * Also note that the diag argument shall take a reference too.
+ *
+ * @emit: The emitter to replace the diagnostic object
+ * @diag: The emitter's new diagnostic object, NULL for default
+ *
+ * Returns:
+ * 0 if everything OK, -1 otherwise
+ */
+int
+fy_emitter_set_diag(struct fy_emitter *emit, struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_emitter_set_finalizer() - Set emitter finalizer
+ *
+ * Set a method callback to be called when the emitter
+ * is disposed of. If finalizer is NULL, then the method
+ * is removed.
+ *
+ * @emit: The emitter to replace the diagnostic object
+ * @finalizer: The finalizer callback
+ */
+void
+fy_emitter_set_finalizer(struct fy_emitter *emit,
+		void (*finalizer)(struct fy_emitter *emit))
+	FY_EXPORT;
+
+/**
+ * struct fy_emitter_default_output_data - emitter default output configuration
+ *
+ * This is the argument to the default output method of the emitter.
+ *
+ * @fp: File where the output is directed to
+ * @colorize: Use ANSI color sequences to colorize the output
+ * @visible: Make whitespace visible (requires a UTF8 capable terminal)
+ */
+struct fy_emitter_default_output_data {
+	FILE *fp;
+	bool colorize;
+	bool visible;
+};
+
+/**
+ * fy_emitter_default_output() - The default colorizing output method
+ *
+ * This is the default colorizing output method.
+ * Will be used when the output field of the emitter configuration is NULL.
+ *
+ * @fye: The emitter
+ * @type: Type of the emitted output
+ * @str: Pointer to the string to output
+ * @len: Length of the string
+ * @userdata: Must point to a fy_emitter_default_output_data structure
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emitter_default_output(struct fy_emitter *fye, enum fy_emitter_write_type type,
+			  const char *str, int len, void *userdata)
+	FY_EXPORT;
+
+/**
+ * fy_document_default_emit_to_fp() - Emit a document to a file, using defaults
+ *
+ * Simple one shot emitter to a file, using the default emitter output.
+ * The output will be colorized if the the file points to a tty.
+ *
+ * @fyd: The document to emit
+ * @fp: The file where the output is sent
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_default_emit_to_fp(struct fy_document *fyd, FILE *fp)
+	FY_EXPORT;
+
+/**
+ * fy_emit_event() - Queue (and possibly emit) an event
+ *
+ * Queue and output using the emitter. This is the streaming
+ * output method which does not require creating a document.
+ *
+ * @emit: The emitter to use
+ * @fye: The event to queue for emission
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_event(struct fy_emitter *emit, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_emit_vevent() - Queue (and possibly emit) an event using varargs
+ *
+ * Queue and output using the emitter. The format is identical to
+ * the one used in fy_emit_event_vcreate().
+ *
+ * @emit: The emitter to use
+ * @type: The event type to create
+ * @ap: The variable argument list pointer.
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_vevent(struct fy_emitter *emit, enum fy_event_type type, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_emit_eventf() - Queue (and possibly emit) an event using variable args
+ *
+ * Queue and output using the emitter. The format is identical to
+ * the one used in fy_emit_event_create().
+ *
+ * @emit: The emitter to use
+ * @type: The event type to create
+ * @...: The optional extra arguments
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_eventf(struct fy_emitter *emit, enum fy_event_type type, ...)
+	FY_EXPORT;
+
+/**
+ * fy_emit_scalar_write() - Emit a scalar with write semantics
+ *
+ * Queue and output using the emitter a scalar using a standard
+ * write interface.
+ *
+ * @fye: The emitter to use
+ * @style: The scalar style to use
+ * @anchor: The anchor or NULL
+ * @tag: The tag or NULL
+ * @buf: Pointer to the buffer
+ * @count: The number of bytes to write
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_scalar_write(struct fy_emitter *fye, enum fy_scalar_style style,
+		     const char *anchor, const char *tag,
+		     const char *buf, size_t count)
+	FY_EXPORT;
+
+/**
+ * fy_emit_scalar_vprintf() - Emit a scalar with vprintf semantics
+ *
+ * Queue and output using the emitter a scalar using a standard
+ * vprintf interface.
+ *
+ * @fye: The emitter to use
+ * @style: The scalar style to use
+ * @anchor: The anchor or NULL
+ * @tag: The tag or NULL
+ * @fmt: The printf like format string
+ * @ap: The argument list
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_scalar_vprintf(struct fy_emitter *fye, enum fy_scalar_style style,
+		       const char *anchor, const char *tag,
+		       const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_emit_scalar_printf() - Emit a scalar with printf semantics
+ *
+ * Queue and output using the emitter a scalar using a standard
+ * printf interface.
+ *
+ * @fye: The emitter to use
+ * @style: The scalar style to use
+ * @anchor: The anchor or NULL
+ * @tag: The tag or NULL
+ * @fmt: The printf like format string
+ * @...: The extra arguments
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_scalar_printf(struct fy_emitter *fye, enum fy_scalar_style style,
+		      const char *anchor, const char *tag,
+		      const char *fmt, ...)
+	FY_FORMAT(printf, 5, 6)
+	FY_EXPORT;
+
+/**
+ * fy_emit_event_from_parser() - Queue (and possibly emit) an event
+ * 			  	 generated by the parser.
+ *
+ * Queue and output using the emitter. This is the streaming
+ * output method which does not require creating a document.
+ * Similar to fy_emit_event() but it is more efficient.
+ *
+ * @emit: The emitter to use
+ * @fyp: The parser that generated the event
+ * @fye: The event to queue for emission
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_event_from_parser(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document() - Emit the document using the emitter
+ *
+ * Emits a document in YAML format using the emitter.
+ *
+ * @emit: The emitter
+ * @fyd: The document to emit
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_document(struct fy_emitter *emit, struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_start() - Emit document start using the emitter
+ *
+ * Emits a document start using the emitter. This is used in case
+ * you need finer control over the emitting output.
+ *
+ * @emit: The emitter
+ * @fyd: The document to use for emitting it's start
+ * @fyn: The root (or NULL for using the document's root)
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_document_start(struct fy_emitter *emit, struct fy_document *fyd,
+		       struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_end() - Emit document end using the emitter
+ *
+ * Emits a document end using the emitter. This is used in case
+ * you need finer control over the emitting output.
+ *
+ * @emit: The emitter
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_document_end(struct fy_emitter *emit)
+	FY_EXPORT;
+
+/**
+ * fy_emit_node() - Emit a single node using the emitter
+ *
+ * Emits a single node using the emitter. This is used in case
+ * you need finer control over the emitting output.
+ *
+ * @emit: The emitter
+ * @fyn: The node to emit
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_node(struct fy_emitter *emit, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_emit_root_node() - Emit a single root node using the emitter
+ *
+ * Emits a single root node using the emitter. This is used in case
+ * you need finer control over the emitting output.
+ *
+ * @emit: The emitter
+ * @fyn: The root node to emit
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_root_node(struct fy_emitter *emit, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_emit_body_node() - Emit a single body node using the emitter
+ *
+ * Emits a single body node using the emitter. This is used in case
+ * you need finer control over the emitting output.
+ * No stream and document events will be generated at all.
+ *
+ * @emit: The emitter
+ * @fyn: The body node to emit
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_body_node(struct fy_emitter *emit, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_emit_explicit_document_end() - Emit an explicit document end
+ *
+ * Emits an explicit document end, i.e. ... . Use this if you
+ * you need finer control over the emitting output.
+ *
+ * @emit: The emitter
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_explicit_document_end(struct fy_emitter *emit)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_to_fp() - Emit a document to an file pointer
+ *
+ * Emits a document from the root to the given file pointer.
+ *
+ * @fyd: The document to emit
+ * @flags: The emitter flags to use
+ * @fp: The file pointer to output to
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_document_to_fp(struct fy_document *fyd,
+		       enum fy_emitter_cfg_flags flags, FILE *fp)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_to_file() - Emit a document to file
+ *
+ * Emits a document from the root to the given file.
+ * The file will be fopen'ed using a "wa" mode.
+ *
+ * @fyd: The document to emit
+ * @flags: The emitter flags to use
+ * @filename: The filename to output to, or NULL for stdout
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_document_to_file(struct fy_document *fyd,
+			 enum fy_emitter_cfg_flags flags,
+			 const char *filename)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_to_fd() - Emit a document to a file descriptor
+ *
+ * Emits a document from the root to the given file descriptor
+ *
+ * @fyd: The document to emit
+ * @flags: The emitter flags to use
+ * @fd: The file descriptor to output to
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_emit_document_to_fd(struct fy_document *fyd,
+		       enum fy_emitter_cfg_flags flags, int fd)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_to_buffer() - Emit a document to a buffer
+ *
+ * Emits an document from the root to the given buffer.
+ * If the document does not fit, an error will be returned.
+ *
+ * @fyd: The document to emit
+ * @flags: The emitter flags to use
+ * @buf: Pointer to the buffer area to fill
+ * @size: Size of the buffer
+ *
+ * Returns:
+ * A positive number, which is the size of the emitted document
+ * on the buffer on success, -1 on error
+ */
+int
+fy_emit_document_to_buffer(struct fy_document *fyd,
+			   enum fy_emitter_cfg_flags flags,
+			   char *buf, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_emit_document_to_string() - Emit a document to an allocated string
+ *
+ * Emits an document from the root to a string which will be dynamically
+ * allocated.
+ *
+ * @fyd: The document to emit
+ * @flags: The emitter flags to use
+ *
+ * Returns:
+ * A pointer to the allocated string, or NULL in case of an error
+ */
+char *
+fy_emit_document_to_string(struct fy_document *fyd,
+			   enum fy_emitter_cfg_flags flags)
+	FY_EXPORT;
+
+#define fy_emit_document_to_string_alloca(_fyd, _flags) \
+	FY_ALLOCA_COPY_FREE(fy_emit_document_to_string((_fyd), (_flags)), FY_NT)
+
+/**
+ * fy_emit_node_to_buffer() - Emit a node (recursively) to a buffer
+ *
+ * Emits a node recursively to the given buffer.
+ * If the document does not fit, an error will be returned.
+ *
+ * @fyn: The node to emit
+ * @flags: The emitter flags to use
+ * @buf: Pointer to the buffer area to fill
+ * @size: Size of the buffer
+ *
+ * Returns:
+ * A positive number, which is the size of the emitted node
+ * on the buffer on success, -1 on error
+ */
+int
+fy_emit_node_to_buffer(struct fy_node *fyn, enum fy_emitter_cfg_flags flags,
+		       char *buf, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_emit_node_to_string() - Emit a node to an allocated string
+ *
+ * Emits a node recursively to a string which will be dynamically
+ * allocated.
+ *
+ * @fyn: The node to emit
+ * @flags: The emitter flags to use
+ *
+ * Returns:
+ * A pointer to the allocated string, or NULL in case of an error
+ */
+char *
+fy_emit_node_to_string(struct fy_node *fyn, enum fy_emitter_cfg_flags flags)
+	FY_EXPORT;
+
+#define fy_emit_node_to_string_alloca(_fyn, _flags) \
+	FY_ALLOCA_COPY_FREE(fy_emit_node_to_string((_fyn), (_flags)), FY_NT)
+
+/**
+ * fy_emit_to_buffer() - Create an emitter for buffer output.
+ *
+ * Creates a special purpose emitter for buffer output.
+ * Calls to fy_emit_event() populate the buffer.
+ * The contents are retreived by a call to fy_emit_to_buffer_collect()
+ *
+ * @flags: The emitter flags to use
+ * @buf: Pointer to the buffer area to fill
+ * @size: Size of the buffer
+ *
+ * Returns:
+ * The newly created emitter or NULL on error.
+ */
+struct fy_emitter *
+fy_emit_to_buffer(enum fy_emitter_cfg_flags flags, char *buf, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_emit_to_buffer_collect() - Collect the buffer emitter output
+ *
+ * Collects the output of the emitter which was created by
+ * fy_emit_to_buffer() and populated using fy_emit_event() calls.
+ * The NULL terminated returned buffer is the same as the one used in the
+ * fy_emit_to_buffer() call and the sizep argument will be filled with
+ * the size of the buffer.
+ *
+ * @emit: The emitter
+ * @sizep: Pointer to the size to be filled
+ *
+ * Returns:
+ * The buffer or NULL in case of an error.
+ */
+char *
+fy_emit_to_buffer_collect(struct fy_emitter *emit, size_t *sizep)
+	FY_EXPORT;
+
+/**
+ * fy_emit_to_string() - Create an emitter to create a dynamically
+ *                       allocated string.
+ *
+ * Creates a special purpose emitter for output to a dynamically
+ * allocated string.
+ * Calls to fy_emit_event() populate the buffer.
+ * The contents are retreived by a call to fy_emit_to_string_collect()
+ *
+ * @flags: The emitter flags to use
+ *
+ * Returns:
+ * The newly created emitter or NULL on error.
+ */
+struct fy_emitter *
+fy_emit_to_string(enum fy_emitter_cfg_flags flags)
+	FY_EXPORT;
+
+/**
+ * fy_emit_to_string_collect() - Collect the string emitter output
+ *
+ * Collects the output of the emitter which was created by
+ * fy_emit_to_string() and populated using fy_emit_event() calls.
+ * The NULL terminated returned buffer is dynamically allocated
+ * and must be freed via a call to free().
+ * The sizep argument will be filled with the size of the buffer.
+ *
+ * @emit: The emitter
+ * @sizep: Pointer to the size to be filled
+ *
+ * Returns:
+ * The dynamically allocated string or NULL in case of an error.
+ */
+char *
+fy_emit_to_string_collect(struct fy_emitter *emit, size_t *sizep)
+	FY_EXPORT;
+
+/**
+ * fy_node_copy() - Copy a node, associating the new node with the given document
+ *
+ * Make a deep copy of a node, associating the copy with the given document.
+ * Note that no content copying takes place as the contents of the nodes
+ * are reference counted. This means that the operation is relatively inexpensive.
+ *
+ * Note that the copy includes all anchors contained in the subtree of the
+ * source, so this call will register them with the document.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ * @fyn_from: The source node to recursively copy
+ *
+ * Returns:
+ * The copied node on success, NULL on error
+ */
+struct fy_node *
+fy_node_copy(struct fy_document *fyd, struct fy_node *fyn_from)
+	FY_EXPORT;
+
+/**
+ * fy_document_clone() - Clones a document
+ *
+ * Clone a document, by making a deep copy of the source.
+ * Note that no content copying takes place as the contents of the nodes
+ * are reference counted. This means that the operation is relatively inexpensive.
+ *
+ * @fydsrc: The source document to clone
+ *
+ * Returns:
+ * The newly created clone document, or NULL in case of an error
+ */
+struct fy_document *
+fy_document_clone(struct fy_document *fydsrc)
+	FY_EXPORT;
+
+/**
+ * fy_node_insert() - Insert a node to the given node
+ *
+ * Insert a node to another node. If @fyn_from is NULL then this
+ * operation will delete the @fyn_to node.
+ *
+ * The operation varies according to the types of the arguments:
+ *
+ * from: scalar
+ *
+ * to: another-scalar -> scalar
+ * to: { key: value } -> scalar
+ * to: [ seq0, seq1 ] -> scalar
+ *
+ * from: [ seq2 ]
+ * to: scalar -> [ seq2 ]
+ * to: { key: value } -> [ seq2 ]
+ * to: [ seq0, seq1 ] -> [ seq0, seq1, sec2 ]
+ *
+ * from: { another-key: another-value }
+ * to: scalar -> { another-key: another-value }
+ * to: { key: value } -> { key: value, another-key: another-value }
+ * to: [ seq0, seq1 ] -> { another-key: another-value }
+ *
+ * from: { key: another-value }
+ * to: scalar -> { key: another-value }
+ * to: { key: value } -> { key: another-value }
+ * to: [ seq0, seq1 ] -> { key: another-value }
+ *
+ * The rules are:
+ * - If target node changes type, source ovewrites target.
+ * - If source or target node are scalars, source it overwrites target.
+ * - If target and source are sequences the items of the source sequence
+ *   are appended to the target sequence.
+ * - If target and source are maps the key, value pairs of the source
+ *   are appended to the target map. If the target map contains a
+ *   key-value pair that is present in the source map, it is overwriten
+ *   by it.
+ *
+ * @fyn_to: The target node
+ * @fyn_from: The source node
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_insert(struct fy_node *fyn_to, struct fy_node *fyn_from)
+	FY_EXPORT;
+
+/**
+ * fy_node_delete() - Delete a node from a document
+ *
+ * Delete the given node.
+ * If it's part of a sequence it will be removed from it.
+ * If it's the value of a node key value pair, it will
+ * be removed from the mapping.
+ *
+ * This is an alias for fy_document_insert_at(fyn, NULL)
+ *
+ * Note that it is expected this node is attached to a document.
+ * Do not call this to free a node, because if it's part of
+ * a collection it will not be properly removed.
+ *
+ * @fyn: The node to delete.
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_delete(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_document_insert_at() - Insert a node to the given path in the document
+ *
+ * Insert a node to a given point in the document. If @fyn is NULL then this
+ * operation will delete the target node.
+ *
+ * Please see fy_node_insert for details of operation.
+ *
+ * Note that in any case the fyn node will be unref'ed.
+ * So if the operation fails, and the reference is 0
+ * the node will be freed. If you want it to stick around
+ * take a reference before.
+ *
+ * @fyd: The document
+ * @path: The path where the insert operation will target
+ * @pathlen: The length of the path (or -1 if '\0' terminated)
+ * @fyn: The source node
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_insert_at(struct fy_document *fyd,
+		      const char *path, size_t pathlen,
+		      struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * enum fy_node_type - Node type
+ *
+ * Each node may be one of the following types
+ *
+ * @FYNT_SCALAR: Node is a scalar
+ * @FYNT_SEQUENCE: Node is a sequence
+ * @FYNT_MAPPING: Node is a mapping
+ */
+enum fy_node_type {
+	FYNT_SCALAR,
+	FYNT_SEQUENCE,
+	FYNT_MAPPING,
+};
+
+/**
+ * enum fy_node_style - Node style
+ *
+ * A node may contain a hint of how it should be
+ * rendered, encoded as a style.
+ *
+ * @FYNS_ANY: No hint, let the emitter decide
+ * @FYNS_FLOW: Prefer flow style (for sequence/mappings)
+ * @FYNS_BLOCK: Prefer block style (for sequence/mappings)
+ * @FYNS_PLAIN: Plain style preferred
+ * @FYNS_SINGLE_QUOTED: Single quoted style preferred
+ * @FYNS_DOUBLE_QUOTED: Double quoted style preferred
+ * @FYNS_LITERAL: Literal style preferred (valid in block context)
+ * @FYNS_FOLDED: Folded style preferred (valid in block context)
+ * @FYNS_ALIAS: It's an alias
+ */
+enum fy_node_style {
+	FYNS_ANY = -1,
+	FYNS_FLOW,
+	FYNS_BLOCK,
+	FYNS_PLAIN,
+	FYNS_SINGLE_QUOTED,
+	FYNS_DOUBLE_QUOTED,
+	FYNS_LITERAL,
+	FYNS_FOLDED,
+	FYNS_ALIAS,
+};
+
+/* maximum depth is 256 */
+#define FYNWF_MAXDEPTH_SHIFT	4
+#define FYNWF_MAXDEPTH_MASK	0xff
+#define FYNWF_MAXDEPTH(x)	(((x) & FYNWF_MAXDEPTH_MASK) << FYNWF_MAXDEPTH_SHIFT)
+#define FYNWF_MARKER_SHIFT	12
+#define FYNWF_MARKER_MASK	0x1f
+#define FYNWF_MARKER(x)		(((x) & FYNWF_MARKER_MASK) << FYNWF_MARKER_SHIFT)
+#define FYNWF_PTR_SHIFT		16
+#define FYNWF_PTR_MASK		0x03
+#define FYNWF_PTR(x)		(((x) & FYNWF_PTR_MASK) << FYNWF_PTR_SHIFT)
+
+/**
+ * enum fy_node_walk_flags - Node walk flags
+ *
+ * @FYNWF_DONT_FOLLOW: Don't follow aliases during pathwalk
+ * @FYNWF_FOLLOW: Follow aliases during pathwalk
+ * @FYNWF_PTR_YAML: YAML pointer path walks
+ * @FYNWF_PTR_JSON: JSON pointer path walks
+ * @FYNWF_PTR_RELJSON: Relative JSON pointer path walks
+ * @FYNWF_PTR_YPATH: YPATH pointer path walks
+ * @FYNWF_URI_ENCODED: The path is URI encoded
+ * @FYNWF_MAXDEPTH_DEFAULT: Max follow depth is automatically determined
+ * @FYNWF_MARKER_DEFAULT: Default marker to use when scanning
+ * @FYNWF_PTR_DEFAULT: Default path type
+ */
+enum fy_node_walk_flags {
+	FYNWF_DONT_FOLLOW = 0,
+	FYNWF_FOLLOW = FY_BIT(0),
+	FYNWF_PTR_YAML = FYNWF_PTR(0),
+	FYNWF_PTR_JSON = FYNWF_PTR(1),
+	FYNWF_PTR_RELJSON = FYNWF_PTR(2),
+	FYNWF_PTR_YPATH = FYNWF_PTR(3),
+	FYNWF_URI_ENCODED = FY_BIT(18),
+	FYNWF_MAXDEPTH_DEFAULT = FYNWF_MAXDEPTH(0),
+	FYNWF_MARKER_DEFAULT = FYNWF_MARKER(0),
+	FYNWF_PTR_DEFAULT = FYNWF_PTR(0),
+};
+
+/* the maximum user marker */
+#define FYNWF_MAX_USER_MARKER	24
+
+/**
+ * fy_node_style_from_scalar_style() - Convert from scalar to node style
+ *
+ * Convert a scalar style to a node style.
+ *
+ * @sstyle: The input scalar style
+ *
+ * Returns:
+ * The matching node style
+ */
+static inline enum fy_node_style
+fy_node_style_from_scalar_style(enum fy_scalar_style sstyle)
+{
+	if (sstyle == FYSS_ANY)
+		return FYNS_ANY;
+	return (enum fy_node_style)(FYNS_PLAIN + (sstyle - FYSS_PLAIN));
+}
+
+/**
+ * typedef fy_node_mapping_sort_fn - Mapping sorting method function
+ *
+ * @fynp_a: The first node_pair used in the comparison
+ * @fynp_b: The second node_pair used in the comparison
+ * @arg: The opaque user provided pointer to the sort operation
+ *
+ * Returns:
+ * <0 if @fynp_a is less than @fynp_b
+ * 0 if @fynp_a is equal to fynp_b
+ * >0 if @fynp_a is greater than @fynp_b
+ */
+typedef int (*fy_node_mapping_sort_fn)(const struct fy_node_pair *fynp_a,
+				       const struct fy_node_pair *fynp_b,
+				       void *arg);
+
+/**
+ * typedef fy_node_scalar_compare_fn - Node compare method function for scalars
+ *
+ * @fyn_a: The first scalar node used in the comparison
+ * @fyn_b: The second scalar node used in the comparison
+ * @arg: The opaque user provided pointer to the compare operation
+ *
+ * Returns:
+ * <0 if @fyn_a is less than @fyn_b
+ * 0 if @fyn_a is equal to fyn_b
+ * >0 if @fyn_a is greater than @fyn_b
+ */
+typedef int (*fy_node_scalar_compare_fn)(struct fy_node *fyn_a,
+					 struct fy_node *fyn_b,
+					 void *arg);
+
+/**
+ * fy_node_compare() - Compare two nodes for equality
+ *
+ * Compare two nodes for equality.
+ * The comparison is 'deep', i.e. it recurses in subnodes,
+ * and orders the keys of maps using default libc strcmp
+ * ordering. For scalar the comparison is performed after
+ * any escaping so it's a true content comparison.
+ *
+ * @fyn1: The first node to use in the comparison
+ * @fyn2: The second node to use in the comparison
+ *
+ * Returns:
+ * true if the nodes contain the same content, false otherwise
+ */
+bool
+fy_node_compare(struct fy_node *fyn1, struct fy_node *fyn2)
+	FY_EXPORT;
+
+/**
+ * fy_node_compare_user() - Compare two nodes for equality using
+ * 			    user supplied sort and scalar compare methods
+ *
+ * Compare two nodes for equality using user supplied sot and scalar
+ * compare methods.
+ * The comparison is 'deep', i.e. it recurses in subnodes,
+ * and orders the keys of maps using the supplied mapping sort method for
+ * ordering. For scalars the comparison is performed using the supplied
+ * scalar node compare methods.
+ *
+ * @fyn1: The first node to use in the comparison
+ * @fyn2: The second node to use in the comparison
+ * @sort_fn: The method to use for sorting maps, or NULL for the default
+ * @sort_fn_arg: The extra user supplied argument to the @sort_fn
+ * @cmp_fn: The method to use for comparing scalars, or NULL for the default
+ * @cmp_fn_arg: The extra user supplied argument to the @cmp_fn
+ *
+ * Returns:
+ * true if the nodes contain the same content, false otherwise
+ */
+bool
+fy_node_compare_user(struct fy_node *fyn1, struct fy_node *fyn2,
+		     fy_node_mapping_sort_fn sort_fn, void *sort_fn_arg,
+		     fy_node_scalar_compare_fn cmp_fn, void *cmp_fn_arg)
+	FY_EXPORT;
+
+/**
+ * fy_node_compare_string() - Compare a node for equality with a YAML string
+ *
+ * Compare a node for equality with a YAML string.
+ * The comparison is performed using fy_node_compare() with the
+ * first node supplied as an argument and the second being generated
+ * by calling fy_document_build_from_string with the YAML string.
+ *
+ * @fyn: The node to use in the comparison
+ * @str: The YAML string to compare against
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * true if the node and the string are equal.
+ */
+bool
+fy_node_compare_string(struct fy_node *fyn, const char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_compare_token() - Compare a node for equality against a token
+ *
+ * Compare a node for equality with a token.
+ * Both the node and the tokens must be a scalars.
+ *
+ * @fyn: The node to use in the comparison
+ * @fyt: The scalar token
+ *
+ * Returns:
+ * true if the node and the token are equal.
+ */
+bool
+fy_node_compare_token(struct fy_node *fyn, struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_node_compare_text() - Compare a node for equality with a raw C text
+ *
+ * Compare a node for equality with a raw C string.
+ * The node must be a scalar.
+ *
+ * @fyn: The node to use in the comparison
+ * @text: The raw C text to compare against
+ * @len: The length of the text (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * true if the node and the text are equal.
+ */
+bool
+fy_node_compare_text(struct fy_node *fyn, const char *text, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_document_create() - Create an empty document
+ *
+ * Create an empty document using the provided parser configuration.
+ * If NULL use the default parse configuration.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ *
+ * Returns:
+ * The created empty document, or NULL on error.
+ */
+struct fy_document *
+fy_document_create(const struct fy_parse_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_document_destroy() - Destroy a document previously created via
+ *                         fy_document_create()
+ *
+ * Destroy a document (along with all children documents)
+ *
+ * @fyd: The document to destroy
+ *
+ */
+void
+fy_document_destroy(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_get_cfg() - Get the configuration of a document
+ *
+ * @fyd: The document
+ *
+ * Returns:
+ * The configuration of the document
+ */
+const struct fy_parse_cfg *
+fy_document_get_cfg(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_get_diag() - Get the diagnostic object of a document
+ *
+ * Return a pointer to the diagnostic object of a document object.
+ * Note that the returned diag object has a reference taken so
+ * you should fy_diag_unref() it when you're done with it.
+ *
+ * @fyd: The document to get the diagnostic object
+ *
+ * Returns:
+ * A pointer to a ref'ed diagnostic object or NULL in case of an
+ * error.
+ */
+struct fy_diag *
+fy_document_get_diag(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_set_diag() - Set the diagnostic object of a document
+ *
+ * Replace the documents's current diagnostic object with the one
+ * given as an argument. The previous diagnostic object will be
+ * unref'ed (and freed if its reference gets to 0).
+ * Also note that the diag argument shall take a reference too.
+ *
+ * @fyd: The document to replace the diagnostic object
+ * @diag: The document's new diagnostic object, NULL for default
+ *
+ * Returns:
+ * 0 if everything OK, -1 otherwise
+ */
+int
+fy_document_set_diag(struct fy_document *fyd, struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_document_set_parent() - Make a document a child of another
+ *
+ * Set the parent of @fyd_child document to be @fyd
+ *
+ * @fyd: The parent document
+ * @fyd_child: The child document
+ *
+ * Returns:
+ * 0 if all OK, -1 on error.
+ */
+int
+fy_document_set_parent(struct fy_document *fyd, struct fy_document *fyd_child)
+	FY_EXPORT;
+
+/**
+ * fy_document_build_from_string() - Create a document using the provided YAML source.
+ *
+ * Create a document parsing the provided string as a YAML source.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @str: The YAML source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_document_build_from_string(const struct fy_parse_cfg *cfg,
+			      const char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_document_build_from_malloc_string() - Create a document using the provided YAML source which was malloced.
+ *
+ * Create a document parsing the provided string as a YAML source. The string is expected to have been
+ * allocated by malloc(3) and when the document is destroyed it will be automatically freed.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @str: The YAML source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_document_build_from_malloc_string(const struct fy_parse_cfg *cfg,
+				     char *str, size_t len)
+	FY_EXPORT;
+/**
+ * fy_document_build_from_file() - Create a document parsing the given file
+ *
+ * Create a document parsing the provided file as a YAML source.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @file: The name of the file to parse
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_document_build_from_file(const struct fy_parse_cfg *cfg, const char *file)
+	FY_EXPORT;
+
+/**
+ * fy_document_build_from_fp() - Create a document parsing the given file pointer
+ *
+ * Create a document parsing the provided file pointer as a YAML source.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @fp: The file pointer
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_document_build_from_fp(const struct fy_parse_cfg *cfg, FILE *fp)
+	FY_EXPORT;
+
+/**
+ * fy_document_vbuildf() - Create a document using the provided YAML via vprintf formatting
+ *
+ * Create a document parsing the provided string as a YAML source. The string
+ * is created by applying vprintf formatting.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @fmt: The format string creating the YAML source to use.
+ * @ap: The va_list argument pointer
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_document_vbuildf(const struct fy_parse_cfg *cfg,
+		    const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_document_buildf() - Create a document using the provided YAML source via printf formatting
+ *
+ * Create a document parsing the provided string as a YAML source. The string
+ * is created by applying printf formatting.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @fmt: The format string creating the YAML source to use.
+ * @...: The printf arguments
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_document_buildf(const struct fy_parse_cfg *cfg, const char *fmt, ...)
+	FY_FORMAT(printf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * fy_flow_document_build_from_string() - Create a document using the provided YAML source.
+ *
+ * Create a document parsing the provided string as a YAML source.
+ *
+ * The document is a flow document, i.e. does not contain any block content
+ * and is usually laid out in a single line.
+ *
+ * Example of flow documents:
+ *
+ * plain-scalar
+ * "double-quoted-scalar"
+ * 'single-quoted-scalar'
+ * { foo: bar }
+ * [ 0, 1, 2 ]
+ *
+ * A flow document is important because parsing stops at the end
+ * of it, and so can be placed in other non-yaml content.
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @str: The YAML source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ * @consumed: A pointer to the consumed amount
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_flow_document_build_from_string(const struct fy_parse_cfg *cfg,
+				   const char *str, size_t len, size_t *consumed)
+	FY_EXPORT;
+
+/**
+ * fy_block_document_build_from_string() - Create a document using the provided YAML source.
+ *
+ * Create a document parsing the provided string as a YAML source.
+ *
+ * The document is a block document, and it terminates when indentation
+ * appears to do so.
+ *
+ * Example of block documents::
+ *
+ *   this-is-yaml
+ *     foo: bar    <- starts here
+ *     baz: [1, 2]
+ *   this-is-yaml-no-more
+ *
+ * @cfg: The parse configuration to use or NULL for the default.
+ * @str: The YAML source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ * @consumed: A pointer to the consumed amount
+ *
+ * Returns:
+ * The created document, or NULL on error.
+ */
+struct fy_document *
+fy_block_document_build_from_string(const struct fy_parse_cfg *cfg,
+				   const char *str, size_t len, size_t *consumed)
+	FY_EXPORT;
+
+/**
+ * fy_document_root() - Return the root node of the document
+ *
+ * Returns the root of the document. If the document is empty
+ * NULL will be returned instead.
+ *
+ * @fyd: The document
+ *
+ * Returns:
+ * The root of the document, or NULL if the document is empty.
+ */
+struct fy_node *
+fy_document_root(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_set_root() - Set the root of the document
+ *
+ * Set the root of a document. If the document was not empty
+ * the old root will be freed. If @fyn is NULL then the
+ * document is set to empty.
+ *
+ * @fyd: The document
+ * @fyn: The new root of the document.
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_set_root(struct fy_document *fyd, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_type() - Get the node type
+ *
+ * Retrieve the node type. It is one of FYNT_SCALAR, FYNT_SEQUENCE
+ * or FYNT_MAPPING. A NULL node argument is a FYNT_SCALAR.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node type
+ */
+enum fy_node_type
+fy_node_get_type(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_style() - Get the node style
+ *
+ * Retrieve the node rendering style.
+ * If the node is NULL then the style is FYNS_PLAIN.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node style
+ */
+enum fy_node_style
+fy_node_get_style(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_style() - Set the node style
+ *
+ * Try to set the node rendering style of a node.
+ * If the style of node is illegal (for example
+ * you can't set an arbitrary scalar that contains
+ * zeroes to plain) then the actual style that was
+ * set will be returned.
+ *
+ * @fyn:   The node
+ * @style: The requested node rendering style
+ *
+ * Returns:
+ * The final node style
+ */
+enum fy_node_style
+fy_node_set_style(struct fy_node *fyn, enum fy_node_style style)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_start_token() - Get the node start token
+ *
+ * Retrieve the node start token.
+ *
+ * For scalars, this is the same as the end token.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node start token
+ */
+struct fy_token * fy_node_get_start_token(struct fy_node *fyn)
+        FY_EXPORT;
+
+/**
+ * fy_node_get_end_token() - Get the node end token
+ *
+ * Retrieve the node end token.
+ *
+ * For scalars, this is the same as the start token.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node end token
+ */
+ struct fy_token * fy_node_get_end_token(struct fy_node *fyn)
+        FY_EXPORT;
+
+/**
+ * fy_node_is_scalar() - Check whether the node is a scalar
+ *
+ * Convenience method for checking whether a node is a scalar.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * true if the node is a scalar, false otherwise
+ */
+static inline bool
+fy_node_is_scalar(struct fy_node *fyn)
+{
+	return fy_node_get_type(fyn) == FYNT_SCALAR;
+}
+
+/**
+ * fy_node_is_sequence() - Check whether the node is a sequence
+ *
+ * Convenience method for checking whether a node is a sequence.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * true if the node is a sequence, false otherwise
+ */
+static inline bool
+fy_node_is_sequence(struct fy_node *fyn)
+{
+	return fy_node_get_type(fyn) == FYNT_SEQUENCE;
+}
+
+/**
+ * fy_node_is_mapping() - Check whether the node is a mapping
+ *
+ * Convenience method for checking whether a node is a mapping.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * true if the node is a mapping, false otherwise
+ */
+static inline bool
+fy_node_is_mapping(struct fy_node *fyn)
+{
+	return fy_node_get_type(fyn) == FYNT_MAPPING;
+}
+
+/**
+ * fy_node_is_alias() - Check whether the node is an alias
+ *
+ * Convenience method for checking whether a node is an alias.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * true if the node is an alias, false otherwise
+ */
+static inline bool
+fy_node_is_alias(struct fy_node *fyn)
+{
+	return fy_node_get_type(fyn) == FYNT_SCALAR &&
+	       fy_node_get_style(fyn) == FYNS_ALIAS;
+}
+
+/**
+ * fy_node_is_null() - Check whether the node is a NULL
+ *
+ * Convenience method for checking whether a node is a NULL scalar..
+ * Note that a NULL node argument returns true...
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * true if the node is a NULL scalar, false otherwise
+ */
+bool
+fy_node_is_null(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_is_attached() - Check whether the node is attached
+ *
+ * Checks whether a node is attached in a document structure.
+ * An attached node may not be freed, before being detached.
+ * Note that there is no method that explicitly detaches
+ * a node, since this is handled internaly by the sequence
+ * and mapping removal methods.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * true if the node is attached, false otherwise
+ */
+bool
+fy_node_is_attached(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_tag_token() - Gets the tag token of a node (if it exists)
+ *
+ * Gets the tag token of a node, if it exists
+ *
+ * @fyn: The node which has the tag token to be returned
+ *
+ * Returns:
+ * The tag token of the given node, or NULL if the tag does not
+ * exist.
+ */
+struct fy_token *
+fy_node_get_tag_token(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_scalar_token() - Gets the scalar token of a node (if it exists)
+ *
+ * Gets the scalar token of a node, if it exists and the node is a valid scalar
+ * node. Note that aliases are scalars, so if this call is issued on an alias
+ * node the return shall be of an alias token.
+ *
+ * @fyn: The node which has the scalar token to be returned
+ *
+ * Returns:
+ * The scalar token of the given node, or NULL if the node is not a scalar.
+ */
+struct fy_token *
+fy_node_get_scalar_token(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_resolve_alias() - Resolve an alias node
+ *
+ * Resolve an alias node, following any subsequent aliases until
+ * a non alias node has been found. This call performs cycle detection
+ * and excessive redirections checks so it's safe to call in any
+ * context.
+ *
+ * @fyn: The alias node to be resolved
+ *
+ * Returns:
+ * The resolved alias node, or NULL if either fyn is not an alias, or
+ * resolution fails due to a graph cycle.
+ */
+struct fy_node *
+fy_node_resolve_alias(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_dereference() - Dereference a single alias node
+ *
+ * Dereference an alias node. This is different than resolution
+ * in that will only perform a single alias follow call and
+ * it will fail if the input is not an alias.
+ * This call performs cycle detection
+ * and excessive redirections checks so it's safe to call in any
+ * context.
+ *
+ * @fyn: The alias node to be dereferenced
+ *
+ * Returns:
+ * The dereferenced alias node, or NULL if either fyn is not an alias, or
+ * resolution fails due to a graph cycle.
+ */
+struct fy_node *
+fy_node_dereference(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_free() - Free a node
+ *
+ * Recursively frees the given node releasing the memory it uses, removing
+ * any anchors on the document it contains, and releasing references
+ * on the tokens it contains.
+ *
+ * This method will return an error if the node is attached, or
+ * if not NULL it is not a member of a document.
+ *
+ * @fyn: The node to free
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_free(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_build_from_string() - Create a node using the provided YAML source.
+ *
+ * Create a node parsing the provided string as a YAML source. The
+ * node created will be associated with the provided document.
+ *
+ * @fyd: The document
+ * @str: The YAML source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_build_from_string(struct fy_document *fyd,
+			  const char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_build_from_malloc_string() - Create a node using the provided YAML source which was malloced.
+ *
+ * Create a node parsing the provided string as a YAML source. The
+ * node created will be associated with the provided document. The string is expected to have been
+ * allocated by malloc(3) and when the document is destroyed it will be automatically freed.
+ *
+ * @fyd: The document
+ * @str: The YAML source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_build_from_malloc_string(struct fy_document *fyd,
+				 char *str, size_t len)
+	FY_EXPORT;
+
+
+/**
+ * fy_node_build_from_file() - Create a node using the provided YAML file.
+ *
+ * Create a node parsing the provided file as a YAML source. The
+ * node created will be associated with the provided document.
+ *
+ * @fyd: The document
+ * @file: The name of the file to parse
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_build_from_file(struct fy_document *fyd, const char *file)
+	FY_EXPORT;
+
+/**
+ * fy_node_build_from_fp() - Create a node using the provided file pointer.
+ *
+ * Create a node parsing the provided file pointer as a YAML source. The
+ * node created will be associated with the provided document.
+ *
+ * @fyd: The document
+ * @fp: The file pointer
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_build_from_fp(struct fy_document *fyd, FILE *fp)
+	FY_EXPORT;
+
+/**
+ * fy_node_vbuildf() - Create a node using the provided YAML source via vprintf formatting
+ *
+ * Create a node parsing the resulting string as a YAML source. The string
+ * is created by applying vprintf formatting.
+ *
+ * @fyd: The document
+ * @fmt: The format string creating the YAML source to use.
+ * @ap: The va_list argument pointer
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_vbuildf(struct fy_document *fyd, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_node_buildf() - Create a node using the provided YAML source via printf formatting
+ *
+ * Create a node parsing the resulting string as a YAML source. The string
+ * is created by applying printf formatting.
+ *
+ * @fyd: The document
+ * @fmt: The format string creating the YAML source to use.
+ * @...: The printf arguments
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_buildf(struct fy_document *fyd, const char *fmt, ...)
+	FY_FORMAT(printf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * fy_node_by_path() - Retrieve a node using the provided path spec.
+ *
+ * This method will retrieve a node relative to the given node using
+ * the provided path spec.
+ *
+ * Path specs are comprised of keys seperated by slashes '/'.
+ * Keys are either regular YAML expressions in flow format for traversing
+ * mappings, or indexes in brackets for traversing sequences.
+ * Path specs may start with '/' which is silently ignored.
+ *
+ * A few examples will make this clear::
+ *
+ *   fyn = { foo: bar } - fy_node_by_path(fyn, "/foo") -> bar
+ *   fyn = [ foo, bar ] - fy_node_by_path(fyn, "1") -> bar
+ *   fyn = { { foo: bar }: baz } - fy_node_by_path(fyn, "{foo: bar}") -> baz
+ *   fyn = [ foo, { bar: baz } } - fy_node_by_path(fyn, "1/bar") -> baz
+ *
+ * Note that the special characters /{}[] are not escaped in plain style,
+ * so you will not be able to use them as path traversal keys.
+ * In that case you can easily use either the single, or double quoted forms::
+ *
+ *   fyn = { foo/bar: baz } - fy_node_by_path(fyn, "'foo/bar'") -> baz
+ *
+ * @fyn: The node to use as start of the traversal operation
+ * @path: The path spec to use in the traversal operation
+ * @len: The length of the path (or -1 if '\0' terminated)
+ * @flags: The extra path walk flags
+ *
+ * Returns:
+ * The retrieved node, or NULL if not possible to be found.
+ */
+struct fy_node *
+fy_node_by_path(struct fy_node *fyn, const char *path, size_t len,
+		enum fy_node_walk_flags flags)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_path() - Get the path of this node
+ *
+ * Retrieve the given node's path address relative to the document root.
+ * The address is dynamically allocated and should be freed when
+ * you're done with it.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node's address, or NULL if fyn is the root.
+ */
+char *
+fy_node_get_path(struct fy_node *fyn)
+	FY_EXPORT;
+
+#define fy_node_get_path_alloca(_fyn) \
+	FY_ALLOCA_COPY_FREE_NO_NULL(fy_node_get_path((_fyn)), FY_NT)
+
+/**
+ * fy_node_get_parent() - Get the parent node of a node
+ *
+ * Get the parent node of a node. The parent of a document's root
+ * is NULL, and so is the parent of the root of a key node's of a mapping.
+ * This is because the nodes of a key may not be addressed using a
+ * path expression.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node's parent, or NULL if fyn is the root, or the root of a key mapping.
+ */
+struct fy_node *
+fy_node_get_parent(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_document_parent() - Get the document parent node of a node
+ *
+ * Get the document parent node of a node. The document parent differs
+ * than the regular parent in that a key's root node of a mapping is not
+ * NULL, rather it points to the actual node parent.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node's document parent, or NULL if fyn is the root
+ */
+struct fy_node *
+fy_node_get_document_parent(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_parent_address() - Get the path address of this node's parent
+ *
+ * Retrieve the given node's parent path address
+ * The address is dynamically allocated and should be freed when
+ * you're done with it.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The parent's address, or NULL if fyn is the root.
+ */
+char *
+fy_node_get_parent_address(struct fy_node *fyn)
+	FY_EXPORT;
+
+#define fy_node_get_parent_address_alloca(_fyn) \
+	FY_ALLOCA_COPY_FREE_NO_NULL(fy_node_get_parent_address((_fyn)), FY_NT)
+
+/**
+ * fy_node_get_path_relative_to() - Get a path address of a node relative
+ *                                  to one of it's parents
+ *
+ * Retrieve the given node's path address relative to an arbitrary
+ * parent in the tree.
+ * The address is dynamically allocated and should be freed when
+ * you're done with it.
+ *
+ * @fyn_parent: The node parent/grandparent...
+ * @fyn: The node
+ *
+ * Returns:
+ * The relative address from the parent to the node
+ */
+char *
+fy_node_get_path_relative_to(struct fy_node *fyn_parent, struct fy_node *fyn)
+	FY_EXPORT;
+
+#define fy_node_get_path_relative_to_alloca(_fynp, _fyn) \
+	FY_ALLOCA_COPY_FREE_NO_NULL(fy_node_get_path_relative_to((_fynp), (_fyn)), FY_NT)
+
+/**
+ * fy_node_get_short_path() - Get a path address of a node in the shortest path possible
+ *
+ * Retrieve the given nodes short path address relative to the
+ * closest anchor (either on this node, or its parent).
+ * If no such parent is found then returns the absolute path
+ * from the start of the document.
+ *
+ * Example::
+ *
+ *   --- &foo
+ *   foo: &bar
+ *       bar
+ *   baz
+ *
+ *   - The short path of /foo is \*foo
+ *   - The short path of /foo/bar is \*bar
+ *   - The short path of /baz is \*foo/baz
+ *
+ * The address is dynamically allocated and should be freed when
+ * you're done with it.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The shortest path describing the node
+ */
+char *
+fy_node_get_short_path(struct fy_node *fyn)
+	FY_EXPORT;
+
+#define fy_node_get_short_path_alloca(_fyn) \
+	FY_ALLOCA_COPY_FREE_NO_NULL(fy_node_get_short_path((_fyn)), FY_NT)
+
+/**
+ * fy_node_get_reference() - Get a textual reference to a node
+ *
+ * Retrieve the given node's textual reference. If the node
+ * contains an anchor the expression that references the anchor
+ * will be returned, otherwise an absolute path reference relative
+ * to the root of the document will be returned.
+ *
+ * The address is dynamically allocated and should be freed when
+ * you're done with it.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node's text reference.
+ */
+char *
+fy_node_get_reference(struct fy_node *fyn)
+	FY_EXPORT;
+
+#define fy_node_get_reference_alloca(_fyn) \
+	FY_ALLOCA_COPY_FREE_NO_NULL(fy_node_get_reference((_fyn)), FY_NT)
+
+/**
+ * fy_node_create_reference() - Create an alias reference node
+ *
+ * Create an alias node reference. If the node
+ * contains an anchor the expression that references the alias will
+ * use the anchor, otherwise an absolute path reference relative
+ * to the root of the document will be created.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * An alias node referencing the argument node
+ */
+struct fy_node *
+fy_node_create_reference(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_relative_reference() - Get a textual reference to a node
+ * 				      relative to a base node.
+ *
+ * Retrieve the given node's textual reference as generated using
+ * another parent (or grand parent) as a base.
+ * If the node contains an anchor the expression that references the anchor
+ * will be returned.
+ * If the base node contains an anchor the reference will be relative to it
+ * otherwise an absolute path reference will be returned.
+ *
+ * The address is dynamically allocated and should be freed when
+ * you're done with it.
+ *
+ * @fyn_base: The base node
+ * @fyn: The node
+ *
+ * Returns:
+ * The node's text reference.
+ */
+char *
+fy_node_get_relative_reference(struct fy_node *fyn_base, struct fy_node *fyn)
+	FY_EXPORT;
+
+#define fy_node_get_relative_reference_alloca(_fynb, _fyn) \
+	FY_ALLOCA_COPY_FREE_NO_NULL(fy_node_get_relative_reference((_fynb), (_fyn)), FY_NT)
+
+/**
+ * fy_node_create_relative_reference() - Create an alias reference node
+ *
+ * Create a relative alias node reference using
+ * another parent (or grand parent) as a base.
+ * If the node contains an anchor the alias will reference the anchor.
+ * If the base node contains an anchor the alias will be relative to it
+ * otherwise an absolute path reference will be created.
+ *
+ * @fyn_base: The base node
+ * @fyn: The node
+ *
+ * Returns:
+ * An alias node referencing the argument node relative to the base
+ */
+struct fy_node *
+fy_node_create_relative_reference(struct fy_node *fyn_base, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_scalar() - Create a scalar node.
+ *
+ * Create a scalar node using the provided memory area as input.
+ * The input is expected to be regular utf8 encoded. It may contain
+ * escaped characters in which case the style of the scalar will be
+ * set to double quoted.
+ *
+ * Note that the data are not copied, merely a reference is taken, so
+ * it must be available while the node is in use.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ * @data: Pointer to the data area
+ * @size: Size of the data area, or (size_t)-1 for '\0' terminated data.
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_create_scalar(struct fy_document *fyd,
+		      const char *data, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_scalar_copy() - Create a scalar node copying the data.
+ *
+ * Create a scalar node using the provided memory area as input.
+ * The input is expected to be regular utf8 encoded. It may contain
+ * escaped characters in which case the style of the scalar will be
+ * set to double quoted.
+ *
+ * A copy of the data will be made, so it is safe to free the data
+ * after the call.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ * @data: Pointer to the data area
+ * @size: Size of the data area, or (size_t)-1 for '\0' terminated data.
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_create_scalar_copy(struct fy_document *fyd,
+			   const char *data, size_t size)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_vscalarf() - vprintf interface for creating scalars
+ *
+ * Create a scalar node using a vprintf interface.
+ * The input is expected to be regular utf8 encoded. It may contain
+ * escaped characters in which case the style of the scalar will be
+ * set to double quoted.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ * @fmt: The printf based format string
+ * @ap: The va_list containing the arguments
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_create_vscalarf(struct fy_document *fyd, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_scalarf() - printf interface for creating scalars
+ *
+ * Create a scalar node using a printf interface.
+ * The input is expected to be regular utf8 encoded. It may contain
+ * escaped characters in which case the style of the scalar will be
+ * set to double quoted.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ * @fmt: The printf based format string
+ * @...: The arguments
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_create_scalarf(struct fy_document *fyd, const char *fmt, ...)
+	FY_FORMAT(printf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_sequence() - Create an empty sequence node.
+ *
+ * Create an empty sequence node associated with the given document.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_create_sequence(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_mapping() - Create an empty mapping node.
+ *
+ * Create an empty mapping node associated with the given document.
+ *
+ * @fyd: The document which the resulting node will be associated with
+ *
+ * Returns:
+ * The created node, or NULL on error.
+ */
+struct fy_node *
+fy_node_create_mapping(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_tag() - Set the tag of node
+ *
+ * Manually set the tag of a node. The tag must be a valid one for
+ * the document the node belongs to.
+ *
+ * Note that the data are not copied, merely a reference is taken, so
+ * it must be available while the node is in use.
+ *
+ * If the node already contains a tag it will be overwriten.
+ *
+ * @fyn: The node to set it's tag.
+ * @data: Pointer to the tag data.
+ * @len: Size of the tag data, or (size_t)-1 for '\0' terminated.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_set_tag(struct fy_node *fyn, const char *data, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_remove_tag() - Remove the tag of node
+ *
+ * Remove the tag of a node.
+ *
+ * @fyn: The node to remove it's tag.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_remove_tag(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_tag() - Get the tag of the node
+ *
+ * This method will return a pointer to the text of a tag
+ * along with the length of it. Note that this text is *not*
+ * NULL terminated.
+ *
+ * @fyn: The node
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the tag of the node, while @lenp will be assigned the
+ * length of said tag.
+ * A NULL will be returned in case of an error.
+ */
+const char *
+fy_node_get_tag(struct fy_node *fyn, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_tag0() - Get the tag of the node
+ *
+ * This method will return a pointer to the text of a tag,
+ * which will be NULL terminated.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * A pointer to the null terminated tag of the node.
+ * A NULL will be returned in case of an error.
+ */
+const char *
+fy_node_get_tag0(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_tag_length() - Get the length of the tag of the node
+ *
+ * This method will return the size of the tag of the node.
+ * If the node is not tagged it will return 0.
+ *
+ * @fyn: The tagged node
+ *
+ * Returns:
+ * The size of the tag, or 0 if node is not tagged.
+ */
+size_t
+fy_node_get_tag_length(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_scalar() - Get the scalar content of the node
+ *
+ * This method will return a pointer to the text of the scalar
+ * content of a node along with the length of it.
+ * Note that this pointer is *not* NULL terminated.
+ *
+ * @fyn: The scalar node
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the scalar content of the node, while @lenp will be assigned the
+ * length of said content.
+ * A NULL will be returned in case of an error, i.e. the node is not
+ * a scalar.
+ */
+const char *
+fy_node_get_scalar(struct fy_node *fyn, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_scalar0() - Get the scalar content of the node
+ *
+ * This method will return a pointer to the text of the scalar
+ * content of a node as a null terminated string.
+ * Note that this call will allocate memory to hold the null terminated
+ * string so if possible use fy_node_get_scalar()
+ *
+ * @fyn: The scalar node
+ *
+ * Returns:
+ * A pointer to the scalar content of the node or NULL in returned in case of an error.
+ */
+const char *
+fy_node_get_scalar0(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_scalar_length() - Get the length of the scalar content
+ *
+ * This method will return the size of the scalar content of the node.
+ * If the node is not a scalar it will return 0.
+ *
+ * @fyn: The scalar node
+ *
+ * Returns:
+ * The size of the scalar content, or 0 if node is not scalar.
+ */
+size_t
+fy_node_get_scalar_length(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_scalar_utf8_length() - Get the length of the scalar content
+ * 				      in utf8 characters
+ *
+ * This method will return the size of the scalar content of the node in
+ * utf8 characters.
+ * If the node is not a scalar it will return 0.
+ *
+ * @fyn: The scalar node
+ *
+ * Returns:
+ * The size of the scalar content in utf8 characters, or 0 if node is not scalar.
+ */
+size_t
+fy_node_get_scalar_utf8_length(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_iterate() - Iterate over a sequence node
+ *
+ * This method iterates over all the item nodes in the sequence node.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @fyn: The sequence node
+ * @prevp: The previous sequence iterator
+ *
+ * Returns:
+ * The next node in sequence or NULL at the end of the sequence.
+ */
+struct fy_node *
+fy_node_sequence_iterate(struct fy_node *fyn, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_reverse_iterate() - Iterate over a sequence node in reverse
+ *
+ * This method iterates in reverse over all the item nodes in the sequence node.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @fyn: The sequence node
+ * @prevp: The previous sequence iterator
+ *
+ * Returns:
+ * The next node in reverse sequence or NULL at the end of the sequence.
+ */
+struct fy_node *
+fy_node_sequence_reverse_iterate(struct fy_node *fyn, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_item_count() - Return the item count of the sequence
+ *
+ * Get the item count of the sequence.
+ *
+ * @fyn: The sequence node
+ *
+ * Returns:
+ * The count of items in the sequence or -1 in case of an error.
+ */
+int
+fy_node_sequence_item_count(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_is_empty() - Check whether the sequence is empty
+ *
+ * Check whether the sequence contains items.
+ *
+ * @fyn: The sequence node
+ *
+ * Returns:
+ * true if the node is a sequence containing items, false otherwise
+ */
+bool
+fy_node_sequence_is_empty(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_get_by_index() - Return a sequence item by index
+ *
+ * Retrieve a node in the sequence using it's index. If index
+ * is positive or zero the count is from the start of the sequence,
+ * while if negative from the end. I.e. -1 returns the last item
+ * in the sequence.
+ *
+ * @fyn: The sequence node
+ * @index: The index of the node to retrieve.
+ *         - >= 0 counting from the start
+ *         - < 0 counting from the end
+ *
+ * Returns:
+ * The node at the specified index or NULL if no such item exist.
+ */
+struct fy_node *
+fy_node_sequence_get_by_index(struct fy_node *fyn, int index)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_append() - Append a node item to a sequence
+ *
+ * Append a node item to a sequence.
+ *
+ * @fyn_seq: The sequence node
+ * @fyn: The node item to append
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_sequence_append(struct fy_node *fyn_seq, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_prepend() - Append a node item to a sequence
+ *
+ * Prepend a node item to a sequence.
+ *
+ * @fyn_seq: The sequence node
+ * @fyn: The node item to prepend
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int fy_node_sequence_prepend(struct fy_node *fyn_seq, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_insert_before() - Insert a node item before another
+ *
+ * Insert a node item before another in the sequence.
+ *
+ * @fyn_seq: The sequence node
+ * @fyn_mark: The node item which the node will be inserted before.
+ * @fyn: The node item to insert in the sequence.
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_sequence_insert_before(struct fy_node *fyn_seq,
+			       struct fy_node *fyn_mark, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_insert_after() - Insert a node item after another
+ *
+ * Insert a node item after another in the sequence.
+ *
+ * @fyn_seq: The sequence node
+ * @fyn_mark: The node item which the node will be inserted after.
+ * @fyn: The node item to insert in the sequence.
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_sequence_insert_after(struct fy_node *fyn_seq,
+			      struct fy_node *fyn_mark, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_remove() - Remove an item from a sequence
+ *
+ * Remove a node item from a sequence and return it.
+ *
+ * @fyn_seq: The sequence node
+ * @fyn: The node item to remove from the sequence.
+ *
+ * Returns:
+ * The removed node item fyn, or NULL in case of an error.
+ */
+struct fy_node *
+fy_node_sequence_remove(struct fy_node *fyn_seq, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+* typedef fy_node_sequence_sort_fn - Sequence sorting method function
+*
+* @fyn_a: The first node used in the comparison
+* @fyn_b: The second node used in the comparison
+* @arg: The opaque user provided pointer to the sort operation
+*
+* Returns:
+* <0 if @fyn_a is less than @fyn_b
+* 0 if @fyn_a is equal to fyn_b
+* >0 if @fyn_a is greater than @fyn_b
+*/
+typedef int (*fy_node_sequence_sort_fn)(struct fy_node *fyn_a,
+				struct fy_node *fyn_b,
+				void *arg);
+
+/**
+* fy_node_sequence_sort() - Sort a sequence's items
+*
+* Sort the items of a sequence node using the given comparison method.
+*
+* @fyn_seq: The sequence node to sort
+* @cmp: The comparison method
+* @arg: An opaque user pointer for the comparison method
+*
+* Returns:
+* 0 on success, -1 on error
+*/
+int
+fy_node_sequence_sort(struct fy_node *fyn_seq, fy_node_sequence_sort_fn cmp, void *arg)
+FY_EXPORT;
+
+/**
+ * fy_node_mapping_iterate() - Iterate over a mapping node
+ *
+ * This method iterates over all the node pairs in the mapping node.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * Note that while a mapping is an unordered collection of key/values
+ * the order of which they are created is important for presentation
+ * purposes.
+ *
+ * @fyn: The mapping node
+ * @prevp: The previous sequence iterator
+ *
+ * Returns:
+ * The next node pair in the mapping or NULL at the end of the mapping.
+ */
+struct fy_node_pair *
+fy_node_mapping_iterate(struct fy_node *fyn, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_reverse_iterate() - Iterate over a mapping node in reverse
+ *
+ * This method iterates in reverse over all the node pairs in the mapping node.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * Note that while a mapping is an unordered collection of key/values
+ * the order of which they are created is important for presentation
+ * purposes.
+ *
+ * @fyn: The mapping node
+ * @prevp: The previous sequence iterator
+ *
+ * Returns:
+ * The next node pair in reverse sequence in the mapping or NULL at the end of the mapping.
+ */
+struct fy_node_pair *
+fy_node_mapping_reverse_iterate(struct fy_node *fyn, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_item_count() - Return the node pair count of the mapping
+ *
+ * Get the count of the node pairs in the mapping.
+ *
+ * @fyn: The mapping node
+ *
+ * Returns:
+ * The count of node pairs in the mapping or -1 in case of an error.
+ */
+int
+fy_node_mapping_item_count(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_is_empty() - Check whether the mapping is empty
+ *
+ * Check whether the mapping contains any node pairs.
+ *
+ * @fyn: The mapping node
+ *
+ * Returns:
+ * true if the node is a mapping containing node pairs, false otherwise
+ */
+bool
+fy_node_mapping_is_empty(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_get_by_index() - Return a node pair by index
+ *
+ * Retrieve a node pair in the mapping using its index. If index
+ * is positive or zero the count is from the start of the sequence,
+ * while if negative from the end. I.e. -1 returns the last node pair
+ * in the mapping.
+ *
+ * @fyn: The mapping node
+ * @index: The index of the node pair to retrieve.
+ *         - >= 0 counting from the start
+ *         - < 0 counting from the end
+ *
+ * Returns:
+ * The node pair at the specified index or NULL if no such item exist.
+ */
+struct fy_node_pair *
+fy_node_mapping_get_by_index(struct fy_node *fyn, int index)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_pair_by_string() - Lookup a node pair in mapping by string
+ *
+ * This method will return the node pair that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using fy_node_compare()
+ *
+ * @fyn: The mapping node
+ * @key: The YAML source to use as key
+ * @len: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The value matching the given key, or NULL if not found.
+ */
+struct fy_node_pair *
+fy_node_mapping_lookup_pair_by_string(struct fy_node *fyn,
+				      const char *key, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_by_string() - Lookup a node value in mapping by string
+ *
+ * This method will return the value of node pair that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using fy_node_compare()
+ *
+ * @fyn: The mapping node
+ * @key: The YAML source to use as key
+ * @len: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The value matching the given key, or NULL if not found.
+ */
+struct fy_node *
+fy_node_mapping_lookup_by_string(struct fy_node *fyn,
+				 const char *key, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_value_by_string() - Lookup a node value in mapping by string
+ *
+ * This method will return the value of node pair that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using fy_node_compare()
+ *
+ * It is synonymous with fy_node_mapping_lookup_by_string().
+ *
+ * @fyn: The mapping node
+ * @key: The YAML source to use as key
+ * @len: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The value matching the given key, or NULL if not found.
+ */
+struct fy_node *
+fy_node_mapping_lookup_value_by_string(struct fy_node *fyn,
+				       const char *key, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_key_by_string() - Lookup a node key in mapping by string
+ *
+ * This method will return the key of node pair that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using fy_node_compare()
+ *
+ * @fyn: The mapping node
+ * @key: The YAML source to use as key
+ * @len: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The key matching the given key, or NULL if not found.
+ */
+struct fy_node *
+fy_node_mapping_lookup_key_by_string(struct fy_node *fyn,
+				     const char *key, size_t len)
+	FY_EXPORT;
+
+
+/**
+ * fy_node_mapping_lookup_pair_by_simple_key() - Lookup a node pair in mapping by simple string
+ *
+ * This method will return the node pair that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using by comparing the strings for identity.
+ *
+ * @fyn: The mapping node
+ * @key: The string to use as key
+ * @len: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The node pair matching the given key, or NULL if not found.
+ */
+struct fy_node_pair *
+fy_node_mapping_lookup_pair_by_simple_key(struct fy_node *fyn,
+					  const char *key, size_t len)
+	FY_EXPORT;
+/**
+ * fy_node_mapping_lookup_value_by_simple_key() - Lookup a node value in mapping by simple string
+ *
+ * This method will return the value of node pair that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using by comparing the strings for identity.
+ *
+ * @fyn: The mapping node
+ * @key: The string to use as key
+ * @len: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The value matching the given key, or NULL if not found.
+ */
+struct fy_node *
+fy_node_mapping_lookup_value_by_simple_key(struct fy_node *fyn,
+					   const char *key, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_pair_by_null_key() - Lookup a node pair in mapping that has a NULL key
+ *
+ * This method will return the node pair that has a NULL key.
+ * Note this method is not using the mapping accelerator
+ * and arguably NULL keys should not exist. Alas...
+ *
+ * @fyn: The mapping node
+ *
+ * Returns:
+ * The node pair with a NULL key, NULL otherwise
+ */
+struct fy_node_pair *
+fy_node_mapping_lookup_pair_by_null_key(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_value_by_null_key() - Lookup a node value with a NULL key.
+ *
+ * Return the value of a node pair that has a NULL key.
+ *
+ * @fyn: The mapping node
+ *
+ * Returns:
+ * The value matching the null key, NULL otherwise.
+ * Note that the value may be NULL too, but for that pathological case
+ * use the node pair method instead.
+ */
+struct fy_node *
+fy_node_mapping_lookup_value_by_null_key(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_scalar_by_simple_key() - Lookup a scalar in mapping by simple string
+ *
+ * This method will return the scalar contents that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using by comparing the strings for identity.
+ *
+ * @fyn: The mapping node
+ * @lenp: Pointer to a variable that will hold the returned length
+ * @key: The string to use as key
+ * @keylen: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The scalar contents matching the given key, or NULL if not found.
+ */
+const char *
+fy_node_mapping_lookup_scalar_by_simple_key(struct fy_node *fyn, size_t *lenp,
+					    const char *key, size_t keylen)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_scalar0_by_simple_key() - Lookup a scalar in mapping by simple string
+ * 						    returning a '\0' terminated scalar
+ *
+ * This method will return the NUL terminated scalar contents that contains the same key
+ * from the YAML node created from the @key argument. The comparison of the
+ * node is using by comparing the strings for identity.
+ *
+ * @fyn: The mapping node
+ * @key: The string to use as key
+ * @keylen: The length of the key (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The NUL terminated scalar contents matching the given key, or NULL if not found.
+ */
+const char *
+fy_node_mapping_lookup_scalar0_by_simple_key(struct fy_node *fyn,
+					     const char *key, size_t keylen)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_lookup_pair() - Lookup a node pair matching the provided key
+ *
+ * This method will return the node pair that matches the provided @fyn_key
+ *
+ * @fyn: The mapping node
+ * @fyn_key: The node to use as key
+ *
+ * Returns:
+ * The node pair matching the given key, or NULL if not found.
+ */
+struct fy_node_pair *
+fy_node_mapping_lookup_pair(struct fy_node *fyn, struct fy_node *fyn_key)
+	FY_EXPORT;
+
+
+/**
+ * fy_node_mapping_lookup_value_by_key() - Lookup a node pair's value matching the provided key
+ *
+ * This method will return the node pair that matches the provided @fyn_key
+ * The key may be collection and a content match check is performed recursively
+ * in order to find the right key.
+ *
+ * @fyn: The mapping node
+ * @fyn_key: The node to use as key
+ *
+ * Returns:
+ * The node value matching the given key, or NULL if not found.
+ */
+struct fy_node *
+fy_node_mapping_lookup_value_by_key(struct fy_node *fyn, struct fy_node *fyn_key);
+
+/**
+ * fy_node_mapping_lookup_key_by_key() - Lookup a node pair's key matching the provided key
+ *
+ * This method will return the node pair that matches the provided @fyn_key
+ * The key may be collection and a content match check is performed recursively
+ * in order to find the right key.
+ *
+ * @fyn: The mapping node
+ * @fyn_key: The node to use as key
+ *
+ * Returns:
+ * The node key matching the given key, or NULL if not found.
+ */
+struct fy_node *
+fy_node_mapping_lookup_key_by_key(struct fy_node *fyn, struct fy_node *fyn_key);
+
+/**
+ * fy_node_mapping_get_pair_index() - Return the node pair index in the mapping
+ *
+ * This method will return the node pair index in the mapping of the given
+ * node pair argument.
+ *
+ * @fyn: The mapping node
+ * @fynp: The node pair
+ *
+ * Returns:
+ * The index of the node pair in the mapping or -1 in case of an error.
+ */
+int
+fy_node_mapping_get_pair_index(struct fy_node *fyn,
+			       const struct fy_node_pair *fynp)
+	FY_EXPORT;
+
+/**
+ * fy_node_pair_key() - Return the key of a node pair
+ *
+ * This method will return the node pair's key.
+ * Note that this may be NULL, which is returned also in case
+ * the node pair argument is NULL, so you should protect against
+ * such a case.
+ *
+ * @fynp: The node pair
+ *
+ * Returns:
+ * The node pair key
+ */
+struct fy_node *
+fy_node_pair_key(struct fy_node_pair *fynp)
+	FY_EXPORT;
+
+/**
+ * fy_node_pair_value() - Return the value of a node pair
+ *
+ * This method will return the node pair's value.
+ * Note that this may be NULL, which is returned also in case
+ * the node pair argument is NULL, so you should protect against
+ * such a case.
+ *
+ * @fynp: The node pair
+ *
+ * Returns:
+ * The node pair value
+ */
+struct fy_node *
+fy_node_pair_value(struct fy_node_pair *fynp)
+	FY_EXPORT;
+
+/**
+ * fy_node_pair_set_key() - Sets the key of a node pair
+ *
+ * This method will set the key part of the node pair.
+ * It will ovewrite any previous key.
+ *
+ * Note that no checks for duplicate keys are going to be
+ * performed.
+ *
+ * @fynp: The node pair
+ * @fyn: The key node
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_pair_set_key(struct fy_node_pair *fynp, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_pair_set_value() - Sets the value of a node pair
+ *
+ * This method will set the value part of the node pair.
+ * It will ovewrite any previous value.
+ *
+ * @fynp: The node pair
+ * @fyn: The value node
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_pair_set_value(struct fy_node_pair *fynp, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_append() - Append a node item to a mapping
+ *
+ * Append a node pair to a mapping.
+ *
+ * @fyn_map: The mapping node
+ * @fyn_key: The node pair's key
+ * @fyn_value: The node pair's value
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_mapping_append(struct fy_node *fyn_map,
+		       struct fy_node *fyn_key, struct fy_node *fyn_value)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_prepend() - Prepend a node item to a mapping
+ *
+ * Prepend a node pair to a mapping.
+ *
+ * @fyn_map: The mapping node
+ * @fyn_key: The node pair's key
+ * @fyn_value: The node pair's value
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_mapping_prepend(struct fy_node *fyn_map,
+			struct fy_node *fyn_key, struct fy_node *fyn_value)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_remove() - Remove a node pair from a mapping
+ *
+ * Remove node pair from a mapping.
+ *
+ * @fyn_map: The mapping node
+ * @fynp: The node pair to remove
+ *
+ * Returns:
+ * 0 on success, -1 on failure.
+ */
+int
+fy_node_mapping_remove(struct fy_node *fyn_map, struct fy_node_pair *fynp)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_sort() - Sort a single mapping's keys
+ *
+ * Sort the keys of a single mapping node using the given comparison method (if NULL use the default one).
+ * Unlike fy_node_sort(), this does not recurse into child nodes.
+ *
+ * @fyn_map: The mapping node to sort
+ * @key_cmp: The comparison method
+ * @arg: An opaque user pointer for the comparison method
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_mapping_sort(struct fy_node *fyn_map, fy_node_mapping_sort_fn key_cmp, void *arg)
+	FY_EXPORT;
+
+/**
+ * fy_node_mapping_remove_by_key() - Remove a node pair from a mapping returning the value
+ *
+ * Remove node pair from a mapping using the supplied key.
+ *
+ * @fyn_map: The mapping node
+ * @fyn_key: The node pair's key
+ *
+ * Returns:
+ * The value part of removed node pair, or NULL in case of an error.
+ */
+struct fy_node *
+fy_node_mapping_remove_by_key(struct fy_node *fyn_map, struct fy_node *fyn_key)
+	FY_EXPORT;
+
+/**
+ * fy_node_sort() - Recursively sort node
+ *
+ * Recursively sort all mappings of the given node, using the given
+ * comparison method (if NULL use the default one).
+ *
+ * @fyn: The node to sort
+ * @key_cmp: The comparison method
+ * @arg: An opaque user pointer for the comparison method
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_sort(struct fy_node *fyn, fy_node_mapping_sort_fn key_cmp, void *arg)
+	FY_EXPORT;
+
+/**
+ * fy_node_vscanf() - Retrieve data via vscanf
+ *
+ * This method easily retrieves data using a familiar vscanf interface.
+ * The format string is a regular scanf format string with the following format.
+ *
+ *   "pathspec %opt pathspec %opt..."
+ *
+ * Each pathspec is separated with space from the scanf option
+ *
+ * For example:
+ * fyn = { foo: 3 } -> fy_node_scanf(fyn, "/foo %d", &var) -> var = 3
+ *
+ *
+ * @fyn: The node to use as a pathspec root
+ * @fmt: The scanf based format string
+ * @ap: The va_list containing the arguments
+ *
+ * Returns:
+ * The number of scanned arguments, or -1 on error.
+ */
+int fy_node_vscanf(struct fy_node *fyn, const char *fmt, va_list ap);
+
+/**
+ * fy_node_scanf() - Retrieve data via scanf
+ *
+ * This method easily retrieves data using a familiar vscanf interface.
+ * The format string is a regular scanf format string with the following format.
+ *
+ *   "pathspec %opt pathspec %opt..."
+ *
+ * Each pathspec is separated with space from the scanf option
+ *
+ * For example:
+ * fyn = { foo: 3 } -> fy_node_scanf(fyn, "/foo %d", &var) -> var = 3
+ *
+ *
+ * @fyn: The node to use as a pathspec root
+ * @fmt: The scanf based format string
+ * @...: The arguments
+ *
+ * Returns:
+ * The number of scanned arguments, or -1 on error.
+ */
+int
+fy_node_scanf(struct fy_node *fyn, const char *fmt, ...)
+	FY_FORMAT(scanf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * fy_document_vscanf() - Retrieve data via vscanf relative to document root
+ *
+ * This method easily retrieves data using a familiar vscanf interface.
+ * The format string is a regular scanf format string with the following format.
+ *
+ *   "pathspec %opt pathspec %opt..."
+ *
+ * Each pathspec is separated with space from the scanf option
+ *
+ * For example:
+ * fyd = { foo: 3 } -> fy_document_scanf(fyd, "/foo %d", &var) -> var = 3
+ *
+ *
+ * @fyd: The document
+ * @fmt: The scanf based format string
+ * @ap: The va_list containing the arguments
+ *
+ * Returns:
+ * The number of scanned arguments, or -1 on error.
+ */
+int
+fy_document_vscanf(struct fy_document *fyd, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_document_scanf() - Retrieve data via scanf relative to document root
+ *
+ * This method easily retrieves data using a familiar vscanf interface.
+ * The format string is a regular scanf format string with the following format.
+ *
+ *   "pathspec %opt pathspec %opt..."
+ *
+ * Each pathspec is separated with space from the scanf option
+ *
+ * For example:
+ * fyn = { foo: 3 } -> fy_node_scanf(fyd, "/foo %d", &var) -> var = 3
+ *
+ *
+ * @fyd: The document
+ * @fmt: The scanf based format string
+ * @...: The arguments
+ *
+ * Returns:
+ * The number of scanned arguments, or -1 on error.
+ */
+int
+fy_document_scanf(struct fy_document *fyd, const char *fmt, ...)
+	FY_FORMAT(scanf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * fy_document_tag_directive_iterate() - Iterate over a document's tag directives
+ *
+ * This method iterates over all the documents tag directives.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @fyd: The document
+ * @prevp: The previous state of the iterator
+ *
+ * Returns:
+ * The next tag directive token in the document or NULL at the end of them.
+ */
+struct fy_token *
+fy_document_tag_directive_iterate(struct fy_document *fyd, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_document_tag_directive_lookup() - Retreive a document's tag directive
+ *
+ * Retreives the matching tag directive token of the document matching the handle.
+ *
+ * @fyd: The document
+ * @handle: The handle to look for
+ *
+ * Returns:
+ * The tag directive token with the given handle or NULL if not found
+ */
+struct fy_token *
+fy_document_tag_directive_lookup(struct fy_document *fyd, const char *handle)
+	FY_EXPORT;
+
+/**
+ * fy_tag_directive_token_handle() - Get a tag directive handle
+ *
+ * Retreives the tag directives token handle value. Only valid on
+ * tag directive tokens.
+ *
+ * @fyt: The tag directive token
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the tag directive's handle, while @lenp will be assigned the
+ * length of said handle.
+ * A NULL will be returned in case of an error.
+ */
+const char *
+fy_tag_directive_token_handle(struct fy_token *fyt, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_tag_directive_token_prefix() - Get a tag directive prefix
+ *
+ * Retreives the tag directives token prefix value. Only valid on
+ * tag directive tokens.
+ *
+ * @fyt: The tag directive token
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the tag directive's prefix, while @lenp will be assigned the
+ * length of said prefix.
+ * A NULL will be returned in case of an error.
+ */
+const char *
+fy_tag_directive_token_prefix(struct fy_token *fyt, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_document_tag_directive_add() - Add a tag directive to a document
+ *
+ * Add tag directive to the document.
+ *
+ * @fyd: The document
+ * @handle: The handle of the tag directive
+ * @prefix: The prefix of the tag directive
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_tag_directive_add(struct fy_document *fyd,
+			      const char *handle, const char *prefix)
+	FY_EXPORT;
+
+/**
+ * fy_document_tag_directive_remove() - Remove a tag directive
+ *
+ * Remove a tag directive from a document.
+ * Note that removal is prohibited if any node is still using this tag directive.
+ *
+ * @fyd: The document
+ * @handle: The handle of the tag directive to remove.
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_tag_directive_remove(struct fy_document *fyd, const char *handle)
+	FY_EXPORT;
+
+/**
+ * fy_document_lookup_anchor() - Lookup an anchor
+ *
+ * Lookup for an anchor having the name provided
+ *
+ * @fyd: The document
+ * @anchor: The anchor to look for
+ * @len: The length of the anchor (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The anchor if found, NULL otherwise
+ */
+struct fy_anchor *
+fy_document_lookup_anchor(struct fy_document *fyd,
+			  const char *anchor, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_document_lookup_anchor_by_token() - Lookup an anchor by token text
+ *
+ * Lookup for an anchor having the name provided from the text of the token
+ *
+ * @fyd: The document
+ * @anchor: The token contains the anchor text to look for
+ *
+ * Returns:
+ * The anchor if found, NULL otherwise
+ */
+struct fy_anchor *
+fy_document_lookup_anchor_by_token(struct fy_document *fyd,
+				   struct fy_token *anchor)
+	FY_EXPORT;
+
+/**
+ * fy_document_lookup_anchor_by_node() - Lookup an anchor by node
+ *
+ * Lookup for an anchor located in the given node
+ *
+ * @fyd: The document
+ * @fyn: The node
+ *
+ * Returns:
+ * The anchor if found, NULL otherwise
+ */
+struct fy_anchor *
+fy_document_lookup_anchor_by_node(struct fy_document *fyd,
+				  struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_anchor_get_text() - Get the text of an anchor
+ *
+ * This method will return a pointer to the text of an anchor
+ * along with the length of it. Note that this text is *not*
+ * NULL terminated.
+ *
+ * @fya: The anchor
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the text of the anchor, while @lenp will be assigned the
+ * length of said anchor.
+ * A NULL will be returned in case of an error.
+ */
+const char *
+fy_anchor_get_text(struct fy_anchor *fya, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_anchor_node() - Get the node of an anchor
+ *
+ * This method returns the node associated with the anchor.
+ *
+ * @fya: The anchor
+ *
+ * Returns:
+ * The node of the anchor, or NULL in case of an error.
+ */
+struct fy_node *
+fy_anchor_node(struct fy_anchor *fya)
+	FY_EXPORT;
+
+/**
+ * fy_document_anchor_iterate() - Iterate over a document's anchors
+ *
+ * This method iterates over all the documents anchors.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @fyd: The document
+ * @prevp: The previous state of the iterator
+ *
+ * Returns:
+ * The next anchor in the document or NULL at the end of them.
+ */
+struct fy_anchor *
+fy_document_anchor_iterate(struct fy_document *fyd, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_document_set_anchor() - Place an anchor
+ *
+ * Places an anchor to the node with the give text name.
+ *
+ * Note that the data are not copied, merely a reference is taken, so
+ * it must be available while the node is in use.
+ *
+ * Also not that this method is deprecated; use fy_node_set_anchor()
+ * instead.
+ *
+ * @fyd: The document
+ * @fyn: The node to set the anchor to
+ * @text: Pointer to the anchor text
+ * @len: Size of the anchor text, or (size_t)-1 for '\0' terminated.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_document_set_anchor(struct fy_document *fyd, struct fy_node *fyn,
+		       const char *text, size_t len)
+	FY_EXPORT FY_DEPRECATED;
+
+/**
+ * fy_node_set_anchor() - Place an anchor to the node
+ *
+ * Places an anchor to the node with the give text name.
+ *
+ * Note that the data are not copied, merely a reference is taken, so
+ * it must be available while the node is in use.
+ *
+ * This is similar to fy_document_set_anchor() with the document set
+ * to the document of the @fyn node.
+ *
+ * @fyn: The node to set the anchor to
+ * @text: Pointer to the anchor text
+ * @len: Size of the anchor text, or (size_t)-1 for '\0' terminated.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_set_anchor(struct fy_node *fyn, const char *text, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_anchor_copy() - Place an anchor to the node copying the text
+ *
+ * Places an anchor to the node with the give text name, which
+ * will be copied, so it's safe to dispose the text after the call.
+ *
+ * @fyn: The node to set the anchor to
+ * @text: Pointer to the anchor text
+ * @len: Size of the anchor text, or (size_t)-1 for '\0' terminated.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_set_anchor_copy(struct fy_node *fyn, const char *text, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_vanchorf() - Place an anchor to the node using a vprintf interface.
+ *
+ * Places an anchor to the node with the give text name as created
+ * via vprintf'ing the arguments.
+ *
+ * @fyn: The node to set the anchor to
+ * @fmt: Pointer to the anchor format string
+ * @ap: The argument list.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_set_vanchorf(struct fy_node *fyn, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_anchorf() - Place an anchor to the node using a printf interface.
+ *
+ * Places an anchor to the node with the give text name as created
+ * via printf'ing the arguments.
+ *
+ * @fyn: The node to set the anchor to
+ * @fmt: Pointer to the anchor format string
+ * @...: The extra arguments.
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_set_anchorf(struct fy_node *fyn, const char *fmt, ...)
+	FY_FORMAT(printf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * fy_node_remove_anchor() - Remove an anchor
+ *
+ * Remove an anchor for the given node (if it exists)
+ *
+ * @fyn: The node to remove anchors from
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_remove_anchor(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_anchor() - Get the anchor of a node
+ *
+ * Retrieve the anchor of the given node (if it exists)
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The anchor if there's one at the node, or NULL otherwise
+ */
+struct fy_anchor *
+fy_node_get_anchor(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_nearest_anchor() - Get the nearest anchor of the node
+ *
+ * Retrieve the anchor of the nearest parent of the given node or
+ * the given node if it has one.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The nearest anchor if there's one, or NULL otherwise
+ */
+struct fy_anchor *
+fy_node_get_nearest_anchor(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_nearest_child_of() - Get the nearest node which is a
+ * 				    child of the base
+ *
+ * Retrieve the nearest node which is a child of fyn_base starting
+ * at fyn and working upwards.
+ *
+ * @fyn_base: The base node
+ * @fyn: The node to start from
+ *
+ * Returns:
+ * The nearest child of the base if there's one, or NULL otherwise
+ */
+struct fy_node *
+fy_node_get_nearest_child_of(struct fy_node *fyn_base, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_alias() - Create an alias node
+ *
+ * Create an alias on the given document
+ *
+ * Note that the data are not copied, merely a reference is taken, so
+ * it must be available while the node is in use.
+ *
+ * @fyd: The document
+ * @alias: The alias text
+ * @len: The length of the alias (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created alias node, or NULL in case of an error
+ */
+struct fy_node *
+fy_node_create_alias(struct fy_document *fyd,
+		     const char *alias, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_alias_copy() - Create an alias node copying the data
+ *
+ * Create an alias on the given document
+ *
+ * A copy of the data will be made, so it is safe to free the data
+ * after the call.
+ *
+ * @fyd: The document
+ * @alias: The alias text
+ * @len: The length of the alias (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created alias node, or NULL in case of an error
+ */
+struct fy_node *
+fy_node_create_alias_copy(struct fy_document *fyd,
+			  const char *alias, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_node_get_meta() - Get the meta pointer of a node
+ *
+ * Return the meta pointer of a node.
+ *
+ * @fyn: The node to get meta data from
+ *
+ * Returns:
+ * The stored meta data pointer
+ */
+void *
+fy_node_get_meta(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_meta() - Set the meta pointer of a node
+ *
+ * Set the meta pointer of a node. If @meta is NULL
+ * then clear the meta data.
+ *
+ * @fyn: The node to set meta data
+ * @meta: The meta data pointer
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_set_meta(struct fy_node *fyn, void *meta)
+	FY_EXPORT;
+
+/**
+ * fy_node_clear_meta() - Clear the meta data of a node
+ *
+ * Clears the meta data of a node.
+ *
+ * @fyn: The node to clear meta data
+ */
+void
+fy_node_clear_meta(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * typedef fy_node_meta_clear_fn - Meta data clear method
+ *
+ * This is the callback called when meta data are cleared.
+ *
+ * @fyn: The node which the meta data is being cleared
+ * @meta: The meta data of the node assigned via fy_node_set_meta()
+ * @user: The user pointer of fy_document_register_meta()
+ *
+ */
+typedef void (*fy_node_meta_clear_fn)(struct fy_node *fyn, void *meta, void *user);
+
+/**
+ * fy_document_register_meta() - Register a meta cleanup hook
+ *
+ * Register a meta data cleanup hook, to be called when
+ * the node is freed via a final call to fy_node_free().
+ * The hook is active for all nodes belonging to the document.
+ *
+ * @fyd: The document which the hook is registered to
+ * @clear_fn: The clear hook method
+ * @user: Opaque user provided pointer to the clear method
+ *
+ * Returns:
+ * 0 on success, -1 if another hook is already registered.
+ */
+int
+fy_document_register_meta(struct fy_document *fyd,
+			  fy_node_meta_clear_fn clear_fn, void *user)
+	FY_EXPORT;
+
+/**
+ * fy_document_unregister_meta() - Unregister a meta cleanup hook
+ *
+ * Unregister the currently active meta cleanup hook.
+ * The previous cleanup hook will be called for every node in
+ * the document.
+ *
+ * @fyd: The document to unregister it's meta cleanup hook.
+ */
+void
+fy_document_unregister_meta(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_node_set_marker() - Set a marker of a node
+ *
+ * Sets the marker of the given node, while returning
+ * the previous state of the marker. Note that the
+ * markers use the same space as the node follow markers.
+ *
+ * @fyn: The node
+ * @marker: The marker to set
+ *
+ * Returns:
+ * The previous value of the marker
+ */
+bool
+fy_node_set_marker(struct fy_node *fyn, unsigned int marker)
+	FY_EXPORT;
+
+/**
+ * fy_node_clear_marker() - Clear a marker of a node
+ *
+ * Clears the marker of the given node, while returning
+ * the previous state of the marker. Note that the
+ * markers use the same space as the node follow markers.
+ *
+ * @fyn: The node
+ * @marker: The marker to clear
+ *
+ * Returns:
+ * The previous value of the marker
+ */
+bool
+fy_node_clear_marker(struct fy_node *fyn, unsigned int marker)
+	FY_EXPORT;
+
+/**
+ * fy_node_is_marker_set() - Checks whether a marker is set
+ *
+ * Check the state of the given marker.
+ *
+ * @fyn: The node
+ * @marker: The marker index (must be less that FYNWF_MAX_USER_MARKER)
+ *
+ * Returns:
+ * The value of the marker (invalid markers return false)
+ */
+bool
+fy_node_is_marker_set(struct fy_node *fyn, unsigned int marker)
+	FY_EXPORT;
+
+/**
+ * fy_node_vreport() - Report about a node vprintf style
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document.
+ *
+ * @fyn: The node
+ * @type: The error type
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_node_vreport(struct fy_node *fyn, enum fy_error_type type,
+		const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_node_report() - Report about a node printf style
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document.
+ *
+ * @fyn: The node
+ * @type: The error type
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_node_report(struct fy_node *fyn, enum fy_error_type type,
+	       const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4)
+	FY_EXPORT;
+
+/**
+ * fy_node_override_vreport() - Report about a node vprintf style,
+ * 				overriding file, line and column info
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document. This method will use the overrides provided in order
+ * to massage the reporting information.
+ * If @file is NULL, no file location will be reported.
+ * If either @line or @column is negative no location will be reported.
+ *
+ * @fyn: The node
+ * @type: The error type
+ * @file: The file override
+ * @line: The line override
+ * @column: The column override
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_node_override_vreport(struct fy_node *fyn, enum fy_error_type type,
+			 const char *file, int line, int column,
+			 const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_node_override_report() - Report about a node printf style,
+ * 				overriding file, line and column info
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document. This method will use the overrides provided in order
+ * to massage the reporting information.
+ * If @file is NULL, no file location will be reported.
+ * If either @line or @column is negative no location will be reported.
+ *
+ * @fyn: The node
+ * @type: The error type
+ * @file: The file override
+ * @line: The line override
+ * @column: The column override
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_node_override_report(struct fy_node *fyn, enum fy_error_type type,
+			const char *file, int line, int column,
+			const char *fmt, ...)
+	FY_FORMAT(printf, 6, 7)
+	FY_EXPORT;
+
+/**
+ * fy_event_vreport() - Report about an event vprintf style
+ *
+ * Output a report about the given event via the specific
+ * error type, focusing at the given event part.
+ *
+ * @fyp: The parser of which the event was generated from
+ * @fye: The event
+ * @fyep: The event part which the report is about
+ * @type: The error type
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_event_vreport(struct fy_parser *fyp, struct fy_event *fye,
+		 enum fy_event_part fyep, enum fy_error_type type,
+		 const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_event_report() - Report about an event printf style
+ *
+ * Output a report about the given event via the specific
+ * error type, focusing at the given event part.
+ *
+ * @fyp: The parser of which the event was generated from
+ * @fye: The event
+ * @fyep: The event part which the report is about
+ * @type: The error type
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_event_report(struct fy_parser *fyp, struct fy_event *fye,
+		enum fy_event_part fyep, enum fy_error_type type,
+		const char *fmt, ...)
+	FY_FORMAT(printf, 5, 6)
+	FY_EXPORT;
+
+typedef void (*fy_diag_output_fn)(struct fy_diag *diag, void *user,
+				  const char *buf, size_t len);
+
+/**
+ * struct fy_diag_cfg - The diagnostics configuration
+ *
+ * @fp: File descriptor of the error output
+ * @output_fn: Callback to use when fp is NULL
+ * @user: User pointer to pass to the output_fn
+ * @level: The minimum debugging level
+ * @module_mask: A bitmask of the enabled modules
+ * @colorize: true if output should be colorized using ANSI sequences
+ * @show_source: true if source location should be displayed
+ * @show_position: true if position should be displayed
+ * @show_type: true if the type should be displayed
+ * @show_module: true if the module should be displayed
+ * @source_width: Width of the source field
+ * @position_width: Width of the position field
+ * @type_width: Width of the type field
+ * @module_width: Width of the module field
+ *
+ * This structure contains the configuration of the
+ * diagnostic object.
+ */
+struct fy_diag_cfg {
+	FILE *fp;
+	fy_diag_output_fn output_fn;
+	void *user;
+	enum fy_error_type level;
+	unsigned int module_mask;
+	bool colorize : 1;
+	bool show_source : 1;
+	bool show_position : 1;
+	bool show_type : 1;
+	bool show_module : 1;
+	int source_width;
+	int position_width;
+	int type_width;
+	int module_width;
+};
+
+/**
+ * struct fy_diag_error - A collected diagnostic error
+ *
+ * @type: Error type
+ * @module: The module
+ * @fyt: The token (may be NULL)
+ * @msg: The message to be output alongside
+ * @file: The file which contained the input
+ * @line: The line at the error
+ * @column: The column at the error
+ *
+ * This structure contains information about an error
+ * being collected by the diagnostic object.
+ */
+struct fy_diag_error {
+	enum fy_error_type type;
+	enum fy_error_module module;
+	struct fy_token *fyt;
+	const char *msg;
+	const char *file;
+	int line;
+	int column;
+};
+
+/**
+ * fy_diag_create() - Create a diagnostic object
+ *
+ * Creates a diagnostic object using the provided configuration.
+ *
+ * @cfg: The configuration for the diagnostic object (NULL is default)
+ *
+ * Returns:
+ * A pointer to the diagnostic object or NULL in case of an error.
+ */
+struct fy_diag *
+fy_diag_create(const struct fy_diag_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_diag_destroy() - Destroy a diagnostic object
+ *
+ * Destroy a diagnostic object; note that the actual
+ * destruction only occurs when no more references to the
+ * object are present. However no output will be generated
+ * after this call.
+ *
+ * @diag: The diagnostic object to destroy
+ */
+void
+fy_diag_destroy(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_get_cfg() - Get a diagnostic object's configuration
+ *
+ * Return the current configuration of a diagnostic object
+ *
+ * @diag: The diagnostic object
+ *
+ * Returns:
+ * A const pointer to the diagnostic object configuration, or NULL
+ * in case where diag is NULL
+ */
+const struct fy_diag_cfg *
+fy_diag_get_cfg(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_set_cfg() - Set a diagnostic object's configuration
+ *
+ * Replace the current diagnostic configuration with the given
+ * configuration passed as an argument.
+ *
+ * @diag: The diagnostic object
+ * @cfg: The diagnostic configuration
+ */
+void
+fy_diag_set_cfg(struct fy_diag *diag, const struct fy_diag_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_diag_set_level() - Set a diagnostic object's debug error level
+ *
+ * @diag: The diagnostic object
+ * @level: The debugging level to set
+ */
+void
+fy_diag_set_level(struct fy_diag *diag, enum fy_error_type level);
+
+/**
+ * fy_diag_set_colorize() - Set a diagnostic object's colorize option
+ *
+ * @diag: The diagnostic object
+ * @colorize: The colorize option
+ */
+void
+fy_diag_set_colorize(struct fy_diag *diag, bool colorize);
+
+/**
+ * fy_diag_ref() - Increment that reference counter of a diagnostic object
+ *
+ * Increment the reference.
+ *
+ * @diag: The diagnostic object to reference
+ *
+ * Returns:
+ * Always returns the @diag argument
+ */
+struct fy_diag *
+fy_diag_ref(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_unref() - Take away a ref from a diagnostic object
+ *
+ * Take away a reference, if it gets to 0, the diagnostic object
+ * is freed.
+ *
+ * @diag: The diagnostic object to unref
+ */
+void
+fy_diag_unref(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_got_error() - Test whether an error level diagnostic
+ *                       has been produced
+ *
+ * Tests whether an error diagnostic has been produced.
+ *
+ * @diag: The diagnostic object
+ *
+ * Returns:
+ * true if an error has been produced, false otherwise
+ */
+bool
+fy_diag_got_error(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_set_error() - Sets the error produced state
+ *
+ * Sets the error produced state
+ *
+ * @diag: The diagnostic object
+ * @on_error: The set error state
+ */
+void
+fy_diag_set_error(struct fy_diag *diag, bool on_error)
+	FY_EXPORT;
+
+/**
+ * fy_diag_reset_error() - Reset the error flag of
+ * 			   the diagnostic object
+ *
+ * Clears the error flag which was set by an output
+ * of an error level diagnostic
+ *
+ * @diag: The diagnostic object
+ */
+void
+fy_diag_reset_error(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_set_collect_errors() - Collect errors instead of outputting
+ *
+ * Set the collect errors mode. When true instead of outputting to
+ * the diagnostic interface, errors are collected for later
+ * retrieval.
+ *
+ * @diag: The diagnostic object
+ * @collect_errors: The collect errors mode
+ */
+void
+fy_diag_set_collect_errors(struct fy_diag *diag, bool collect_errors)
+	FY_EXPORT;
+
+/**
+ * fy_diag_get_collect_errors() - Get collect errors state
+ *
+ * Get the collect errors mode.
+ *
+ * @diag: The diagnostic object
+ *
+ * Returns:
+ * true collecting errors, false otherwise
+ */
+bool
+fy_diag_get_collect_errors(struct fy_diag *diag)
+	FY_EXPORT;
+
+/**
+ * fy_diag_cfg_default() - Fill in the configuration structure
+ * 			   with defaults
+ *
+ * Fills the configuration structure with defaults. The default
+ * always associates the file descriptor to stderr.
+ *
+ * @cfg: The diagnostic configuration structure
+ */
+void
+fy_diag_cfg_default(struct fy_diag_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_diag_cfg_from_parser_flags() - Fill partial diagnostic config
+ * 				     structure from parser config flags
+ *
+ * Fills in part of the configuration structure using parser flags.
+ * Since the parser flags do not contain debugging flags anymore this
+ * method is deprecated.
+ *
+ * @cfg: The diagnostic configuration structure
+ * @pflags: The parser flags
+ */
+void
+fy_diag_cfg_from_parser_flags(struct fy_diag_cfg *cfg,
+			      enum fy_parse_cfg_flags pflags)
+	FY_EXPORT FY_DEPRECATED;
+
+/**
+ * fy_diag_vprintf() - vprintf raw interface to diagnostics
+ *
+ * Raw output to the diagnostic object using a standard
+ * vprintf interface. Note that this is the lowest level
+ * interface, and as such is not recommended for use, since
+ * no formatting or coloring will take place.
+ *
+ * @diag: The diagnostic object to use
+ * @fmt: The vprintf format string
+ * @ap: The arguments
+ *
+ * Returns:
+ * The number of characters output, or -1 in case of an error
+ * Note that 0 shall be returned if the diagnostic object has
+ * been destroyed but not yet freed.
+ */
+int
+fy_diag_vprintf(struct fy_diag *diag, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diag_printf() - printf raw interface to diagnostics
+ *
+ * Raw output to the diagnostic object using a standard
+ * printf interface. Note that this is the lowest level
+ * interface, and as such is not recommended for use, since
+ * no formatting or coloring will take place.
+ *
+ * @diag: The diagnostic object to use
+ * @fmt: The printf format string
+ * @...: The arguments
+ *
+ * Returns:
+ * The number of characters output, or -1 in case of an error
+ * Note that 0 shall be returned if the diagnostic object has
+ * been destroyed but not yet freed.
+ */
+int
+fy_diag_printf(struct fy_diag *diag, const char *fmt, ...)
+	FY_FORMAT(printf, 2, 3)
+	FY_EXPORT;
+
+/**
+ * struct fy_diag_ctx - The diagnostics context
+ *
+ * @level: The level of the diagnostic
+ * @module: The module of the diagnostic
+ * @source_func: The source function
+ * @source_file: The source file
+ * @source_line: The source line
+ * @file: The file that caused the error
+ * @line: The line where the diagnostic occured
+ * @column: The column where the diagnostic occured
+ *
+ * This structure contains the diagnostic context
+ */
+struct fy_diag_ctx {
+	enum fy_error_type level;
+	enum fy_error_module module;
+	const char *source_func;
+	const char *source_file;
+	int source_line;
+	const char *file;
+	int line;
+	int column;
+};
+
+/**
+ * fy_vdiag() - context aware diagnostic output like vprintf
+ *
+ * Context aware output to the diagnostic object using a standard
+ * vprintf interface.
+ *
+ * @diag: The diagnostic object to use
+ * @fydc: The diagnostic context
+ * @fmt: The vprintf format string
+ * @ap: The arguments
+ *
+ * Returns:
+ * The number of characters output, or -1 in case of an error
+ * Note that 0 shall be returned if the diagnostic object has
+ * been destroyed but not yet freed.
+ */
+int
+fy_vdiag(struct fy_diag *diag, const struct fy_diag_ctx *fydc,
+	 const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diagf() - context aware diagnostic output like printf
+ *
+ * Context aware output to the diagnostic object using a standard
+ * printf interface.
+ *
+ * @diag: The diagnostic object to use
+ * @fydc: The diagnostic context
+ * @fmt: The vprintf format string
+ *
+ * Returns:
+ * The number of characters output, or -1 in case of an error
+ * Note that 0 shall be returned if the diagnostic object has
+ * been destroyed but not yet freed.
+ */
+int
+fy_diagf(struct fy_diag *diag, const struct fy_diag_ctx *fydc,
+	 const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4)
+	FY_EXPORT;
+
+#ifdef _MSC_VER
+/* MSVC doesn't support GCC statement expressions, use do-while(0) instead */
+#define fy_diag_diag(_diag, _level, _fmt, ...) \
+	do { \
+		struct fy_diag_ctx _ctx; \
+		memset(&_ctx, 0, sizeof(_ctx)); \
+		_ctx.level = (_level); \
+		_ctx.module = FYEM_UNKNOWN; \
+		_ctx.source_func = __func__; \
+		_ctx.source_file = __FILE__; \
+		_ctx.source_line = __LINE__; \
+		fy_diagf((_diag), &_ctx, (_fmt) , ## __VA_ARGS__); \
+	} while(0)
+#else
+#define fy_diag_diag(_diag, _level, _fmt, ...) \
+	({ \
+		struct fy_diag_ctx _ctx = { \
+			.level = (_level), \
+			.module = FYEM_UNKNOWN, \
+			.source_func = __func__, \
+			.source_file = __FILE__, \
+			.source_line = __LINE__, \
+			.file = NULL, \
+			.line = 0, \
+			.column = 0, \
+		}; \
+		fy_diagf((_diag), &_ctx, (_fmt) , ## __VA_ARGS__); \
+	})
+#endif
+
+#ifndef NDEBUG
+
+#define fy_debug(_diag, _fmt, ...) \
+	fy_diag_diag((_diag), FYET_DEBUG, (_fmt) , ## __VA_ARGS__)
+#else
+
+#define fy_debug(_diag, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fy_info(_diag, _fmt, ...) \
+	fy_diag_diag((_diag), FYET_INFO, (_fmt) , ## __VA_ARGS__)
+#define fy_notice(_diag, _fmt, ...) \
+	fy_diag_diag((_diag), FYET_NOTICE, (_fmt) , ## __VA_ARGS__)
+#define fy_warning(_diag, _fmt, ...) \
+	fy_diag_diag((_diag), FYET_WARNING, (_fmt) , ## __VA_ARGS__)
+#define fy_error(_diag, _fmt, ...) \
+	fy_diag_diag((_diag), FYET_ERROR, (_fmt) , ## __VA_ARGS__)
+
+/**
+ * fy_diag_token_vreport() - Report about a token vprintf style using
+ *                          the given diagnostic object
+ *
+ * Output a report about the given token via the specific
+ * error type, and using the reporting configuration of the token's
+ * document.
+ *
+ * @diag: The diag object
+ * @fyt: The token
+ * @type: The error type
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_diag_token_vreport(struct fy_diag *diag, struct fy_token *fyt,
+		     enum fy_error_type type, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diag_token_report() - Report about a token printf style using
+ *                          the given diagnostic object
+ *
+ * Output a report about the given token via the specific
+ * error type, and using the reporting configuration of the token's
+ * document.
+ *
+ * @diag: The diag object
+ * @fye: The token
+ * @type: The error type
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_diag_token_report(struct fy_diag *diag, struct fy_token *fye,
+		    enum fy_error_type type, const char *fmt, ...)
+	FY_FORMAT(printf, 4, 5)
+	FY_EXPORT;
+
+/**
+ * fy_diag_token_override_vreport() - Report about a token vprintf style,
+ * 				     overriding file, line and column info using
+ * 				     the given diagnostic object
+ *
+ * Output a report about the given token via the specific
+ * error type, and using the reporting configuration of the token's
+ * document. This method will use the overrides provided in order
+ * to massage the reporting information.
+ * If @file is NULL, no file location will be reported.
+ * If either @line or @column is negative no location will be reported.
+ *
+ * @diag: The diag object
+ * @fyt: The token
+ * @type: The error type
+ * @file: The file override
+ * @line: The line override
+ * @column: The column override
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_diag_token_override_vreport(struct fy_diag *diag, struct fy_token *fyt,
+			      enum fy_error_type type, const char *file,
+			      int line, int column, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diag_token_override_report() - Report about a token printf style,
+ * 				    overriding file, line and column info using
+ * 				    the given diagnostic object
+ *
+ * Output a report about the given token via the specific
+ * error type, and using the reporting configuration of the token's
+ * document. This method will use the overrides provided in order
+ * to massage the reporting information.
+ * If @file is NULL, no file location will be reported.
+ * If either @line or @column is negative no location will be reported.
+ *
+ * @diag: The diag object
+ * @fyt: The token
+ * @type: The error type
+ * @file: The file override
+ * @line: The line override
+ * @column: The column override
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_diag_token_override_report(struct fy_diag *diag, struct fy_token *fyt,
+			     enum fy_error_type type, const char *file,
+			     int line, int column, const char *fmt, ...)
+	FY_FORMAT(printf, 7, 8)
+	FY_EXPORT;
+
+/**
+ * fy_diag_node_vreport() - Report about a node vprintf style using
+ *                          the given diagnostic object
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document.
+ *
+ * @diag: The diag object
+ * @fyn: The node
+ * @type: The error type
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_diag_node_vreport(struct fy_diag *diag, struct fy_node *fyn,
+		     enum fy_error_type type, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diag_node_report() - Report about a node printf style using
+ *                          the given diagnostic object
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document.
+ *
+ * @diag: The diag object
+ * @fyn: The node
+ * @type: The error type
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_diag_node_report(struct fy_diag *diag, struct fy_node *fyn,
+		    enum fy_error_type type, const char *fmt, ...)
+	FY_FORMAT(printf, 4, 5)
+	FY_EXPORT;
+
+/**
+ * fy_diag_node_override_vreport() - Report about a node vprintf style,
+ * 				     overriding file, line and column info using
+ * 				     the given diagnostic object
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document. This method will use the overrides provided in order
+ * to massage the reporting information.
+ * If @file is NULL, no file location will be reported.
+ * If either @line or @column is negative no location will be reported.
+ *
+ * @diag: The diag object
+ * @fyn: The node
+ * @type: The error type
+ * @file: The file override
+ * @line: The line override
+ * @column: The column override
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_diag_node_override_vreport(struct fy_diag *diag, struct fy_node *fyn,
+			      enum fy_error_type type, const char *file,
+			      int line, int column, const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diag_node_override_report() - Report about a node printf style,
+ * 				    overriding file, line and column info using
+ * 				    the given diagnostic object
+ *
+ * Output a report about the given node via the specific
+ * error type, and using the reporting configuration of the node's
+ * document. This method will use the overrides provided in order
+ * to massage the reporting information.
+ * If @file is NULL, no file location will be reported.
+ * If either @line or @column is negative no location will be reported.
+ *
+ * @diag: The diag object
+ * @fyn: The node
+ * @type: The error type
+ * @file: The file override
+ * @line: The line override
+ * @column: The column override
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_diag_node_override_report(struct fy_diag *diag, struct fy_node *fyn,
+			     enum fy_error_type type, const char *file,
+			     int line, int column, const char *fmt, ...)
+	FY_FORMAT(printf, 7, 8)
+	FY_EXPORT;
+
+/**
+ * fy_diag_event_vreport() - Report about an event vprintf style using
+ *                          the given diagnostic object
+ *
+ * Output a report about the given event part via the specific
+ * error type.
+ *
+ * @diag: The diag object
+ * @fye: The event
+ * @fyep: The event part
+ * @type: The error type
+ * @fmt: The printf format string
+ * @ap: The argument list
+ */
+void
+fy_diag_event_vreport(struct fy_diag *diag, struct fy_event *fye,
+		      enum fy_event_part fyep, enum fy_error_type type,
+		      const char *fmt, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_diag_event_report() - Report about a event printf style using
+ *                          the given diagnostic object
+ *
+ * Output a report about the given event part via the specific
+ * error type.
+ *
+ * @diag: The diag object
+ * @fye: The event
+ * @fyep: The event part
+ * @type: The error type
+ * @fmt: The printf format string
+ * @...: The extra arguments.
+ */
+void
+fy_diag_event_report(struct fy_diag *diag, struct fy_event *fye,
+		     enum fy_event_part fyep, enum fy_error_type type,
+		     const char *fmt, ...)
+	FY_FORMAT(printf, 5, 6)
+	FY_EXPORT;
+
+/**
+ * fy_diag_errors_iterate() - Iterate over the errors of a diagnostic object
+ *
+ * This method iterates over all the errors collected on the diagnostic object.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @diag: The diagnostic object
+ * @prevp: The previous result iterator
+ *
+ * Returns:
+ * The next errors or NULL when there are not any more.
+ */
+struct fy_diag_error *
+fy_diag_errors_iterate(struct fy_diag *diag, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_checkpoint_create() - Create a parser checkpoint
+ *
+ * Create a checkpoint of the parser's current state. This allows you
+ * to save the parser state and potentially roll back to it later using
+ * fy_parser_rollback(). The checkpoint must be destroyed via
+ * fy_parser_checkpoint_destroy() when no longer needed.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * A pointer to the checkpoint, or NULL in case of an error
+ */
+struct fy_parser_checkpoint *
+fy_parser_checkpoint_create(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parser_checkpoint_destroy() - Destroy a parser checkpoint
+ *
+ * Destroy a checkpoint created earlier via fy_parser_checkpoint_create().
+ *
+ * @fypchk: The checkpoint to destroy
+ */
+void
+fy_parser_checkpoint_destroy(struct fy_parser_checkpoint *fypchk)
+	FY_EXPORT;
+
+/**
+ * fy_parser_rollback() - Roll back the parser to a checkpoint
+ *
+ * Roll back the parser state to a previously created checkpoint. This allows
+ * you to revert the parser to an earlier state and re-parse from that point.
+ * The checkpoint remains valid after rollback and can be used again or
+ * destroyed via fy_parser_checkpoint_destroy().
+ *
+ * @fyp: The parser
+ * @fypc: The checkpoint to roll back to
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_parser_rollback(struct fy_parser *fyp, struct fy_parser_checkpoint *fypc)
+	FY_EXPORT;
+
+/**
+ * enum fy_token_type - Token types
+ *
+ * @FYTT_NONE: No token
+ * @FYTT_STREAM_START: Stream start token
+ * @FYTT_STREAM_END: Stream end token
+ * @FYTT_VERSION_DIRECTIVE: Version directive token
+ * @FYTT_TAG_DIRECTIVE: Tag directive token
+ * @FYTT_DOCUMENT_START: Document start token
+ * @FYTT_DOCUMENT_END: Document end token
+ * @FYTT_BLOCK_SEQUENCE_START: Block sequence start token
+ * @FYTT_BLOCK_MAPPING_START: Block mapping start token
+ * @FYTT_BLOCK_END: Block end token
+ * @FYTT_FLOW_SEQUENCE_START: Flow sequence start token
+ * @FYTT_FLOW_SEQUENCE_END: Flow sequence end token
+ * @FYTT_FLOW_MAPPING_START: Flow mapping start token
+ * @FYTT_FLOW_MAPPING_END: Flow mapping end token
+ * @FYTT_BLOCK_ENTRY: Block entry token
+ * @FYTT_FLOW_ENTRY: Flow entry token
+ * @FYTT_KEY: Key token
+ * @FYTT_VALUE: Value token
+ * @FYTT_ALIAS: Alias token
+ * @FYTT_ANCHOR: Anchor token
+ * @FYTT_TAG: Tag token
+ * @FYTT_SCALAR: Scalar token
+ * @FYTT_INPUT_MARKER: Input marker token
+ * @FYTT_PE_SLASH: Path expression slash token
+ * @FYTT_PE_ROOT: Path expression root token
+ * @FYTT_PE_THIS: Path expression this token
+ * @FYTT_PE_PARENT: Path expression parent token
+ * @FYTT_PE_MAP_KEY: Path expression map key token
+ * @FYTT_PE_SEQ_INDEX: Path expression sequence index token
+ * @FYTT_PE_SEQ_SLICE: Path expression sequence slice token
+ * @FYTT_PE_SCALAR_FILTER: Path expression scalar filter token
+ * @FYTT_PE_COLLECTION_FILTER: Path expression collection filter token
+ * @FYTT_PE_SEQ_FILTER: Path expression sequence filter token
+ * @FYTT_PE_MAP_FILTER: Path expression map filter token
+ * @FYTT_PE_UNIQUE_FILTER: Path expression unique filter token
+ * @FYTT_PE_EVERY_CHILD: Path expression every child token
+ * @FYTT_PE_EVERY_CHILD_R: Path expression every child recursive token
+ * @FYTT_PE_ALIAS: Path expression alias token
+ * @FYTT_PE_SIBLING: Path expression sibling token
+ * @FYTT_PE_COMMA: Path expression comma token
+ * @FYTT_PE_BARBAR: Path expression || token
+ * @FYTT_PE_AMPAMP: Path expression && token
+ * @FYTT_PE_LPAREN: Path expression ( token
+ * @FYTT_PE_RPAREN: Path expression ) token
+ * @FYTT_PE_EQEQ: Path expression == token
+ * @FYTT_PE_NOTEQ: Path expression != token
+ * @FYTT_PE_LT: Path expression < token
+ * @FYTT_PE_GT: Path expression > token
+ * @FYTT_PE_LTE: Path expression <= token
+ * @FYTT_PE_GTE: Path expression >= token
+ * @FYTT_SE_PLUS: Scalar expression + token
+ * @FYTT_SE_MINUS: Scalar expression - token
+ * @FYTT_SE_MULT: Scalar expression \* token
+ * @FYTT_SE_DIV: Scalar expression / token
+ * @FYTT_PE_METHOD: Path expression method token
+ * @FYTT_SE_METHOD: Scalar expression method token
+ * @FYTT_PE_BANG: Path expression ! token
+ * @FYTT_PE_AT: Path expression \@ token
+ */
+enum fy_token_type {
+	/* non-content token types */
+	FYTT_NONE,
+	FYTT_STREAM_START,
+	FYTT_STREAM_END,
+	FYTT_VERSION_DIRECTIVE,
+	FYTT_TAG_DIRECTIVE,
+	FYTT_DOCUMENT_START,
+	FYTT_DOCUMENT_END,
+	/* content token types */
+	FYTT_BLOCK_SEQUENCE_START,
+	FYTT_BLOCK_MAPPING_START,
+	FYTT_BLOCK_END,
+	FYTT_FLOW_SEQUENCE_START,
+	FYTT_FLOW_SEQUENCE_END,
+	FYTT_FLOW_MAPPING_START,
+	FYTT_FLOW_MAPPING_END,
+	FYTT_BLOCK_ENTRY,
+	FYTT_FLOW_ENTRY,
+	FYTT_KEY,
+	FYTT_VALUE,
+	FYTT_ALIAS,
+	FYTT_ANCHOR,
+	FYTT_TAG,
+	FYTT_SCALAR,
+
+	/* special error reporting */
+	FYTT_INPUT_MARKER,
+
+	/* path expression tokens */
+	FYTT_PE_SLASH,
+	FYTT_PE_ROOT,
+	FYTT_PE_THIS,
+	FYTT_PE_PARENT,
+	FYTT_PE_MAP_KEY,
+	FYTT_PE_SEQ_INDEX,
+	FYTT_PE_SEQ_SLICE,
+	FYTT_PE_SCALAR_FILTER,
+	FYTT_PE_COLLECTION_FILTER,
+	FYTT_PE_SEQ_FILTER,
+	FYTT_PE_MAP_FILTER,
+	FYTT_PE_UNIQUE_FILTER,
+	FYTT_PE_EVERY_CHILD,
+	FYTT_PE_EVERY_CHILD_R,
+	FYTT_PE_ALIAS,
+	FYTT_PE_SIBLING,
+	FYTT_PE_COMMA,
+	FYTT_PE_BARBAR,
+	FYTT_PE_AMPAMP,
+	FYTT_PE_LPAREN,
+	FYTT_PE_RPAREN,
+
+	/* comparison operators */
+	FYTT_PE_EQEQ,
+	FYTT_PE_NOTEQ,
+	FYTT_PE_LT,
+	FYTT_PE_GT,
+	FYTT_PE_LTE,
+	FYTT_PE_GTE,
+
+	/* scalar expression tokens */
+	FYTT_SE_PLUS,
+	FYTT_SE_MINUS,
+	FYTT_SE_MULT,
+	FYTT_SE_DIV,
+
+	FYTT_PE_METHOD,
+	FYTT_SE_METHOD,
+
+	FYTT_PE_BANG,
+	FYTT_PE_AT,
+};
+
+/* The number of token types available */
+#define FYTT_COUNT	(FYTT_PE_AT+1)
+
+/**
+ * fy_token_type_is_valid() - Check token type validity
+ *
+ * Check if argument token type is a valid one.
+ *
+ * @type: The token type
+ *
+ * Returns:
+ * true if the token type is valid, false otherwise
+ */
+static inline bool
+fy_token_type_is_valid(enum fy_token_type type)
+{
+	return type >= FYTT_NONE && type < FYTT_COUNT;
+}
+
+/**
+ * fy_token_type_is_yaml() - Check if token type is valid for YAML
+ *
+ * Check if argument token type is a valid YAML one.
+ *
+ * @type: The token type
+ *
+ * Returns:
+ * true if the token type is a valid YAML one, false otherwise
+ */
+static inline bool
+fy_token_type_is_yaml(enum fy_token_type type)
+{
+	return type >= FYTT_STREAM_START && type <= FYTT_SCALAR;
+}
+
+/**
+ * fy_token_type_is_content() - Check if token type is
+ *                              valid for YAML content
+ *
+ * Check if argument token type is a valid YAML content one.
+ *
+ * @type: The token type
+ *
+ * Returns:
+ * true if the token type is a valid YAML content one, false otherwise
+ */
+static inline bool
+fy_token_type_is_content(enum fy_token_type type)
+{
+	return type >= FYTT_BLOCK_SEQUENCE_START && type <= FYTT_SCALAR;
+}
+
+/**
+ * fy_token_type_is_path_expr() - Check if token type is
+ *                                valid for a YPATH expression
+ *
+ * Check if argument token type is a valid YPATH parse expression token
+ *
+ * @type: The token type
+ *
+ * Returns:
+ * true if the token type is a valid YPATH one, false otherwise
+ */
+static inline bool
+fy_token_type_is_path_expr(enum fy_token_type type)
+{
+	return type >= FYTT_PE_SLASH && type <= FYTT_PE_GTE;
+}
+
+/**
+ * fy_token_type_is_scalar_expr() - Check if token type is
+ *                                  valid for a YPATH scalar expression
+ *
+ * Check if argument token type is a valid YPATH parse scalar expression token
+ *
+ * @type: The token type
+ *
+ * Returns:
+ * true if the token type is a valid YPATH scalar one, false otherwise
+ */
+static inline bool
+fy_token_type_is_scalar_expr(enum fy_token_type type)
+{
+	return type >= FYTT_SE_PLUS && type <= FYTT_SE_DIV;
+}
+
+/**
+ * fy_token_get_type() - Return the token's type
+ *
+ * Return the token's type; if NULL then FYTT_NONE is returned
+ *
+ * @fyt: The token
+ *
+ * Returns:
+ * The token's type; FYTT_NONE if not a valid token (or NULL)
+ */
+enum fy_token_type
+fy_token_get_type(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_start_mark() - Get token's start marker
+ *
+ * Return the token's start marker if it exists. Note
+ * it is permissable for some token types to have no
+ * start marker because they are without content.
+ *
+ * @fyt: The token to get its start marker
+ *
+ * Returns:
+ * The token's start marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_token_start_mark(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_end_mark() - Get token's end marker
+ *
+ * Return the token's end marker if it exists. Note
+ * it is permissable for some token types to have no
+ * end marker because they are without content.
+ *
+ * @fyt: The token to get its end marker
+ *
+ * Returns:
+ * The token's end marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_token_end_mark(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_style_start_mark() - Get token's start marker (style)
+ *
+ * Return the token's start marker if it exists, including the style
+ * indicators. Note it is permissable for some token types to have no
+ * start marker because they are without content.
+ *
+ * @fyt: The token to get its style start marker
+ *
+ * Returns:
+ * The token's style start marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_token_style_start_mark(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_token_style_end_mark() - Get token's end marker (style
+ *
+ * Return the token's end marker if it exists, including the
+ * style indicators. Note it is permissable for some token types to
+ * have no end marker because they are without content.
+ *
+ * @fyt: The token to get its style end marker
+ *
+ * Returns:
+ * The token's style end marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_token_style_end_mark(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_scan() - Low level access to the scanner
+ *
+ * Return the next scanner token. Note this is a very
+ * low level interface, intended for users that want/need
+ * to implement their own YAML parser. The returned
+ * token is expected to be disposed using fy_scan_token_free()
+ *
+ * @fyp: The parser to get the next token from.
+ *
+ * Returns:
+ * The next token, or NULL if no more tokens are available.
+ */
+struct fy_token *
+fy_scan(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_scan_token_free() - Free the token returned by fy_scan()
+ *
+ * Free the token returned by fy_scan().
+ *
+ * @fyp: The parser of which the token was returned by fy_scan()
+ * @fyt: The token to free
+ */
+void
+fy_scan_token_free(struct fy_parser *fyp, struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_directive_token_prefix0() - Get the prefix contained in the
+ * 				      tag directive token as zero terminated
+ * 				      string
+ *
+ * Retrieve the tag directive's prefix contents as a zero terminated string.
+ * It is similar to fy_tag_directive_token_prefix(), with the difference
+ * that the returned string is zero terminated and memory may be allocated
+ * to hold it associated with the token.
+ *
+ * @fyt: The tag directive token out of which the prefix pointer
+ *       will be returned.
+ *
+ * Returns:
+ * A pointer to the zero terminated text representation of the prefix token.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_directive_token_prefix0(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_directive_token_handle0() - Get the handle contained in the
+ * 				      tag directive token as zero terminated
+ * 				      string
+ *
+ * Retrieve the tag directive's handle contents as a zero terminated string.
+ * It is similar to fy_tag_directive_token_handle(), with the difference
+ * that the returned string is zero terminated and memory may be allocated
+ * to hold it associated with the token.
+ *
+ * @fyt: The tag directive token out of which the handle pointer
+ *       will be returned.
+ *
+ * Returns:
+ * A pointer to the zero terminated text representation of the handle token.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_directive_token_handle0(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_handle() - Get the handle contained in the
+ * 			   tag token
+ *
+ * Retrieve the tag handle contents. Will fail if
+ * token is not a tag token, or if a memory error happens.
+ *
+ * @fyt: The tag token out of which the handle pointer
+ *       will be returned.
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the text representation of the handle token, while
+ * @lenp will be assigned the character length of said representation.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_token_handle(struct fy_token *fyt, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_suffix() - Get the suffix contained in the
+ * 			   tag token
+ *
+ * Retrieve the tag suffix contents. Will fail if
+ * token is not a tag token, or if a memory error happens.
+ *
+ * @fyt: The tag token out of which the suffix pointer
+ *       will be returned.
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the text representation of the suffix token, while
+ * @lenp will be assigned the character length of said representation.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_token_suffix(struct fy_token *fyt, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_short() - Get the short tag of the tag token
+ *
+ * Retrieve the short tag contents. The short tag is the same
+ * one that will need to be emitted.
+ * Will fail if token is not a tag token, or if a memory error happens.
+ *
+ * @fyt: The tag token out of which the short pointer
+ *       will be returned.
+ * @lenp: Pointer to a variable that will hold the returned length
+ *
+ * Returns:
+ * A pointer to the text representation of the short tag, while
+ * @lenp will be assigned the character length of said representation.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_token_short(struct fy_token *fyt, size_t *lenp)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_handle0() - Get the handle contained in the
+ * 			    tag token as zero terminated string
+ *
+ * Retrieve the tag handle contents as a zero terminated string.
+ * It is similar to fy_tag_token_handle(), with the difference
+ * that the returned string is zero terminated and memory may be allocated
+ * to hold it associated with the token.
+ *
+ * @fyt: The tag token out of which the handle pointer will be returned.
+ *
+ * Returns:
+ * A pointer to the zero terminated text representation of the handle token.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_token_handle0(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_short0() - Get the short tag of the tag token as zero
+ *                         terminated string.
+ *
+ * Retrieve the short tag contents. The short tag is the same
+ * one that will need to be emitted.
+ * Will fail if token is not a tag token, or if a memory error happens.
+ *
+ * @fyt: The tag token out of which the short pointer will be returned.
+ *
+ * Returns:
+ * A pointer to the null terminated text representation of the short tag.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_token_short0(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_suffix0() - Get the suffix contained in the
+ * 			    tag token as zero terminated string
+ *
+ * Retrieve the tag suffix contents as a zero terminated string.
+ * It is similar to fy_tag_token_suffix(), with the difference
+ * that the returned string is zero terminated and memory may be allocated
+ * to hold it associated with the token.
+ *
+ * @fyt: The tag token out of which the suffix pointer will be returned.
+ *
+ * Returns:
+ * A pointer to the zero terminated text representation of the suffix token.
+ * NULL in case of an error.
+ */
+const char *
+fy_tag_token_suffix0(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_version_directive_token_version() - Return the version of a version
+ * 					  directive token
+ *
+ * Retrieve the version stored in a version directive token.
+ *
+ * @fyt: The version directive token
+ *
+ * Returns:
+ * A pointer to the version stored in the version directive token, or
+ * NULL in case of an error, or the token not being a version directive token.
+ */
+const struct fy_version *
+fy_version_directive_token_version(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_scalar_token_get_style() - Return the style of a scalar token
+ *
+ * Retrieve the style of a scalar token.
+ *
+ * @fyt: The scalar token
+ *
+ * Returns:
+ * The scalar style of the token, or FYSS_ANY for an error
+ */
+enum fy_scalar_style
+fy_scalar_token_get_style(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_token_tag() - Get tag of a tag token
+ *
+ * Retrieve the tag of a tag token.
+ *
+ * @fyt: The tag token
+ *
+ * Returns:
+ * A pointer to the tag or NULL in case of an error
+ */
+const struct fy_tag *
+fy_tag_token_tag(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_tag_directive_token_tag() - Get tag of a tag directive token
+ *
+ * Retrieve the tag of a tag directive token.
+ *
+ * @fyt: The tag directive token
+ *
+ * Returns:
+ * A pointer to the tag or NULL in case of an error
+ */
+const struct fy_tag *
+fy_tag_directive_token_tag(struct fy_token *fyt)
+	FY_EXPORT;
+
+/**
+ * fy_event_get_token() - Return the main token of an event
+ *
+ * Retrieve the main token (i.e. not the tag or the anchor) of
+ * an event. It may be NULL in case of an implicit event.
+ *
+ * @fye: The event to get its main token
+ *
+ * Returns:
+ * The main token if it exists, NULL otherwise or in case of an error
+ */
+struct fy_token *
+fy_event_get_token(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_get_anchor_token() - Return the anchor token of an event
+ *
+ * Retrieve the anchor token if it exists. Only valid for
+ * mapping/sequence start and scalar events.
+ *
+ * @fye: The event to get its anchor token
+ *
+ * Returns:
+ * The anchor token if it exists, NULL otherwise or in case of an error
+ */
+struct fy_token *
+fy_event_get_anchor_token(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_get_tag_token() - Return the tag token of an event
+ *
+ * Retrieve the tag token if it exists. Only valid for
+ * mapping/sequence start and scalar events.
+ *
+ * @fye: The event to get its tag token
+ *
+ * Returns:
+ * The tag token if it exists, NULL otherwise or in case of an error
+ */
+struct fy_token *
+fy_event_get_tag_token(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_start_mark() - Get event's start marker
+ *
+ * Return the event's start marker if it exists. The
+ * start marker is the one of the event's main token.
+ *
+ * @fye: The event to get its start marker
+ *
+ * Returns:
+ * The event's start marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_event_start_mark(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_end_mark() - Get event's end marker
+ *
+ * Return the event's end marker if it exists. The
+ * end marker is the one of the event's main token.
+ *
+ * @fye: The event to get its end marker
+ *
+ * Returns:
+ * The event's end marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_event_end_mark(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_style_start_mark() - Get event's start marker (style)
+ *
+ * Return the event's style start marker if it exists. The
+ * start marker is the one of the event's main token, including
+ * the style marks. But if the event contains a tag then the
+ * start mark is the start of the tag token.
+ *
+ * @fye: The event to get its style start marker
+ *
+ * Returns:
+ * The event's start marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_event_style_start_mark(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_style_end_mark() - Get event's end marker (style)
+ *
+ * Return the event's style end marker if it exists. The
+ * end marker is the one of the event's main token.
+ *
+ * @fye: The event to get its end marker
+ *
+ * Returns:
+ * The event's end marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_event_style_end_mark(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_event_get_node_style() - Get the node style of an event
+ *
+ * Return the node style (FYNS_*) of an event. May return
+ * FYNS_ANY if the event is implicit.
+ * For collection start events the only possible values is
+ * FYNS_ANY, FYNS_FLOW, FYNS_BLOCK.
+ * A scalar event may return any.
+ *
+ * @fye: The event to get it's node style
+ *
+ * Returns:
+ * The event's end marker, NULL if not available.
+ */
+enum fy_node_style
+fy_event_get_node_style(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_document_start_event_version() - Return the version of a document
+ * 				       start event
+ *
+ * Retrieve the version stored in a document start event
+ *
+ * @fye: The document start event
+ *
+ * Returns:
+ * A pointer to the version, or NULL in case of an error, or the event
+ * not being a document start event.
+ */
+const struct fy_version *
+fy_document_start_event_version(struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_version() - Return the version of a document state
+ * 				 object
+ *
+ * Retrieve the version stored in a document state object
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * A pointer to the version, or NULL in case of an error
+ */
+const struct fy_version *
+fy_document_state_version(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_start_mark() - Get document state's start mark
+ *
+ * Return the document state's start mark (if it exists).
+ * Note that purely synthetic documents do not contain one
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * The document's start marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_document_state_start_mark(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_end_mark() - Get document state's end mark
+ *
+ * Return the document state's end mark (if it exists).
+ * Note that purely synthetic documents do not contain one
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * The document's end marker, NULL if not available.
+ */
+const struct fy_mark *
+fy_document_state_end_mark(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_version_explicit() - Version explicit?
+ *
+ * Find out if a document state object's version was explicitly
+ * set in the document.
+ * Note that for synthetic documents this method returns false.
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * true if version was set explicitly, false otherwise
+ */
+bool
+fy_document_state_version_explicit(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_tags_explicit() - Tags explicit?
+ *
+ * Find out if a document state object's tags were explicitly
+ * set in the document.
+ * Note that for synthetic documents this method returns false.
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * true if document had tags set explicitly, false otherwise
+ */
+bool
+fy_document_state_tags_explicit(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_start_implicit() - Started implicitly?
+ *
+ * Find out if a document state object's document was
+ * started implicitly.
+ * Note that for synthetic documents this method returns false.
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * true if document was started implicitly, false otherwise
+ */
+bool
+fy_document_state_start_implicit(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_end_implicit() - Started implicitly?
+ *
+ * Find out if a document state object's document was
+ * ended implicitly.
+ * Note that for synthetic documents this method returns false.
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * true if document was ended implicitly, false otherwise
+ */
+bool
+fy_document_state_end_implicit(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_json_mode() - Input was JSON?
+ *
+ * Find out if a document state object's document was
+ * created by a JSON input.
+ * Note that for synthetic documents this method returns false.
+ *
+ * @fyds: The document state object
+ *
+ * Returns:
+ * true if document was created in JSON mode, false otherwise
+ */
+bool
+fy_document_state_json_mode(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_tag_directive_iterate() - Iterate over the tag
+ * 					       directives of a document state
+ * 					       object
+ *
+ * This method iterates over all the tag directives nodes in the document state
+ * object.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @fyds: The document state
+ * @prevp: The previous iterator
+ *
+ * Returns:
+ * The next tag or NULL at the end of the iteration sequence.
+ */
+const struct fy_tag *
+fy_document_state_tag_directive_iterate(struct fy_document_state *fyds, void **prevp)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_tag_directives() - Get all the tag directives in a
+ *                                      malloc'ed array
+ *
+ * Return all the tag directives in a dynamically allocated area.
+ * Must be free()'d when not in use.
+ *
+ * @fyds: The document state
+ *
+ * Returns:
+ * An array of fy_tag pointer structures, terminated with a NULL pointer
+ * NULL on error
+ */
+struct fy_tag **
+fy_document_state_tag_directives(struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_state_tag_is_default() - Test whether the given tag is a default one
+ *
+ * Test whether a tag is a default (i.e. impliciticly set)
+ *
+ * @fyds: The document state
+ * @tag: The tag to check
+ *
+ * Returns:
+ * true in case that the tag is a default one, false otherwise
+ */
+bool
+fy_document_state_tag_is_default(struct fy_document_state *fyds, const struct fy_tag *tag)
+	FY_EXPORT;
+
+/**
+ * fy_parser_get_document_state() - Get the document state of a parser object
+ *
+ * Retrieve the document state object of a parser. Note that this is only
+ * valid during parsing.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The active document state object of the parser, NULL otherwise
+ */
+struct fy_document_state *
+fy_parser_get_document_state(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_document_get_document_state() - Get the document state of a document
+ *
+ * Retrieve the document state object of a document.
+ *
+ * @fyd: The document
+ *
+ * Returns:
+ * The document state object of the document, NULL otherwise
+ */
+struct fy_document_state *
+fy_document_get_document_state(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_set_document_state() - Set the document state of a document
+ *
+ * Set the document state of a document
+ *
+ * @fyd: The document
+ * @fyds: The document state to use, or NULL for default
+ *
+ * Returns:
+ * 0 if set operation was successful, -1 otherwise
+ */
+int
+fy_document_set_document_state(struct fy_document *fyd, struct fy_document_state *fyds)
+	FY_EXPORT;
+
+/**
+ * fy_document_create_from_event() - Create an empty document using the event
+ *
+ * Create an empty document using the FYET_DOCUMENT_START event generated
+ * by the parser.
+ *
+ * @fyp: The parser
+ * @fye: The event
+ *
+ * Returns:
+ * The created empty document, or NULL on error.
+ */
+struct fy_document *
+fy_document_create_from_event(struct fy_parser *fyp, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_document_update_from_event() - Update the document with the event
+ *
+ * Update the document using the FYET_DOCUMENT_END event generated
+ * by the parser.
+ *
+ * @fyd: The document
+ * @fyp: The parser
+ * @fye: The event
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_update_from_event(struct fy_document *fyd, struct fy_parser *fyp, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_node_create_from_event() - Create a node using the event
+ *
+ * Create a new node using the supplied event.
+ * Allowed events are FYET_SCALAR, FYET_ALIAS, FYET_MAPPING_START & FYET_SEQUENCE_START
+ *
+ * @fyd: The document
+ * @fyp: The parser
+ * @fye: The event
+ *
+ * Returns:
+ * The newly created node, or NULL on error
+ */
+struct fy_node *
+fy_node_create_from_event(struct fy_document *fyd, struct fy_parser *fyp, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_node_update_from_event() - Update a node using the event
+ *
+ * Update information of node created using fy_node_create_from_event()
+ * Allowed events are FYET_MAPPING_END & FYET_SEQUENCE_END
+ *
+ * @fyn: The node
+ * @fyp: The parser
+ * @fye: The event
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_update_from_event(struct fy_node *fyn, struct fy_parser *fyp, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_node_pair_create_with_key() - Create a new node pair and set it's key
+ *
+ * Create a new node pair using the supplied fyn_parent mapping and fyn node as
+ * a key. Note that the nodes _must_ have been created by fy_node_create_from_event
+ * and they are not interchangeable with other node pair methods.
+ *
+ * The node pair will be added to the fyn_parent mapping with a subsequent call
+ * to fy_node_pair_update_with_value().
+ *
+ * @fyd: The document
+ * @fyn_parent: The mapping
+ * @fyn: The node pair key
+ *
+ * Returns:
+ * The newly created node pair, or NULL on error
+ */
+struct fy_node_pair *
+fy_node_pair_create_with_key(struct fy_document *fyd, struct fy_node *fyn_parent, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_pair_update_with_value() - Update a node pair with a value and add it to the parent mapping
+ *
+ * Update the node pair with the given value and add it to the parent mapping.
+ * Note that the fyn node _must_ have been created by fy_node_create_from_event
+ * and the node pair created by fy_node_pair_create_with_key().
+ * Do not intermix other node pair manipulation methods.
+ *
+ * @fynp: The node pair
+ * @fyn: The node pair value
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_pair_update_with_value(struct fy_node_pair *fynp, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_node_sequence_add_item() - Add an item node to a sequence node
+ *
+ * Add an item to the end of the sequence node fyn_parent.
+ * Note that the fyn_parent and fyn nodes _must_ have been created by
+ * fy_node_create_from_event.
+ * Do not intermix other sequence node manipulation methods.
+ *
+ * @fyn_parent: The parent sequence node
+ * @fyn: The node pair item
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_node_sequence_add_item(struct fy_node *fyn_parent, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_emitter_get_document_state() - Get the document state of an emitter  object
+ *
+ * Retrieve the document state object of an emitter. Note that this is only
+ * valid during emitting.
+ *
+ * @emit: The emitter
+ *
+ * Returns:
+ * The active document state object of the emitter, NULL otherwise
+ */
+struct fy_document_state *
+fy_emitter_get_document_state(struct fy_emitter *emit)
+	FY_EXPORT;
+
+/**
+ * fy_emit_event_create() - Create an emit event.
+ *
+ * Create an emit event to pass to fy_emit_event()
+ * The extra arguments differ according to the event to be created
+ *
+ * FYET_STREAM_START:
+ * 	- None
+ *
+ * FYET_STREAM_END:
+ * 	- None
+ *
+ * FYET_DOCUMENT_START:
+ * 	- int implicit
+ * 		true if document start should be marked implicit
+ * 		false if document start should not be marked implicit
+ * 	- const struct fy_version \*vers
+ * 		Pointer to version to use for the document, or NULL for default
+ * 	- const struct fy_tag \* const \*tags
+ * 		Pointer to a NULL terminated array of tag pointers (like argv)
+ * 		NULL if no extra tags are to be used
+ *
+ * FYET_DOCUMENT_END:
+ * 	- int implicit
+ * 		true if document end should be marked implicit
+ * 		false if document end should not be marked implicit
+ *
+ * FYET_MAPPING_START:
+ * 	- enum fy_node_style style
+ * 		Style of the mapping (one of FYNS_ANY, FYNS_BLOCK or FYNS_FLOW)
+ *	- const char \*anchor
+ *		Anchor to place at the mapping, or NULL for none
+ *	- const char \*tag
+ *		Tag to place at the mapping, or NULL for none
+ *
+ * FYET_MAPPING_END:
+ * 	- None
+ *
+ * FYET_SEQUENCE_START:
+ * 	- enum fy_node_style style
+ * 		Style of the sequence (one of FYNS_ANY, FYNS_BLOCK or FYNS_FLOW)
+ *	- const char \*anchor
+ *		Anchor to place at the sequence, or NULL for none
+ *	- const char \*tag
+ *		Tag to place at the sequence, or NULL for none
+ *
+ * FYET_SEQUENCE_END:
+ * 	- None
+ *
+ * FYET_SCALAR:
+ * 	- enum fy_scalar_style style
+ * 		Style of the scalar, any valid FYSS_* value
+ * 		Note that certain styles may not be used according to the
+ * 		contents of the data
+ *	- const char \*value
+ *		Pointer to the scalar contents.
+ *	- size_t len
+ *		Length of the scalar contents, of FY_NT (-1) for strlen(value)
+ *	- const char \*anchor
+ *		Anchor to place at the scalar, or NULL for none
+ *	- const char \*tag
+ *		Tag to place at the scalar, or NULL for none
+ *
+ * FYET_ALIAS:
+ *	- const char \*value
+ *		Pointer to the alias.
+ *
+ * @emit: The emitter
+ * @type: The event type to create
+ * @...: The optional extra arguments
+ *
+ * Returns:
+ * The created event or NULL in case of an error
+ */
+struct fy_event *
+fy_emit_event_create(struct fy_emitter *emit, enum fy_event_type type, ...)
+	FY_EXPORT;
+
+/**
+ * fy_emit_event_vcreate() - Create an emit event using varargs.
+ *
+ * Create an emit event to pass to fy_emit_event()
+ * The varargs analogous to fy_emit_event_create().
+ *
+ * @emit: The emitter
+ * @type: The event type to create
+ * @ap: The variable argument list pointer.
+ *
+ * Returns:
+ * The created event or NULL in case of an error
+ */
+struct fy_event *
+fy_emit_event_vcreate(struct fy_emitter *emit, enum fy_event_type type, va_list ap)
+	FY_EXPORT;
+
+/**
+ * fy_emit_event_free() - Free an event created via fy_emit_event_create()
+ *
+ * Free an event previously created via fy_emit_event_create(). Note
+ * that usually you don't have to call this method since if you pass
+ * the event to fy_emit_event() it shall be disposed properly.
+ * Only use is error recovery and cleanup.
+ *
+ * @emit: The emitter
+ * @fye: The event to free
+ */
+void
+fy_emit_event_free(struct fy_emitter *emit, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_parse_event_create() - Create an emit event.
+ *
+ * See fy_emit_event_create()...
+ *
+ * @fyp: The parser
+ * @type: The event type to create
+ *
+ * Returns:
+ * The created event or NULL in case of an error
+ */
+struct fy_event *
+fy_parse_event_create(struct fy_parser *fyp, enum fy_event_type type, ...)
+	FY_EXPORT;
+
+/**
+ * fy_parse_event_vcreate() - Create an emit event using varargs.
+ *
+ * Create an emit event to pass to fy_emit_event()
+ * The varargs analogous to fy_parse_event_create().
+ *
+ * @fyp: The parser
+ * @type: The event type to create
+ * @ap: The variable argument list pointer.
+ *
+ * Returns:
+ * The created event or NULL in case of an error
+ */
+struct fy_event *
+fy_parse_event_vcreate(struct fy_parser *fyp, enum fy_event_type type, va_list ap)
+	FY_EXPORT;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBFYAML_CORE_H */

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-docbuild.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-docbuild.h
@@ -1,0 +1,297 @@
+/*
+ * libfyaml-docbuild.h - libfyaml document builder API
+ *
+ * Copyright (c) 2023-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBFYAML_DOCBUILD_H
+#define LIBFYAML_DOCBUILD_H
+
+#include <libfyaml/libfyaml-core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: Document builder — event-stream to document-tree conversion
+ *
+ * This header provides ``struct fy_document_builder``, which accumulates
+ * YAML parser events and assembles them into a ``struct fy_document`` tree.
+ *
+ * The builder supports two operating modes:
+ *
+ * **Pull mode** — the builder drives a parser internally::
+ *
+ *   struct fy_document_builder *fydb =
+ *       fy_document_builder_create_on_parser(fyp);
+ *   struct fy_document *fyd;
+ *   while ((fyd = fy_document_builder_load_document(fydb, fyp)) != NULL) {
+ *       process(fyd);
+ *       fy_document_destroy(fyd);
+ *   }
+ *   fy_document_builder_destroy(fydb);
+ *
+ * **Push mode** — the caller feeds events one at a time and takes
+ * ownership when the document is complete::
+ *
+ *   fy_document_builder_set_in_stream(fydb);
+ *   struct fy_event *fye;
+ *   while ((fye = get_next_event()) != NULL) {
+ *       fy_document_builder_process_event(fydb, fye);
+ *       if (fy_document_builder_is_document_complete(fydb)) {
+ *           struct fy_document *fyd =
+ *               fy_document_builder_take_document(fydb);
+ *           process(fyd);
+ *           fy_document_destroy(fyd);
+ *       }
+ *   }
+ *
+ * Push mode is useful when events arrive asynchronously or from a source
+ * other than a libfyaml parser, such as a document iterator or a network
+ * stream.
+ *
+ * ``fy_parse_load_document_with_builder()`` provides the simplest interface:
+ * a single call that returns the next complete document from a parser.
+ */
+
+/**
+ * struct fy_document_builder_cfg - document builder configuration structure.
+ *
+ * Argument to the fy_document_builder_create() method
+ *
+ * @parse_cfg: Parser configuration
+ * @userdata: Opaque user data pointer
+ * @diag: Optional diagnostic interface to use
+ */
+struct fy_document_builder_cfg {
+	struct fy_parse_cfg parse_cfg;
+	void *userdata;
+	struct fy_diag *diag;
+};
+
+/**
+ * fy_document_builder_create() - Create a document builder
+ *
+ * Creates a document builder with its configuration @cfg
+ * The document builder may be destroyed by a corresponding call to
+ * fy_document_builder_destroy().
+ *
+ * @cfg: The configuration for the document builder
+ *
+ * Returns:
+ * A pointer to the document builder or NULL in case of an error.
+ */
+struct fy_document_builder *
+fy_document_builder_create(const struct fy_document_builder_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_create_on_parser() - Create a document builder
+ * 					    pulling state from the parser
+ *
+ * Creates a document builder pulling state from the given parser
+ *
+ * @fyp: The parser to associate with
+ *
+ * Returns:
+ * A pointer to the document builder or NULL in case of an error.
+ */
+struct fy_document_builder *
+fy_document_builder_create_on_parser(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_reset() - Reset a document builder
+ *
+ * Resets a document builder without destroying it
+ *
+ * @fydb: The document builder
+ */
+void
+fy_document_builder_reset(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_destroy() - Destroy a document builder
+ *
+ * Destroy a document builder
+ *
+ * @fydb: The document builder
+ */
+void
+fy_document_builder_destroy(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_get_document() - Get the document of a builder
+ *
+ * Retrieve the document of a document builder. This document
+ * may be incomplete. If you need to take ownership use
+ * fy_document_builder_take_document().
+ *
+ * @fydb: The document builder
+ *
+ * Returns:
+ * The document that the builder built, or NULL in case of an error
+ */
+struct fy_document *
+fy_document_builder_get_document(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_is_in_stream() - Test document builder in stream
+ *
+ * Find out if the document builder is in 'stream' state,
+ * i.e. after stream start but before stream end events are generated.
+ *
+ * @fydb: The document builder
+ *
+ * Returns:
+ * true if in stream, false otherwise
+ */
+bool
+fy_document_builder_is_in_stream(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_is_in_document() - Test document builder in document
+ *
+ * Find out if the document builder is in 'document' state,
+ * i.e. after document start but before document end events are generated.
+ *
+ * @fydb: The document builder
+ *
+ * Returns:
+ * true if in document, false otherwise
+ */
+bool
+fy_document_builder_is_in_document(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_is_document_complete() - Test document builder complete
+ *
+ * Find out if the document of the builder is complete.
+ * If it is complete then a call to fy_document_builder_take_document() will
+ * transfer ownership of the document to the caller.
+ *
+ * @fydb: The document builder
+ *
+ * Returns:
+ * true if document complete, false otherwise
+ */
+bool
+fy_document_builder_is_document_complete(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_take_document() - Take ownership the document of a builder
+ *
+ * Take ownership of the document of a document builder.
+ * The document builder's document must be complete.
+ *
+ * @fydb: The document builder
+ *
+ * Returns:
+ * The document that the builder built, or NULL in case of an error
+ */
+struct fy_document *
+fy_document_builder_take_document(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_peek_document() - Peek at the document of a builder
+ *
+ * Peek at the document of a document builder.
+ * Ownership still remains with the builder.
+ *
+ * @fydb: The document builder
+ *
+ * Returns:
+ * A peek to the document that the builder built, or NULL in case of an error
+ */
+struct fy_document *
+fy_document_builder_peek_document(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_set_in_stream() - Set the builders state in 'stream'
+ *
+ * Set the document builders state to in 'stream'
+ *
+ * @fydb: The document builder
+ */
+void
+fy_document_builder_set_in_stream(struct fy_document_builder *fydb)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_set_in_document() - Set the builders state in 'document'
+ *
+ * Set the document builders state to in 'document'
+ *
+ * @fydb: The document builder
+ * @fyds: The document state
+ * @single: Single document mode
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_builder_set_in_document(struct fy_document_builder *fydb, struct fy_document_state *fyds, bool single)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_load_document() - Create a document from parser events
+ *
+ * Load a document by pumping the parser for events and then processing them
+ * with the builder.
+ *
+ * @fydb: The document builder
+ * @fyp: The parser
+ *
+ * Returns:
+ * The document that results from the parser, or NULL in case of an error (or EOF)
+ */
+struct fy_document *
+fy_document_builder_load_document(struct fy_document_builder *fydb, struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_parse_load_document_with_builder() - Parse a document via built-in builder
+ *
+ * Load a document by pumping the parser for events and then processing them
+ * with the in-parser builder.
+ *
+ * @fyp: The parser
+ *
+ * Returns:
+ * The document that results from the parser, or NULL in case of an error (or EOF)
+ */
+struct fy_document *
+fy_parse_load_document_with_builder(struct fy_parser *fyp)
+	FY_EXPORT;
+
+/**
+ * fy_document_builder_process_event() - Process an event with a builder
+ *
+ * Pump an event to a document builder for processing.
+ *
+ * @fydb: The document builder
+ * @fye: The event
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_document_builder_process_event(struct fy_document_builder *fydb, struct fy_event *fye)
+	FY_EXPORT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_DOCBUILD_H

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-dociter.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-dociter.h
@@ -1,0 +1,356 @@
+/*
+ * libfyaml-dociter.h - libfyaml document iterator API
+ *
+ * Copyright (c) 2023-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBFYAML_DOCITER_H
+#define LIBFYAML_DOCITER_H
+
+#include <libfyaml/libfyaml-core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: Document iterator — stack-free tree traversal and event replay
+ *
+ * This header provides ``struct fy_document_iterator``, which traverses a
+ * document tree depth-first without using system stack recursion.  Two
+ * usage modes are supported:
+ *
+ * **Node iteration** — visit every node in a subtree in document order::
+ *
+ *   struct fy_document_iterator *fydi = fy_document_iterator_create();
+ *   fy_document_iterator_node_start(fydi, fy_document_root(fyd));
+ *   struct fy_node *fyn;
+ *   while ((fyn = fy_document_iterator_node_next(fydi)) != NULL)
+ *       process(fyn);
+ *   fy_document_iterator_destroy(fydi);
+ *
+ * **Event replay** — regenerate the YAML event stream that produced the
+ * document, suitable for feeding into a parser, emitter, or composer::
+ *
+ *   struct fy_document_iterator *fydi =
+ *       fy_document_iterator_create_on_document(fyd);
+ *   struct fy_event *fye;
+ *   while ((fye = fy_document_iterator_generate_next(fydi)) != NULL) {
+ *       process_event(fye);
+ *       fy_document_iterator_event_free(fydi, fye);
+ *   }
+ *   fy_document_iterator_destroy(fydi);
+ *
+ * The iterator can also be attached to a ``struct fy_parser`` via
+ * ``fy_parser_set_document_iterator()``, making a parser transparently
+ * replay the events of an existing document rather than parsing fresh input.
+ *
+ * Events emitted by the iterator are in the same order as those that
+ * originally created the document, so round-trip fidelity is preserved.
+ */
+
+/* Shift amount of the want mode */
+#define FYDICF_WANT_SHIFT		0
+/* Mask of the WANT mode */
+#define FYDICF_WANT_MASK			((1U << 2) - 1)
+/* Build a WANT mode option */
+#define FYDICF_WANT(x)			(((unsigned int)(x) & FYDICF_WANT_MASK) << FYDICF_WANT_SHIFT)
+
+/**
+ * enum fy_document_iterator_cfg_flags - Document iterator configuration flags
+ *
+ * These flags control the operation of the document iterator
+ *
+ * @FYDICF_WANT_BODY_EVENTS: Generate body events
+ * @FYDICF_WANT_DOCUMENT_BODY_EVENTS: Generate document and body events
+ * @FYDICF_WANT_STREAM_DOCUMENT_BODY_EVENTS: Generate stream, document and body events
+ */
+enum fy_document_iterator_cfg_flags {
+	FYDICF_WANT_BODY_EVENTS			= FYDICF_WANT(0),
+	FYDICF_WANT_DOCUMENT_BODY_EVENTS	= FYDICF_WANT(1),
+	FYDICF_WANT_STREAM_DOCUMENT_BODY_EVENTS	= FYDICF_WANT(2),
+};
+
+/**
+ * struct fy_document_iterator_cfg - document iterator configuration structure.
+ *
+ * Argument to the fy_document_iterator_create_cfg() method.
+ *
+ * @flags: The document iterator flags
+ * @fyd: The document to iterate on (or NULL if iterate_root is set)
+ * @iterate_root: The root of iteration (NULL when fyd is not NULL)
+ */
+struct fy_document_iterator_cfg {
+	enum fy_document_iterator_cfg_flags flags;
+	struct fy_document *fyd;
+	struct fy_node *iterate_root;
+};
+
+/**
+ * fy_document_iterator_create() - Create a document iterator
+ *
+ * Creates a document iterator, that can trawl through a document
+ * without using recursion.
+ *
+ * Returns:
+ * The newly created document iterator or NULL on error
+ */
+struct fy_document_iterator *
+fy_document_iterator_create(void)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_create_cfg() - Create a document iterator using config
+ *
+ * Creates a document iterator, that can trawl through a document
+ * without using recursion. The iterator will generate all the events
+ * that created the given document starting at iterator root.
+ *
+ * @cfg: The document iterator to destroy
+ *
+ * Returns:
+ * The newly created document iterator or NULL on error
+ */
+struct fy_document_iterator *
+fy_document_iterator_create_cfg(const struct fy_document_iterator_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_create_on_document() - Create a document iterator on document
+ *
+ * Creates a document iterator, starting at the root of the given document.
+ *
+ * @fyd: The document to iterate on
+ *
+ * Returns:
+ * The newly created document iterator or NULL on error
+ */
+struct fy_document_iterator *
+fy_document_iterator_create_on_document(struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_create_on_node() - Create a document iterator on node
+ *
+ * Creates a document iterator, starting at the given node
+ *
+ * @fyn: The node to iterate on
+ *
+ * Returns:
+ * The newly created document iterator or NULL on error
+ */
+struct fy_document_iterator *
+fy_document_iterator_create_on_node(struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_destroy() - Destroy the given document iterator
+ *
+ * Destroy a document iterator created earlier via fy_document_iterator_create().
+ *
+ * @fydi: The document iterator to destroy
+ */
+void
+fy_document_iterator_destroy(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_event_free() - Free an event that was created by a document iterator
+ *
+ * Free (possibly recycling) an event that was created by a document iterator.
+ *
+ * @fydi: The document iterator that created the event
+ * @fye: The event
+ */
+void
+fy_document_iterator_event_free(struct fy_document_iterator *fydi, struct fy_event *fye)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_stream_start() - Create a stream start event using the iterator
+ *
+ * Creates a stream start event on the document iterator and advances the internal state
+ * of it accordingly.
+ *
+ * @fydi: The document iterator to create the event
+ *
+ * Returns:
+ * The newly created stream start event, or NULL on error.
+ */
+struct fy_event *
+fy_document_iterator_stream_start(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_stream_end() - Create a stream end event using the iterator
+ *
+ * Creates a stream end event on the document iterator and advances the internal state
+ * of it accordingly.
+ *
+ * @fydi: The document iterator to create the event
+ *
+ * Returns:
+ * The newly created stream end event, or NULL on error.
+ */
+struct fy_event *
+fy_document_iterator_stream_end(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_document_start() - Create a document start event using the iterator
+ *
+ * Creates a document start event on the document iterator and advances the internal state
+ * of it accordingly. The document must not be released until an error, cleanup or a call
+ * to fy_document_iterator_document_end().
+ *
+ * @fydi: The document iterator to create the event
+ * @fyd: The document containing the document state that is used in the event
+ *
+ * Returns:
+ * The newly created document start event, or NULL on error.
+ */
+struct fy_event *
+fy_document_iterator_document_start(struct fy_document_iterator *fydi, struct fy_document *fyd)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_document_end() - Create a document end event using the iterator
+ *
+ * Creates a document end event on the document iterator and advances the internal state
+ * of it accordingly. The document that was used earlier in the call of
+ * fy_document_iterator_document_start() can now be released.
+ *
+ * @fydi: The document iterator to create the event
+ *
+ * Returns:
+ * The newly created document end event, or NULL on error.
+ */
+struct fy_event *
+fy_document_iterator_document_end(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_body_next() - Create document body events until the end
+ *
+ * Creates the next document body, depth first until the end of the document.
+ * The events are created depth first and are in same exact sequence that the
+ * original events that created the document.
+ *
+ * That means that the finite event stream that generated the document is losslesly
+ * preserved in such a way that the document tree representation is functionally
+ * equivalent.
+ *
+ * Repeated calls to this function will generate a stream of SCALAR, ALIAS, SEQUENCE
+ * START, SEQUENCE END, MAPPING START and MAPPING END events, returning NULL at the
+ * end of the body event stream.
+ *
+ * @fydi: The document iterator to create the event
+ *
+ * Returns:
+ * The newly created document body event or NULL at an error, or an end of the
+ * event stream. Use fy_document_iterator_get_error() to check if an error occured.
+ */
+struct fy_event *
+fy_document_iterator_body_next(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_node_start() - Start a document node iteration run using a starting point
+ *
+ * Starts an iteration run starting at the given node.
+ *
+ * @fydi: The document iterator to run with
+ * @fyn: The iterator root for the iteration
+ */
+void
+fy_document_iterator_node_start(struct fy_document_iterator *fydi, struct fy_node *fyn)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_node_next() - Return the next node in the iteration sequence
+ *
+ * Returns a pointer to the next node iterating using as a start the node given
+ * at fy_document_iterator_node_start(). The first node returned will be that,
+ * followed by all the remaing nodes in the subtree.
+ *
+ * @fydi: The document iterator to use for the iteration
+ *
+ * Returns:
+ * The next node in the iteration sequence or NULL at the end, or if an error occured.
+ */
+struct fy_node *
+fy_document_iterator_node_next(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_generate_next() - Create events from document iterator
+ *
+ * This is a method that will handle the complex state of generating
+ * stream, document and body events on the given iterator.
+ *
+ * When generation is complete a NULL event will be generated.
+ *
+ * @fydi: The document iterator to create the event
+ *
+ * Returns:
+ * The newly created event or NULL at an error, or an end of the
+ * event stream. Use fy_document_iterator_get_error() to check if an error occured.
+ */
+struct fy_event *
+fy_document_iterator_generate_next(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * fy_document_iterator_get_error() - Get the error state of the document iterator
+ *
+ * Returns the error state of the iterator. If it's in error state, return true
+ * and reset the iterator to the state just after creation.
+ *
+ * @fydi: The document iterator to use for checking it's error state.
+ *
+ * Returns:
+ * true if it was in an error state, false otherwise.
+ */
+bool
+fy_document_iterator_get_error(struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+/**
+ * enum fy_parser_event_generator_flags - The parser event generator flags
+ *
+ * @FYPEGF_GENERATE_DOCUMENT_EVENTS: generate document events
+ * @FYPEGF_GENERATE_STREAM_EVENTS: generate stream events
+ * @FYPEGF_GENERATE_ALL_EVENTS: generate all events
+ */
+enum fy_parser_event_generator_flags {
+	FYPEGF_GENERATE_DOCUMENT_EVENTS	= FY_BIT(0),
+	FYPEGF_GENERATE_STREAM_EVENTS	= FY_BIT(1),
+	FYPEGF_GENERATE_ALL_EVENTS	= FYPEGF_GENERATE_STREAM_EVENTS | FYPEGF_GENERATE_DOCUMENT_EVENTS,
+};
+
+/**
+ * fy_parser_set_document_iterator() - Associate a parser with a document iterator
+ *
+ * Associate a parser with a document iterator, that is instead of parsing the events
+ * will be generated by the document iterator.
+ *
+ * @fyp: The parser
+ * @flags: The event generation flags
+ * @fydi: The document iterator to associate
+ *
+ * Returns:
+ * 0 on success, -1 on error
+ */
+int
+fy_parser_set_document_iterator(struct fy_parser *fyp, enum fy_parser_event_generator_flags flags,
+				struct fy_document_iterator *fydi)
+	FY_EXPORT;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_DOCITER_H

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-endian.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-endian.h
@@ -1,0 +1,98 @@
+/*
+ * libfyaml-endian.h - simple system endian header wrapper
+ *
+ * Copyright (c) 2023-2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * DOC: Endian detection and byte-swap utilities
+ *
+ * This header provides a portable way to include the platform's byte-order
+ * detection headers and ensures the following macros are always defined:
+ *
+ * - ``__BYTE_ORDER``  — the byte order of the current platform
+ * - ``__BIG_ENDIAN``  — big-endian sentinel value
+ * - ``__LITTLE_ENDIAN`` — little-endian sentinel value
+ *
+ * Usage::
+ *
+ *   #include <libfyaml/fy-internal-endian.h>
+ *
+ *   #if __BYTE_ORDER == __LITTLE_ENDIAN
+ *       // little-endian path
+ *   #else
+ *       // big-endian path
+ *   #endif
+ *
+ * Supported platforms:
+ * - Linux / Cygwin / OpenBSD / GNU Hurd / Emscripten — via ``<endian.h>``
+ * - macOS / iOS — via ``<libkern/OSByteOrder.h>`` + ``<machine/endian.h>``
+ * - NetBSD / FreeBSD / DragonFly BSD — via ``<sys/endian.h>``
+ * - Windows (MSVC) — via ``<winsock2.h>`` (+ ``<sys/param.h>`` for MinGW)
+ *
+ * The non-standard ``BYTE_ORDER``, ``BIG_ENDIAN``, and ``LITTLE_ENDIAN``
+ * spellings are aliased to the double-underscore variants if needed.
+ */
+#ifndef LIBFYAML_ENDIAN_H
+#define LIBFYAML_ENDIAN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__GNU__) || defined(__EMSCRIPTEN__)
+# include <endian.h>
+#elif defined(__APPLE__)
+# include <libkern/OSByteOrder.h>
+# include <machine/endian.h>
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+# include <sys/endian.h>
+#elif defined(_WIN32) || defined(_MSC_VER)
+/* Windows is always little-endian on supported platforms */
+# define __LITTLE_ENDIAN 1234
+# define __BIG_ENDIAN    4321
+# define __BYTE_ORDER    __LITTLE_ENDIAN
+#else
+# error unsupported platform
+#endif
+
+#if !defined(__BYTE_ORDER) && defined(BYTE_ORDER)
+#define __BYTE_ORDER	BYTE_ORDER
+#endif
+
+#if !defined(__BIG_ENDIAN) && defined(BIG_ENDIAN)
+#define __BIG_ENDIAN	BIG_ENDIAN
+#endif
+
+#if !defined(__LITTLE_ENDIAN) && defined(LITTLE_ENDIAN)
+#define __LITTLE_ENDIAN	LITTLE_ENDIAN
+#endif
+
+#if !defined(__BYTE_ORDER) || !defined(__BIG_ENDIAN) || !defined(__LITTLE_ENDIAN)
+# error Platform does not define endian macros
+#endif
+
+/* no-one cares about PDP endian anymore */
+
+/**
+ * bswap_8() - Byte-swap an 8-bit value (no-op).
+ *
+ * Defined for symmetry with ``bswap_16()``, ``bswap_32()``, and ``bswap_64()``.
+ * Swapping a single byte is always a no-op.
+ *
+ * @x: The 8-bit value.
+ *
+ * Returns: @x unchanged.
+ */
+/* make the macros work for 8 bit too */
+#ifndef bswap_8
+#define bswap_8(x) (x)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_ENDIAN_H

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-path-exec.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-path-exec.h
@@ -1,0 +1,334 @@
+/*
+ * libfyaml-path-exec.h - libfyaml path exec API
+ * Copyright (c) 2023-2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef LIBFYAML_PATH_EXEC_H
+#define LIBFYAML_PATH_EXEC_H
+
+#include <libfyaml/libfyaml-core.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: YAML path expression parser and executor
+ *
+ * This header provides the ypath subsystem — a JSONPath / XPath-like query
+ * language for navigating YAML document trees.
+ *
+ * A ypath expression such as ``/servers/0/host`` is first *parsed* into a
+ * compiled ``struct fy_path_expr`` and then *executed* against a starting
+ * node in any ``struct fy_document`` to produce a result set of matching
+ * nodes.  Filter predicates and wildcards are also supported.
+ *
+ * **Typical workflow**::
+ *
+ *   // 1. Create a path parser
+ *   struct fy_path_parser *fypp = fy_path_parser_create(NULL);
+ *
+ *   // 2. Compile an expression
+ *   struct fy_path_expr *expr =
+ *       fy_path_parse_expr_from_string(fypp, "/servers/0/host", -1);
+ *
+ *   // 3. Create an executor and run the expression
+ *   struct fy_path_exec *fypx = fy_path_exec_create(NULL);
+ *   fy_path_exec_execute(fypx, expr, fy_document_root(fyd));
+ *
+ *   // 4. Iterate results
+ *   void *iter = NULL;
+ *   struct fy_node *fyn;
+ *   while ((fyn = fy_path_exec_results_iterate(fypx, &iter)) != NULL)
+ *       process(fyn);
+ *
+ *   // 5. Cleanup
+ *   fy_path_exec_destroy(fypx);
+ *   fy_path_expr_free(expr);
+ *   fy_path_parser_destroy(fypp);
+ *
+ * For one-shot use, ``fy_path_expr_build_from_string()`` wraps steps 1 and 2
+ * into a single call.
+ *
+ * The executor can be reset and re-used for multiple executions against the
+ * same or different documents.  The compiled expression is independent of any
+ * document and may be executed repeatedly.
+ */
+
+struct fy_path_parser;
+struct fy_path_expr;
+struct fy_path_exec;
+struct fy_path_component;
+struct fy_path;
+
+/**
+ * enum fy_path_parse_cfg_flags - Path parse configuration flags
+ *
+ * These flags control the operation of the path parse
+ *
+ * @FYPPCF_QUIET: Quiet, do not output any information messages
+ * @FYPPCF_DISABLE_RECYCLING: Disable recycling optimization
+ * @FYPPCF_DISABLE_ACCELERATORS: Disable use of access accelerators (saves memory)
+ */
+enum fy_path_parse_cfg_flags {
+	FYPPCF_QUIET			= FY_BIT(0),
+	FYPPCF_DISABLE_RECYCLING	= FY_BIT(1),
+	FYPPCF_DISABLE_ACCELERATORS	= FY_BIT(2),
+};
+
+/**
+ * struct fy_path_parse_cfg - path parser configuration structure.
+ *
+ * Argument to the fy_path_parser_create() method which
+ * performs parsing of a ypath expression
+ *
+ * @flags: Configuration flags
+ * @userdata: Opaque user data pointer
+ * @diag: Optional diagnostic interface to use
+ */
+struct fy_path_parse_cfg {
+	enum fy_path_parse_cfg_flags flags;
+	void *userdata;
+	struct fy_diag *diag;
+};
+
+/**
+ * fy_path_parser_create() - Create a ypath parser.
+ *
+ * Creates a path parser with its configuration @cfg
+ * The path parser may be destroyed by a corresponding call to
+ * fy_path_parser_destroy().
+ * If @cfg is NULL a default yaml parser is created.
+ *
+ * @cfg: The configuration for the path parser
+ *
+ * Returns:
+ * A pointer to the path parser or NULL in case of an error.
+ */
+struct fy_path_parser *
+fy_path_parser_create(const struct fy_path_parse_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_path_parser_destroy() - Destroy the given path parser
+ *
+ * Destroy a path parser created earlier via fy_path_parser_create().
+ *
+ * @fypp: The path parser to destroy
+ */
+void
+fy_path_parser_destroy(struct fy_path_parser *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_parser_reset() - Reset a path parser completely
+ *
+ * Completely reset a path parser, including after an error
+ * that caused a parser error to be emitted.
+ *
+ * @fypp: The path parser to reset
+ *
+ * Returns:
+ * 0 if the reset was successful, -1 otherwise
+ */
+int
+fy_path_parser_reset(struct fy_path_parser *fypp)
+	FY_EXPORT;
+
+/**
+ * fy_path_parse_expr_from_string() - Parse an expression from a given string
+ *
+ * Create a path expression from a string using the provided path parser.
+ *
+ * @fypp: The path parser to use
+ * @str: The ypath source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created path expression or NULL on error.
+ */
+struct fy_path_expr *
+fy_path_parse_expr_from_string(struct fy_path_parser *fypp,
+			       const char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_path_expr_build_from_string() - Parse an expression from a given string
+ *
+ * Create a path expression from a string using the provided path parser
+ * configuration.
+ *
+ * @pcfg: The path parser configuration to use, or NULL for default
+ * @str: The ypath source to use.
+ * @len: The length of the string (or -1 if '\0' terminated)
+ *
+ * Returns:
+ * The created path expression or NULL on error.
+ */
+struct fy_path_expr *
+fy_path_expr_build_from_string(const struct fy_path_parse_cfg *pcfg,
+			       const char *str, size_t len)
+	FY_EXPORT;
+
+/**
+ * fy_path_expr_free() - Free a path expression
+ *
+ * Free a previously returned expression from any of the path parser
+ * methods like fy_path_expr_build_from_string()
+ *
+ * @expr: The expression to free (may be NULL)
+ */
+void
+fy_path_expr_free(struct fy_path_expr *expr)
+	FY_EXPORT;
+
+/**
+ * fy_path_expr_dump() - Dump the contents of a path expression to
+ * 			 the diagnostic object
+ *
+ * Dumps the expression using the provided error level.
+ *
+ * @expr: The expression to dump
+ * @diag: The diagnostic object to use
+ * @errlevel: The error level which the diagnostic will use
+ * @level: The nest level; should be set to 0
+ * @banner: The banner to display on level 0
+ */
+void
+fy_path_expr_dump(struct fy_path_expr *expr, struct fy_diag *diag,
+		  enum fy_error_type errlevel, int level, const char *banner)
+	FY_EXPORT;
+
+/**
+ * fy_path_expr_to_document() - Converts the path expression to a YAML document
+ *
+ * Converts the expression to a YAML document which is useful for
+ * understanding what the expression evaluates to.
+ *
+ * @expr: The expression to convert to a document
+ *
+ * Returns:
+ * The document of the expression or NULL on error.
+ */
+struct fy_document *
+fy_path_expr_to_document(struct fy_path_expr *expr)
+	FY_EXPORT;
+
+/**
+ * enum fy_path_exec_cfg_flags - Path executor configuration flags
+ *
+ * These flags control the operation of the path expression executor
+ *
+ * @FYPXCF_QUIET: Quiet, do not output any information messages
+ * @FYPXCF_DISABLE_RECYCLING: Disable recycling optimization
+ * @FYPXCF_DISABLE_ACCELERATORS: Disable use of access accelerators (saves memory)
+ */
+enum fy_path_exec_cfg_flags {
+	FYPXCF_QUIET			= FY_BIT(0),
+	FYPXCF_DISABLE_RECYCLING	= FY_BIT(1),
+	FYPXCF_DISABLE_ACCELERATORS	= FY_BIT(2),
+};
+
+/**
+ * struct fy_path_exec_cfg - path expression executor configuration structure.
+ *
+ * Argument to the fy_path_exec_create() method which
+ * performs execution of a ypath expression
+ *
+ * @flags: Configuration flags
+ * @userdata: Opaque user data pointer
+ * @diag: Optional diagnostic interface to use
+ */
+struct fy_path_exec_cfg {
+	enum fy_path_exec_cfg_flags flags;
+	void *userdata;
+	struct fy_diag *diag;
+};
+
+/**
+ * fy_path_exec_create() - Create a ypath expression executor.
+ *
+ * Creates a ypath expression parser with its configuration @cfg
+ * The executor may be destroyed by a corresponding call to
+ * fy_path_exec_destroy().
+ *
+ * @xcfg: The configuration for the executor
+ *
+ * Returns:
+ * A pointer to the executor or NULL in case of an error.
+ */
+struct fy_path_exec *
+fy_path_exec_create(const struct fy_path_exec_cfg *xcfg)
+	FY_EXPORT;
+
+/**
+ * fy_path_exec_destroy() - Destroy the given path expression executor
+ *
+ * Destroy ane executor  created earlier via fy_path_exec_create().
+ *
+ * @fypx: The path parser to destroy
+ */
+void
+fy_path_exec_destroy(struct fy_path_exec *fypx)
+	FY_EXPORT;
+
+/**
+ * fy_path_exec_reset() - Reset an executor
+ *
+ * Completely reset an executor without releasing it.
+ *
+ * @fypx: The executor to reset
+ *
+ * Returns:
+ * 0 if the reset was successful, -1 otherwise
+ */
+int
+fy_path_exec_reset(struct fy_path_exec *fypx)
+	FY_EXPORT;
+
+/**
+ * fy_path_exec_execute() - Execute a path expression starting at
+ *                          the given start node
+ *
+ * Execute the expression starting at fyn_start. If execution
+ * is successful the results are available via fy_path_exec_results_iterate()
+ *
+ * Note that it is illegal to modify the state of the document that the
+ * results reside between this call and the results collection.
+ *
+ * @fypx: The executor to use
+ * @expr: The expression to use
+ * @fyn_start: The node on which the expression will begin.
+ *
+ * Returns:
+ * 0 if the execution was successful, -1 otherwise
+ *
+ * Note that the execution may be successful but no results were
+ * produced, in which case the iterator will return NULL.
+ */
+int
+fy_path_exec_execute(struct fy_path_exec *fypx, struct fy_path_expr *expr,
+		     struct fy_node *fyn_start)
+	FY_EXPORT;
+
+/**
+ * fy_path_exec_results_iterate() - Iterate over the results of execution
+ *
+ * This method iterates over all the results in the executor.
+ * The start of the iteration is signalled by a NULL in \*prevp.
+ *
+ * @fypx: The executor
+ * @prevp: The previous result iterator
+ *
+ * Returns:
+ * The next node in the result set or NULL at the end of the results.
+ */
+struct fy_node *
+fy_path_exec_results_iterate(struct fy_path_exec *fypx, void **prevp)
+	FY_EXPORT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBFYAML_PATH_EXEC_H */

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-thread.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-thread.h
@@ -1,0 +1,346 @@
+/*
+ * libfyaml-thread.h - libfyaml thread API
+ * Copyright (c) 2019-2026 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef LIBFYAML_THREAD_H
+#define LIBFYAML_THREAD_H
+
+#include <stddef.h>
+
+/* pull in common definitions and platform abstraction macros */
+#include <libfyaml/libfyaml-util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * DOC: Thread pool for parallel work execution
+ *
+ * This header provides a simple, portable thread pool built on POSIX threads.
+ * It is used internally by the BLAKE3 hasher and the generic type system's
+ * parallel map/filter/reduce operations, and is also available as a public
+ * API for application use.
+ *
+ * Two operational modes are supported:
+ *
+ * **Work-stealing mode** (``FYTPCF_STEAL_MODE``): the recommended mode for
+ * data-parallel loops.  Submit a batch of work items with
+ * ``fy_thread_work_join()``; the pool distributes items across threads and
+ * the caller participates in the execution.  About 30% faster than
+ * reservation mode for typical workloads.
+ *
+ * **Reservation mode**: explicitly reserve a thread with
+ * ``fy_thread_reserve()``, submit a single work item with
+ * ``fy_thread_submit_work()``, continue doing other work in the calling
+ * thread, then synchronise with ``fy_thread_wait_work()``.  Release the
+ * thread afterwards with ``fy_thread_unreserve()``.
+ *
+ * Three convenience wrappers over ``fy_thread_work_join()`` cover the
+ * most common data-parallel patterns:
+ *
+ * - ``fy_thread_args_join()``      — array of heterogeneous argument pointers
+ * - ``fy_thread_arg_array_join()`` — flat array of equal-sized argument items
+ * - ``fy_thread_arg_join()``       — same argument broadcast to N invocations
+ *
+ * An optional ``fy_work_check_fn`` callback lets each call site decide at
+ * runtime whether a given item is worth offloading to a thread or running
+ * inline.
+ */
+
+/* opaque types for the user */
+struct fy_thread_pool;
+struct fy_thread;
+struct fy_work_pool;
+
+/**
+ * typedef fy_work_exec_fn - Work exec function
+ *
+ * The callback executed on work submission
+ *
+ * @arg: The argument to the method
+ *
+ */
+typedef void (*fy_work_exec_fn)(void *arg);
+
+/**
+ * typedef fy_work_check_fn - Work check function
+ *
+ * Work checker function to decide if it's worth to
+ * offload to a thread.
+ *
+ * @arg: The argument to the method
+ *
+ * Returns:
+ * true if it should offload to thread, false otherwise
+ *
+ */
+typedef bool (*fy_work_check_fn)(const void *arg);
+
+/**
+ * struct fy_thread_work - Work submitted to a thread for execution
+ *
+ * @fn: The execution function for this work
+ * @arg: The argument to the fn
+ * @wp: Used internally, must be set to NULL on entry
+ *
+ * This is the structure describing the work submitted
+ * to a thread for execution.
+ */
+struct fy_thread_work {
+	fy_work_exec_fn fn;
+	void *arg;
+	struct fy_work_pool *wp;
+};
+
+/**
+ * enum fy_thread_pool_cfg_flags - Thread pool configuration flags
+ *
+ * These flags control the operation of the thread pool.
+ * For now only the steal mode flag is defined.
+ *
+ * @FYTPCF_STEAL_MODE: Enable steal mode for the thread pool
+ */
+enum fy_thread_pool_cfg_flags {
+	FYTPCF_STEAL_MODE	= FY_BIT(0),
+};
+
+/**
+ * struct fy_thread_pool_cfg - thread pool configuration structure.
+ *
+ * Argument to the fy_thread_pool_create() method.
+ *
+ * @flags: Thread pool configuration flags
+ * @num_threads: Number of threads, if 0 == online CPUs
+ * @userdata: A userdata pointer
+ */
+struct fy_thread_pool_cfg {
+	enum fy_thread_pool_cfg_flags flags;
+	unsigned int num_threads;
+	void *userdata;
+};
+
+/**
+ * fy_thread_pool_create() - Create a thread pool
+ *
+ * Creates a thread pool with its configuration @cfg
+ * The thread pool may be destroyed by a corresponding call to
+ * fy_thread_pool_destroy().
+ *
+ * @cfg: The configuration for the thread pool
+ *
+ * Returns:
+ * A pointer to the thread pool or NULL in case of an error.
+ */
+struct fy_thread_pool *
+fy_thread_pool_create(const struct fy_thread_pool_cfg *cfg)
+	FY_EXPORT;
+
+/**
+ * fy_thread_pool_destroy() - Destroy the given thread pool
+ *
+ * Destroy a thread pool created earlier via fy_thread_pool_create().
+ * Note that this function will block until all threads
+ * of the pool are destroyed.
+ *
+ * @tp: The thread pool to destroy
+ */
+void
+fy_thread_pool_destroy(struct fy_thread_pool *tp)
+	FY_EXPORT;
+
+/**
+ * fy_thread_pool_get_num_threads() - Get the number of threads
+ *
+ * Returns the actual number of created threads.
+ *
+ * @tp: The thread pool
+ *
+ * Returns:
+ * > 0 for the number of actual threads created,
+ * -1 on error
+ */
+int
+fy_thread_pool_get_num_threads(struct fy_thread_pool *tp)
+	FY_EXPORT;
+
+/**
+ * fy_thread_pool_get_cfg() - Get the configuration of a thread pool
+ *
+ * @tp: The thread pool
+ *
+ * Returns:
+ * The configuration of the thread pool
+ */
+const struct fy_thread_pool_cfg *
+fy_thread_pool_get_cfg(struct fy_thread_pool *tp)
+	FY_EXPORT;
+
+/**
+ * fy_thread_reserve() - Reserve a thread from the pool.
+ *
+ * Reserve a thread from the pool and return it.
+ * Note this is only valid for a non-work stealing thread pool.
+ * You release the thread again via a call to fy_thread_unreserve.
+ *
+ * @tp: The thread pool
+ *
+ * Returns:
+ * A reserved thread if not NULL, NULL if no threads are available.
+ */
+struct fy_thread *
+fy_thread_reserve(struct fy_thread_pool *tp)
+	FY_EXPORT;
+
+/**
+ * fy_thread_unreserve() - Unreserve a previously reserved thread
+ *
+ * Unreserve a thread previously reserved via a call to fy_thread_reserve()
+ * Note this is only valid for a non-work stealing thread pool.
+ *
+ * @t: The thread
+ */
+void
+fy_thread_unreserve(struct fy_thread *t)
+	FY_EXPORT;
+
+/**
+ * fy_thread_submit_work() - Submit work for execution
+ *
+ * Submit work for execution. If successful the thread
+ * will start executing the work in parallel with the
+ * calling thread. You can wait for the thread to
+ * terminate via a call to fy_thread_wait_work().
+ * The thread must have been reserved earlier via fy_thread_reserve()
+ *
+ * Note this is only valid for a non-work stealing thread pool.
+ *
+ * @t: The thread
+ * @work: The work
+ *
+ * Returns:
+ * 0 if work has been submitted, -1 otherwise.
+ */
+int
+fy_thread_submit_work(struct fy_thread *t, struct fy_thread_work *work)
+	FY_EXPORT;
+
+/**
+ * fy_thread_wait_work() - Wait for completion of submitted work
+ *
+ * Wait until submitted work to the thread has finished.
+ * Note this is only valid for a non-work stealing thread pool.
+ *
+ * @t: The thread
+ *
+ * Returns:
+ * 0 if work finished, -1 on error.
+ */
+int
+fy_thread_wait_work(struct fy_thread *t)
+	FY_EXPORT;
+
+/**
+ * fy_thread_pool_are_all_reserved() - Check whether no threads are free
+ *
+ * @tp: The thread pool
+ *
+ * Returns:
+ * true if all threads are currently reserved, false otherwise.
+ */
+bool
+fy_thread_pool_are_all_reserved(struct fy_thread_pool *tp)
+	FY_EXPORT;
+
+/**
+ * fy_thread_pool_is_any_reserved() - Check whether at least one thread is reserved
+ *
+ * @tp: The thread pool
+ *
+ * Returns:
+ * true if any thread is currently reserved, false otherwise.
+ */
+bool
+fy_thread_pool_is_any_reserved(struct fy_thread_pool *tp)
+	FY_EXPORT;
+
+/**
+ * fy_thread_work_join() - Submit works for execution and wait
+ *
+ * Submit works for possible parallel execution. If no offloading
+ * is possible at the time execute in the current context.
+ * It is possible to use in both stealing and non-stealing mode
+ * with the difference being that stealing mode is about 30% faster.
+ *
+ * @tp: The thread pool
+ * @works: Pointer to an array of works sized @work_count
+ * @work_count: The size of the @works array
+ * @check_fn: Pointer to a check function, or NULL for no checks
+ */
+void
+fy_thread_work_join(struct fy_thread_pool *tp,
+		    struct fy_thread_work *works, size_t work_count,
+		    fy_work_check_fn check_fn)
+	FY_EXPORT;
+
+/**
+ * fy_thread_args_join() - Execute function in parallel using arguments as pointers
+ *
+ * Execute @fn possibly in parallel using the threads in the thread pool.
+ * The arguments of the function are provided by the args array.
+ *
+ * @tp: The thread pool
+ * @fn: The function to execute in parallel
+ * @check_fn: Pointer to a check function, or NULL for no checks
+ * @args: An args array sized @count of argument pointers
+ * @count: The count of the args array items
+ */
+void
+fy_thread_args_join(struct fy_thread_pool *tp,
+		    fy_work_exec_fn fn, fy_work_check_fn check_fn,
+		    void **args, size_t count)
+	FY_EXPORT;
+
+/**
+ * fy_thread_arg_array_join() - Execute function in parallel using argument array
+ *
+ * Execute @fn possibly in parallel using the threads in the thread pool.
+ * The arguments of the function are provided by the args array.
+ *
+ * @tp: The thread pool
+ * @fn: The function to execute in parallel
+ * @check_fn: Pointer to a check function, or NULL for no checks
+ * @args: An args array of @argsize items
+ * @argsize: The size of each argument array item
+ * @count: The count of the args array items
+ */
+void
+fy_thread_arg_array_join(struct fy_thread_pool *tp,
+			 fy_work_exec_fn fn, fy_work_check_fn check_fn,
+			 void *args, size_t argsize, size_t count)
+	FY_EXPORT;
+
+/**
+ * fy_thread_arg_join() - Execute function in parallel with the same argument
+ *
+ * Execute @fn possibly in parallel using the threads in the thread pool.
+ * The argument of the functions is the same.
+ *
+ * @tp: The thread pool
+ * @fn: The function to execute in parallel
+ * @check_fn: Pointer to a check function, or NULL for no checks
+ * @arg: The common argument
+ * @count: The count of executions
+ */
+void
+fy_thread_arg_join(struct fy_thread_pool *tp,
+		   fy_work_exec_fn fn, fy_work_check_fn check_fn,
+		   void *arg, size_t count)
+	FY_EXPORT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBFYAML_THREAD_H */

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-util.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-util.h
@@ -1,0 +1,1455 @@
+/*
+ * libfyaml-util.h - Various utilities for libfyaml
+ *
+ * Copyright (c) 2019-2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * NOTE: This file contains internals that are not part of the public API.
+ * Things may change at any time. Use at your own peril.
+ */
+
+#ifndef LIBFYAML_UTIL_H
+#define LIBFYAML_UTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <assert.h>
+#include <float.h>
+
+#if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+#include <unistd.h>
+#include <sys/uio.h>
+#elif defined(_WIN32)
+/* Windows compatibility definitions */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+#ifdef _WIN64
+typedef __int64 ssize_t;
+#else
+typedef int ssize_t;
+#endif
+#endif
+/* Windows doesn't have sys/uio.h, provide iovec definition */
+#ifndef _FY_IOVEC_DEFINED
+#define _FY_IOVEC_DEFINED
+struct iovec {
+	void *iov_base;
+	size_t iov_len;
+};
+#endif
+#else
+#include <sys/uio.h>
+#endif
+
+/**
+ * DOC: General-purpose utility macros and portability helpers
+ *
+ * This header provides the low-level building blocks shared by all other
+ * libfyaml public headers.  It has no libfyaml dependencies of its own and
+ * is safe to include in isolation.
+ *
+ * **Platform portability**
+ *
+ * - ``ssize_t`` shim for MSVC / Windows toolchains
+ * - ``struct iovec`` shim for Windows (``sys/uio.h`` substitute)
+ * - ``FY_EXPORT`` / ``FY_DEPRECATED`` / ``FY_FORMAT`` — symbol visibility
+ *   and compiler-attribute portability macros
+ * - ``FY_UNUSED``, ``FY_ALWAYS_INLINE``, ``FY_DEBUG_UNUSED`` — compiler hint
+ *   wrappers with safe fallbacks on non-GCC/Clang toolchains
+ * - ``FY_CONSTRUCTOR`` / ``FY_DESTRUCTOR`` — GCC-style constructor/destructor
+ *   attributes with availability guards (``FY_HAS_CONSTRUCTOR``,
+ *   ``FY_HAS_DESTRUCTOR``)
+ *
+ * **Core constants and sentinel values**
+ *
+ * - ``FY_BIT(x)``   — single-bit mask (``1U << x``)
+ * - ``FY_NT``       — sentinel meaning "null-terminated"; pass as a length
+ *   argument to indicate that the string length should be inferred via strlen
+ *
+ * **Memory helpers**
+ *
+ * - ``FY_ALLOCA_COPY_FREE`` / ``FY_ALLOCA_COPY_FREE_NO_NULL`` — copy a
+ *   malloc-returned string onto the stack and immediately free the heap
+ *   allocation; produces an alloca-lifetime copy in a single expression
+ * - ``fy_vsprintfa`` / ``fy_sprintfa`` — printf-style formatting into a
+ *   stack-allocated (alloca) buffer; the result is valid for the lifetime
+ *   of the enclosing function
+ *
+ * **Container and array helpers**
+ *
+ * - ``container_of`` — recover a pointer to an enclosing struct from a
+ *   pointer to one of its members
+ * - ``ARRAY_SIZE``   — number of elements in a stack-allocated array
+ *
+ * **Type safety and compile-time checks**
+ *
+ * - ``FY_SAME_TYPE`` / ``FY_CHECK_SAME_TYPE`` — assert two expressions share
+ *   the same C type (wraps ``__builtin_types_compatible_p`` with a fallback)
+ * - ``FY_COMPILE_ERROR_ON_ZERO`` — produce a compile-time error when the
+ *   argument evaluates to zero; used for macro-level static assertions
+ *
+ * **Overflow-safe arithmetic**
+ *
+ * - ``FY_ADD_OVERFLOW``, ``FY_SUB_OVERFLOW``, ``FY_MUL_OVERFLOW`` — wrappers
+ *   around ``__builtin_*_overflow`` with portable fallback implementations
+ *
+ * **Miscellaneous**
+ *
+ * - ``FY_IMPOSSIBLE_ABORT`` — mark unreachable code paths; aborts at runtime
+ * - ``FY_STACK_SAVE`` / ``FY_STACK_RESTORE`` — save and restore the stack
+ *   pointer for alloca-based temporary arenas
+ * - Lambda / closure macros and a CPP metaprogramming framework for
+ *   building variadic generic APIs
+ * - Diagnostic helpers and floating-point precision constants
+ */
+
+/* make things fail easy on non GCC/clang */
+#ifndef __has_builtin
+/**
+ * __has_builtin() - Fallback for compilers that do not provide __has_builtin.
+ *
+ * Always evaluates to 0 (false) so that all ``#if __has_builtin(...)`` guards
+ * safely fall back to the portable implementation.
+ *
+ * @x: The builtin name to query.
+ *
+ * Returns: 0.
+ */
+#define __has_builtin(x) 0
+#endif
+
+/**
+ * FY_BIT() - Produce an unsigned bitmask with bit @x set.
+ *
+ * @x: Zero-based bit position (0–31 for a 32-bit result).
+ *
+ * Returns: ``1U << x``.
+ */
+#ifndef FY_BIT
+#define FY_BIT(x) (1U << (x))
+#endif
+
+/**
+ * FY_NT - Sentinel value meaning "null-terminated; compute length at runtime".
+ *
+ * Pass as the @len argument to any libfyaml function that accepts a
+ * ``(const char *str, size_t len)`` pair to indicate that @str is a
+ * NUL-terminated C string whose length should be determined with ``strlen()``.
+ *
+ * Value: ``(size_t)-1``
+ */
+/* NULL terminated string length specifier */
+#define FY_NT	((size_t)-1)
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+/**
+ * FY_EXPORT - Mark a symbol as part of the shared-library public ABI.
+ *
+ * On GCC/Clang (version >= 4) expands to ``__attribute__((visibility("default")))``,
+ * overriding ``-fvisibility=hidden`` for the annotated symbol.
+ * On other compilers expands to nothing (all symbols are visible by default).
+ */
+#define FY_EXPORT __attribute__ ((visibility ("default")))
+/**
+ * FY_DEPRECATED - Mark a function or variable as deprecated.
+ *
+ * On GCC/Clang expands to ``__attribute__((deprecated))``, causing a
+ * compile-time warning whenever the annotated symbol is used.
+ * On other compilers expands to nothing.
+ */
+#define FY_DEPRECATED __attribute__ ((deprecated))
+/**
+ * FY_FORMAT() - Annotate a function with printf-style format checking.
+ *
+ * On GCC/Clang expands to ``__attribute__((format(_t, _x, _y)))``, enabling
+ * the compiler to type-check the format string and variadic arguments.
+ *
+ * @_t: Format type token (e.g. ``printf``, ``scanf``, ``strftime``).
+ * @_x: 1-based index of the format-string parameter.
+ * @_y: 1-based index of the first variadic argument (0 for ``va_list`` wrappers).
+ */
+#define FY_FORMAT(_t, _x, _y) __attribute__ ((format(_t, _x, _y)))
+#else
+#define FY_EXPORT /* nothing */
+#define FY_DEPRECATED /* nothing */
+#define FY_FORMAT(_t, x, y)	/* nothing */
+#endif
+
+#ifdef _MSC_VER
+/*
+ * MSVC doesn't support GCC statement expressions, so we provide
+ * function-based alternatives using thread-local storage.
+ */
+#define FY_ALLOCA_COPY_FREE_BUFSZ 8192
+static __declspec(thread) char fy_alloca_copy_free_buf[FY_ALLOCA_COPY_FREE_BUFSZ];
+
+static __inline const char *fy_alloca_copy_free_impl(char *str, size_t len)
+{
+	size_t actual_len;
+	if (!str)
+		return NULL;
+	actual_len = (len == FY_NT) ? strlen(str) : len;
+	if (actual_len >= FY_ALLOCA_COPY_FREE_BUFSZ)
+		actual_len = FY_ALLOCA_COPY_FREE_BUFSZ - 1;
+	memcpy(fy_alloca_copy_free_buf, str, actual_len);
+	fy_alloca_copy_free_buf[actual_len] = '\0';
+	free(str);
+	return fy_alloca_copy_free_buf;
+}
+
+#define FY_ALLOCA_COPY_FREE(_str, _len) \
+	fy_alloca_copy_free_impl((_str), (size_t)(_len))
+
+#define FY_ALLOCA_COPY_FREE_NO_NULL(_str, _len) \
+	(fy_alloca_copy_free_impl((_str), (size_t)(_len)) ? fy_alloca_copy_free_buf : "")
+
+#else
+
+/**
+ * FY_ALLOCA_COPY_FREE() - Copy a heap string onto the stack and free the original.
+ *
+ * Expands to a statement expression that:
+ * 1. Copies @_str (up to @_len bytes, or the full NUL-terminated length when
+ *    @_len is %FY_NT) into a NUL-terminated stack buffer via ``alloca()``.
+ * 2. Calls ``free(@_str)`` to release the heap allocation.
+ * 3. Evaluates to a ``const char *`` pointing to the stack copy.
+ *
+ * When @_str is NULL the macro evaluates to NULL and performs no copy or free.
+ *
+ * The stack buffer is valid only for the lifetime of the enclosing function.
+ * Do not call this in a loop — each invocation grows the stack frame.
+ *
+ * @_str: Heap-allocated string to copy and free (may be NULL).
+ * @_len: Length in bytes, or %FY_NT to use ``strlen()``.
+ *
+ * Returns: ``const char *`` to the stack copy, or NULL if @_str was NULL.
+ */
+#define FY_ALLOCA_COPY_FREE(_str, _len)				\
+        ({							\
+                char *__str = (_str), *__stra = NULL;		\
+                size_t __len = (size_t)(_len);			\
+								\
+		if (__str) {					\
+			if (__len == FY_NT) 			\
+				__len = strlen(__str);		\
+			__stra = alloca(__len + 1);		\
+			memcpy(__stra, __str, __len);		\
+			__stra[__len] = '\0';			\
+			free(__str);				\
+		}						\
+                (const char *)__stra;				\
+        })
+
+/**
+ * FY_ALLOCA_COPY_FREE_NO_NULL() - Like FY_ALLOCA_COPY_FREE() but returns "" for NULL.
+ *
+ * Identical to %FY_ALLOCA_COPY_FREE but substitutes an empty string literal
+ * ``""`` when @_str is NULL, so callers never receive a NULL pointer.
+ *
+ * @_str: Heap-allocated string to copy and free (may be NULL).
+ * @_len: Length in bytes, or %FY_NT to use ``strlen()``.
+ *
+ * Returns: ``const char *`` to the stack copy, or ``""`` if @_str was NULL.
+ */
+#ifndef FY_ALLOCA_COPY_FREE_NO_NULL
+#define FY_ALLOCA_COPY_FREE_NO_NULL(_str, _len)			\
+        ({							\
+                const char *__strb;				\
+								\
+		__strb = FY_ALLOCA_COPY_FREE(_str, _len);	\
+		if (!__strb)					\
+			__strb = "";				\
+		__strb;						\
+        })
+#endif
+#endif
+
+/**
+ * container_of() - Recover a pointer to a containing struct from a member pointer.
+ *
+ * Given a pointer @ptr to a field named @member inside a struct of type @type,
+ * returns a pointer to the enclosing @type instance.
+ *
+ * Uses ``__typeof__`` to catch type mismatches at compile time (GCC/Clang).
+ *
+ * @ptr:    Pointer to the member field.
+ * @type:   Type of the containing struct.
+ * @member: Name of the member field within @type.
+ *
+ * Returns: Pointer to the containing struct of type @type.
+ */
+#ifndef container_of
+#if defined(_MSC_VER)
+#define container_of(ptr, type, member) \
+	((type *)((char *)(ptr) - offsetof(type, member)))
+#else
+#define container_of(ptr, type, member) \
+	({ \
+		const __typeof__(((type *)0)->member) *__mptr = (ptr); \
+		(type *)((void *)__mptr - offsetof(type,member)); \
+	 })
+#endif /* _MSC_VER */
+#endif /* container_of */
+
+/**
+ * ARRAY_SIZE() - Compute the number of elements in a stack-allocated array.
+ *
+ * Evaluates to a compile-time constant. Only valid for arrays with a known
+ * size at compile time (not pointers or VLAs).
+ *
+ * @x: The array expression.
+ *
+ * Returns: Number of elements, as a ``size_t``.
+ */
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) ((sizeof(x)/sizeof((x)[0])))
+#endif
+
+/**
+ * FY_UNUSED - Suppress "unused variable/parameter" warnings.
+ *
+ * On GCC/Clang (version >= 4) expands to ``__attribute__((unused))``.
+ * On other compilers expands to nothing.
+ *
+ * Use on parameters or local variables that are intentionally unreferenced,
+ * e.g. in debug-only code paths.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define FY_UNUSED __attribute__((unused))
+#else
+#define FY_UNUSED /* nothing */
+#endif
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+/**
+ * FY_CONSTRUCTOR - Run a function automatically before main().
+ *
+ * On GCC/Clang expands to ``__attribute__((constructor))``. Also defines
+ * %FY_HAS_CONSTRUCTOR so callers can detect support at compile time.
+ * On other compilers expands to nothing and %FY_HAS_CONSTRUCTOR is not defined.
+ */
+#define FY_CONSTRUCTOR __attribute__((constructor))
+/**
+ * FY_DESTRUCTOR - Run a function automatically after main() (or on exit()).
+ *
+ * On GCC/Clang expands to ``__attribute__((destructor))``. Also defines
+ * %FY_HAS_DESTRUCTOR so callers can detect support at compile time.
+ * On other compilers expands to nothing and %FY_HAS_DESTRUCTOR is not defined.
+ */
+#define FY_DESTRUCTOR __attribute__((destructor))
+#define FY_HAS_CONSTRUCTOR
+#define FY_HAS_DESTRUCTOR
+#else
+#define FY_CONSTRUCTOR /* nothing */
+#define FY_DESTRUCTOR /* nothing */
+#endif
+
+/*
+ * FY_ALWAYS_INLINE - Force inlining of a function regardless of optimisation level.
+ *
+ * Expands to __attribute__((always_inline)) on GCC/Clang when NDEBUG
+ * is defined (i.e. in release builds). In debug builds expands to nothing so
+ * that functions remain visible to the debugger.
+ */
+#if defined(NDEBUG) && (defined(__GNUC__) && __GNUC__ >= 4)
+#define FY_ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define FY_ALWAYS_INLINE /* nothing */
+#endif
+
+/**
+ * FY_DEBUG_UNUSED - Mark a variable as potentially unused in non-debug builds.
+ *
+ * Expands to ``__attribute__((unused))`` on GCC/Clang when ``NDEBUG`` is
+ * defined, silencing warnings for variables that are only referenced inside
+ * ``assert()`` calls (which disappear in release builds).
+ * In debug builds (``NDEBUG`` not set) expands to nothing.
+ */
+#if defined(NDEBUG) && defined(__GNUC__) && __GNUC__ >= 4
+#define FY_DEBUG_UNUSED __attribute__((unused))
+#else
+#define FY_DEBUG_UNUSED /* nothing */
+#endif
+
+/*
+ * FY_DESTRUCTOR_SHOW_LEFTOVERS - Defined when destructor-based leak reporting is active.
+ *
+ * Defined when both %FY_DESTRUCTOR (constructor/destructor attribute support)
+ * and ``NDEBUG`` are in effect. Internal subsystems use this flag to register
+ * ``FY_DESTRUCTOR`` functions that log any objects still alive at process exit,
+ * providing a lightweight leak summary in release builds.
+ */
+#if defined(FY_DESTRUCTOR) && defined(NDEBUG)
+#define FY_DESTRUCTOR_SHOW_LEFTOVERS
+#endif
+
+/**
+ * FY_IMPOSSIBLE_ABORT() - Assert that an unreachable code path has been reached.
+ *
+ * Calls ``assert(0)`` followed by ``abort()`` to terminate the process
+ * immediately. Use to mark code paths that must never execute in a correct
+ * program, such as the default branch of a switch that covers all enum values.
+ *
+ * The double invocation ensures termination even when assertions are disabled
+ * (``NDEBUG``).
+ */
+/* something impossible is happening, assert/abort */
+#define FY_IMPOSSIBLE_ABORT() \
+	do { \
+		assert(0); \
+		abort(); \
+	} while(0)
+
+/**
+ * FY_COMPILE_ERROR_ON_ZERO() - Trigger a compile error if expression @_e is zero.
+ *
+ * Evaluates @_e at compile time. If @_e is zero, ``sizeof(char[-1])`` is
+ * ill-formed and the build fails. If @_e is non-zero, the expression is a
+ * no-op void cast.
+ *
+ * Prefer %FY_CHECK_SAME_TYPE or ``static_assert`` for clearer error messages;
+ * use this primitive when a compile-time boolean is needed in a macro context.
+ *
+ * @_e: Compile-time expression that must be non-zero.
+ */
+/* if expression is zero, then the build will break */
+#define FY_COMPILE_ERROR_ON_ZERO(_e) ((void)(sizeof(char[1 - 2*!!(_e)])))
+
+/**
+ * FY_SAME_TYPE() - Test whether two expressions have the same type.
+ *
+ * On GCC/Clang uses ``__builtin_types_compatible_p`` to compare the types of
+ * @_a and @_b (via ``__typeof__``). On compilers without this builtin always
+ * evaluates to true to avoid false negatives.
+ *
+ * @_a: First expression.
+ * @_b: Second expression.
+ *
+ * Returns: Non-zero (true) if the types match, zero (false) otherwise.
+ */
+/* true, if types are the same, false otherwise (depends on builtin_types_compatible_p) */
+#if __has_builtin(__builtin_types_compatible_p)
+#define FY_SAME_TYPE(_a, _b) __builtin_types_compatible_p(__typeof__(_a), __typeof__(_b))
+#else
+#define FY_SAME_TYPE(_a, _b) true
+#endif
+
+/**
+ * FY_CHECK_SAME_TYPE() - Trigger a compile error if two expressions have different types.
+ *
+ * Combines %FY_SAME_TYPE and %FY_COMPILE_ERROR_ON_ZERO. Use in macros that
+ * require two operands to have the same type (e.g. overflow-safe arithmetic).
+ *
+ * @_a: First expression.
+ * @_b: Second expression.
+ */
+/* compile error if types are not the same */
+#define FY_CHECK_SAME_TYPE(_a, _b) \
+    FY_COMPILE_ERROR_ON_ZERO(!FY_SAME_TYPE(_a, _b))
+
+/**
+ * FY_ADD_OVERFLOW() - Checked addition: detect signed/unsigned integer overflow.
+ *
+ * On GCC/Clang maps directly to ``__builtin_add_overflow(_a, _b, _resp)``,
+ * which is a single compiler intrinsic with full type generality.
+ *
+ * On other compilers a portable fallback is used that:
+ * - Requires @_a and @_b to have the same type (enforced at compile time via
+ *   %FY_CHECK_SAME_TYPE).
+ * - Computes ``*_resp = _a + _b`` and returns true if the addition wrapped.
+ *
+ * @_a:    First operand.
+ * @_b:    Second operand (must have the same type as @_a).
+ * @_resp: Pointer to receive the result (written even on overflow).
+ *
+ * Returns: true if the addition overflowed, false otherwise.
+ */
+/* type safe add overflow */
+#if __has_builtin(__builtin_add_overflow)
+#define FY_ADD_OVERFLOW(_a, _b, _resp) __builtin_add_overflow(_a, _b, _resp)
+#else
+#ifndef _MSC_VER
+#define FY_ADD_OVERFLOW(_a, _b, _resp) \
+({ \
+	__typeof__(_a) __a = (_a), __res; \
+	__typeof__(_b) __b = (_b); \
+	bool __overflow; \
+	\
+	FY_CHECK_SAME_TYPE(__a, __b); \
+	\
+	__res = __a + __b; \
+	/* overflow when signs of a, b same, but results different */ \
+	__overflow = ((__a ^ __res) & (__b & __res)) < 0; \
+	*(_resp) = __res; \
+	__overflow; \
+})
+#else
+/* no overflow checks for MSVC; tread carefully */
+#define FY_ADD_OVERFLOW(_a, _b, _resp) \
+	(*(_resp) = (_a) + (_b), false)
+#endif
+#endif
+
+/**
+ * FY_SUB_OVERFLOW() - Checked subtraction: detect signed/unsigned integer overflow.
+ *
+ * On GCC/Clang maps to ``__builtin_sub_overflow(_a, _b, _resp)``.
+ * The portable fallback requires @_a and @_b to have the same type.
+ *
+ * @_a:    Minuend.
+ * @_b:    Subtrahend (must have the same type as @_a).
+ * @_resp: Pointer to receive the result (written even on overflow).
+ *
+ * Returns: true if the subtraction overflowed, false otherwise.
+ */
+/* type safe sub overflow */
+#if __has_builtin(__builtin_sub_overflow)
+#define FY_SUB_OVERFLOW(_a, _b, _resp) __builtin_sub_overflow(_a, _b, _resp)
+#else
+#ifndef _MSC_VER
+#define FY_SUB_OVERFLOW(_a, _b, _resp) \
+({ \
+	__typeof__(_a) __a = (_a), __res; \
+	__typeof__(_b) __b = (_b); \
+	bool __overflow; \
+	\
+	FY_CHECK_SAME_TYPE(__a, __b); \
+	\
+	__res = __a - __b; \
+	/* overflow when signs of a, b differ, but results different from minuend */ \
+	__overflow = ((__a ^ __b) & (__a & __res)) < 0; \
+	*(_resp) = __res; \
+	__overflow; \
+})
+#else
+/* no overflow checks for MSVC; tread carefully */
+#define FY_SUB_OVERFLOW(_a, _b, _resp) \
+	(*(_resp) = (_a) - (_b), false)
+#endif
+#endif
+
+/**
+ * FY_MUL_OVERFLOW() - Checked multiplication: detect signed/unsigned integer overflow.
+ *
+ * On GCC/Clang maps to ``__builtin_mul_overflow(_a, _b, _resp)``.
+ * The portable fallback requires @_a and @_b to have the same type and detects
+ * overflow by dividing the product back and comparing with the original operand.
+ *
+ * @_a:    First factor.
+ * @_b:    Second factor (must have the same type as @_a).
+ * @_resp: Pointer to receive the result (written even on overflow).
+ *
+ * Returns: true if the multiplication overflowed, false otherwise.
+ */
+/* type safe multiply overflow */
+#if __has_builtin(__builtin_mul_overflow)
+#define FY_MUL_OVERFLOW(_a, _b, _resp) __builtin_mul_overflow(_a, _b, _resp)
+#else
+#ifndef _MSC_VER
+#define FY_MUL_OVERFLOW(_a, _b, _resp) \
+({ \
+	__typeof__(_a) __a = (_a), __res; \
+	__typeof__(_b) __b = (_b); \
+	bool __overflow; \
+	\
+	FY_CHECK_SAME_TYPE(__a, __b); \
+	\
+	if (!__a || !__b) { \
+	    __overflow = false; \
+	    __res = 0; \
+	} else { \
+	    __res = __a * __b; \
+	    /* overflow when division of the result differs */ \
+	    __overflow = (__res / __a) != __b; \
+	} \
+	*(_resp) = __res; \
+	__overflow; \
+})
+#else
+/* no overflow checks for MSVC; tread carefully */
+#define FY_MUL_OVERFLOW(_a, _b, _resp) \
+	(*(_resp) = (_a) * (_b), false)
+#endif
+#endif
+
+/**
+ * DOC: fy_vsprintfa() - Format a string into a stack buffer using a va_list
+ *
+ * ``fy_vsprintfa(_fmt, _ap)`` expands to a statement expression that first
+ * measures the required output length with ``vsnprintf()``, then allocates a
+ * stack buffer with ``alloca()``, formats into it, and evaluates to a
+ * NUL-terminated ``char *``.
+ *
+ * The returned pointer is valid only for the lifetime of the enclosing
+ * function. The ``va_list`` argument is consumed and must not be reused
+ * afterwards.
+ */
+/* alloca formatted print methods */
+#ifdef _MSC_VER
+/*
+ * MSVC doesn't support GCC statement expressions, so we provide
+ * function-based alternatives. These use a static thread-local buffer
+ * which is less flexible but works for typical use cases.
+ */
+#define FY_ALLOCA_SPRINTF_BUFSZ 4096
+
+static __declspec(thread) char fy_alloca_sprintf_buf[FY_ALLOCA_SPRINTF_BUFSZ];
+
+static inline char *fy_alloca_vsprintf_impl(const char *fmt, va_list ap)
+{
+	va_list ap_copy;
+	int len;
+	char *s;
+
+	va_copy(ap_copy, ap);
+	len = vsnprintf(fy_alloca_sprintf_buf, FY_ALLOCA_SPRINTF_BUFSZ, fmt, ap_copy);
+	va_end(ap_copy);
+	if (len < 0)
+		return NULL;
+	/* strip trailing newlines */
+	s = fy_alloca_sprintf_buf + strlen(fy_alloca_sprintf_buf);
+	while (s > fy_alloca_sprintf_buf && s[-1] == '\n')
+		*--s = '\0';
+	return fy_alloca_sprintf_buf;
+}
+
+/* For MSVC, we can't use variadic macros that return values easily,
+ * so fy_vsprintfa needs a different approach
+ * This is not very efficient and wastes memory but it's the best
+ * we can do with the potato compiler
+ */
+#define fy_vsprintfa(_fmt, _ap) \
+	strcpy(alloca(FY_ALLOCA_SPRINTF_BUFSZ + 1), \
+			fy_alloca_vsprintf_impl((_fmt), (_ap)))
+#define fy_sprintfa(_fmt, ...) \
+	strcpy(alloca(FY_ALLOCA_SPRINTF_BUFSZ + 1), \
+			(snprintf(fy_alloca_sprintf_buf, FY_ALLOCA_SPRINTF_BUFSZ, (_fmt), __VA_ARGS__) < 0 ? \
+				"" : fy_alloca_sprintf_buf))
+#else
+/* GCC/Clang version with statement expressions */
+#define fy_vsprintfa(_fmt, _ap) \
+	({ \
+		const char *__fmt = (_fmt); \
+		va_list _ap_orig; \
+		int _size; \
+		char *_buf; \
+		\
+		va_copy(_ap_orig, (_ap)); \
+		_size = vsnprintf(NULL, 0, __fmt, _ap_orig); \
+		va_end(_ap_orig); \
+		_buf = alloca(_size + 1); \
+		(void)vsnprintf(_buf, _size + 1, __fmt, (_ap)); \
+		_buf; \
+	})
+
+/**
+ * fy_sprintfa() - Format a string into a stack buffer using inline arguments.
+ *
+ * Like fy_vsprintfa() but accepts arguments directly (uses ``__VA_ARGS__``).
+ * Two calls to ``snprintf()`` are made: the first with a NULL buffer to
+ * measure the required length, the second to write the result into a
+ * stack-allocated buffer.
+ *
+ * The returned pointer is valid only for the lifetime of the enclosing function.
+ *
+ * @_fmt: printf-style format string.
+ * @...:  Format arguments.
+ *
+ * Returns: ``char *`` to a NUL-terminated stack buffer.
+ */
+#define fy_sprintfa(_fmt, ...) \
+	({ \
+		const char *__fmt = (_fmt); \
+		int _size; \
+		char *_buf; \
+		\
+		_size = snprintf(NULL, 0, __fmt, ## __VA_ARGS__); \
+		_buf = alloca(_size + 1); \
+		(void)snprintf(_buf, _size + 1, __fmt, __VA_ARGS__); \
+		_buf; \
+	})
+#endif
+
+/**
+ * DOC: C preprocessor metaprogramming framework
+ *
+ * This section implements a portable ``FY_CPP_*`` macro toolkit that enables
+ * applying an operation to every argument in a ``__VA_ARGS__`` list — the
+ * equivalent of a compile-time ``map()`` function.
+ *
+ * **The core challenge**: The C preprocessor does not support recursion. A
+ * macro cannot call itself. The standard workaround is *deferred evaluation*:
+ * a macro is "postponed" so that it is not expanded in the current scan pass,
+ * only in a future one.  Multiple passes are forced by the ``FY_CPP_EVALn``
+ * ladder which re-expands the token stream a power-of-two number of times.
+ *
+ * **Evaluation levels** (``FY_CPP_EVAL1`` .. ``FY_CPP_EVAL``):
+ *
+ * - ``FY_CPP_EVAL1``  — one pass (no re-expansion)
+ * - ``FY_CPP_EVAL2``  — 2 passes
+ * - ``FY_CPP_EVAL4``  — 4 passes
+ * - ``FY_CPP_EVAL8``  — 8 passes
+ * - ``FY_CPP_EVAL16`` — 16 passes (GCC only; Clang craps out at 8)
+ * - ``FY_CPP_EVAL``   — full depth (32 passes on GCC, 16 on Clang)
+ *
+ * Each doubling allows mapping over twice as many arguments.  ``FY_CPP_EVAL``
+ * supports lists of up to ~32 elements (GCC) or ~16 elements (Clang) in practice.
+ *
+ * **Argument accessors** — extract positional arguments from ``__VA_ARGS__``:
+ *
+ * - ``FY_CPP_FIRST(...)``  — first argument (0 if list is empty)
+ * - ``FY_CPP_SECOND(...)`` — second argument
+ * - ``FY_CPP_THIRD(...)``  — third argument
+ * - ``FY_CPP_FOURTH(...)`` — fourth argument
+ * - ``FY_CPP_FIFTH(...)``  — fifth argument
+ * - ``FY_CPP_SIXTH(...)``  — sixth argument
+ * - ``FY_CPP_REST(...)``   — all arguments after the first (empty if < 2)
+ *
+ * **Map operations**:
+ *
+ * - ``FY_CPP_MAP(macro, ...)`` — expand ``macro(x)`` for each argument @x.
+ * - ``FY_CPP_MAP2(a, macro, ...)`` — expand ``macro(a, x)`` for each @x,
+ *   threading a fixed first argument @a through every call.
+ *
+ * **Utility**:
+ *
+ * - ``FY_CPP_VA_COUNT(...)``         — number of arguments (integer expression).
+ * - ``FY_CPP_VA_ITEMS(_type, ...)``  — compound-literal array of @_type from varargs.
+ * - ``FY_CPP_EMPTY()``               — deferred empty token (used to postpone macros).
+ * - ``FY_CPP_POSTPONE1(macro)``      — postpone a one-argument macro one pass.
+ * - ``FY_CPP_POSTPONE2(a, macro)``   — postpone a two-argument macro one pass.
+ *
+ * **Short-name mode** (``FY_CPP_SHORT_NAMES``):
+ *
+ * By default the implementation uses abbreviated internal names (``_E1``,
+ * ``_FM``, etc.) to reduce token-expansion buffer pressure. Define
+ * ``FY_CPP_SHORT_NAMES_DEBUG`` before including this header to force the
+ * original long-name implementation (``FY_CPP_EVAL1``, ``_FY_CPP_MAP_ONE``,
+ * etc.) which is easier to read in expansion traces.
+ *
+ * **Example**::
+ *
+ *   // Count and collect variadic integer arguments into a C array:
+ *   int do_sum(int count, int *items) { ... }
+ *
+ *   #define do_sum_macro(...) \
+ *       do_sum(FY_CPP_VA_COUNT(__VA_ARGS__), \
+ *              FY_CPP_VA_ITEMS(int, __VA_ARGS__))
+ *
+ *   // do_sum_macro(1, 2, 5, 100) expands to:
+ *   // do_sum(4, ((int [4]){ 1, 2, 5, 100 }))
+ */
+
+// C preprocessor magic follows (pilfered and adapted from h4x0r.org)
+
+/* applies an expansion over a varargs list */
+
+/*
+ * Define FY_CPP_SHORT_NAMES to use shortened macro names in the implementation.
+ * This significantly reduces expansion buffer usage during recursive macro expansion,
+ * which can help avoid internal compiler errors and speed up compilation.
+ *
+ * The public API (FY_CPP_*) remains the same regardless of this setting.
+ */
+
+#ifndef FY_CPP_SHORT_NAMES_DEBUG
+#define FY_CPP_SHORT_NAMES
+#endif
+
+#ifdef FY_CPP_SHORT_NAMES
+
+/* Short-name implementation - reduces expansion buffer usage by ~60% */
+
+#define _E1(...)	__VA_ARGS__
+#define _E2(...)	_E1(_E1(__VA_ARGS__))
+#define _E4(...)	_E2(_E2(__VA_ARGS__))
+#define _E8(...)	_E4(_E4(__VA_ARGS__))
+#define _E16(...)	_E8(_E8(__VA_ARGS__))
+#define _E32(...)	_E16(_E16(__VA_ARGS__))
+#define _E(...)		_E32(_E32(__VA_ARGS__))
+
+#define _FMT()
+#define _FP1(m) m _FMT()
+#define _FP2(a, m) m _FMT()
+
+#define _F1(_1, ...)		_1
+#define _F1F(...)			_F1(__VA_OPT__(__VA_ARGS__ ,) 0)
+
+#define _F2(_1, _2, ...)	_2
+#define _F2F(...)			_F2(__VA_OPT__(__VA_ARGS__ ,) 0, 0)
+
+#define _F3(_1, _2, _3, ...)		_3
+#define _F3F(...)			_F3(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0)
+
+#define _F4(_1, _2, _3, _4, ...)	_4
+#define _F4F(...)			_F4(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0, 0)
+
+#define _F5(_1, _2, _3, _4, _5, ...)	_5
+#define _F5F(...) \
+	_F5(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0, 0, 0)
+
+#define _F6(_1, _2, _3, _4, _5, _6, ...)	_6
+#define _F6F(...) \
+	_F6(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0, 0, 0, 0)
+
+#define _FR(x, ...) __VA_ARGS__
+#define _FRF(...)     __VA_OPT__(_FR(__VA_ARGS__))
+
+#define _FM(m, ...) \
+    __VA_OPT__(_E(_FM1(m, __VA_ARGS__)))
+#define _FM1(m, x, ...) m(x) \
+    __VA_OPT__(_FP1(_FMI)()(m, __VA_ARGS__))
+#define _FMI() _FM1
+
+#define _FCB(x) +1
+#define _FVC(...)  (__VA_OPT__((_FM(_FCB, __VA_ARGS__) + 0)) + 0)
+
+#define _FI1(a) a
+#define _FIL(a) , _FI1(a)
+#define _FILS(...) _FM(_FIL, __VA_ARGS__)
+
+#define _FVIS(...) \
+    _FI1(_F1F(__VA_ARGS__)) \
+    _FILS(_FRF(__VA_ARGS__))
+
+#define _FVISF(_t, ...) \
+	((_t [_FVC(__VA_ARGS__)]) { _FVIS(__VA_ARGS__) })
+
+#define _FM2(a, m, ...) \
+    __VA_OPT__(_E(_FM12(a, m, __VA_ARGS__)))
+
+#define _FM12(a, m, x, ...) m(a, x) \
+    __VA_OPT__(_FP2(a, _FMI2)()(a, m, __VA_ARGS__))
+#define _FMI2() _FM12
+
+/* Public API - maps to short names */
+
+/**
+ * FY_CPP_EVAL1() - Force one additional macro-expansion pass.
+ *
+ * Expands its argument list once. Use as a building block for deeper
+ * evaluation levels; prefer FY_CPP_EVAL() for most uses.
+ *
+ * @...: Token sequence to re-expand.
+ */
+#define FY_CPP_EVAL1(...)	_E1(__VA_ARGS__)
+/**
+ * FY_CPP_EVAL2() - Force two additional macro-expansion passes.
+ * @...: Token sequence to re-expand.
+ */
+#define FY_CPP_EVAL2(...)	_E2(__VA_ARGS__)
+/**
+ * FY_CPP_EVAL4() - Force four additional macro-expansion passes.
+ * @...: Token sequence to re-expand.
+ */
+#define FY_CPP_EVAL4(...)	_E4(__VA_ARGS__)
+/**
+ * FY_CPP_EVAL8() - Force eight additional macro-expansion passes.
+ * @...: Token sequence to re-expand.
+ */
+#define FY_CPP_EVAL8(...)	_E8(__VA_ARGS__)
+#if !defined(__clang__)
+/**
+ * FY_CPP_EVAL16() - Force 16 additional macro-expansion passes (GCC only).
+ *
+ * Not defined on Clang, which exhausts its expansion buffer before reaching
+ * 16 levels. Wrap FY_CPP_MAP() / FY_CPP_MAP2() in FY_CPP_EVAL() instead of
+ * calling this directly.
+ *
+ * @...: Token sequence to re-expand.
+ */
+#define FY_CPP_EVAL16(...)	_E16(__VA_ARGS__)
+#endif
+/**
+ * FY_CPP_EVAL() - Force maximum macro-expansion depth.
+ *
+ * On GCC performs 32 expansion passes (supports lists up to ~32 elements).
+ * On Clang performs 16 passes (supports lists up to ~16 elements).
+ *
+ * Always use this (rather than a specific EVALn) unless you have a known
+ * bound on the number of arguments.
+ *
+ * @...: Token sequence to fully expand.
+ */
+#define FY_CPP_EVAL(...)	_E(__VA_ARGS__)
+
+/**
+ * FY_CPP_EMPTY() - Produce an empty token sequence (deferred).
+ *
+ * Expands to nothing. Used in combination with FY_CPP_POSTPONE1() /
+ * FY_CPP_POSTPONE2() to defer macro expansion by one scan pass, breaking
+ * the preprocessor's blue-paint recursion guard.
+ */
+#define FY_CPP_EMPTY()		_FMT()
+/**
+ * FY_CPP_POSTPONE1() - Defer a single-argument macro by one expansion pass.
+ *
+ * Expands to the macro name @macro followed by a deferred FY_CPP_EMPTY(),
+ * so the macro call is not completed until the next pass.
+ *
+ * @macro: Macro token to postpone.
+ */
+#define FY_CPP_POSTPONE1(macro)	_FP1(macro)
+/**
+ * FY_CPP_POSTPONE2() - Defer a two-argument macro by one expansion pass.
+ *
+ * Like FY_CPP_POSTPONE1() but for macros that take a leading fixed argument @a.
+ *
+ * @a:     Fixed first argument (carried along, not expanded yet).
+ * @macro: Macro token to postpone.
+ */
+#define FY_CPP_POSTPONE2(a, macro)	_FP2(a, macro)
+
+/**
+ * FY_CPP_FIRST() - Extract the first argument from a variadic list.
+ *
+ * Returns the first argument, or 0 if the list is empty.
+ *
+ * @...: Variadic argument list.
+ *
+ * Returns: First argument token, or ``0``.
+ */
+#define FY_CPP_FIRST(...)	_F1F(__VA_ARGS__)
+/**
+ * FY_CPP_SECOND() - Extract the second argument from a variadic list.
+ *
+ * Returns the second argument, or 0 if fewer than two arguments are present.
+ *
+ * @...: Variadic argument list.
+ *
+ * Returns: Second argument token, or ``0``.
+ */
+#define FY_CPP_SECOND(...)	_F2F(__VA_ARGS__)
+/**
+ * FY_CPP_THIRD() - Extract the third argument.
+ * @...: Variadic argument list. Returns: Third argument, or ``0``.
+ */
+#define FY_CPP_THIRD(...)	_F3F(__VA_ARGS__)
+/**
+ * FY_CPP_FOURTH() - Extract the fourth argument.
+ * @...: Variadic argument list. Returns: Fourth argument, or ``0``.
+ */
+#define FY_CPP_FOURTH(...)	_F4F(__VA_ARGS__)
+/**
+ * FY_CPP_FIFTH() - Extract the fifth argument.
+ * @...: Variadic argument list. Returns: Fifth argument, or ``0``.
+ */
+#define FY_CPP_FIFTH(...)	_F5F(__VA_ARGS__)
+/**
+ * FY_CPP_SIXTH() - Extract the sixth argument.
+ * @...: Variadic argument list. Returns: Sixth argument, or ``0``.
+ */
+#define FY_CPP_SIXTH(...)	_F6F(__VA_ARGS__)
+/**
+ * FY_CPP_REST() - Return all arguments after the first.
+ *
+ * Expands to the tail of the variadic list with the first element removed.
+ * Expands to nothing if the list has zero or one element.
+ *
+ * @...: Variadic argument list.
+ */
+#define FY_CPP_REST(...)	_FRF(__VA_ARGS__)
+
+/**
+ * FY_CPP_MAP() - Apply a macro to every argument in a variadic list.
+ *
+ * Expands ``macro(x)`` for each argument @x in ``__VA_ARGS__``, concatenating
+ * all the results. The argument list must be non-empty. Uses FY_CPP_EVAL()
+ * internally, so the list length is bounded by the evaluation depth.
+ *
+ * For example::
+ *
+ *   #define PRINT_ITEM(x)  printf("%d\n", x);
+ *   FY_CPP_MAP(PRINT_ITEM, 1, 2, 3)
+ *   // expands to: printf("%d\n", 1); printf("%d\n", 2); printf("%d\n", 3);
+ *
+ * @macro: Single-argument macro to apply.
+ * @...:   Arguments to map over.
+ */
+#define FY_CPP_MAP(macro, ...)	_FM(macro, __VA_ARGS__)
+#define _FY_CPP_MAP_ONE		_FM1
+#define _FY_CPP_MAP_INDIRECT	_FMI
+#define _FY_CPP_COUNT_BODY	_FCB
+/**
+ * FY_CPP_VA_COUNT() - Count the number of arguments in a variadic list.
+ *
+ * Evaluates to a compile-time integer expression equal to the number of
+ * arguments. Returns 0 for an empty list.
+ *
+ * @...: Variadic argument list.
+ *
+ * Returns: Integer expression giving the argument count.
+ */
+#define FY_CPP_VA_COUNT(...)	_FVC(__VA_ARGS__)
+#define _FY_CPP_ITEM_ONE	_FI1
+#define _FY_CPP_ITEM_LATER_ARG	_FIL
+#define _FY_CPP_ITEM_LIST	_FILS
+#define _FY_CPP_VA_ITEMS	_FVIS
+/**
+ * FY_CPP_VA_ITEMS() - Build a compound-literal array from variadic arguments.
+ *
+ * Expands to a compound literal of type ``_type[N]`` (where N is the number
+ * of arguments) initialised with the provided values. Useful for passing a
+ * variadic argument list as an array to a function.
+ *
+ * For example::
+ *
+ *   // FY_CPP_VA_ITEMS(int, 1, 2, 5, 100)
+ *   // expands to: ((int [4]){ 1, 2, 5, 100 })
+ *
+ * @_type: Element type of the resulting array.
+ * @...:   Values to place in the array.
+ */
+#define FY_CPP_VA_ITEMS(_type, ...)	_FVISF(_type, __VA_ARGS__)
+/**
+ * FY_CPP_MAP2() - Apply a binary macro to every argument, threading a fixed first argument.
+ *
+ * Expands ``macro(a, x)`` for each argument @x in ``__VA_ARGS__``. The fixed
+ * argument @a is passed as the first argument to every invocation.
+ *
+ * @a:     Fixed first argument threaded into every call.
+ * @macro: Two-argument macro to apply.
+ * @...:   Arguments to map over.
+ */
+#define FY_CPP_MAP2(a, macro, ...)	_FM2(a, macro, __VA_ARGS__)
+#define _FY_CPP_MAP_ONE2	_FM12
+#define _FY_CPP_MAP_INDIRECT2	_FMI2
+
+#else /* !FY_CPP_SHORT_NAMES */
+
+/* Original long-name implementation */
+
+#define FY_CPP_EVAL1(...)	__VA_ARGS__
+#define FY_CPP_EVAL2(...)	FY_CPP_EVAL1(FY_CPP_EVAL1(__VA_ARGS__))
+#define FY_CPP_EVAL4(...)	FY_CPP_EVAL2(FY_CPP_EVAL2(__VA_ARGS__))
+#define FY_CPP_EVAL8(...)	FY_CPP_EVAL4(FY_CPP_EVAL4(__VA_ARGS__))
+#if !defined(__clang__)
+// gcc is better, goes to 16
+#define FY_CPP_EVAL16(...)	FY_CPP_EVAL8(FY_CPP_EVAL8(__VA_ARGS__))
+#define FY_CPP_EVAL(...)	FY_CPP_EVAL16(FY_CPP_EVAL16(__VA_ARGS__))
+#else
+// clang craps out at 8
+#define FY_CPP_EVAL(...)	FY_CPP_EVAL8(FY_CPP_EVAL8(__VA_ARGS__))
+#endif
+
+#define FY_CPP_EMPTY()
+#define FY_CPP_POSTPONE1(macro) macro FY_CPP_EMPTY()
+
+#define FY_CPP_MAP(macro, ...) \
+    __VA_OPT__(FY_CPP_EVAL(_FY_CPP_MAP_ONE(macro, __VA_ARGS__)))
+#define _FY_CPP_MAP_ONE(macro, x, ...) macro(x) \
+    __VA_OPT__(FY_CPP_POSTPONE1(_FY_CPP_MAP_INDIRECT)()(macro, __VA_ARGS__))
+#define _FY_CPP_MAP_INDIRECT() _FY_CPP_MAP_ONE
+
+#define FY_CPP_POSTPONE2(a, macro) macro FY_CPP_EMPTY()
+
+#define _FY_CPP_FIRST(_1, ...)			_1
+#define FY_CPP_FIRST(...)			_FY_CPP_FIRST(__VA_OPT__(__VA_ARGS__ ,) 0)
+
+#define _FY_CPP_SECOND(_1, _2, ...)		_2
+#define FY_CPP_SECOND(...)			_FY_CPP_SECOND(__VA_OPT__(__VA_ARGS__ ,) 0, 0)
+
+#define _FY_CPP_THIRD(_1, _2, _3, ...)		_3
+#define FY_CPP_THIRD(...)			_FY_CPP_THIRD(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0)
+
+#define _FY_CPP_FOURTH(_1, _2, _3, _4, ...)	_4
+#define FY_CPP_FOURTH(...)			_FY_CPP_FOURTH(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0, 0)
+
+#define _FY_CPP_FIFTH(_1, _2, _3, _4, _5, ...)	_5
+#define FY_CPP_FIFTH(...) \
+	_FY_CPP_FIFTH(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0, 0, 0)
+
+#define _FY_CPP_SIXTH(_1, _2, _3, _4, _5, _6, ...)	_6
+#define FY_CPP_SIXTH(...) \
+	_FY_CPP_SIXTH(__VA_OPT__(__VA_ARGS__ ,) 0, 0, 0, 0, 0, 0)
+
+#define _FY_CPP_REST(x, ...) __VA_ARGS__
+#define FY_CPP_REST(...)     __VA_OPT__(_FY_CPP_REST(__VA_ARGS__))
+
+#define _FY_CPP_COUNT_BODY(x) +1
+#define FY_CPP_VA_COUNT(...)  (__VA_OPT__((FY_CPP_MAP(_FY_CPP_COUNT_BODY, __VA_ARGS__) + 0)) + 0)
+
+#define _FY_CPP_ITEM_ONE(arg) arg
+#define _FY_CPP_ITEM_LATER_ARG(arg) , _FY_CPP_ITEM_ONE(arg)
+#define _FY_CPP_ITEM_LIST(...) FY_CPP_MAP(_FY_CPP_ITEM_LATER_ARG, __VA_ARGS__)
+
+#define _FY_CPP_VA_ITEMS(...)          \
+    _FY_CPP_ITEM_ONE(FY_CPP_FIRST(__VA_ARGS__)) \
+    _FY_CPP_ITEM_LIST(FY_CPP_REST(__VA_ARGS__))
+
+#define FY_CPP_VA_ITEMS(_type, ...) \
+	((_type [FY_CPP_VA_COUNT(__VA_ARGS__)]) { _FY_CPP_VA_ITEMS(__VA_ARGS__) })
+
+#define FY_CPP_MAP2(a, macro, ...) \
+    __VA_OPT__(FY_CPP_EVAL(_FY_CPP_MAP_ONE2(a, macro, __VA_ARGS__)))
+
+#define _FY_CPP_MAP_ONE2(a, macro, x, ...) macro(a, x) \
+    __VA_OPT__(FY_CPP_POSTPONE2(a, _FY_CPP_MAP_INDIRECT2)()(a, macro, __VA_ARGS__))
+#define _FY_CPP_MAP_INDIRECT2() _FY_CPP_MAP_ONE2
+
+#endif /* FY_CPP_SHORT_NAMES */
+
+/*
+ * example usage:
+ *
+ * int do_sum(int count, int *items)
+ * {
+ * 	int i;
+ * 	int sum;
+ *
+ * 	sum = 0;
+ * 	for (i = 0; i < count; i++)
+ * 		sum += items[i];
+ *
+ * 	return sum;
+ * }
+ *
+ * #define do_sum_macro(...) \
+ * 	do_sum( \
+ * 		FY_CPP_VA_COUNT(__VA_ARGS__), \
+ * 		FY_CPP_VA_ITEMS(int, __VA_ARGS__))
+ *
+ *   sum = do_sum_macro(1, 2, 5, 100);
+ *
+ * will expand to:
+ *
+ *   sum = do_sum(4, ((int [4]){ 1, 2, 5, 100 }));
+ *
+ * printf("sum=%d\n", sum);
+ */
+
+/**
+ * FY_CONCAT() - Token-paste two arguments after full macro expansion.
+ *
+ * Unlike the raw ``##`` operator, this macro forces both @_a and @_b to be
+ * fully expanded before concatenation, so macro arguments are substituted
+ * correctly.
+ *
+ * @_a: Left token (expanded before pasting).
+ * @_b: Right token (expanded before pasting).
+ */
+#define FY_CONCAT(_a, _b) FY_CONCAT_INNER(_a, _b)
+#define FY_CONCAT_INNER(_a, _b) _a ## _b
+
+/**
+ * FY_UNIQUE() - Generate a unique identifier using ``__COUNTER__``.
+ *
+ * Concatenates @_base with the current value of the ``__COUNTER__``
+ * preprocessor counter, which increments by one for each use in a
+ * translation unit. Guarantees unique names across multiple macro expansions
+ * in the same file.
+ *
+ * @_base: Identifier prefix.
+ */
+#define FY_UNIQUE(_base) FY_CONCAT(_base, __COUNTER__)
+
+/**
+ * FY_LUNIQUE() - Generate a unique identifier using ``__LINE__``.
+ *
+ * Like FY_UNIQUE() but uses the current source line number instead of
+ * ``__COUNTER__``. Sufficient when only one such identifier is needed per
+ * source line; prefer FY_UNIQUE() in general.
+ *
+ * @_base: Identifier prefix.
+ */
+#define FY_LUNIQUE(_base) FY_CONCAT(_base, __LINE__)
+
+#if __has_builtin(__builtin_stack_save) && __has_builtin(__builtin_stack_restore)
+/**
+ * FY_STACK_SAVE() - Save the current stack pointer.
+ *
+ * On compilers that provide ``__builtin_stack_save()`` (GCC, Clang) returns
+ * the current stack pointer as a ``void *``, allowing it to be restored later
+ * with FY_STACK_RESTORE(). On other compilers returns ``(void *)NULL``.
+ *
+ * Use together with FY_STACK_RESTORE() to bound the stack growth of a loop
+ * that calls ``alloca()`` on each iteration.
+ *
+ * Returns: Opaque stack pointer value, or NULL if unsupported.
+ */
+#define FY_STACK_SAVE()		__builtin_stack_save()
+/**
+ * FY_STACK_RESTORE() - Restore the stack pointer to a previously saved value.
+ *
+ * On compilers that provide ``__builtin_stack_restore()`` rewinds the stack
+ * pointer to the value captured by FY_STACK_SAVE(). On other compilers this
+ * is a no-op that discards @_x.
+ *
+ * @_x: Value previously returned by FY_STACK_SAVE().
+ */
+#define FY_STACK_RESTORE(_x)	__builtin_stack_restore((_x))
+#else
+/* no builtin? just ignore */
+#define FY_STACK_SAVE()		((void *)NULL)
+#define FY_STACK_RESTORE(_x)	do { (void)(_x); } while(0)
+#endif
+
+/* possible have lambdas, either gcc or clang with block support */
+#ifdef __clang__
+#ifdef __BLOCKS__
+/**
+ * FY_HAVE_LAMBDAS - Defined when the compiler supports anonymous functions.
+ *
+ * Set when either:
+ * - Clang is compiling with ``-fblocks`` (Blocks extension) — also sets
+ *   %FY_HAVE_BLOCK_LAMBDAS; or
+ * - GCC is in use — also sets %FY_HAVE_NESTED_FUNC_LAMBDAS (nested functions).
+ *
+ * Code using lambdas should guard against this macro and provide a fallback
+ * for environments where it is not defined.
+ */
+#define FY_HAVE_LAMBDAS 1
+/**
+ * FY_HAVE_BLOCK_LAMBDAS - Defined when Clang Block lambdas are available.
+ *
+ * Set on Clang when compiled with ``-fblocks``. Implies %FY_HAVE_LAMBDAS.
+ * Block lambdas use the ``^(args){ body }`` syntax.
+ */
+#define FY_HAVE_BLOCK_LAMBDAS 1
+#endif
+#elif defined(__GNUC__)
+/* FY_HAVE_LAMBDAS is documented in the __clang__ branch above */
+#define FY_HAVE_LAMBDAS 1
+/**
+ * FY_HAVE_NESTED_FUNC_LAMBDAS - Defined when GCC nested-function lambdas are available.
+ *
+ * Set on GCC. Implies %FY_HAVE_LAMBDAS. Nested function lambdas are defined
+ * as local functions inside the enclosing function and cannot outlive it.
+ */
+#define FY_HAVE_NESTED_FUNC_LAMBDAS 1
+#endif
+
+/**
+ * DOC: Compiler diagnostic control helpers
+ *
+ * Portable wrappers around GCC/Clang ``#pragma GCC diagnostic`` directives.
+ * Use FY_DIAG_PUSH() and FY_DIAG_POP() to bracket a region where a specific
+ * warning is suppressed::
+ *
+ *   FY_DIAG_PUSH
+ *   FY_DIAG_IGNORE_ARRAY_BOUNDS
+ *   ... code that triggers -Warray-bounds ...
+ *   FY_DIAG_POP
+ *
+ * On compilers other than GCC/Clang all macros in this group expand to nothing.
+ */
+
+/* Compiler diagnostic helpers */
+
+#if defined(__clang__) || defined(__GNUC__)
+/**
+ * FY_DIAG_PUSH - Save the current diagnostic state onto the compiler's stack.
+ *
+ * Always paired with FY_DIAG_POP.
+ */
+#define FY_DIAG_PUSH           _Pragma("GCC diagnostic push")
+/**
+ * FY_DIAG_POP - Restore the diagnostic state saved by the last FY_DIAG_PUSH.
+ */
+#define FY_DIAG_POP            _Pragma("GCC diagnostic pop")
+/**
+ * FY_DIAG_IGNORE() - Suppress a specific warning by pragma string.
+ *
+ * @_warn: A string literal suitable for use in a ``_Pragma()`` call,
+ *         e.g. ``"GCC diagnostic ignored \"-Wsomething\""`` .
+ */
+#define FY_DIAG_IGNORE(_warn)   _Pragma(_warn)
+/**
+ * FY_DIAG_IGNORE_ARRAY_BOUNDS - Suppress ``-Warray-bounds`` in the current region.
+ */
+#define FY_DIAG_IGNORE_ARRAY_BOUNDS \
+	_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+/**
+ * FY_DIAG_IGNORE_UNUSED_VARIABLE - Suppress ``-Wunused-variable`` in the current region.
+ */
+#define FY_DIAG_IGNORE_UNUSED_VARIABLE \
+	_Pragma("GCC diagnostic ignored \"-Wunused-variable\"")
+/**
+ * FY_DIAG_IGNORE_UNUSED_PARAMETER - Suppress ``-Wunused-parameter`` in the current region.
+ */
+#define FY_DIAG_IGNORE_UNUSED_PARAMETER \
+	_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
+
+#else
+#define FY_DIAG_PUSH
+#define FY_DIAG_POP
+#define FY_DIAG_IGNORE(_warn)
+
+#define FY_DIAG_IGNORE_ARRAY_BOUNDS /* nothing */
+#define FY_DIAG_IGNORE_UNUSED_VARIABLE /* nothing */
+#define FY_DIAG_IGNORE_UNUSED_PARAMETER /* nothing */
+
+#endif
+
+/**
+ * DOC: Floating-point precision constants
+ *
+ * Portable wrappers for the mantissa-digit and decimal-digit counts of
+ * ``float``, ``double``, and ``long double``.  Each macro tries three
+ * sources in order:
+ *
+ * 1. The standard ``<float.h>`` macro (e.g. ``FLT_MANT_DIG``).
+ * 2. The GCC/Clang predefined macro (e.g. ``__FLT_MANT_DIG__``).
+ * 3. A conservative hard-coded fallback.
+ *
+ * These constants are used when formatting floating-point values as YAML
+ * scalars to ensure round-trip fidelity.
+ */
+
+/**
+ * FY_FLT_MANT_DIG - Number of base-2 mantissa digits in a ``float``.
+ *
+ * Typically 24 (IEEE 754 single precision). Fallback: 9.
+ */
+/* float point digits abstraction */
+#if defined(FLT_MANT_DIG)
+#define FY_FLT_MANT_DIG	FLT_MANT_DIG
+#elif defined(__FLT_MANT_DIG__)
+#define FY_FLT_MANT_DIG	__FLT_MANT_DIG__
+#else
+#define FY_FLT_MANT_DIG	9
+#endif
+
+/**
+ * FY_DBL_MANT_DIG - Number of base-2 mantissa digits in a ``double``.
+ *
+ * Typically 53 (IEEE 754 double precision). Fallback: 17.
+ */
+#if defined(DBL_MANT_DIG)
+#define FY_DBL_MANT_DIG	DBL_MANT_DIG
+#elif defined(__DBL_MANT_DIG__)
+#define FY_DBL_MANT_DIG	__DBL_MANT_DIG__
+#else
+#define FY_DBL_MANT_DIG	17
+#endif
+
+/**
+ * FY_LDBL_MANT_DIG - Number of base-2 mantissa digits in a ``long double``.
+ *
+ * Varies by platform (64-bit x87 extended: 64; MSVC/ARM ``== double``: 53).
+ * Fallback: 17.
+ */
+#if defined(LDBL_MANT_DIG)
+#define FY_LDBL_MANT_DIG	LDBL_MANT_DIG
+#elif defined(__LDBL_MANT_DIG__)
+#define FY_LDBL_MANT_DIG	__LDBL_MANT_DIG__
+#else
+#define FY_LDBL_MANT_DIG	17
+#endif
+
+/**
+ * FY_FLT_DECIMAL_DIG - Decimal digits required for a round-trip ``float``.
+ *
+ * The minimum number of significant decimal digits such that converting
+ * a ``float`` to decimal and back recovers the original value exactly.
+ * Typically 9. Fallback: 9.
+ */
+#if defined(FLT_DECIMAL_DIG)
+#define FY_FLT_DECIMAL_DIG	FLT_DECIMAL_DIG
+#elif defined(__FLT_DECIMAL_DIG__)
+#define FY_FLT_DECIMAL_DIG	__FLT_DECIMAL_DIG__
+#else
+#define FY_FLT_DECIMAL_DIG	9
+#endif
+
+/**
+ * FY_DBL_DECIMAL_DIG - Decimal digits required for a round-trip ``double``.
+ *
+ * Typically 17. Fallback: 17.
+ */
+#if defined(DBL_DECIMAL_DIG)
+#define FY_DBL_DECIMAL_DIG	DBL_DECIMAL_DIG
+#elif defined(__DBL_DECIMAL_DIG__)
+#define FY_DBL_DECIMAL_DIG	__DBL_DECIMAL_DIG__
+#else
+#define FY_DBL_DECIMAL_DIG	17
+#endif
+
+/**
+ * FY_LDBL_DECIMAL_DIG - Decimal digits required for a round-trip ``long double``.
+ *
+ * Varies by platform; same as double on most non-x87 targets. Fallback: 17.
+ */
+#if defined(LDBL_DECIMAL_DIG)
+#define FY_LDBL_DECIMAL_DIG	LDBL_DECIMAL_DIG
+#elif defined(__LDBL_DECIMAL_DIG__)
+#define FY_LDBL_DECIMAL_DIG	__LDBL_DECIMAL_DIG__
+#else
+#define FY_LDBL_DECIMAL_DIG	17	// same as double
+#endif
+
+/* platform detection - needed by both reflection and generic sections */
+// define FY_HAS_FP16 if __fp16 is available
+#if defined(__is_identifier)
+#if ! __is_identifier(__fp16)
+#define FY_HAS_FP16
+#endif
+#endif
+
+// define FY_HAS_FLOAT128 if __fp128 is available
+#if defined(__SIZEOF_FLOAT128__)
+#if __SIZEOF_FLOAT128__ == 16
+#define FY_HAS_FLOAT128
+#endif
+#endif
+
+// define FY_HAS_INT128 if __int128 is available
+#if defined(__SIZEOF_INT128__)
+#if __SIZEOF_INT128__ == 16
+#define FY_HAS_INT128
+#endif
+#endif
+
+#ifdef UINTPTR_MAX
+#if UINTPTR_MAX == 0xffffffff
+#define FY_HAS_32BIT_PTR
+#elif UINTPTR_MAX == 0xffffffffffffffff
+#define FY_HAS_64BIT_PTR
+#endif
+#endif
+
+// windows is the crazy one still
+#if defined(_WIN64) || defined(_WIN32) || defined(__CYGWIN__) || defined(__MSYS__)
+#define FY_VA_ARG_SIZE_T(ap)  ((size_t)va_arg(ap, unsigned int))
+#define FY_VA_ARG_SSIZE_T(ap)  ((ssize_t)va_arg(ap, int))
+#else
+#define FY_VA_ARG_SIZE_T(ap)  ((size_t)va_arg(ap, size_t))
+#define FY_VA_ARG_SSIZE_T(ap)  ((ssize_t)va_arg(ap, ssize_t))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_UTIL_H

--- a/numcosmo/external/libfyaml/include/libfyaml/libfyaml-vlsize.h
+++ b/numcosmo/external/libfyaml/include/libfyaml/libfyaml-vlsize.h
@@ -1,0 +1,836 @@
+/*
+ * libfyaml-vlsize.h - variable length size encoding
+ *
+ * Copyright (c) 2023-2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * DOC: Variable-length size encoding
+ *
+ * Encodes unsigned integer sizes into a compact, self-delimiting byte stream.
+ * The encoding is modelled after the variable-length quantity (VLQ / LEB128
+ * big-endian variant) used in MIDI and other binary formats:
+ *
+ * - Each byte carries 7 bits of payload in bits 6..0.
+ * - Bit 7 (MSB) is a *continuation flag*: 1 means more bytes follow, 0 means
+ *   this is the last byte.
+ * - Exception: the final (maximum-length) byte is always 8 bits of payload
+ *   with no continuation bit, allowing the full 64-bit / 32-bit range.
+ *
+ * **64-bit encoding** (up to 9 bytes)::
+ *
+ *   bytes   bits   value range
+ *   1       7      0 .. 127
+ *   2       14     128 .. 16383
+ *   3       21     16384 .. 2097151
+ *   4       28     2097152 .. 268435455
+ *   5       35     268435456 .. 34359738367
+ *   6       42     ..
+ *   7       49     ..
+ *   8       56     ..
+ *   9       64     full uint64_t range
+ *
+ * **32-bit encoding** (up to 5 bytes)::
+ *
+ *   bytes   bits   value range
+ *   1       7      0 .. 127
+ *   2       14     128 .. 16383
+ *   3       21     16384 .. 2097151
+ *   4       28     2097152 .. 268435455
+ *   5       32     full uint32_t range (top 4 bits of byte 0 ignored)
+ *
+ * The native-width ``fy_encode_size()`` / ``fy_decode_size()`` family selects
+ * the 64-bit or 32-bit variant based on ``SIZE_MAX``.
+ *
+ * Each family provides four operations:
+ *
+ * - ``_bytes()``     — compute the encoded length without writing anything
+ * - ``encode()``     — write the encoding into a bounded buffer
+ * - ``decode()``     — read and validate from a bounded buffer
+ * - ``decode_nocheck()`` — read without bounds checking (caller guarantees room)
+ * - ``skip()``       — advance past an encoded value in a bounded buffer
+ * - ``skip_nocheck()``   — advance without bounds checking
+ */
+#ifndef LIBFYAML_VLSIZE_H
+#define LIBFYAML_VLSIZE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// size encoding for 64 bit
+//
+// high bit is set, more follow with 0 ending the run
+// The final 9th byte always terminates the run
+//
+//  0  1  2  3  4  5  6  7  8
+// -- -- -- -- -- -- -- -- --
+// 0k	                       7 bit length k
+// 1k 0l                      14 bit length kl
+// 1k 1l 0m                   21 bit length klm
+// 1k 1l 1m 0n                28 bit length klmn
+// 1k 1l 1m 1n 0o             35 bit length klmno
+// 1k 1l 1m 1n 1o 0p          42 bit length klmnop
+// 1k 1l 1m 1n 1o 1p 0q       49 bit length klmnopq
+// 1k 1l 1m 1n 1o 1p 1q 0r    56 bit length klmnopqr
+// 1k 1l 1m 1n 1o 1p 1q 1r  t 64 bit length klmnopqrt
+//
+// size encoding for 32 bit
+//
+// high bit is set, more follow with 0 ending the run
+// The final 9th byte always terminates the run
+//
+//  0   1  2  3  4  5  6  7  8
+// --  -- -- -- -- -- -- -- --
+// 0k 	                       7 bit length k
+// 1k  0l                      14 bit length kl
+// 1k  1l 0m                   21 bit length klm
+// 1k  1l 1m 0n                28 bit length klmn
+// 1xk 1l 1m 1n o              32 bit length klmno 4 high bits ignored (at byte 0)
+//
+
+/**
+ * FYVL_SIZE_ENCODING_MAX_64 - Maximum encoded length of a 64-bit size value.
+ *
+ * A 64-bit value requires at most 9 bytes: 8 x 7-bit groups plus one
+ * final unconstrained byte = 7 x 8 + 8 = 64 bits.
+ */
+#define FYVL_SIZE_ENCODING_MAX_64 9 	// 7 * 8 + 8 = 64 bits
+
+/**
+ * FYVL_SIZE_ENCODING_MAX_32 - Maximum encoded length of a 32-bit size value.
+ *
+ * A 32-bit value requires at most 5 bytes: 4 x 7-bit groups plus one
+ * final unconstrained byte = 7 x 4 + 4 = 32 bits.
+ */
+#define FYVL_SIZE_ENCODING_MAX_32 5	// 7 * 4 + 4 = 32 bits
+
+/* 32 bit specific */
+
+/**
+ * fy_encode_size32_bytes() - Compute the encoded byte count for a 32-bit size.
+ *
+ * Returns the number of bytes that fy_encode_size32() would write for @size,
+ * without actually writing anything. Useful for pre-allocating buffers.
+ *
+ * @size: The value whose encoded length is queried.
+ *
+ * Returns: Number of bytes required (1–5).
+ */
+static inline unsigned int
+fy_encode_size32_bytes(uint32_t size)
+{
+	if (size < ((uint32_t)1 << 7))
+		return 1;
+	if (size < ((uint32_t)1 << 14))
+		return 2;
+	if (size < ((uint32_t)1 << 21))
+		return 3;
+	if (size < ((uint32_t)1 << 28))
+		return 4;
+	return 5;
+}
+
+/**
+ * fy_encode_size32() - Encode a 32-bit size into a buffer.
+ *
+ * Writes the variable-length encoding of @size into the buffer [@p, @p+@bufsz).
+ *
+ * @p:     Start of the output buffer.
+ * @bufsz: Available space in bytes.
+ * @size:  Value to encode.
+ *
+ * Returns: Pointer to one past the last written byte, or NULL if @bufsz was
+ *          too small.
+ */
+static inline uint8_t *
+fy_encode_size32(uint8_t *p, uint32_t bufsz, uint32_t size)
+{
+	uint8_t *end = p + bufsz;
+
+	if (size < ((uint32_t)1 << 7)) {
+		if (p + 1 > end)
+			return NULL;
+		p[0] = (uint8_t)size;
+		return p + 1;
+	}
+	if (size < ((uint32_t)1 << 14)) {
+		if (p + 2 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 7) | 0x80;
+		p[1] = (uint8_t)size & 0x7f;
+		return p + 2;
+	}
+	if (size < ((uint32_t)1 << 21)) {
+		if (p + 3 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 14) | 0x80;
+		p[1] = (uint8_t)(size >>  7) | 0x80;
+		p[2] = (uint8_t)size & 0x7f;
+		return p + 3;
+	}
+	if (size < ((uint32_t)1 << 28)) {
+		if (p + 4 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 21) | 0x80;
+		p[1] = (uint8_t)(size >> 14) | 0x80;
+		p[2] = (uint8_t)(size >>  7) | 0x80;
+		p[3] = (uint8_t)size & 0x7f;
+		return p + 4;
+	}
+	if (p + 5 > end)
+		return NULL;
+	p[0] = (uint8_t)(size >> 29) | 0x80;
+	p[1] = (uint8_t)(size >> 22) | 0x80;
+	p[2] = (uint8_t)(size >> 15) | 0x80;
+	p[3] = (uint8_t)(size >>  8) | 0x80;
+	p[4] = (uint8_t)size;
+	return p + 5;
+}
+
+/**
+ * fy_decode_size32() - Decode a variable-length 32-bit size from a buffer.
+ *
+ * Reads bytes from [@start, @start+@bufsz) and reconstructs the encoded
+ * 32-bit value. Stops after %FYVL_SIZE_ENCODING_MAX_32 bytes at most.
+ *
+ * @start:  Start of the encoded data.
+ * @bufsz:  Available bytes to read.
+ * @sizep:  Output: the decoded value. Set to ``(uint32_t)-1`` on error.
+ *
+ * Returns: Pointer to one past the last consumed byte, or NULL if the buffer
+ *          was exhausted before a complete value was found.
+ */
+static inline const uint8_t *
+fy_decode_size32(const uint8_t *start, size_t bufsz, uint32_t *sizep)
+{
+	const uint8_t *p, *end, *end_scan, *end_max_scan;
+	uint32_t size;
+
+	end = start + bufsz;
+
+	end_max_scan = start + FYVL_SIZE_ENCODING_MAX_32;
+
+	if (end_max_scan < end)
+		end_scan = end_max_scan;
+	else
+		end_scan = end;
+
+	end_max_scan--;
+
+	p = start;
+	size = 0;
+	while (p < end_scan) {
+		if (p < end_max_scan) {
+			size <<= 7;
+			size |= (*p & 0x7f);
+			if (!(*p & 0x80))
+				goto done;
+		} else {
+			/* last one is always the full 8 bit */
+			size <<= 8;
+			size |= *p;
+			goto done;
+		}
+		p++;
+	}
+
+	*sizep = (uint32_t)-1;
+	return NULL;
+done:
+	if (++p >= end)
+		p = end;
+	*sizep = size;
+	return p;
+}
+
+/**
+ * fy_decode_size32_nocheck() - Decode a 32-bit size without bounds checking.
+ *
+ * Like fy_decode_size32() but assumes the buffer is large enough to hold a
+ * complete encoding. The caller must guarantee at least
+ * %FYVL_SIZE_ENCODING_MAX_32 bytes are available at @start.
+ *
+ * @start: Start of the encoded data.
+ * @sizep: Output: the decoded value as a uint64_t for uniform handling.
+ *
+ * Returns: Pointer to one past the last consumed byte.
+ */
+static inline const uint8_t *
+fy_decode_size32_nocheck(const uint8_t *start, uint64_t *sizep)
+{
+	const uint8_t *p;
+	size_t size;
+	unsigned int i;
+
+	p = start;
+	size = 0;
+	for (i = 0; i < FYVL_SIZE_ENCODING_MAX_32-1; i++) {
+		size <<= 7;
+		size |= (p[i] & 0x7f);
+		if ((int8_t)p[i] >= 0)
+			goto out;
+	}
+	size <<= 8;
+	size |= p[i];
+out:
+	*sizep = size;
+	return p + i + 1;
+}
+
+/**
+ * fy_skip_size32() - Skip past a variable-length 32-bit size in a buffer.
+ *
+ * Advances past the encoded value without decoding it. Useful when the
+ * value itself is not needed.
+ *
+ * @start:  Start of the encoded data.
+ * @bufsz:  Available bytes.
+ *
+ * Returns: Pointer to one past the last consumed byte, or NULL if the buffer
+ *          was exhausted before a complete encoding was found.
+ */
+static inline const uint8_t *
+fy_skip_size32(const uint8_t *start, size_t bufsz)
+{
+	const uint8_t *p, *end, *end_scan, *end_max_scan;
+
+	end = start + bufsz;
+
+	end_max_scan = start + FYVL_SIZE_ENCODING_MAX_32;
+
+	if (end_max_scan < end)
+		end_scan = end_max_scan;
+	else
+		end_scan = end;
+
+	end_max_scan--;
+
+	p = start;
+	while (p < end_scan) {
+		if (p < end_max_scan) {
+			if (!(*p & 0x80))
+				goto done;
+		} else
+			goto done;
+		p++;
+	}
+
+	return NULL;
+done:
+	if (++p >= end)
+		p = end;
+	return p;
+}
+
+/**
+ * fy_skip_size32_nocheck() - Skip a 32-bit encoded size without bounds checking.
+ *
+ * Like fy_skip_size32() but assumes the buffer is large enough. The caller
+ * must guarantee at least %FYVL_SIZE_ENCODING_MAX_32 bytes are readable.
+ *
+ * @p: Start of the encoded data.
+ *
+ * Returns: Pointer to one past the last consumed byte.
+ */
+static inline const uint8_t *
+fy_skip_size32_nocheck(const uint8_t *p)
+{
+	unsigned int i;
+
+	for (i = 0; i < FYVL_SIZE_ENCODING_MAX_32; ) {
+		if ((int8_t)p[i++] >= 0)
+			break;
+	}
+	return p + i;
+}
+
+/**
+ * fy_encode_size64_bytes() - Compute the encoded byte count for a 64-bit size.
+ *
+ * Returns the number of bytes that fy_encode_size64() would write for @size,
+ * without writing anything.
+ *
+ * @size: The value whose encoded length is queried.
+ *
+ * Returns: Number of bytes required (1–9).
+ */
+static inline unsigned int
+fy_encode_size64_bytes(uint64_t size)
+{
+	if (size < ((uint64_t)1 << 7))
+		return 1;
+	if (size < ((uint64_t)1 << 14))
+		return 2;
+	if (size < ((uint64_t)1 << 21))
+		return 3;
+	if (size < ((uint64_t)1 << 28))
+		return 4;
+	if (size < ((uint64_t)1 << 35))
+		return 5;
+	if (size < ((uint64_t)1 << 42))
+		return 6;
+	if (size < ((uint64_t)1 << 49))
+		return 7;
+	if (size < ((uint64_t)1 << 56))
+		return 8;
+	return 9;
+}
+
+/**
+ * fy_encode_size64() - Encode a 64-bit size into a buffer.
+ *
+ * Writes the variable-length encoding of @size into the buffer [@p, @p+@bufsz).
+ *
+ * @p:     Start of the output buffer.
+ * @bufsz: Available space in bytes.
+ * @size:  Value to encode.
+ *
+ * Returns: Pointer to one past the last written byte, or NULL if @bufsz was
+ *          too small.
+ */
+static inline uint8_t *
+fy_encode_size64(uint8_t *p, size_t bufsz, uint64_t size)
+{
+	uint8_t *end = p + bufsz;
+
+	if (size < ((uint64_t)1 << 7)) {
+		if (p + 1 > end)
+			return NULL;
+		p[0] = (uint8_t)size;
+		return p + 1;
+	}
+	if (size < ((uint64_t)1 << 14)) {
+		if (p + 2 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 7) | 0x80;
+		p[1] = (uint8_t)size & 0x7f;
+		return p + 2;
+	}
+	if (size < ((uint64_t)1 << 21)) {
+		if (p + 3 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 14) | 0x80;
+		p[1] = (uint8_t)(size >>  7) | 0x80;
+		p[2] = (uint8_t)size & 0x7f;
+		return p + 3;
+	}
+	if (size < ((uint64_t)1 << 28)) {
+		if (p + 4 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 21) | 0x80;
+		p[1] = (uint8_t)(size >> 14) | 0x80;
+		p[2] = (uint8_t)(size >>  7) | 0x80;
+		p[3] = (uint8_t)size & 0x7f;
+		return p + 4;
+	}
+	if (size < ((uint64_t)1 << 35)) {
+		if (p + 5 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 28) | 0x80;
+		p[1] = (uint8_t)(size >> 21) | 0x80;
+		p[2] = (uint8_t)(size >> 14) | 0x80;
+		p[3] = (uint8_t)(size >>  7) | 0x80;
+		p[4] = (uint8_t)size & 0x7f;
+		return p + 5;
+	}
+	if (size < ((uint64_t)1 << 42)) {
+		if (p + 6 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 35) | 0x80;
+		p[1] = (uint8_t)(size >> 28) | 0x80;
+		p[2] = (uint8_t)(size >> 21) | 0x80;
+		p[3] = (uint8_t)(size >> 14) | 0x80;
+		p[4] = (uint8_t)(size >>  7) | 0x80;
+		p[5] = (uint8_t)size & 0x7f;
+		return p + 6;
+	}
+	if (size < ((uint64_t)1 << 49)) {
+		if (p + 7 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 42) | 0x80;
+		p[1] = (uint8_t)(size >> 35) | 0x80;
+		p[2] = (uint8_t)(size >> 28) | 0x80;
+		p[3] = (uint8_t)(size >> 21) | 0x80;
+		p[4] = (uint8_t)(size >> 14) | 0x80;
+		p[5] = (uint8_t)(size >>  7) | 0x80;
+		p[6] = (uint8_t)size & 0x7f;
+		return p + 7;
+	}
+	if (size < ((uint64_t)1 << 56)) {
+		if (p + 8 > end)
+			return NULL;
+		p[0] = (uint8_t)(size >> 49) | 0x80;
+		p[1] = (uint8_t)(size >> 42) | 0x80;
+		p[2] = (uint8_t)(size >> 35) | 0x80;
+		p[3] = (uint8_t)(size >> 28) | 0x80;
+		p[4] = (uint8_t)(size >> 21) | 0x80;
+		p[5] = (uint8_t)(size >> 14) | 0x80;
+		p[6] = (uint8_t)(size >>  7) | 0x80;
+		p[7] = (uint8_t)size & 0x7f;
+		return p + 8;
+	}
+	if (p + 9 > end)
+		return NULL;
+	p[0] = (uint8_t)(size >> 57) | 0x80;
+	p[1] = (uint8_t)(size >> 50) | 0x80;
+	p[2] = (uint8_t)(size >> 43) | 0x80;
+	p[3] = (uint8_t)(size >> 36) | 0x80;
+	p[4] = (uint8_t)(size >> 29) | 0x80;
+	p[5] = (uint8_t)(size >> 22) | 0x80;
+	p[6] = (uint8_t)(size >> 15) | 0x80;
+	p[7] = (uint8_t)(size >>  8) | 0x80;
+	p[8] = (uint8_t)size;
+	return p + 9;
+}
+
+/**
+ * fy_decode_size64() - Decode a variable-length 64-bit size from a buffer.
+ *
+ * Reads bytes from [@start, @start+@bufsz) and reconstructs the encoded
+ * 64-bit value. Stops after %FYVL_SIZE_ENCODING_MAX_64 bytes at most.
+ *
+ * @start:  Start of the encoded data.
+ * @bufsz:  Available bytes to read.
+ * @sizep:  Output: the decoded value. Set to ``(size_t)-1`` on error.
+ *
+ * Returns: Pointer to one past the last consumed byte, or NULL if the buffer
+ *          was exhausted before a complete value was found.
+ */
+static inline const uint8_t *
+fy_decode_size64(const uint8_t *start, size_t bufsz, uint64_t *sizep)
+{
+	const uint8_t *p, *end, *end_scan, *end_max_scan;
+	size_t size;
+
+	end = start + bufsz;
+
+	end_max_scan = start + FYVL_SIZE_ENCODING_MAX_64;
+
+	if (end_max_scan < end)
+		end_scan = end_max_scan;
+	else
+		end_scan = end;
+
+	end_max_scan--;
+
+	p = start;
+	size = 0;
+	while (p < end_scan) {
+		if (p < end_max_scan) {
+			size <<= 7;
+			size |= (*p & 0x7f);
+			if (!(*p & 0x80))
+				goto done;
+		} else {
+			/* last one is always 8 bit */
+			size <<= 8;
+			size |= *p;
+			goto done;
+		}
+		p++;
+	}
+
+	*sizep = (size_t)-1;
+	return NULL;
+done:
+	if (++p >= end)
+		p = end;
+	*sizep = size;
+	return p;
+}
+
+/**
+ * fy_decode_size64_nocheck() - Decode a 64-bit size without bounds checking.
+ *
+ * Like fy_decode_size64() but assumes the buffer is large enough. The caller
+ * must guarantee at least %FYVL_SIZE_ENCODING_MAX_64 bytes are readable.
+ *
+ * @start: Start of the encoded data.
+ * @sizep: Output: the decoded value.
+ *
+ * Returns: Pointer to one past the last consumed byte.
+ */
+static inline const uint8_t *
+fy_decode_size64_nocheck(const uint8_t *start, uint64_t *sizep)
+{
+	const uint8_t *p;
+	size_t size;
+	unsigned int i;
+
+	p = start;
+	size = 0;
+	for (i = 0; i < FYVL_SIZE_ENCODING_MAX_64-1; i++) {
+		size <<= 7;
+		size |= (p[i] & 0x7f);
+		if ((int8_t)p[i] >= 0)
+			goto out;
+	}
+	size <<= 8;
+	size |= p[i];
+out:
+	*sizep = size;
+	return p + i + 1;
+}
+
+/**
+ * fy_skip_size64() - Skip past a variable-length 64-bit size in a buffer.
+ *
+ * Advances past the encoded value without decoding it.
+ *
+ * @start:  Start of the encoded data.
+ * @bufsz:  Available bytes.
+ *
+ * Returns: Pointer to one past the last consumed byte, or NULL if the buffer
+ *          was exhausted before a complete encoding was found.
+ */
+static inline const uint8_t *
+fy_skip_size64(const uint8_t *start, size_t bufsz)
+{
+	const uint8_t *p, *end, *end_scan, *end_max_scan;
+
+	end = start + bufsz;
+
+	end_max_scan = start + FYVL_SIZE_ENCODING_MAX_64;
+
+	if (end_max_scan < end)
+		end_scan = end_max_scan;
+	else
+		end_scan = end;
+
+	end_max_scan--;
+
+	p = start;
+	while (p < end_scan) {
+		if (p < end_max_scan) {
+			if (!(*p & 0x80))
+				goto done;
+		} else
+			goto done;
+		p++;
+	}
+
+	return NULL;
+done:
+	if (++p >= end)
+		p = end;
+	return p;
+}
+
+/**
+ * fy_skip_size64_nocheck() - Skip a 64-bit encoded size without bounds checking.
+ *
+ * Like fy_skip_size64() but assumes the buffer is large enough. The caller
+ * must guarantee at least %FYVL_SIZE_ENCODING_MAX_64 bytes are readable.
+ *
+ * @p: Start of the encoded data.
+ *
+ * Returns: Pointer to one past the last consumed byte.
+ */
+static inline const uint8_t *
+fy_skip_size64_nocheck(const uint8_t *p)
+{
+	unsigned int i;
+
+	for (i = 0; i < FYVL_SIZE_ENCODING_MAX_64; ) {
+		if ((int8_t)p[i++] >= 0)
+			break;
+	}
+	return p + i;
+}
+
+/* is pointless to pretend size_t is anything other than 64 or 32 bits */
+#if SIZE_MAX == UINT64_MAX
+
+/**
+ * fy_encode_size_bytes() - Compute encoded byte count for a native size_t.
+ *
+ * Selects fy_encode_size64_bytes() or fy_encode_size32_bytes() based on
+ * ``SIZE_MAX``.
+ *
+ * @size: The value whose encoded length is queried.
+ *
+ * Returns: Number of bytes required.
+ */
+static inline unsigned int
+fy_encode_size_bytes(size_t size)
+{
+	return fy_encode_size64_bytes(size);
+}
+
+/**
+ * fy_encode_size() - Encode a native size_t into a buffer.
+ *
+ * Selects fy_encode_size64() or fy_encode_size32() based on ``SIZE_MAX``.
+ *
+ * @p:     Start of the output buffer.
+ * @bufsz: Available space in bytes.
+ * @size:  Value to encode.
+ *
+ * Returns: Pointer to one past the last written byte, or NULL on overflow.
+ */
+static inline uint8_t *
+fy_encode_size(uint8_t *p, size_t bufsz, size_t size)
+{
+	return fy_encode_size64(p, bufsz, size);
+}
+
+/**
+ * fy_decode_size() - Decode a native size_t from a buffer.
+ *
+ * Selects fy_decode_size64() or fy_decode_size32() based on ``SIZE_MAX``.
+ *
+ * @start:  Start of the encoded data.
+ * @bufsz:  Available bytes.
+ * @sizep:  Output: the decoded value.
+ *
+ * Returns: Pointer to one past the last consumed byte, or NULL on error.
+ */
+static inline const uint8_t *
+fy_decode_size(const uint8_t *start, size_t bufsz, size_t *sizep)
+{
+	uint64_t sz;
+	const uint8_t *ret;
+
+	ret = fy_decode_size64(start, bufsz, &sz);
+	if (!ret) {
+		*sizep = 0;
+		return NULL;
+	}
+	*sizep = sz;
+	return ret;
+}
+
+/**
+ * fy_decode_size_nocheck() - Decode a native size_t without bounds checking.
+ *
+ * Selects the 64-bit or 32-bit nocheck variant based on ``sizeof(size_t)``.
+ * The caller must guarantee enough bytes are available at @start.
+ *
+ * @start:  Start of the encoded data.
+ * @sizep:  Output: the decoded value.
+ *
+ * Returns: Pointer to one past the last consumed byte.
+ */
+static inline const uint8_t *
+fy_decode_size_nocheck(const uint8_t *start, size_t *sizep)
+{
+	uint64_t size64;
+	const uint8_t *s;
+
+	switch (sizeof(size_t)) {
+	case sizeof(uint64_t):
+		s = fy_decode_size64_nocheck(start, &size64);
+		break;
+	case sizeof(uint32_t):
+		s = fy_decode_size32_nocheck(start, &size64);
+		break;
+	default:
+		size64 = 0;
+		s = NULL;
+		break;
+	}
+	*sizep = (size_t)size64;
+	return s;
+}
+
+/**
+ * fy_skip_size() - Skip a native size_t encoding in a buffer.
+ *
+ * Selects fy_skip_size64() or fy_skip_size32() based on ``SIZE_MAX``.
+ *
+ * @start:  Start of the encoded data.
+ * @bufsz:  Available bytes.
+ *
+ * Returns: Pointer to one past the last consumed byte, or NULL on error.
+ */
+static inline const uint8_t *
+fy_skip_size(const uint8_t *start, size_t bufsz)
+{
+	return fy_skip_size64(start, bufsz);
+}
+
+/**
+ * fy_skip_size_nocheck() - Skip a native size_t encoding without bounds checking.
+ *
+ * Selects the 64-bit or 32-bit nocheck variant based on ``SIZE_MAX``.
+ * The caller must guarantee enough bytes are available.
+ *
+ * @start: Start of the encoded data.
+ *
+ * Returns: Pointer to one past the last consumed byte.
+ */
+static inline const uint8_t *
+fy_skip_size_nocheck(const uint8_t *start)
+{
+	return fy_skip_size64_nocheck(start);
+}
+
+/**
+ * FYVL_SIZE_ENCODING_MAX - Maximum encoded length for a native size_t.
+ *
+ * Equals %FYVL_SIZE_ENCODING_MAX_64 on 64-bit platforms,
+ * %FYVL_SIZE_ENCODING_MAX_32 on 32-bit platforms.
+ */
+#define FYVL_SIZE_ENCODING_MAX FYVL_SIZE_ENCODING_MAX_64
+
+#else
+
+static inline unsigned int
+fy_encode_size_bytes(size_t size)
+{
+	return fy_encode_size32_bytes(size);
+}
+
+static inline uint8_t *
+fy_encode_size(uint8_t *p, size_t bufsz, size_t size)
+{
+	return fy_encode_size32(p, bufsz, size);
+}
+
+static inline const uint8_t *
+fy_decode_size(const uint8_t *start, size_t bufsz, size_t *sizep)
+{
+	uint32_t sz;
+	const uint8_t *ret;
+
+	ret = fy_decode_size32(start, bufsz, &sz);
+	if (!ret)
+		return NULL;
+	*sizep = sz;
+	return ret;
+}
+
+static inline const uint8_t *
+fy_decode_size_nocheck(const uint8_t *start, size_t *sizep)
+{
+	return fy_decode_size32_nocheck(start, sizep);
+}
+
+static inline const uint8_t *
+fy_skip_size(const uint8_t *start, size_t bufsz)
+{
+	return fy_skip_size32(start, bufsz, &sz);
+}
+
+static inline const uint8_t *
+fy_skip_size_nocheck(const uint8_t *start)
+{
+	return fy_skip_size32_nocheck(start);
+}
+
+#define FYVL_SIZE_ENCODING_MAX FYVL_SIZE_ENCODING_MAX_32
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// LIBFYAML_VLSIZE_H

--- a/numcosmo/external/libfyaml/meson.build
+++ b/numcosmo/external/libfyaml/meson.build
@@ -1,0 +1,108 @@
+
+# Vendored subset of libfyaml v0.9.6 (https://github.com/pantoniou/libfyaml, MIT
+# license, see LICENSE in this directory).
+#
+# Only the sources that make up libfyaml itself are vendored -- the upstream CLI
+# tool, reflection/libclang backend, python bindings, and test harness are not
+# needed by NumCosmo and are not included. Within src/blake3/, only the portable
+# hashing backend is built (no SSE2/SSE41/AVX2/AVX512/NEON variants, which would
+# also need matching hand-written assembly): blake3_backend.c gracefully
+# registers only the portable hasher when the TARGET_HAS_* macros are undefined,
+# and content-hash throughput doesn't matter for parsing config-sized YAML
+# documents.
+#
+# config.h in this directory is a hand-written replacement for the header
+# upstream's own configure/CMake would generate, defining only the small set of
+# HAVE_*/TARGET_HAS_* macros the vendored sources actually branch on.
+
+libfyaml_thread_dep = dependency('threads')
+
+libfyaml_sources = files(
+    'src/lib/fy-accel.c',
+    'src/lib/fy-atom.c',
+    'src/lib/fy-composer.c',
+    'src/lib/fy-composer-diag.c',
+    'src/lib/fy-diag.c',
+    'src/lib/fy-docbuilder.c',
+    'src/lib/fy-docbuilder-diag.c',
+    'src/lib/fy-doc.c',
+    'src/lib/fy-doc-diag.c',
+    'src/lib/fy-docstate.c',
+    'src/lib/fy-dump.c',
+    'src/lib/fy-emit.c',
+    'src/lib/fy-event.c',
+    'src/lib/fy-input.c',
+    'src/lib/fy-input-diag.c',
+    'src/lib/fy-parse.c',
+    'src/lib/fy-parse-diag.c',
+    'src/lib/fy-path.c',
+    'src/lib/fy-token.c',
+    'src/lib/fy-types.c',
+    'src/lib/fy-walk.c',
+    'src/util/fy-blob.c',
+    'src/util/fy-ctype.c',
+    'src/util/fy-utf8.c',
+    'src/util/fy-utils.c',
+    'src/xxhash/xxhash.c',
+    'src/thread/fy-thread.c',
+    'src/allocator/fy-allocator.c',
+    'src/allocator/fy-allocator-linear.c',
+    'src/allocator/fy-allocator-malloc.c',
+    'src/allocator/fy-allocator-mremap.c',
+    'src/allocator/fy-allocator-dedup.c',
+    'src/allocator/fy-allocator-auto.c',
+    'src/blake3/blake3_portable.c',
+    'src/blake3/blake3.c',
+    'src/blake3/blake3_backend.c',
+    'src/blake3/blake3_be_cpusimd.c',
+    'src/blake3/blake3_host_state.c',
+    'src/blake3/fy-blake3.c',
+)
+
+libfyaml_inc_local = include_directories(
+    '.',
+    'include',
+    'src/lib',
+    'src/util',
+    'src/xxhash',
+    'src/thread',
+    'src/allocator',
+    'src/blake3',
+)
+
+# blake3.c is upstream's generic hasher driver, built once per SIMD backend with
+# these two defines set by the build system (CMake builds it once per variant
+# object library). We only build the portable backend, so these are fixed.
+libfyaml_c_args = [
+    '-DG_LOG_DOMAIN="NUMCOSMO"',
+    '-DHAVE_CONFIG_H',
+    '-DHASHER_SUFFIX=portable',
+    '-DSIMD_DEGREE=1',
+]
+
+disable_warnings = [
+    '-Wno-unused-but-set-variable',
+    '-Wno-unused-but-set-parameter',
+    '-Wno-type-limits',
+    '-Wno-array-bounds',
+]
+
+foreach flag : disable_warnings
+  if cc.has_argument(flag)
+    libfyaml_c_args += flag
+  endif
+endforeach
+
+libfyaml = static_library(
+    'fyaml',
+    sources: libfyaml_sources,
+    dependencies: [libfyaml_thread_dep],
+    include_directories: libfyaml_inc_local,
+    install: false,
+    gnu_symbol_visibility: 'hidden',
+    c_args: libfyaml_c_args,
+    # Upstream requires C17 (CMAKE_C_STANDARD 17 in their CMakeLists.txt): its
+    # atomics header and use of DBL_DECIMAL_DIG depend on C11-or-later features
+    # that NumCosmo's project-wide '-std=gnu99' default doesn't provide.
+    override_options: ['c_std=gnu17'],
+)

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-auto.c
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-auto.c
@@ -1,0 +1,399 @@
+/*
+ * fy-allocator-auto.c - automatic allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdalign.h>
+#include <time.h>
+#include <inttypes.h>
+#include <math.h>
+
+#include <stdio.h>
+
+#include "fy-utils.h"
+#include "fy-allocator-mremap.h"
+#include "fy-allocator-dedup.h"
+#include "fy-allocator-linear.h"
+#include "fy-allocator-auto.h"
+
+/* fixed parameters */
+#ifndef AUTO_ALLOCATOR_BIG_ALLOC_THRESHOLD
+#define AUTO_ALLOCATOR_BIG_ALLOC_THRESHOLD	SIZE_MAX
+#endif
+
+#ifndef AUTO_ALLOCATOR_EMPTY_THRESHOLD
+#define AUTO_ALLOCATOR_EMPTY_THRESHOLD		64
+#endif
+
+#ifndef AUTO_ALLOCATOR_GROW_RATIO
+#define AUTO_ALLOCATOR_GROW_RATIO		1.5
+#endif
+
+#ifndef AUTO_ALOCATOR_BALLOON_RATIO
+#define AUTO_ALOCATOR_BALLOON_RATIO		8.0
+#endif
+
+#ifndef AUTO_ALLOCATOR_ARENA_TYPE
+#define AUTO_ALLOCATOR_ARENA_TYPE		FYMRAT_MMAP
+#endif
+
+#ifndef AUTO_ALLOCATOR_MINIMUM_ARENA_SIZE
+#define AUTO_ALLOCATOR_MINIMUM_ARENA_SIZE	((size_t)16 << 20)	/* 16 MB */
+#endif
+
+#ifndef AUTO_ALLOCATOR_DEFAULT_ESTIMATED_MAX_SIZE
+#define AUTO_ALLOCATOR_DEFAULT_ESTIMATED_MAX_SIZE ((size_t)1 << 20)	/* 1MB */
+#endif
+
+#ifndef AUTO_ALLOCATOR_DEFAULT_BLOOM_FILTER_BITS
+#define AUTO_ALLOCATOR_DEFAULT_BLOOM_FILTER_BITS	0
+#endif
+
+#ifndef AUTO_ALLOCATOR_DEFAULT_BUCKET_COUNT_BITS
+#define AUTO_ALLOCATOR_DEFAULT_BUCKET_COUNT_BITS	0
+#endif
+
+#ifndef AUTO_ALLOCATOR_DEFAULT_DEDUP_THRESHOLD
+#define AUTO_ALLOCATOR_DEFAULT_DEDUP_THRESHOLD		0	/* dedup everything */
+#endif
+
+#ifndef AUTO_ALLOCATOR_DEFAULT_CHAIN_LENGTH_GROW_TRIGGER
+#define AUTO_ALLOCATOR_DEFAULT_CHAIN_LENGTH_GROW_TRIGGER	0	/* let dedup decide */
+#endif
+
+static const struct fy_auto_allocator_cfg default_cfg = {
+	.scenario = FYAST_PER_TAG_FREE_DEDUP,
+	.estimated_max_size = AUTO_ALLOCATOR_DEFAULT_ESTIMATED_MAX_SIZE,
+};
+
+static void fy_auto_cleanup(struct fy_allocator *a);
+
+static int fy_auto_setup(struct fy_allocator *a, struct fy_allocator *parent, int parent_tag, const void *cfg_data)
+{
+	size_t pagesz, size;
+	struct fy_auto_allocator *aa;
+	const struct fy_auto_allocator_cfg *cfg;
+	struct fy_mremap_allocator_cfg mrcfg;
+	struct fy_dedup_allocator_cfg dcfg;
+	struct fy_linear_allocator_cfg lcfg;
+	struct fy_allocator *mra = NULL, *da = NULL, *ma = NULL, *la = NULL;
+	struct fy_allocator *topa = NULL, *suba = NULL;
+
+	cfg = cfg_data ? cfg_data : &default_cfg;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	memset(aa, 0, sizeof(*aa));
+	aa->a.name = "auto";
+	aa->a.ops = &fy_auto_allocator_ops;
+	aa->a.parent = parent;
+	aa->a.parent_tag = parent_tag;
+	aa->cfg = *cfg;
+
+	pagesz = sysconf(_SC_PAGESIZE);
+	size = cfg->estimated_max_size && cfg->estimated_max_size != SIZE_MAX ?
+			cfg->estimated_max_size :
+			AUTO_ALLOCATOR_MINIMUM_ARENA_SIZE;
+
+	/* first allocator */
+	switch (cfg->scenario) {
+	case FYAST_PER_TAG_FREE:
+	case FYAST_PER_TAG_FREE_DEDUP:
+		memset(&mrcfg, 0, sizeof(mrcfg));
+		mrcfg.big_alloc_threshold = AUTO_ALLOCATOR_BIG_ALLOC_THRESHOLD;
+		mrcfg.empty_threshold = AUTO_ALLOCATOR_EMPTY_THRESHOLD;
+		mrcfg.grow_ratio = AUTO_ALLOCATOR_GROW_RATIO;
+		mrcfg.balloon_ratio = AUTO_ALOCATOR_BALLOON_RATIO;
+		mrcfg.arena_type = AUTO_ALLOCATOR_ARENA_TYPE;
+
+		mrcfg.minimum_arena_size = fy_size_t_align(size, pagesz);
+
+		mra = fy_allocator_create("mremap", &mrcfg);
+		if (!mra)
+			goto err_out;
+		topa = mra;
+
+		break;
+
+	case FYAST_PER_OBJ_FREE:
+	case FYAST_PER_OBJ_FREE_DEDUP:
+		ma = fy_allocator_create("malloc", NULL);
+		if (!ma)
+			goto err_out;
+		topa = ma;
+		break;
+
+	case FYAST_SINGLE_LINEAR_RANGE:
+	case FYAST_SINGLE_LINEAR_RANGE_DEDUP:
+		memset(&lcfg, 0, sizeof(lcfg));
+		lcfg.size = fy_size_t_align(size, pagesz);
+
+		la = fy_allocator_create("linear", &lcfg);
+		if (!la)
+			goto err_out;
+		topa = la;
+		break;
+
+	default:
+		goto err_out;
+	}
+
+	if (!topa)
+		goto err_out;
+
+	/* stack the dedup */
+	switch (cfg->scenario) {
+	case FYAST_PER_TAG_FREE_DEDUP:
+	case FYAST_PER_OBJ_FREE_DEDUP:
+	case FYAST_SINGLE_LINEAR_RANGE_DEDUP:
+		memset(&dcfg, 0, sizeof(dcfg));
+		dcfg.parent_allocator = topa;
+		dcfg.bloom_filter_bits = AUTO_ALLOCATOR_DEFAULT_BLOOM_FILTER_BITS;
+		dcfg.bucket_count_bits = AUTO_ALLOCATOR_DEFAULT_BUCKET_COUNT_BITS;
+		dcfg.dedup_threshold = AUTO_ALLOCATOR_DEFAULT_DEDUP_THRESHOLD;
+		dcfg.chain_length_grow_trigger = AUTO_ALLOCATOR_DEFAULT_CHAIN_LENGTH_GROW_TRIGGER;
+		dcfg.estimated_content_size = size;
+		dcfg.minimum_bucket_occupancy = 0.5;
+
+		da = fy_allocator_create("dedup", &dcfg);
+		if (!da)
+			goto err_out;
+		/* the top is sub now */
+		suba = topa;
+		topa = da;
+
+		break;
+
+		/* nothing to stack for these */
+	case FYAST_PER_TAG_FREE:
+	case FYAST_PER_OBJ_FREE:
+	case FYAST_SINGLE_LINEAR_RANGE:
+		break;
+
+	default:
+		goto err_out;
+	}
+
+	/* OK, assign the allocators now */
+	aa->parent_allocator = topa;
+	aa->sub_parent_allocator = suba;
+
+	return 0;
+
+err_out:
+	fy_allocator_destroy(suba);
+	fy_allocator_destroy(topa);
+	fy_auto_cleanup(a);
+	return -1;
+}
+
+static void fy_auto_cleanup(struct fy_allocator *a)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+
+	/* order is important! */
+	if (aa->parent_allocator) {
+		fy_allocator_destroy(aa->parent_allocator);
+		aa->parent_allocator = NULL;
+	}
+
+	if (aa->sub_parent_allocator) {
+		fy_allocator_destroy(aa->sub_parent_allocator);
+		aa->sub_parent_allocator = NULL;
+	}
+}
+
+struct fy_allocator *fy_auto_create(struct fy_allocator *parent, int parent_tag, const void *cfg)
+{
+	struct fy_auto_allocator *aa = NULL;
+	int rc;
+
+	aa = fy_early_parent_allocator_alloc(parent, parent_tag, sizeof(*aa), _Alignof(struct fy_auto_allocator));
+
+	rc = fy_auto_setup(&aa->a, parent, parent_tag, cfg);
+	if (rc)
+		goto err_out;
+
+	return &aa->a;
+
+err_out:
+	fy_early_parent_allocator_free(parent, parent_tag, aa);
+
+	return NULL;
+}
+
+void fy_auto_destroy(struct fy_allocator *a)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+
+	fy_auto_cleanup(a);
+
+	fy_parent_allocator_free(a, aa);
+}
+
+void fy_auto_dump(struct fy_allocator *a)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+
+	fy_allocator_dump_nocheck(aa->parent_allocator);
+}
+
+static void *fy_auto_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_alloc_nocheck(aa->parent_allocator, tag, size, align);
+}
+
+static void fy_auto_free(struct fy_allocator *a, int tag, void *data)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	fy_allocator_free_nocheck(aa->parent_allocator, tag, data);
+}
+
+static int fy_auto_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_update_stats_nocheck(aa->parent_allocator, tag, stats);
+}
+
+static const void *fy_auto_storev(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_storev_hash_nocheck(aa->parent_allocator, tag, iov, iovcnt, align, hash);
+}
+
+static const void *fy_auto_lookupv(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_lookupv_nocheck(aa->parent_allocator, tag, iov, iovcnt, align, hash);
+}
+
+static void fy_auto_release(struct fy_allocator *a, int tag, const void *data, size_t size)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	fy_allocator_release_nocheck(aa->parent_allocator, tag, data, size);
+}
+
+static int fy_auto_get_tag(struct fy_allocator *a)
+{
+	struct fy_auto_allocator *aa;
+
+	/* TODO, convert tag config? */
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_get_tag_nocheck(aa->parent_allocator);
+}
+
+static void fy_auto_release_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	fy_allocator_release_tag_nocheck(aa->parent_allocator, tag);
+}
+
+static int fy_auto_get_tag_count(struct fy_allocator *a)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_get_tag_count_nocheck(aa->parent_allocator);
+}
+
+static int fy_auto_set_tag_count(struct fy_allocator *a, unsigned int count)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_set_tag_count_nocheck(aa->parent_allocator, count);
+}
+
+static void fy_auto_trim_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	fy_allocator_trim_tag_nocheck(aa->parent_allocator, tag);
+}
+
+static void fy_auto_reset_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	fy_allocator_reset_tag_nocheck(aa->parent_allocator, tag);
+}
+
+static struct fy_allocator_info *
+fy_auto_get_info(struct fy_allocator *a, int tag)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_get_info_nocheck(aa->parent_allocator, tag);
+}
+
+static enum fy_allocator_cap_flags
+fy_auto_get_caps(struct fy_allocator *a)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_get_caps_nocheck(aa->parent_allocator);
+}
+
+static bool fy_auto_contains(struct fy_allocator *a, int tag, const void *ptr)
+{
+	struct fy_auto_allocator *aa;
+
+	aa = container_of(a, struct fy_auto_allocator, a);
+	return fy_allocator_contains_nocheck(aa->parent_allocator, tag, ptr);
+}
+
+const struct fy_allocator_ops fy_auto_allocator_ops = {
+	.setup = fy_auto_setup,
+	.cleanup = fy_auto_cleanup,
+	.create = fy_auto_create,
+	.destroy = fy_auto_destroy,
+	.dump = fy_auto_dump,
+	.alloc = fy_auto_alloc,
+	.free = fy_auto_free,
+	.update_stats = fy_auto_update_stats,
+	.storev = fy_auto_storev,
+	.lookupv = fy_auto_lookupv,
+	.release = fy_auto_release,
+	.get_tag = fy_auto_get_tag,
+	.release_tag = fy_auto_release_tag,
+	.get_tag_count = fy_auto_get_tag_count,
+	.set_tag_count = fy_auto_set_tag_count,
+	.trim_tag = fy_auto_trim_tag,
+	.reset_tag = fy_auto_reset_tag,
+	.get_info = fy_auto_get_info,
+	.get_caps = fy_auto_get_caps,
+	.contains = fy_auto_contains,
+};

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-auto.h
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-auto.h
@@ -1,0 +1,26 @@
+/*
+ * fy-allocator-auto.h - the auto allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ALLOCATOR_AUTO_H
+#define FY_ALLOCATOR_AUTO_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "fy-allocator.h"
+
+struct fy_auto_allocator {
+	struct fy_allocator a;
+	struct fy_auto_allocator_cfg cfg;
+	struct fy_allocator *parent_allocator;
+	struct fy_allocator *sub_parent_allocator;
+};
+
+extern const struct fy_allocator_ops fy_auto_allocator_ops;
+
+#endif

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-dedup.c
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-dedup.c
@@ -1,0 +1,1287 @@
+/*
+ * fy-allocator-dedup.c - dedup allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdalign.h>
+#include <time.h>
+#include <inttypes.h>
+#include <math.h>
+#include <limits.h>
+
+#include <stdio.h>
+
+/* for container_of */
+#include "fy-align.h"
+#include "fy-list.h"
+#include "fy-utils.h"
+#include "fy-win32.h"
+
+#include "fy-allocator-dedup.h"
+
+// #define DEBUG_GROWS
+
+#ifdef DEBUG_GROWS
+
+#undef BEFORE
+#define BEFORE() \
+	do { \
+		clock_gettime(CLOCK_MONOTONIC, &before); \
+	} while(0)
+
+#undef AFTER
+#ifdef _MSC_VER
+static __inline int64_t fy_dedup_after_calc(const struct timespec *before, const struct timespec *after)
+{
+	return (int64_t)(after->tv_sec - before->tv_sec) * (int64_t)1000000000UL + (int64_t)(after->tv_nsec - before->tv_nsec);
+}
+#define AFTER() \
+	(clock_gettime(CLOCK_MONOTONIC, &after), fy_dedup_after_calc(&before, &after))
+#else
+#define AFTER() \
+	({ \
+		clock_gettime(CLOCK_MONOTONIC, &after); \
+		(int64_t)(after.tv_sec - before.tv_sec) * (int64_t)1000000000UL + (int64_t)(after.tv_nsec - before.tv_nsec); \
+	})
+#endif
+
+#endif
+
+static const unsigned int bit_to_chain_length_map[] = {
+	[0] = 1,	/* 1 */
+	[1] = 1,	/* 2 */
+	[2] = 1,	/* 4 */
+	[3] = 1,	/* 8 */
+	[4] = 1,	/* 16 */
+	[5] = 1,	/* 32 */
+	[6] = 2,	/* 64 */
+	[7] = 2,	/* 128 */
+	[8] = 2,	/* 256 */
+	[9] = 2,	/* 512 */
+	[10] = 3,	/* 1024 */
+	[11] = 3,	/* 2048 */
+	[12] = 3,	/* 2048 */
+	[13] = 3,	/* 2048 */
+	[14] = 4,	/* 4096 */
+	[15] = 4,	/* 8192 */
+	[16] = 5,	/* 16384 */
+	[17] = 5,	/* 32768 */
+	[18] = 6,	/* 65536 */
+	[19] = 7,	/* 65536 */
+	[20] = 8,	/* 131072 */
+	[21] = 9,	/* 262144*/
+	[22] = 10,	/* 524288 */
+	[23] = INT_MAX	/* infinite from now on */
+};
+
+void fy_dedup_tag_data_destroy(struct fy_dedup_tag_data *dtd);
+
+static inline struct fy_dedup_tag *
+fy_dedup_tag_from_tag(struct fy_dedup_allocator *da, int tag)
+{
+	if (!da)
+		return NULL;
+
+	if ((unsigned int)tag >= da->tag_count)
+		return NULL;
+
+	if (!fy_id_is_used(da->ids, da->tag_id_count, tag))
+		return NULL;
+
+	return &da->tags[tag];
+}
+
+static void fy_dedup_tag_data_cleanup(struct fy_dedup_tag_data *dtd)
+{
+	struct fy_dedup_allocator *da = dtd->cfg.da;
+
+	fy_parent_allocator_free(&da->a, (void *)dtd->buckets);
+	fy_parent_allocator_free(&da->a, (void *)dtd->bloom_id);
+	fy_parent_allocator_free(&da->a, (void *)dtd->buckets_in_use);
+}
+
+static int fy_dedup_tag_data_setup(struct fy_dedup_tag_data *dtd,
+				   const struct fy_dedup_tag_data_cfg *cfg)
+{
+	struct fy_dedup_allocator *da;
+	unsigned int bloom_filter_bits, bucket_count_bits, chain_length_grow_trigger;
+	size_t dedup_threshold;
+	size_t tmpsz;
+	unsigned int i;
+
+	assert(dtd);
+	assert(cfg);
+
+	da = cfg->da;
+
+	bloom_filter_bits = cfg->bloom_filter_bits;
+	bucket_count_bits = cfg->bucket_count_bits;
+	dedup_threshold = cfg->dedup_threshold;
+	chain_length_grow_trigger = cfg->chain_length_grow_trigger;
+
+	memset(dtd, 0, sizeof(*dtd));
+	dtd->cfg = *cfg;
+
+	dtd->bloom_filter_bits = bloom_filter_bits;
+	dtd->bucket_count_bits = bucket_count_bits;
+	dtd->dedup_threshold = dedup_threshold;
+	dtd->chain_length_grow_trigger = chain_length_grow_trigger;
+	if (!dtd->chain_length_grow_trigger) {
+		if (bucket_count_bits >= ARRAY_SIZE(bit_to_chain_length_map))
+			dtd->chain_length_grow_trigger = bit_to_chain_length_map[ARRAY_SIZE(bit_to_chain_length_map) - 1];
+		else
+			dtd->chain_length_grow_trigger = bit_to_chain_length_map[bucket_count_bits];
+
+		if (dtd->chain_length_grow_trigger == 0)
+			dtd->chain_length_grow_trigger++;
+	}
+
+	dtd->bloom_filter_mask = ((unsigned int)1 << dtd->bloom_filter_bits) - 1;
+	dtd->bucket_count_mask = ((unsigned int)1 << dtd->bucket_count_bits) - 1;
+
+	dtd->bloom_id_count = (((size_t)1 << dtd->bloom_filter_bits) + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+	assert(dtd->bloom_id_count > 0);
+	tmpsz = dtd->bloom_id_count * sizeof(*dtd->bloom_id);
+	dtd->bloom_id = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(fy_id_bits));
+	if (!dtd->bloom_id)
+		goto err_out;
+	fy_id_reset(dtd->bloom_id, dtd->bloom_id_count);
+
+	dtd->bucket_count = (size_t)1 << dtd->bucket_count_bits;
+	assert(dtd->bucket_count);
+
+	tmpsz = sizeof(*dtd->buckets) * dtd->bucket_count;
+	dtd->buckets = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(struct fy_dedup_entry *));
+	if (!dtd->buckets)
+		goto err_out;
+	for (i = 0; i < dtd->bucket_count; i++)
+		atomic_store(&dtd->buckets[i], NULL);
+
+	dtd->bucket_id_count = (((size_t)1 << dtd->bucket_count_bits) + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+	assert(dtd->bucket_id_count > 0);
+	tmpsz = dtd->bucket_id_count * sizeof(*dtd->buckets_in_use);
+	dtd->buckets_in_use = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(fy_id_bits));
+	if (!dtd->buckets_in_use)
+		goto err_out;
+	fy_id_reset(dtd->buckets_in_use, dtd->bucket_id_count);
+
+	return 0;
+
+err_out:
+	fy_dedup_tag_data_cleanup(dtd);
+	return -1;
+}
+
+static void fy_dedup_tag_cleanup(struct fy_dedup_allocator *da, struct fy_dedup_tag *dt)
+{
+	struct fy_dedup_tag_data *dtd;
+
+	if (!da || !dt)
+		return;
+
+	while ((dtd = fy_atomic_load(&dt->tag_datas)) != NULL) {
+
+		/* only do it if you are the winner */
+		if (!fy_atomic_compare_exchange_strong(&dt->tag_datas, &dtd, dtd->next))
+			continue;
+
+#ifdef DEBUG_GROWS
+		fprintf(stderr, "%s: dump of state at close\n", __func__);
+		fprintf(stderr, "%s: bloom count=%u used=%lu\n",
+				__func__, 1 << dtd->bloom_filter_bits,
+				fy_id_count_used(dtd->bloom_id, dtd->bloom_id_count));
+		fprintf(stderr, "%s: bucket count=%u used=%lu\n",
+				__func__, 1 << dtd->bucket_count_bits,
+				fy_id_count_used(dtd->buckets_in_use, dtd->bucket_id_count));
+#endif
+
+		fy_dedup_tag_data_destroy(dtd);
+	}
+
+	/* we just release the tags, the underlying allocator should free everything */
+	if (dt->content_tag != FY_ALLOC_TAG_NONE)
+		fy_allocator_release_tag(da->parent_allocator, dt->content_tag);
+
+	if (dt->content_tag != dt->entries_tag && dt->entries_tag != FY_ALLOC_TAG_NONE)
+		fy_allocator_release_tag(da->parent_allocator, dt->entries_tag);
+
+}
+
+struct fy_dedup_tag_data *
+fy_dedup_tag_data_create(const struct fy_dedup_tag_data_cfg *cfg)
+{
+	struct fy_dedup_allocator *da = cfg->da;
+	struct fy_dedup_tag_data *dtd;
+	int ret;
+
+	dtd = fy_parent_allocator_alloc(&da->a, sizeof(*dtd), _Alignof(struct fy_dedup_tag_data));
+	if (!dtd)
+		return NULL;
+
+	ret = fy_dedup_tag_data_setup(dtd, cfg);
+	if (ret)
+		goto err_out;
+
+	return dtd;
+
+err_out:
+	fy_parent_allocator_free(&da->a, dtd);
+	return NULL;
+}
+
+void fy_dedup_tag_data_destroy(struct fy_dedup_tag_data *dtd)
+{
+	struct fy_dedup_allocator *da;
+
+	if (!dtd)
+		return;
+
+	da = dtd->cfg.da;
+
+	fy_dedup_tag_data_cleanup(dtd);
+	fy_parent_allocator_free(&da->a, dtd);
+}
+
+static int fy_dedup_tag_setup(struct fy_dedup_allocator *da, struct fy_dedup_tag *dt)
+{
+	struct fy_dedup_tag_data *dtd;
+
+	assert(da);
+	assert(dt);
+
+	memset(dt, 0, sizeof(*dt));
+
+	fy_atomic_flag_clear(&dt->growing);
+	if (da->parent_caps & FYACF_CAN_FREE_TAG) {
+		dt->content_tag = fy_allocator_get_tag(da->parent_allocator);
+		if (dt->content_tag == FY_ALLOC_TAG_ERROR)
+			goto err_out;
+		dt->entries_tag = fy_allocator_get_tag(da->parent_allocator);
+		if (dt->entries_tag == FY_ALLOC_TAG_ERROR)
+			goto err_out;
+	} else {
+		dt->content_tag = FY_ALLOC_TAG_DEFAULT;
+		dt->entries_tag = FY_ALLOC_TAG_DEFAULT;
+	}
+
+	fy_atomic_store(&dt->tag_datas, NULL);
+
+	dtd = fy_dedup_tag_data_create(
+			&(struct fy_dedup_tag_data_cfg) {
+				.da = da,
+				.dt = dt,
+				.bloom_filter_bits = da->bloom_filter_bits,
+				.bucket_count_bits = da->bucket_count_bits,
+				.dedup_threshold = da->dedup_threshold,
+				.chain_length_grow_trigger = da->chain_length_grow_trigger
+			});
+	if (!dtd)
+		goto err_out;
+
+	/* start with this one */
+	fy_atomic_store(&dt->tag_datas, dtd);
+
+	return 0;
+
+err_out:
+	fy_dedup_tag_cleanup(da, dt);
+	return -1;
+}
+
+static int
+fy_dedup_tag_prepare_new(struct fy_dedup_tag_data *dtd, struct fy_dedup_tag_data *new_dtd,
+			 int bloom_filter_adjust_bits, int bucket_adjust_bits)
+{
+	unsigned int bit_shift, new_bucket_count_bits, new_bloom_filter_bits;
+	int rc;
+
+	bit_shift = (unsigned int)fy_id_ffs(FY_ID_BITS_BITS);
+
+	new_bucket_count_bits = (unsigned int)((int)dtd->bucket_count_bits + bucket_adjust_bits);
+	if (new_bucket_count_bits > (sizeof(int) * 8 - 1))
+		new_bucket_count_bits = (sizeof(int) * 8) - 1;
+	else if (new_bucket_count_bits < bit_shift)
+		new_bucket_count_bits = bit_shift;
+
+	new_bloom_filter_bits = (unsigned int)((int)dtd->bloom_filter_bits + bloom_filter_adjust_bits);
+	if (new_bloom_filter_bits > (sizeof(int) * 8 - 1))
+		new_bloom_filter_bits = (sizeof(int) * 8) - 1;
+	else if (new_bloom_filter_bits < new_bucket_count_bits)
+		new_bloom_filter_bits = new_bucket_count_bits;
+
+	/* setup the new data */
+	rc = fy_dedup_tag_data_setup(new_dtd,
+			&(struct fy_dedup_tag_data_cfg) {
+				.da = dtd->cfg.da,
+				.dt = dtd->cfg.dt,
+				.bloom_filter_bits = new_bloom_filter_bits,
+				.bucket_count_bits = new_bucket_count_bits,
+				.dedup_threshold = dtd->cfg.da->dedup_threshold,
+				.chain_length_grow_trigger = dtd->cfg.da->chain_length_grow_trigger
+			});
+	return rc;
+}
+
+
+static int
+fy_dedup_tag_adjust(struct fy_dedup_allocator *da, struct fy_dedup_tag *dt,
+		    int bloom_filter_adjust_bits, int bucket_adjust_bits)
+{
+	size_t bucket_count, bucket_used;
+	struct fy_dedup_tag_data *dtd, *new_dtd = NULL;
+	float occupancy_ratio;
+	int rc;
+
+	rc = -1;
+
+	assert(da);
+	assert(dt);
+
+	dtd = fy_atomic_load(&dt->tag_datas);
+	if (!dtd)
+		return -1;
+
+	if (!fy_atomic_flag_test_and_set(&dt->growing)) {
+#ifdef DEBUG_GROWS
+		fprintf(stderr, "grow: abort due another grow in progress\n");
+#endif
+		return -1;
+	}
+
+	bucket_count = (size_t)1 << dtd->bucket_count_bits;
+	bucket_used = fy_id_count_used(dtd->buckets_in_use, dtd->bucket_id_count);
+	occupancy_ratio = (float)((double)bucket_used/(double)bucket_count);
+
+	/* do not grow until we're over 60% full */
+	if (occupancy_ratio < da->cfg.minimum_bucket_occupancy) {
+#ifdef DEBUG_GROWS
+		fprintf(stderr, "grow: abort due to less that %f%% full (is %f)\n",
+				100 * da->cfg.minimum_bucket_occupancy,
+				100 * occupancy_ratio);
+#endif
+		goto out_ok;
+	}
+
+	new_dtd = fy_parent_allocator_alloc(&da->a, sizeof(*new_dtd), _Alignof(struct fy_dedup_tag_data));
+	if (!new_dtd)
+		goto err_out;
+
+	/* prepare the new one */
+	rc = fy_dedup_tag_prepare_new(dtd, new_dtd, bloom_filter_adjust_bits, bucket_adjust_bits);
+	if (rc)
+		goto err_out;
+
+#ifdef DEBUG_GROWS
+	{
+		size_t bloom_count, new_bloom_count, bloom_used;
+		size_t bucket_count, new_bucket_count, bucket_used;
+
+		bloom_count = 1U << dtd->bloom_filter_bits;
+		new_bloom_count = 1U << new_dtd->bloom_filter_bits;
+		bloom_used = fy_id_count_used(dtd->bloom_id, dtd->bloom_id_count);
+		bucket_count = 1U << dtd->bucket_count_bits;
+		new_bucket_count = 1U << new_dtd->bucket_count_bits;
+		bucket_used = fy_id_count_used(dtd->buckets_in_use, dtd->bucket_id_count);
+
+		fprintf(stderr, "grow: chain_length_grow_trigger=%u->%u bloom %zu->%zu used %zu (%2.2f%%) ",
+				dtd->chain_length_grow_trigger, new_dtd->chain_length_grow_trigger,
+				bloom_count, new_bloom_count,
+				bloom_used, 100.0*(double)bloom_used/(double)bloom_count);
+		fprintf(stderr, "bucket %zu->%zu used %zu (%2.2f%%)\n", bucket_count, new_bucket_count,
+				bucket_used, 100.0*(double)bucket_used/(double)bucket_count);
+	}
+#endif
+
+	/* try to add it, if the head changed, then drop our stuff and pretend nothing happened */
+	new_dtd->next = dtd;
+	if (!fy_atomic_compare_exchange_strong(&dt->tag_datas, &dtd, new_dtd)) {
+#ifdef DEBUG_GROWS
+		fprintf(stderr, "grow: Update cancelled, someone beat us to it\n");
+#endif
+		fy_dedup_tag_data_cleanup(new_dtd);
+		fy_parent_allocator_free(&da->a, new_dtd);
+	}
+
+out_ok:
+	rc = 0;
+out:
+	fy_atomic_flag_clear(&dt->growing);
+	return rc;
+
+err_out:
+	fy_parent_allocator_free(&da->a, new_dtd);
+	rc = -1;
+	goto out;
+}
+
+static void fy_dedup_tag_trim(struct fy_dedup_allocator *da, struct fy_dedup_tag *dt)
+{
+	if (!da || !dt)
+		return;
+
+	/* just pass them trim down to the parent */
+	if (da->parent_caps & FYACF_CAN_FREE_TAG) {
+		fy_allocator_trim_tag(da->parent_allocator, dt->content_tag);
+		fy_allocator_trim_tag(da->parent_allocator, dt->entries_tag);
+	}
+}
+
+static void fy_dedup_tag_reset(struct fy_dedup_allocator *da, struct fy_dedup_tag *dt)
+{
+	struct fy_dedup_tag_data *dtd, *dtd_head;
+	size_t i;
+
+	if (!da || !dt)
+		return;
+
+	/* just pass them reset down to the parent */
+	if (da->parent_caps & FYACF_CAN_FREE_TAG) {
+		fy_allocator_reset_tag(da->parent_allocator, dt->content_tag);
+		fy_allocator_reset_tag(da->parent_allocator, dt->entries_tag);
+	}
+
+	/* pop the head which we will keep */
+
+	dtd_head = NULL;
+	while ((dtd = fy_atomic_load(&dt->tag_datas)) != NULL) {
+		if (!fy_atomic_compare_exchange_strong(&dt->tag_datas, &dtd, dtd->next))
+			continue;
+
+		dtd->next = NULL;
+
+		/* keep the head as is */
+		if (!dtd_head)
+			dtd_head = dtd;
+		else
+			fy_dedup_tag_data_destroy(dtd);
+	}
+
+	if (dtd_head) {
+		dtd = dtd_head;
+
+		dtd->next = NULL;
+		fy_id_reset(dtd->bloom_id, dtd->bloom_id_count);
+		for (i = 0; i < dtd->bucket_count; i++)
+			atomic_store(&dtd->buckets[i], NULL);
+		fy_id_reset(dtd->buckets_in_use, dtd->bucket_id_count);
+		fy_atomic_store(&dt->tag_datas, dtd);
+	}
+}
+
+static void fy_dedup_cleanup(struct fy_allocator *a);
+
+#define BUCKET_ESTIMATE_DIV 1024
+#define BLOOM_ESTIMATE_DIV 128
+
+static void fy_dedup_cleanup(struct fy_allocator *a)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	unsigned int i;
+
+	if (!a)
+		return;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	for (i = 0; i < da->tag_count; i++) {
+		dt = fy_dedup_tag_from_tag(da, i);
+		if (!dt)
+			continue;
+		fy_dedup_tag_cleanup(da, dt);
+	}
+
+	fy_parent_allocator_free(&da->a, (void *)da->ids);
+	fy_parent_allocator_free(&da->a, da->tags);
+}
+
+static int fy_dedup_setup(struct fy_allocator *a, struct fy_allocator *parent, int parent_tag, const void *cfg_data)
+{
+	struct fy_dedup_allocator *da = NULL;
+	const struct fy_dedup_allocator_cfg *cfg;
+	unsigned int bloom_filter_bits, bucket_count_bits;
+	unsigned int bit_shift, chain_length_grow_trigger;
+	size_t dedup_threshold, tmpsz;
+	bool has_estimate;
+	struct fy_dedup_tag *dt;
+	int rc;
+
+	if (!a || !cfg_data)
+		return -1;
+
+	cfg = cfg_data;
+	if (!cfg->parent_allocator)
+		return -1;
+
+	has_estimate = cfg->estimated_content_size && cfg->estimated_content_size != SIZE_MAX;
+
+	/* power of two so ffs = log2 */
+	bit_shift = (unsigned int)fy_id_ffs(FY_ID_BITS_BITS);
+
+	bucket_count_bits = cfg->bucket_count_bits;
+	if (!bucket_count_bits && has_estimate) {
+		bucket_count_bits = 1;
+		while (((size_t)1 << bucket_count_bits) < (cfg->estimated_content_size / BUCKET_ESTIMATE_DIV))
+			bucket_count_bits++;
+#ifdef DEBUG_GROWS
+		fprintf(stderr, "bucket_count_bits %u\n", bucket_count_bits);
+#endif
+	}
+	/* at least that amount */
+	if (bucket_count_bits < bit_shift)
+		bucket_count_bits = bit_shift;
+	/* keep the bucket count bits in signed int range */
+	if (bucket_count_bits > (sizeof(int) * 8 - 1))
+		bucket_count_bits = (sizeof(int) * 8) - 1;
+
+	bloom_filter_bits = cfg->bloom_filter_bits;
+	if (!bloom_filter_bits && has_estimate) {
+		bloom_filter_bits = 1;
+		while (((size_t)1 << bloom_filter_bits) < (cfg->estimated_content_size / BLOOM_ESTIMATE_DIV))
+			bloom_filter_bits++;
+#ifdef DEBUG_GROWS
+		fprintf(stderr, "bloom_filter_bits %u\n", bloom_filter_bits);
+#endif
+	}
+	/* must be more than bucket count bits */
+	if (bloom_filter_bits < bucket_count_bits)
+		bloom_filter_bits = bucket_count_bits + 3;	/* minimum fanout */
+	/* keep the bloom filter bits in signed int range */
+	if (bloom_filter_bits > (sizeof(int) * 8 - 1))
+		bloom_filter_bits = (sizeof(int) * 8) - 1;
+
+	dedup_threshold = cfg->dedup_threshold;
+	chain_length_grow_trigger = cfg->chain_length_grow_trigger;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	memset(da, 0, sizeof(*da));
+
+	da->a.name = "dedup";
+	da->a.ops = &fy_dedup_allocator_ops;
+	da->a.parent = parent;
+	da->a.parent_tag = parent_tag;
+	da->cfg = *cfg;
+
+	da->parent_allocator = cfg->parent_allocator;
+	da->parent_caps = fy_allocator_get_caps(da->parent_allocator);
+
+	da->bloom_filter_bits = bloom_filter_bits;
+	da->bucket_count_bits = bucket_count_bits;
+	da->dedup_threshold = dedup_threshold;
+	da->chain_length_grow_trigger = chain_length_grow_trigger;
+
+	/* we use as many tags as the parent allocator */
+	rc = fy_allocator_get_tag_count(da->parent_allocator);
+	if (rc <= 0)
+		goto err_out;
+	da->tag_count = (unsigned int)rc;
+	da->tag_id_count = (da->tag_count + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+
+	tmpsz = da->tag_id_count * sizeof(*da->ids);
+	da->ids = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(fy_id_bits));
+	if (!da->ids)
+		goto err_out;
+	fy_id_reset(da->ids, da->tag_id_count);
+
+	tmpsz = da->tag_count * sizeof(*da->tags);
+	da->tags = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(struct fy_dedup_tag));
+	if (!da->tags)
+		goto err_out;
+
+	/* start with tag 0 as general use */
+	fy_id_set_used(da->ids, da->tag_id_count, 0);
+	dt = fy_dedup_tag_from_tag(da, 0);
+	rc = fy_dedup_tag_setup(da, dt);
+	if (rc)
+		goto err_out;
+
+	return 0;
+err_out:
+	fy_dedup_cleanup(a);
+	return -1;
+}
+
+struct fy_allocator *fy_dedup_create(struct fy_allocator *parent, int parent_tag, const void *cfg)
+{
+	struct fy_dedup_allocator *da = NULL;
+	int rc;
+
+	da = fy_early_parent_allocator_alloc(parent, parent_tag, sizeof(*da), _Alignof(struct fy_dedup_allocator));
+	if (!da)
+		goto err_out;
+
+	rc = fy_dedup_setup(&da->a, parent, parent_tag, cfg);
+	if (rc)
+		goto err_out;
+
+	return &da->a;
+
+err_out:
+	fy_early_parent_allocator_free(parent, parent_tag, da);
+	return NULL;
+}
+
+void fy_dedup_destroy(struct fy_allocator *a)
+{
+	struct fy_dedup_allocator *da;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	fy_dedup_cleanup(a);
+
+	fy_parent_allocator_free(a, da);
+}
+
+void fy_dedup_dump(struct fy_allocator *a)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	unsigned int i;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	fprintf(stderr, "dedup: ");
+	for (i = 0; i < da->tag_count; i++) {
+		dt = fy_dedup_tag_from_tag(da, i);
+		if (!dt)
+			continue;
+		fprintf(stderr, "%c", fy_id_is_free(da->ids, da->tag_id_count, i) ? '.' : 'x');
+	}
+	fprintf(stderr, "\n");
+
+	for (i = 0; i < da->tag_count; i++) {
+		dt = fy_dedup_tag_from_tag(da, i);
+		if (!dt)
+			continue;
+		fprintf(stderr, "  %d: tags: content=%d\n", i, dt->content_tag);
+		fprintf(stderr, "  %d: tags: entries=%d\n", i, dt->entries_tag);
+	}
+
+	fprintf(stderr, "dedup: dumping parent allocator\n");
+	fy_allocator_dump(da->parent_allocator);
+}
+
+static void *fy_dedup_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	void *p;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		goto err_out;
+
+	/* just pass to the parent allocator using the content tag */
+	p = fy_allocator_alloc_nocheck(da->parent_allocator, dt->content_tag, size, align);
+	if (!p)
+		goto err_out;
+
+	return p;
+
+err_out:
+	return NULL;
+}
+
+static void fy_dedup_free(struct fy_allocator *a, int tag, void *data)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	if (!(da->parent_caps & FYACF_CAN_FREE_INDIVIDUAL))
+		return;
+
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return;
+
+	/* just pass to the parent allocator */
+	fy_allocator_free(da->parent_allocator, dt->content_tag, data);
+}
+
+static int fy_dedup_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	int r;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return -1;
+
+	r = fy_allocator_update_stats(da->parent_allocator, dt->content_tag, stats);
+	if (r)
+		return -1;
+	if (dt->content_tag != dt->entries_tag) {
+		r = fy_allocator_update_stats(da->parent_allocator, dt->entries_tag, stats);
+		if (r)
+			return -1;
+	}
+
+	stats->unique_stores += fy_atomic_get_and_clear_counter(&dt->unique_stores);
+	stats->dup_stores += fy_atomic_get_and_clear_counter(&dt->dup_stores);
+	stats->collisions += fy_atomic_get_and_clear_counter(&dt->collisions);
+
+	return 0;
+}
+
+/* we can lookup! */
+static const void *fy_dedup_lookupv(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	struct fy_dedup_tag_data *dtd;
+	struct fy_dedup_entry *de;
+	int bloom_pos, bucket_pos;
+	bool bloom_hit;
+	size_t total_size;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return NULL;
+
+	/* calculate data total size */
+	total_size = fy_iovec_size(iov, iovcnt);
+	if (total_size == SIZE_MAX)
+		return NULL;
+
+	/* if it's under the dedup threshold just allocate and copy */
+	if (total_size < da->cfg.dedup_threshold)
+		return NULL;
+
+	/* calculate hash if not given */
+	if (!hash)
+		hash = fy_iovec_xxhash64(iov, iovcnt);
+
+	for (dtd = fy_atomic_load(&dt->tag_datas); dtd; dtd = dtd->next) {
+		bloom_pos = (int)(hash & (uint64_t)dtd->bloom_filter_mask);
+		bloom_hit = fy_id_is_used(dtd->bloom_id, dtd->bloom_id_count, bloom_pos);
+		if (bloom_hit) {
+			bucket_pos = (int)(hash & (uint64_t)dtd->bucket_count_mask);
+			for (de = fy_atomic_load(&dtd->buckets[bucket_pos]); de; de = de->next) {
+				if (de->hash == hash && total_size == de->size &&
+						!fy_iovec_cmp(iov, iovcnt, de->mem) &&
+						((uintptr_t)de->mem & (align - 1)) == 0)
+					return de->mem;
+			}
+		}
+	}
+	return NULL;
+}
+
+static const void *fy_dedup_storev(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	struct fy_dedup_tag_data *dtd, *dtd_best;
+	struct fy_dedup_entry *de, *de_head;
+	int bloom_pos, bucket_pos;
+	bool bloom_hit;
+	unsigned int chain_length;
+	void *mem = NULL;
+	size_t total_size, de_offset, max_align;
+	bool at_head;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return NULL;
+
+	/* calculate data total size */
+	total_size = fy_iovec_size(iov, iovcnt);
+	if (total_size == SIZE_MAX)
+		return NULL;
+
+	/* if it's under the dedup threshold just allocate and copy */
+	if (total_size < da->cfg.dedup_threshold) {
+
+		/* just pass to the parent allocator using the content tag */
+		void *p = fy_allocator_alloc_nocheck(da->parent_allocator, dt->content_tag, total_size, align);
+		if (!p)
+			return NULL;
+
+		fy_iovec_copy_from(iov, iovcnt, p);
+		return p;
+	}
+
+	/* calculate hash if not given */
+	if (!hash)
+		hash = fy_iovec_xxhash64(iov, iovcnt);
+
+again:
+	de = NULL;
+	chain_length = 0;
+
+	at_head = true;
+	dtd_best = NULL;
+	for (dtd = fy_atomic_load(&dt->tag_datas); dtd; dtd = dtd->next) {
+
+		/* first check in the bloom filter */
+		bloom_pos = (int)(hash & (uint64_t)dtd->bloom_filter_mask);
+		bucket_pos = (int)(hash & (uint64_t)dtd->bucket_count_mask);
+
+		bloom_hit = fy_id_is_used(dtd->bloom_id, dtd->bloom_id_count, bloom_pos);
+		if (bloom_hit) {
+			for (de = fy_atomic_load(&dtd->buckets[bucket_pos]); de; de = de->next) {
+				if (de->hash == hash) {
+				       	if (total_size == de->size && !fy_iovec_cmp(iov, iovcnt, de->mem) &&
+							((uintptr_t)de->mem & (align - 1)) == 0) {
+
+						/* only update stats if someone asked for it */
+						if (a->flags & FYAF_KEEP_STATS)
+							fy_atomic_fetch_add(&dt->dup_stores, 1);
+
+						if (a->flags & FYAF_TRACE) {
+							int i;
+							size_t j;
+							printf("%s: %p: dup-store %p 0x%016"PRIx64" %zx:", __func__,
+									a, de->mem, hash, total_size);
+							for (i = 0; i < iovcnt; i++) {
+								for (j = 0; j < iov[i].iov_len; j++) {
+									printf("%02x", (int)(((uint8_t *)iov[i].iov_base)[j]) & 0xff);
+								}
+							}
+							printf("\n");
+						}
+
+						return de->mem;
+					}
+
+					/* mark that we had a collision here */
+					if (a->flags & FYAF_KEEP_STATS)
+						fy_atomic_fetch_add(&dt->collisions, 1);
+				}
+
+				if (at_head)
+					chain_length++;
+			}
+		} else {
+			if (!dtd_best)
+				dtd_best = dtd;	/* keep whenever we had a empty bloom slot */
+		}
+		at_head = false;
+	}
+
+	/* use the one that had space, otherwise the top */
+	if (dtd_best)
+		dtd = dtd_best;
+	else
+		dtd = fy_atomic_load(&dt->tag_datas);
+
+	/* recalc positions for the delected dtd */
+	bloom_pos = (int)(hash & (uint64_t)dtd->bloom_filter_mask);
+	bucket_pos = (int)(hash & (uint64_t)dtd->bucket_count_mask);
+
+	/* we might be retrying; don't allocate and copy again */
+	if (!mem) {
+		/* place the dedup entry at the aligned offset after the data */
+
+		if (dt->content_tag == dt->entries_tag) {
+			/* we don't have seperate content and entries */
+			de_offset = fy_size_t_align(total_size, _Alignof(struct fy_dedup_entry));
+			max_align = align > _Alignof(struct fy_dedup_entry) ? align : _Alignof(struct fy_dedup_entry);
+			mem = fy_allocator_alloc_nocheck(da->parent_allocator, dt->content_tag, de_offset + sizeof(*de), max_align);
+			if (!mem)
+				return NULL;
+
+			de = (void *)((char *)mem + de_offset);
+		} else {
+			/* separate content and entries */
+			mem = fy_allocator_alloc_nocheck(da->parent_allocator, dt->content_tag,
+							 total_size, align);
+			if (!mem)
+				return NULL;
+
+			de = fy_allocator_alloc_nocheck(da->parent_allocator, dt->entries_tag,
+							sizeof(struct fy_dedup_entry), _Alignof(struct fy_dedup_entry));
+			if (!de)
+				return NULL;
+		}
+
+		/* verify it's aligned correctly */
+		assert(((uintptr_t)mem & (align - 1)) == 0);
+
+		de->hash = hash;
+		de->size = total_size;
+		de->mem = mem;
+
+		/* and copy the data */
+		fy_iovec_copy_from(iov, iovcnt, de->mem);
+	}
+
+	/* set this bucket to used */
+	fy_id_set_used(dtd->buckets_in_use, dtd->bucket_id_count, bucket_pos);
+
+	/* turn the update bit for the bloom position */
+	fy_id_set_used(dtd->bloom_id, dtd->bloom_id_count, bloom_pos);
+
+	/* add to the bucket last atomically */
+	de_head = fy_atomic_load(&dtd->buckets[bucket_pos]);
+	de->next = de_head;
+	if (!fy_atomic_compare_exchange_strong(&dtd->buckets[bucket_pos], &de_head, de))
+		goto again;	// we're leaking the entry, but that's fine
+
+	/* adjust by one bit, if we've hit the trigger */
+	if (chain_length > dtd->chain_length_grow_trigger)
+		fy_dedup_tag_adjust(da, dt, 1, 1);
+
+	/* only update stats if someone asked for it */
+	if (a->flags & FYAF_KEEP_STATS)
+		fy_atomic_fetch_add(&dt->unique_stores, 1);
+
+	if (a->flags & FYAF_TRACE) {
+		int i;
+		size_t j;
+		printf("%s: %p: new-store %p 0x%016"PRIx64" %zx:", __func__,
+				a, de->mem, hash, total_size);
+		for (i = 0; i < iovcnt; i++) {
+			for (j = 0; j < iov[i].iov_len; j++) {
+				printf("%02x", (int)(((uint8_t *)iov[i].iov_base)[j]) & 0xff);
+			}
+		}
+		printf("\n");
+	}
+
+	return de->mem;
+}
+
+static void fy_dedup_release(struct fy_allocator *a, int tag, const void *data, size_t size)
+{
+	/* we do nothing */
+}
+
+static int fy_dedup_get_tag(struct fy_allocator *a)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt = NULL;
+	int tag;
+	int id, rc;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	/* for a single tag, just return 0 */
+	if (!(da->parent_caps & FYACF_CAN_FREE_TAG))
+		return 0;
+
+	/* and one from us */
+	id = fy_id_alloc(da->ids, da->tag_id_count);
+	if (id < 0)
+		goto err_out;
+
+	tag = (int)id;
+
+	dt = fy_dedup_tag_from_tag(da, tag);
+	assert(dt);
+
+	rc = fy_dedup_tag_setup(da, dt);
+	if (rc)
+		goto err_out;
+
+	return tag;
+
+err_out:
+	fy_dedup_tag_cleanup(da, dt);
+	if (id >= 0)
+		fy_id_free(da->ids, da->tag_id_count, id);
+	return FY_ALLOC_TAG_ERROR;
+}
+
+static void fy_dedup_release_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	/* for a single tag, just return */
+	if (!(da->parent_caps & FYACF_CAN_FREE_TAG))
+		return;
+
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return;
+
+	fy_dedup_tag_cleanup(da, dt);
+
+	fy_id_free(da->ids, da->tag_count, tag);
+}
+
+static int fy_dedup_get_tag_count(struct fy_allocator *a)
+{
+	struct fy_dedup_allocator *da;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	return da->tag_count;
+}
+
+static int fy_dedup_set_tag_count(struct fy_allocator *a, unsigned int count)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag_data *dtd;
+	fy_id_bits *ids = NULL, *alloc_ids = NULL;
+	struct fy_dedup_tag *dt, *dt_new, *tags = NULL, *alloc_tags = NULL;
+	unsigned int i, tag_count, tag_id_count;
+	size_t tmpsz;
+	int rc;
+
+	if (count < 1)
+		return -1;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	if (count == da->tag_count)
+		return 0;
+
+	tag_count = count;
+	tag_id_count = (tag_count + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+
+	/* check if all content tag are within limits */
+	for (i = 0; i < da->tag_count; i++) {
+		dt = fy_dedup_tag_from_tag(da, i);
+		if (!dt)
+			continue;
+		if (dt->content_tag >= (int)tag_count)
+			return -1;
+		if (dt->entries_tag >= (int)tag_count)
+			return -1;
+	}
+
+	if (count > da->tag_count) {
+		/* we need to grow */
+		tmpsz = tag_id_count * sizeof(*da->ids);
+		alloc_ids = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(fy_id_bits));
+		if (!alloc_ids)
+			goto err_out;
+		fy_id_reset(alloc_ids, tag_id_count);
+
+		tmpsz = tag_count * sizeof(*tags);
+		alloc_tags = fy_parent_allocator_alloc(&da->a, tmpsz, _Alignof(struct fy_dedup_tag));
+		if (!alloc_tags)
+			goto err_out;
+	}
+
+	/* shrink?, just clip */
+	if (count < da->tag_count) {
+		tags = da->tags;
+		ids = da->ids;
+		for (i = count; i < da->tag_count; i++) {
+			dt = fy_dedup_tag_from_tag(da, i);
+			if (!dt)
+				continue;
+			fy_dedup_tag_cleanup(da, dt);
+			fy_id_free(da->ids, da->tag_id_count, i);
+		}
+	} else {
+		tags = alloc_tags;
+		ids = alloc_ids;
+		/* copy over the old entries */
+		for (i = 0; i < da->tag_count; i++) {
+
+			dt = fy_dedup_tag_from_tag(da, i);
+			if (!dt)
+				continue;
+
+			dt_new = &tags[i];
+
+			fy_dedup_tag_setup(da, dt_new);
+
+			/* move the old entries over */
+			do {
+				dtd = fy_atomic_load(&dt->tag_datas);
+			} while (fy_atomic_compare_exchange_strong(&dt->tag_datas, &dtd, NULL));
+			fy_atomic_store(&dt_new->tag_datas, dtd);
+			dt_new->content_tag = dt->content_tag;
+			dt_new->entries_tag = dt->entries_tag;
+			fy_atomic_flag_clear(&dt_new->growing);
+			fy_atomic_store(&dt_new->unique_stores, fy_atomic_load(&dt->unique_stores));
+			fy_atomic_store(&dt_new->dup_stores, fy_atomic_load(&dt->dup_stores));
+			fy_atomic_store(&dt_new->collisions, fy_atomic_load(&dt->collisions));
+
+			/* clean the old entry */
+			fy_dedup_tag_cleanup(da, dt);
+
+			fy_id_set_used(ids, tag_id_count, i);
+		}
+	}
+
+	/* ok, drop the parent bits first */
+	rc = fy_allocator_set_tag_count(da->parent_allocator, tag_count);
+	if (rc)
+		goto err_out;
+
+	/* switch */
+	if (da->tags != tags) {
+		da->tags = tags;
+		fy_parent_allocator_free(&da->a, da->tags);
+	}
+
+	if (da->ids != ids) {
+		da->ids = ids;
+		fy_parent_allocator_free(&da->a, (void *)da->ids);
+	}
+
+	da->tag_count = tag_count;
+	da->tag_id_count = tag_id_count;
+
+	return 0;
+
+err_out:
+	fy_parent_allocator_free(&da->a, alloc_tags);
+	fy_parent_allocator_free(&da->a, (void *)alloc_ids);
+	return -1;
+}
+
+static void fy_dedup_trim_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return;
+
+	fy_dedup_tag_trim(da, dt);
+}
+
+static void fy_dedup_reset_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	/* if it can't free an individual tag it can't reset it */
+	if (!(da->parent_caps & FYACF_CAN_FREE_TAG))
+		return;
+
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return;
+
+	fy_dedup_tag_reset(da, dt);
+}
+
+static struct fy_allocator_info *
+fy_dedup_get_info(struct fy_allocator *a, int tag)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	struct fy_allocator_info *info;
+	struct fy_allocator_tag_info *tag_info, *content_tag_info;
+	unsigned int i;
+
+	/* full dump not supported yet */
+	if (tag == FY_ALLOC_TAG_NONE)
+		return NULL;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	dt = fy_dedup_tag_from_tag(da, tag);
+	if (!dt)
+		return NULL;
+
+	/* we only return the content tag info */
+	info = fy_allocator_get_info(da->parent_allocator, dt->content_tag);
+	if (!info)
+		return NULL;
+
+	/* we will have to change the tag from content to this one */
+	content_tag_info = NULL;
+	for (i = 0; i < info->num_tag_infos; i++) {
+		tag_info = &info->tag_infos[i];
+		if (tag_info->tag == dt->content_tag) {
+			content_tag_info = tag_info;
+			break;
+		}
+	}
+	if (!content_tag_info)
+		return NULL;
+
+	/* copy to the first */
+	content_tag_info->tag = tag;
+	if (content_tag_info != &info->tag_infos[0])
+		info->tag_infos[0] = *content_tag_info;
+	info->num_tag_infos = 1;
+
+	return info;
+}
+
+static enum fy_allocator_cap_flags
+fy_dedup_get_caps(struct fy_allocator *a)
+{
+	struct fy_dedup_allocator *da;
+	enum fy_allocator_cap_flags flags;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+
+	flags = da->parent_caps | FYACF_CAN_DEDUP | FYACF_CAN_LOOKUP;
+	flags &= ~FYACF_CAN_FREE_INDIVIDUAL;
+
+	return flags;
+}
+
+static bool fy_dedup_contains(struct fy_allocator *a, int tag, const void *ptr)
+{
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	int tag_start, tag_end;
+
+	da = container_of(a, struct fy_dedup_allocator, a);
+	if (!(da->parent_caps & FYACF_HAS_CONTAINS))
+		return false;
+
+	if (tag >= 0) {
+		if (tag >= (int)da->tag_count)
+			return false;
+		tag_start = tag;
+		tag_end = tag + 1;
+	} else {
+		tag_start = 0;
+		tag_end = (int)da->tag_count;
+	}
+
+	for (tag = tag_start; tag < tag_end; tag++) {
+		dt = fy_dedup_tag_from_tag(da, tag);
+		if (!dt)
+			continue;
+
+		if (fy_allocator_contains(da->parent_allocator, dt->content_tag, ptr))
+			return true;
+	}
+	return false;
+}
+
+const struct fy_allocator_ops fy_dedup_allocator_ops = {
+	.setup = fy_dedup_setup,
+	.cleanup = fy_dedup_cleanup,
+	.create = fy_dedup_create,
+	.destroy = fy_dedup_destroy,
+	.dump = fy_dedup_dump,
+	.alloc = fy_dedup_alloc,
+	.free = fy_dedup_free,
+	.update_stats = fy_dedup_update_stats,
+	.storev = fy_dedup_storev,
+	.lookupv = fy_dedup_lookupv,
+	.release = fy_dedup_release,
+	.get_tag = fy_dedup_get_tag,
+	.release_tag = fy_dedup_release_tag,
+	.get_tag_count = fy_dedup_get_tag_count,
+	.set_tag_count = fy_dedup_set_tag_count,
+	.trim_tag = fy_dedup_trim_tag,
+	.reset_tag = fy_dedup_reset_tag,
+	.get_info = fy_dedup_get_info,
+	.get_caps = fy_dedup_get_caps,
+	.contains = fy_dedup_contains,
+};

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-dedup.h
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-dedup.h
@@ -1,0 +1,90 @@
+/*
+ * fy-allocator-dedup.h - the dedup allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ALLOCATOR_DEDUP_H
+#define FY_ALLOCATOR_DEDUP_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "fy-typelist.h"
+#include "fy-id.h"
+#include "xxhash.h"
+
+#include "fy-atomics.h"
+#include "fy-allocator.h"
+
+#define FY_DEDUP_TAG_MAX	128
+
+struct fy_dedup_entry {
+	struct fy_dedup_entry *next;
+	uint64_t hash;
+	size_t size;
+	void *mem;
+};
+
+struct fy_dedup_tag;
+
+struct fy_dedup_tag_data_cfg {
+	struct fy_dedup_allocator *da;
+	struct fy_dedup_tag *dt;
+	unsigned int bloom_filter_bits;
+	unsigned int bucket_count_bits;
+	size_t dedup_threshold;
+	unsigned int chain_length_grow_trigger;
+};
+
+struct fy_dedup_tag_data {
+	struct fy_dedup_tag_data *next;
+	struct fy_dedup_tag_data_cfg cfg;
+	unsigned int bloom_filter_bits;
+	unsigned int bloom_filter_mask;
+	size_t bloom_id_count;
+	fy_id_bits *bloom_id;
+	fy_id_bits *bloom_update_id;
+	unsigned int bucket_count_bits;
+	unsigned int bucket_count_mask;
+	size_t bucket_count;
+	FY_ATOMIC(struct fy_dedup_entry *) *buckets;
+	size_t bucket_id_count;
+	fy_id_bits *buckets_in_use;
+	size_t dedup_threshold;
+	unsigned int chain_length_grow_trigger;
+};
+
+struct fy_dedup_tag {
+	FY_ATOMIC(struct fy_dedup_tag_data *)tag_datas;
+	int content_tag;
+	int entries_tag;
+	fy_atomic_flag growing;
+	FY_ATOMIC(uint64_t) unique_stores;
+	FY_ATOMIC(uint64_t) dup_stores;
+	FY_ATOMIC(uint64_t) collisions;
+};
+
+struct fy_dedup_allocator {
+	struct fy_allocator a;
+	struct fy_dedup_allocator_cfg cfg;
+	struct fy_allocator *parent_allocator;
+	enum fy_allocator_cap_flags parent_caps;
+	int entries_tag;
+	unsigned int bloom_filter_bits;
+	unsigned int bucket_count_bits;
+	size_t dedup_threshold;
+	unsigned int chain_length_grow_trigger;
+	fy_id_bits *ids;
+	unsigned int tag_id_count;
+	struct fy_dedup_tag *tags;
+	unsigned int tag_count;
+};
+
+extern const struct fy_allocator_ops fy_dedup_allocator_ops;
+
+#define FY_DEDUP_XXHASH64_SEED	FY_XXHASH64_SEED
+
+#endif

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-linear.c
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-linear.c
@@ -1,0 +1,395 @@
+/*
+ * fy-allocator-linear.c - linear allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdalign.h>
+#include <time.h>
+#include <inttypes.h>
+#include <math.h>
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+
+#include <stdio.h>
+
+#include "fy-utils.h"
+#include "fy-allocator-linear.h"
+
+static int fy_linear_setup(struct fy_allocator *a, struct fy_allocator *parent, int parent_tag, const void *cfg_data)
+{
+	struct fy_linear_allocator *la;
+	const struct fy_linear_allocator_cfg *cfg;
+	void *buf, *alloc = NULL;
+	bool need_zero;
+
+	if (!a || !cfg_data)
+		return -1;
+
+	cfg = cfg_data;
+	if (!cfg->size)
+		return -1;
+
+	if (!cfg->buf) {
+		alloc = fy_early_parent_allocator_alloc(parent, parent_tag, cfg->size, 0);
+		if (!alloc)
+			goto err_out;
+		buf = alloc;
+		need_zero = true;
+	} else {
+		buf = cfg->buf;
+		need_zero = false;
+	}
+
+	la = container_of(a, struct fy_linear_allocator, a);
+	memset(la, 0, sizeof(*la));
+	la->a.name = "linear";
+	la->a.ops = &fy_linear_allocator_ops;
+	la->a.parent = parent;
+	la->a.parent_tag = parent_tag;
+	la->cfg = *cfg;
+	la->alloc = alloc;
+	la->start = buf;
+	la->need_zero = need_zero;
+
+	fy_atomic_store(&la->next, 0);
+
+	return 0;
+err_out:
+	fy_early_parent_allocator_free(parent, parent_tag, alloc);
+	return -1;
+}
+
+static void fy_linear_cleanup(struct fy_allocator *a)
+{
+	struct fy_linear_allocator *la;
+
+	if (!a)
+		return;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+	fy_parent_allocator_free(&la->a, la->alloc);
+	la->alloc = NULL;
+}
+
+struct fy_allocator *fy_linear_create(struct fy_allocator *parent, int parent_tag, const void *cfg_data)
+{
+	struct fy_linear_allocator *la;
+	const struct fy_linear_allocator_cfg *cfg;
+	struct fy_linear_allocator_cfg newcfg;
+	void *s, *e, *buf, *alloc = NULL;
+	int rc;
+
+	if (!cfg_data)
+		return NULL;
+
+	cfg = cfg_data;
+	if (!cfg->size)
+		return NULL;
+
+	if (!cfg->buf) {
+		alloc = fy_early_parent_allocator_alloc(parent, parent_tag, cfg->size, 0);
+		if (!alloc)
+			goto err_out;
+		buf = alloc;
+	} else
+		buf = cfg->buf;
+
+	s = buf;
+	e = (char *)s + cfg->size;
+
+	s = fy_ptr_align(s, _Alignof(struct fy_linear_allocator));
+	if ((size_t)((char *)e - (char *)s) < sizeof(*la))
+		goto err_out;
+
+	la = s;
+	s = (char *)s + sizeof(*la);
+
+	memset(&newcfg, 0, sizeof(newcfg));
+	newcfg.buf = s;
+	newcfg.size = (size_t)((char *)e - (char *)s);
+
+	rc = fy_linear_setup(&la->a, parent, parent_tag, &newcfg);
+	if (rc)
+		goto err_out;
+
+	la->alloc = alloc;
+
+	return &la->a;
+
+err_out:
+	fy_early_parent_allocator_free(parent, parent_tag, alloc);
+	return NULL;
+}
+
+void fy_linear_destroy(struct fy_allocator *a)
+{
+	struct fy_linear_allocator *la;
+	struct fy_allocator *parent;
+	int parent_tag;
+	void *alloc;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+
+	/* take out the allocation of create */
+	alloc = la->alloc;
+	la->alloc = NULL;
+	parent = la->a.parent;
+	parent_tag = la->a.parent_tag;
+
+	fy_linear_cleanup(a);
+
+	fy_early_parent_allocator_free(parent, parent_tag, alloc);
+}
+
+void fy_linear_dump(struct fy_allocator *a)
+{
+	struct fy_linear_allocator *la;
+	size_t next;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+
+	next = fy_atomic_load(&la->next);
+	fprintf(stderr, "linear: total %zu used %zu free %zu\n",
+			la->cfg.size, next, la->cfg.size - la->next);
+}
+
+static void *fy_linear_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	struct fy_linear_allocator *la;
+	size_t next, new_next, real_size;
+	void *s;
+
+	assert(a);
+
+	la = container_of(a, struct fy_linear_allocator, a);
+
+	/* atomically update the pointer */
+	do {
+		next = fy_atomic_load(&la->next);
+		s = fy_ptr_align((char *)la->start + next, align);
+		new_next = (size_t)(((char *)s + size) - (char *)la->start);
+		/* handle both overflow and underflow */
+		if (new_next > la->cfg.size)
+			goto err_out;
+	} while (!fy_atomic_compare_exchange_strong(&la->next, &next, new_next));
+
+	real_size = new_next - next;
+
+	/* only update stats if someone asked for it */
+	if (a->flags & FYAF_KEEP_STATS) {
+		fy_atomic_fetch_add(&la->allocations, 1);
+		fy_atomic_fetch_add(&la->allocated, real_size);
+	}
+
+	/* zero out buffer if not guaranteed */
+	if (la->need_zero)
+		memset(s, 0, size);
+
+	return s;
+
+err_out:
+	return NULL;
+}
+
+static void fy_linear_free(struct fy_allocator *a, int tag, void *data)
+{
+	/* linear allocator does not free anything */
+}
+
+static int fy_linear_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	struct fy_linear_allocator *la;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+
+	stats->allocations = fy_atomic_get_and_clear_counter(&la->allocations);
+	stats->allocated = fy_atomic_get_and_clear_counter(&la->allocated);
+
+	return 0;
+}
+
+static const void *fy_linear_storev(struct fy_allocator *a, int tag,
+				    const struct iovec *iov, int iovcnt, size_t align,
+				    uint64_t hash)
+{
+	struct fy_linear_allocator *la;
+	void *p;
+	size_t size;
+
+	size = fy_iovec_size(iov, iovcnt);
+	if (size == SIZE_MAX)
+		return NULL;
+
+	p = fy_linear_alloc(a, tag, size, align);
+	if (!p)
+		return NULL;
+
+	fy_iovec_copy_from(iov, iovcnt, p);
+
+	if (a->flags & FYAF_KEEP_STATS) {
+		la = container_of(a, struct fy_linear_allocator, a);
+		fy_atomic_fetch_add(&la->stores, 1);
+		fy_atomic_fetch_add(&la->stores, size);
+	}
+
+	return p;
+}
+
+static const void *fy_linear_lookupv(struct fy_allocator *a, int tag,
+				    const struct iovec *iov, int iovcnt, size_t align,
+				    uint64_t hash)
+{
+	/* no way to lookup */
+	return NULL;
+}
+
+static void fy_linear_release(struct fy_allocator *a, int tag, const void *data, size_t size)
+{
+	/* nothing */
+}
+
+static int fy_linear_get_tag(struct fy_allocator *a)
+{
+	/* always return 0, we don't do tags for linear */
+	return 0;
+}
+
+static void fy_linear_release_tag(struct fy_allocator *a, int tag)
+{
+	/* nothing */
+}
+
+static int fy_linear_get_tag_count(struct fy_allocator *a)
+{
+	return 1;
+}
+
+static int fy_linear_set_tag_count(struct fy_allocator *a, unsigned int count)
+{
+	if (count != 1)
+		return -1;
+	return 0;
+}
+
+static void fy_linear_trim_tag(struct fy_allocator *a, int tag)
+{
+	/* nothing */
+}
+
+static void fy_linear_reset_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_linear_allocator *la;
+
+	if (tag)
+		return;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+
+	/* we just rewind */
+	fy_atomic_store(&la->next, 0);
+}
+
+static struct fy_allocator_info *fy_linear_get_info(struct fy_allocator *a, int tag)
+{
+	struct fy_linear_allocator *la;
+	struct fy_allocator_info *info;
+	struct fy_allocator_tag_info *tag_info;
+	struct fy_allocator_arena_info *arena_info;
+	size_t next, size;
+
+	/* only single tag (or all tags with 0) */
+	if (tag != 0 && tag != FY_ALLOC_TAG_NONE)
+		return NULL;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+
+	/* one of each */
+	size = sizeof(*info) +
+	       sizeof(*tag_info) +
+	       sizeof(*arena_info);
+
+	info = malloc(size);
+	if (!info)
+		return NULL;
+	memset(info, 0, sizeof(*info));
+
+	tag_info = (void *)(info + 1);
+	assert(((uintptr_t)tag_info % _Alignof(struct fy_allocator_tag_info)) == 0);
+	arena_info = (void *)(tag_info + 1);
+	assert(((uintptr_t)arena_info % _Alignof(struct fy_allocator_arena_info)) == 0);
+
+	/* fill-in the single arena */
+	next = fy_atomic_load(&la->next);
+
+	arena_info->free = la->cfg.size - next;
+	arena_info->used = next;
+	arena_info->total = la->cfg.size;
+	arena_info->data = la->start;
+	arena_info->size = arena_info->used;
+
+	/* there's a single tag for linear */
+	tag_info->tag = 0;
+	tag_info->free = arena_info->free;
+	tag_info->used = arena_info->used;
+	tag_info->total = arena_info->total;
+	tag_info->num_arena_infos = 1;
+	tag_info->arena_infos = arena_info;
+
+	/* fill in the single tag */
+	info->free = tag_info->free;
+	info->used = tag_info->used;
+	info->total = tag_info->total;
+	info->num_tag_infos = 1;
+	info->tag_infos = tag_info;
+
+	return info;
+}
+
+static enum fy_allocator_cap_flags
+fy_linear_get_caps(struct fy_allocator *a)
+{
+	return FYACF_HAS_CONTAINS | FYACF_HAS_EFFICIENT_CONTAINS;
+}
+
+static bool fy_linear_contains(struct fy_allocator *a, int tag, const void *ptr)
+{
+	struct fy_linear_allocator *la;
+
+	la = container_of(a, struct fy_linear_allocator, a);
+	return (char *)ptr >= (char *)la->start &&
+	       (char *)ptr < ((char *)la->start + la->cfg.size);
+}
+
+const struct fy_allocator_ops fy_linear_allocator_ops = {
+	.setup = fy_linear_setup,
+	.cleanup = fy_linear_cleanup,
+	.create = fy_linear_create,
+	.destroy = fy_linear_destroy,
+	.dump = fy_linear_dump,
+	.alloc = fy_linear_alloc,
+	.free = fy_linear_free,
+	.update_stats = fy_linear_update_stats,
+	.storev = fy_linear_storev,
+	.lookupv = fy_linear_lookupv,
+	.release = fy_linear_release,
+	.get_tag = fy_linear_get_tag,
+	.release_tag = fy_linear_release_tag,
+	.get_tag_count = fy_linear_get_tag_count,
+	.set_tag_count = fy_linear_set_tag_count,
+	.trim_tag = fy_linear_trim_tag,
+	.reset_tag = fy_linear_reset_tag,
+	.get_info = fy_linear_get_info,
+	.get_caps = fy_linear_get_caps,
+	.contains = fy_linear_contains,
+};

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-linear.h
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-linear.h
@@ -1,0 +1,35 @@
+/*
+ * fy-allocator-linear.h - the linear allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ALLOCATOR_LINEAR_H
+#define FY_ALLOCATOR_LINEAR_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "fy-align.h"
+#include "fy-atomics.h"
+#include "fy-allocator.h"
+
+struct fy_linear_allocator {
+	FY_ATOMIC(size_t) next FY_CACHELINE_ALIGN;	// hot hot hot
+	struct fy_allocator a;
+	struct fy_linear_allocator_cfg cfg;
+	void *alloc;
+	void *start;
+	bool need_zero;
+	/* no need to keep anything else */
+	FY_ATOMIC(uint64_t) allocations;
+	FY_ATOMIC(uint64_t) allocated;
+	FY_ATOMIC(uint64_t) stores;
+	FY_ATOMIC(uint64_t) stored;
+};
+
+extern const struct fy_allocator_ops fy_linear_allocator_ops;
+
+#endif

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-malloc.c
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-malloc.c
@@ -1,0 +1,718 @@
+/*
+ * fy-allocator-malloc.c - malloc allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdalign.h>
+#include <time.h>
+#include <inttypes.h>
+#include <stdio.h>
+
+/* for container_of */
+#include "fy-list.h"
+#include "fy-utils.h"
+#include "fy-align.h"
+#include "fy-win32.h"
+
+#include "fy-allocator-malloc.h"
+
+static inline void
+fy_malloc_tag_list_lock(struct fy_malloc_tag *mt)
+{
+	int loops FY_DEBUG_UNUSED;
+
+	loops = 0;
+	while (!fy_atomic_flag_test_and_set(&mt->lock)) {
+		loops++;
+		assert(loops < 10000000);
+		fy_cpu_relax();
+	}
+}
+
+static inline void
+fy_malloc_tag_list_unlock(struct fy_malloc_tag *mt)
+{
+	fy_atomic_flag_clear(&mt->lock);
+}
+
+static inline struct fy_malloc_tag *
+fy_malloc_tag_from_tag(struct fy_malloc_allocator *ma, int tag)
+{
+	if (!ma)
+		return NULL;
+
+	if ((unsigned int)tag >= ma->tag_count)
+		return NULL;
+
+	if (!fy_id_is_used(ma->ids, ma->tag_id_count, (int)tag))
+		return NULL;
+
+	return &ma->tags[tag];
+}
+
+static void fy_malloc_tag_setup(struct fy_malloc_allocator *ma, struct fy_malloc_tag *mt)
+{
+	fy_malloc_entry_list_init(&mt->entries);
+	atomic_flag_clear(&mt->lock);
+}
+
+static void fy_malloc_tag_cleanup(struct fy_malloc_allocator *ma, struct fy_malloc_tag *mt)
+{
+	struct fy_malloc_entry *me;
+
+	/* cleanup should happen from a single thread */
+	while ((me = fy_malloc_entry_list_pop(&mt->entries)) != NULL)
+		fy_align_free(me->mem);
+}
+
+static void fy_malloc_cleanup(struct fy_allocator *a)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	unsigned int i;
+
+	if (!a)
+		return;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	/* no need for locks, this is one thread only */
+	for (i = 0; i < ma->tag_count; i++) {
+		mt = fy_malloc_tag_from_tag(ma, i);
+		if (!mt)
+			continue;
+		fy_malloc_tag_cleanup(ma, mt);
+	}
+
+	fy_parent_allocator_free(&ma->a, (void *)ma->ids);
+	fy_parent_allocator_free(&ma->a, (void *)ma->tags);
+}
+
+static int fy_malloc_setup(struct fy_allocator *a, struct fy_allocator *parent, int parent_tag, const void *data)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	size_t tmpsz;
+
+	if (!a)
+		return -1;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	memset(ma, 0, sizeof(*ma));
+	ma->a.name = "malloc";
+	ma->a.ops = &fy_malloc_allocator_ops;
+	ma->a.parent = parent;
+	ma->a.parent_tag = parent_tag;
+
+	ma->tag_count = FY_MALLOC_TAG_MAX;
+	ma->tag_id_count = (ma->tag_count + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+
+	tmpsz = ma->tag_id_count * sizeof(*ma->ids);
+	ma->ids = fy_parent_allocator_alloc(&ma->a, tmpsz, _Alignof(fy_id_bits));
+	if (!ma->ids)
+		goto err_out;
+	fy_id_reset(ma->ids, ma->tag_id_count);
+
+	tmpsz = ma->tag_count * sizeof(*ma->tags);
+	ma->tags = fy_parent_allocator_alloc(&ma->a, tmpsz, _Alignof(struct fy_malloc_tag));
+	if (!ma->tags)
+		goto err_out;
+
+	/* start with tag 0 as general use */
+	fy_id_set_used(ma->ids, ma->tag_id_count, 0);
+	mt = fy_malloc_tag_from_tag(ma, 0);
+	fy_malloc_tag_setup(ma, mt);
+
+	return 0;
+
+err_out:
+	fy_malloc_cleanup(a);
+	return -1;
+}
+
+struct fy_allocator *fy_malloc_create(struct fy_allocator *parent, int parent_tag, const void *cfg)
+{
+	struct fy_malloc_allocator *ma = NULL;
+	int rc;
+
+	ma = fy_early_parent_allocator_alloc(parent, parent_tag, sizeof(*ma), _Alignof(struct fy_malloc_allocator));
+	if (!ma)
+		goto err_out;
+
+	rc = fy_malloc_setup(&ma->a, parent, parent_tag, cfg);
+	if (rc)
+		goto err_out;
+
+	return &ma->a;
+
+err_out:
+	fy_early_parent_allocator_free(parent, parent_tag, ma);
+	return NULL;
+}
+
+void fy_malloc_destroy(struct fy_allocator *a)
+{
+	struct fy_malloc_allocator *ma;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	fy_malloc_cleanup(a);
+
+	fy_parent_allocator_free(a, ma);
+}
+
+void fy_malloc_dump(struct fy_allocator *a)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	struct fy_malloc_entry *me;
+	unsigned int i;
+	size_t count, total, system_total;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	fprintf(stderr, "malloc: ");
+	for (i = 0; i < ma->tag_count; i++) {
+		mt = fy_malloc_tag_from_tag(ma, i);
+		if (!mt)
+			continue;
+		fy_malloc_tag_list_lock(mt);
+		fprintf(stderr, "%c", fy_malloc_entry_list_empty(&mt->entries) ? '.' : 'x');
+		fy_malloc_tag_list_unlock(mt);
+	}
+	fprintf(stderr, "\n");
+
+	for (i = 0; i < ma->tag_count; i++) {
+		mt = fy_malloc_tag_from_tag(ma, i);
+		if (!mt)
+			continue;
+		fy_malloc_tag_list_lock(mt);
+		count = total = system_total = 0;
+		if (!fy_malloc_entry_list_empty(&mt->entries)) {
+			for (me = fy_malloc_entry_list_head(&mt->entries); me; me = fy_malloc_entry_next(&mt->entries, me)) {
+				count++;
+				total += me->size;
+				system_total += sizeof(*me) + me->size;
+			}
+		}
+		fy_malloc_tag_list_unlock(mt);
+		if (!count)
+			continue;
+		fprintf(stderr, "  %d: count %zu total %zu system %zu overhead %zu (%2.2f%%)\n", i,
+				count, total, system_total, system_total - total,
+				100.0 * (double)(system_total - total) / (double)system_total);
+	}
+}
+
+static void *fy_malloc_tag_alloc(struct fy_malloc_allocator *ma, struct fy_malloc_tag *mt, size_t size, size_t align)
+{
+	struct fy_malloc_entry *me;
+	size_t me_offset, max_align;
+	void *mem;
+
+	me_offset = fy_size_t_align(size, _Alignof(struct fy_malloc_entry));
+	max_align = align > _Alignof(struct fy_malloc_entry) ? align : _Alignof(struct fy_malloc_entry);
+
+	mem = fy_align_alloc(max_align, me_offset + sizeof(*me));
+	if (!mem)
+		return NULL;
+
+	me = (void *)((char *)mem + me_offset);
+
+	me->size = size;
+	fy_malloc_tag_list_lock(mt);
+	fy_malloc_entry_list_add_tail(&mt->entries, me);
+	fy_malloc_tag_list_unlock(mt);
+	me->mem = mem;
+
+	return mem;
+}
+
+static void fy_malloc_tag_free(struct fy_malloc_allocator *ma, struct fy_malloc_tag *mt, void *data)
+{
+	struct fy_malloc_entry *me;
+
+	me = container_of(data, struct fy_malloc_entry, mem);
+
+	fy_malloc_tag_list_lock(mt);
+	fy_malloc_entry_list_del(&mt->entries, me);
+	fy_malloc_tag_list_unlock(mt);
+
+	fy_align_free(me->mem);
+}
+
+static void *fy_malloc_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	void *p;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		goto err_out;
+
+	p = fy_malloc_tag_alloc(ma, mt, size, align);
+	if (!p)
+		goto err_out;
+
+	mt->stats.allocations++;
+	mt->stats.allocated += size;
+
+	return p;
+
+err_out:
+	return NULL;
+}
+
+static void fy_malloc_free(struct fy_allocator *a, int tag, void *data)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		return;
+
+	fy_malloc_tag_free(ma, mt, data);
+
+	mt->stats.frees++;
+}
+
+static int fy_malloc_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	unsigned int i;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		goto err_out;
+
+	/* and update with this ones */
+	for (i = 0; i < ARRAY_SIZE(mt->stats.counters); i++) {
+		stats->counters[i] += mt->stats.counters[i];
+		mt->stats.counters[i] = 0;
+	}
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static const void *fy_malloc_storev(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	void *start;
+	size_t total_size;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		goto err_out;
+
+	total_size = fy_iovec_size(iov, iovcnt);
+	if (total_size == SIZE_MAX)
+		goto err_out;
+
+	start = fy_malloc_tag_alloc(ma, mt, total_size, align);
+	if (!start)
+		goto err_out;
+
+	fy_iovec_copy_from(iov, iovcnt, start);
+
+	mt->stats.stores++;
+	mt->stats.stored += total_size;
+
+	return start;
+
+err_out:
+	return NULL;
+}
+
+static const void *fy_malloc_lookupv(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	/* no lookups */
+	return NULL;
+}
+
+static void fy_malloc_release(struct fy_allocator *a, int tag, const void *data, size_t size)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		return;
+
+	/* the malloc's release is just a free */
+	fy_malloc_tag_free(ma, mt, (void *)data);
+
+	mt->stats.releases++;
+	mt->stats.released += size;
+}
+
+static void fy_malloc_release_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		return;
+
+	fy_malloc_tag_cleanup(ma, mt);
+
+	fy_id_free(ma->ids, ma->tag_id_count, tag);
+}
+
+static int fy_malloc_get_tag(struct fy_allocator *a)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	int id;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	id = fy_id_alloc(ma->ids, ma->tag_id_count);
+	if (id < 0)
+		goto err_out;
+
+	mt = fy_malloc_tag_from_tag(ma, id);
+	if (!mt)
+		goto err_out;
+
+	fy_malloc_tag_setup(ma, mt);
+
+	return (int)id;
+
+err_out:
+	return FY_ALLOC_TAG_ERROR;
+}
+
+static int fy_malloc_get_tag_count(struct fy_allocator *a)
+{
+	struct fy_malloc_allocator *ma;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	return ma->tag_count;
+}
+
+static int fy_malloc_set_tag_count(struct fy_allocator *a, unsigned int count)
+{
+	struct fy_malloc_allocator *ma;
+	fy_id_bits *ids = NULL;
+	struct fy_malloc_tag *mt, *mt_new, *tags = NULL;
+	struct fy_malloc_entry *me;
+	unsigned int i, tag_count, tag_id_count;
+	size_t tmpsz;
+
+	if (count < 1)
+		return -1;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	if (count == ma->tag_count)
+		return 0;
+
+	tag_count = count;
+	tag_id_count = (tag_count + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+
+	/* shrink?, just clip */
+	if (count < ma->tag_count) {
+		for (i = count; i < ma->tag_count; i++) {
+			mt = fy_malloc_tag_from_tag(ma, i);
+			if (!mt)
+				continue;
+			fy_malloc_tag_cleanup(ma, mt);
+			fy_id_free(ma->ids, ma->tag_id_count, i);
+		}
+		tags = ma->tags;
+		ids = ma->ids;
+	} else {
+		/* we need to grow */
+		tmpsz = tag_id_count * sizeof(*ma->ids);
+		ids = fy_parent_allocator_alloc(&ma->a, tmpsz, _Alignof(fy_id_bits));
+		if (!ids)
+			goto err_out;
+		fy_id_reset(ids, tag_id_count);
+
+		tmpsz = tag_count * sizeof(*tags);
+		tags = fy_parent_allocator_alloc(&ma->a, tmpsz, _Alignof(struct fy_malloc_tag));
+		if (!tags)
+			goto err_out;
+
+		/* copy over the old entries */
+		for (i = 0; i < ma->tag_count; i++) {
+
+			mt = fy_malloc_tag_from_tag(ma, i);
+			if (!mt)
+				continue;
+
+			mt_new = &tags[i];
+
+			fy_malloc_tag_setup(ma, mt_new);
+			/* move the old entries over */
+			fy_malloc_tag_list_lock(mt);
+			while ((me = fy_malloc_entry_list_pop(&mt->entries)) != NULL)
+				fy_malloc_entry_list_add_tail(&mt_new->entries, me);
+			fy_malloc_tag_list_unlock(mt);
+			memcpy(&mt_new->stats, &mt->stats, sizeof(mt->stats));
+
+			/* clean the old entry */
+			fy_malloc_tag_cleanup(ma, mt);
+
+			fy_id_set_used(ids, tag_id_count, i);
+		}
+	}
+
+	if (ma->tags != tags) {
+		ma->tags = tags;
+		fy_parent_allocator_free(&ma->a, ma->tags);
+	}
+	if (ma->ids != ids) {
+		ma->ids = ids;
+		fy_parent_allocator_free(&ma->a, (void *)ma->ids);
+	}
+	ma->tag_count = tag_count;
+	ma->tag_id_count = tag_id_count;
+	return 0;
+
+err_out:
+	fy_parent_allocator_free(&ma->a, tags);
+	fy_parent_allocator_free(&ma->a, (void *)ids);
+	return -1;
+}
+
+static void fy_malloc_trim_tag(struct fy_allocator *a, int tag)
+{
+	/* nothing */
+}
+
+static void fy_malloc_reset_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	struct fy_malloc_entry *me;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	mt = fy_malloc_tag_from_tag(ma, tag);
+	if (!mt)
+		return;
+
+	/* no lock, reset is single thread only */
+	while ((me = fy_malloc_entry_list_pop(&mt->entries)) != NULL)
+		fy_align_free(me);
+}
+
+static struct fy_allocator_info *
+fy_malloc_get_info(struct fy_allocator *a, int tag)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	struct fy_malloc_entry *me;
+	struct fy_allocator_info *info;
+	struct fy_allocator_tag_info *tag_info;
+	struct fy_allocator_arena_info *arena_info;
+	size_t size, free, used, total;
+	size_t tag_free, tag_used, tag_total;
+	size_t arena_free, arena_used, arena_total;
+	unsigned int num_tags, num_arenas, i;
+	int id;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+
+	/* allocate for the worst case always */
+	num_tags = 0;
+	num_arenas = 0;
+
+	free = 0;
+	used = 0;
+	total = 0;
+
+	/* two passes */
+	for (i = 0; i < 2; i++) {
+
+		if (!i) {
+			info = NULL;
+			tag_info = NULL;
+			arena_info = NULL;
+
+		} else {
+			size = sizeof(*info) +
+                               sizeof(*tag_info) * num_tags +
+			       sizeof(*arena_info) * num_arenas;
+
+			info = malloc(size);
+			if (!info)
+				return NULL;
+			memset(info, 0, sizeof(*info));
+
+			tag_info = (void *)(info + 1);
+			assert(((uintptr_t)tag_info % _Alignof(struct fy_allocator_tag_info)) == 0);
+			arena_info = (void *)(tag_info + num_tags);
+			assert(((uintptr_t)arena_info % _Alignof(struct fy_allocator_arena_info)) == 0);
+
+			info->free = free;
+			info->used = used;
+			info->total = total;
+
+			info->num_tag_infos = 0;
+			info->tag_infos = tag_info;
+		}
+
+		free = 0;
+		used = 0;
+		total = sizeof(*ma);
+
+		for (id = 0; id < (int)ma->tag_count; id++) {
+
+			if (!fy_id_is_used(ma->ids, ma->tag_id_count, id))
+				continue;
+
+			mt = &ma->tags[id];
+
+			tag_free = 0;
+			tag_used = 0;
+			tag_total = 0;
+
+			if (i) {
+				tag_info->num_arena_infos = 0;
+				tag_info->arena_infos = arena_info;
+			}
+
+			fy_malloc_tag_list_lock(mt);
+
+			for (me = fy_malloc_entry_list_head(&mt->entries); me; me = fy_malloc_entry_next(&mt->entries, me)) {
+				arena_free = 0;
+				arena_used = me->size;
+				arena_total = sizeof(*me) + me->size;
+
+				tag_free += arena_free;
+				tag_used += arena_used;
+				tag_total += arena_total;
+
+				if (!i) {
+					num_arenas++;
+				} else {
+					arena_info->free = arena_free;
+					arena_info->used = arena_used;
+					arena_info->total = arena_total;
+					arena_info->data = me->mem;
+					arena_info->size = me->size;
+					arena_info++;
+					tag_info->num_arena_infos++;
+				}
+			}
+			fy_malloc_tag_list_unlock(mt);
+
+			if (!i) {
+				num_tags++;
+			} else {
+
+				/* only store the tag if there's a match */
+				if (tag == FY_ALLOC_TAG_NONE || tag == id) {
+					tag_info->tag = id;
+					tag_info->free = tag_free;
+					tag_info->used = tag_used;
+					tag_info->total = tag_total;
+					tag_info++;
+					info->num_tag_infos++;
+				}
+			}
+
+			free += tag_free;
+			used += tag_used;
+			total += tag_total;
+		}
+	}
+
+	return info;
+}
+
+static enum fy_allocator_cap_flags
+fy_malloc_get_caps(struct fy_allocator *a)
+{
+	return FYACF_CAN_FREE_INDIVIDUAL | FYACF_CAN_FREE_TAG |
+	       FYACF_HAS_CONTAINS | FYACF_HAS_TAGS;
+}
+
+/* malloc allocator actually tracks allocations, it's just very inefficient
+ * to scan through. It might be good for debugging though
+ */
+static bool fy_malloc_contains(struct fy_allocator *a, int tag, const void *ptr)
+{
+	struct fy_malloc_allocator *ma;
+	struct fy_malloc_tag *mt;
+	struct fy_malloc_entry *me;
+	int tag_start, tag_end;
+
+	ma = container_of(a, struct fy_malloc_allocator, a);
+	if (tag >= 0) {
+		if (tag >= (int)ma->tag_count)
+			return false;
+		tag_start = tag;
+		tag_end = tag_start + 1;
+	} else {
+		tag_start = 0;
+		tag_end = ma->tag_count;
+	}
+
+	for (tag = tag_start; tag < tag_end; tag++) {
+		mt = fy_malloc_tag_from_tag(ma, tag);
+		if (!mt)
+			continue;
+
+		fy_malloc_tag_list_lock(mt);
+		for (me = fy_malloc_entry_list_head(&mt->entries); me;
+		     me = fy_malloc_entry_next(&mt->entries, me)) {
+
+			if (ptr >= (void *)me->mem &&
+			    ptr < (void *)((char *)me->mem + me->size)) {
+				fy_malloc_tag_list_unlock(mt);
+				return true;
+			}
+		}
+		fy_malloc_tag_list_unlock(mt);
+	}
+
+	return false;
+}
+
+const struct fy_allocator_ops fy_malloc_allocator_ops = {
+	.setup = fy_malloc_setup,
+	.cleanup = fy_malloc_cleanup,
+	.create = fy_malloc_create,
+	.destroy = fy_malloc_destroy,
+	.dump = fy_malloc_dump,
+	.alloc = fy_malloc_alloc,
+	.free = fy_malloc_free,
+	.update_stats = fy_malloc_update_stats,
+	.storev = fy_malloc_storev,
+	.lookupv = fy_malloc_lookupv,
+	.release = fy_malloc_release,
+	.get_tag = fy_malloc_get_tag,
+	.release_tag = fy_malloc_release_tag,
+	.get_tag_count = fy_malloc_get_tag_count,
+	.set_tag_count = fy_malloc_set_tag_count,
+	.trim_tag = fy_malloc_trim_tag,
+	.reset_tag = fy_malloc_reset_tag,
+	.get_info = fy_malloc_get_info,
+	.get_caps = fy_malloc_get_caps,
+	.contains = fy_malloc_contains,
+};

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-malloc.h
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-malloc.h
@@ -1,0 +1,49 @@
+/*
+ * fy-allocator-malloc.h - the malloc allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ALLOCATOR_MALLOC_H
+#define FY_ALLOCATOR_MALLOC_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "fy-typelist.h"
+#include "fy-id.h"
+
+#include "fy-atomics.h"
+#include "fy-allocator.h"
+
+struct fy_malloc_tag;
+
+FY_TYPE_FWD_DECL_LIST(malloc_entry);
+struct fy_malloc_entry {
+	struct list_head node;
+	size_t size;
+	void *mem;
+};
+FY_TYPE_DECL_LIST(malloc_entry);
+
+#define FY_MALLOC_TAG_MAX	32
+
+struct fy_malloc_tag {
+	fy_atomic_flag lock;
+	struct fy_malloc_entry_list entries;
+	struct fy_allocator_stats stats;
+};
+
+struct fy_malloc_allocator {
+	struct fy_allocator a;
+	fy_id_bits *ids;
+	unsigned int tag_id_count;
+	struct fy_malloc_tag *tags;
+	unsigned int tag_count;
+};
+
+extern const struct fy_allocator_ops fy_malloc_allocator_ops;
+
+#endif

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-mremap.c
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-mremap.c
@@ -1,0 +1,1222 @@
+/*
+ * fy-allocator-mremap.c - mremap allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdalign.h>
+#include <time.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+/* for container_of */
+#include "fy-align.h"
+#include "fy-list.h"
+#include "fy-utils.h"
+#include "fy-win32.h"
+
+#include "fy-allocator-mremap.h"
+
+// #define DEBUG_ARENA
+
+#if defined(__NetBSD__) || defined(_WIN32)
+#define DISABLE_MREMAP
+#endif
+
+#if HAVE_MREMAP && !defined(DISABLE_MREMAP)
+#define USE_MREMAP 1
+#else
+#define USE_MREMAP 0
+#endif
+
+#ifndef MREMAP_ALLOCATOR_DEFAULT_BIG_ALLOC_THRESHOLD
+#define MREMAP_ALLOCATOR_DEFAULT_BIG_ALLOC_THRESHOLD	SIZE_MAX
+#endif
+
+#ifndef MREMAP_ALLOCATOR_DEFAULT_EMPTY_THRESHOLD
+#define MREMAP_ALLOCATOR_DEFAULT_EMPTY_THRESHOLD	64
+#endif
+
+#ifndef MREMAP_ALLOCATOR_DEFAULT_MINIMUM_ARENA_SIZE
+#define MREMAP_ALLOCATOR_DEFAULT_MINIMUM_ARENA_SIZE	(1U << 20)	/* 1M */
+#endif
+
+#ifndef MREMAP_ALLOCATOR_DEFAULT_GROW_RATIO
+#define MREMAP_ALLOCATOR_DEFAULT_GROW_RATIO		2.0
+#endif
+
+#ifndef MREMAP_ALLOCATOR_DEFAULT_BALLON_RATIO
+#define MREMAP_ALLOCATOR_DEFAULT_BALLON_RATIO		32.0
+#endif
+
+#ifndef MREMAP_ALLOCATOR_DEFAULT_ARENA_TYPE
+#define MREMAP_ALLOCATOR_DEFAULT_ARENA_TYPE		FYMRAT_MMAP
+#endif
+
+static inline size_t fy_mremap_useable_arena_size(struct fy_mremap_allocator *mra, size_t size)
+{
+	return fy_size_t_align(size + FY_MREMAP_ARENA_OVERHEAD, mra->pagesz) -
+		FY_MREMAP_ARENA_OVERHEAD;
+}
+
+static inline bool fy_mremap_arena_available(struct fy_mremap_arena *mran)
+{
+	return mran->size - fy_atomic_load(&mran->next);
+}
+
+static inline bool fy_mremap_arena_check_fit(struct fy_mremap_arena *mran, size_t size, size_t align)
+{
+	size_t old_next, new_next;
+
+	old_next = fy_atomic_load(&mran->next);
+	new_next = fy_size_t_align(old_next, align) + size;
+	return new_next <= mran->size;
+}
+
+static struct fy_mremap_arena *
+fy_mremap_arena_create(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt, size_t size)
+{
+	struct fy_mremap_arena *mran = NULL;
+	uint64_t flags;
+	void *mem;
+	size_t size_page_align, balloon_size;
+#if !USE_MREMAP
+	int rc FY_DEBUG_UNUSED;
+#endif
+
+	if (size < mra->minimum_arena_size)
+		size = mra->minimum_arena_size;
+
+	/* need to be aligned to page boundary */
+	size_page_align = fy_size_t_align(fy_mremap_useable_arena_size(mra, size), mra->pagesz);
+	switch (mra->arena_type) {
+	case FYMRAT_MALLOC:
+		mran = malloc(size_page_align);
+		if (!mran)
+			return NULL;
+		memset(mran, 0, sizeof(*mran));
+		break;
+
+	case FYMRAT_MMAP:
+		/* allocate an initial ballooned size */
+		balloon_size = fy_size_t_align((size_t)(size_page_align * mra->balloon_ratio), mra->pagesz);
+		if (balloon_size == size_page_align)
+			balloon_size = size_page_align + mra->pagesz;
+		mem = mmap(NULL, balloon_size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+		if (mem == MAP_FAILED) {
+			/* first allocation failed, that's ok, try again */
+			mran = mmap(NULL, size_page_align, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+		} else {
+#if USE_MREMAP
+			mran = mremap(mem, balloon_size, size_page_align, 0);
+			/* either it fails, or it moves we handle it */
+#else
+			/* we don't shrink, we just unmap over the limit  */
+			rc = munmap((char *)mem + size_page_align, balloon_size - size_page_align);
+			if (rc) {
+#ifdef DEBUG_ARENA
+				fprintf(stderr, "%s: failed to unmap for shink\n", __func__);
+#endif
+				size_page_align = balloon_size;	/* keep the balloon size? */
+			}
+			mran = mem;
+#endif
+		}
+		if (mran == MAP_FAILED)
+			return NULL;
+		break;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	mran->next_arena = NULL;
+	flags = 0;
+	if (!fy_mremap_arena_type_is_growable(mra->arena_type))
+		flags |= FYMRAF_CANT_GROW;
+	fy_atomic_store(&mran->flags, flags);
+	mran->size = size_page_align;
+	fy_atomic_store(&mran->next, FY_MREMAP_ARENA_OVERHEAD);
+
+#ifdef DEBUG_ARENA
+	fprintf(stderr, "%s: #%zu created arena %p size=%zu (%zuMB)\n", __func__, mrt - mra->tags, mran, mran->size, mran->size >> 20);
+#endif
+
+	return mran;
+}
+
+static void fy_mremap_arena_destroy(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt, struct fy_mremap_arena *mran)
+{
+	if (!mran)
+		return;
+
+#ifdef DEBUG_ARENA
+	fprintf(stderr, "%s: #%zu destroy arena %p size=%zu (%zuMB)\n", __func__, mrt - mra->tags, mran, mran->size, mran->size >> 20);
+#endif
+	switch (mra->arena_type) {
+	case FYMRAT_MALLOC:
+		free(mran);
+		break;
+
+	case FYMRAT_MMAP:
+		(void)munmap(mran, mran->size);
+		break;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+}
+
+static inline bool
+fy_mremap_arena_should_grow(struct fy_mremap_allocator *mra, struct fy_mremap_arena *mran,
+			    size_t size, size_t align)
+{
+	size_t next;
+
+	if (!mran || !size)
+		return false;
+
+	if (!fy_mremap_arena_type_is_growable(mra->arena_type))
+		return false;
+
+	/* there's no point trying to grow something this big */
+	if (mra->big_alloc_threshold && size >= mra->big_alloc_threshold)
+		return false;
+
+	/* if the grow needs to be larger than double, don't bother */
+	next = atomic_load(&mran->next);
+	if (fy_size_t_align(next, align) + size > 2 * mran->size)
+		return false;
+
+	/* go for it */
+	return true;
+}
+
+static int fy_mremap_arena_grow(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt,
+				struct fy_mremap_arena *mran, size_t size, size_t align)
+{
+	void *mem;
+
+	if (!fy_mremap_arena_should_grow(mra, mran, size, align))
+		return -1;
+
+	switch (mra->arena_type) {
+	case FYMRAT_MALLOC:
+		/* can't grow malloc without moving the pointer */
+		break;
+
+	case FYMRAT_MMAP:
+#if USE_MREMAP
+		/* double the arena */
+		mem = mremap(mran, mran->size, mran->size * 2, 0);
+		if (mem == MAP_FAILED)
+			break;
+
+		assert(mem == mran);
+#else
+		/* do a mmap right after the one we have, if it succeeds we have grown */
+		mem = mmap((char *)mran + mran->size, mran->size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+		if (mem != (char *)mran + mran->size) {
+			if (mem != MAP_FAILED)
+				munmap(mem, mran->size);
+			break;
+		}
+#endif
+		mran->size *= 2;
+
+#ifdef DEBUG_ARENA
+		fprintf(stderr, "%s: #%zu grew arena %p size=%zu (%zuMB)\n", __func__, mrt - mra->tags, mran, mran->size, mran->size >> 20);
+#endif
+		return 0;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	return -1;
+}
+
+static int fy_mremap_arena_trim(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt, struct fy_mremap_arena *mran)
+{
+	size_t next, new_size;
+#if USE_MREMAP
+	void *mem FY_DEBUG_UNUSED;
+#else
+	int rc FY_DEBUG_UNUSED;
+#endif
+
+	if (!mran)
+		return -1;
+
+	switch (mra->arena_type) {
+	case FYMRAT_MALLOC:
+		/* trim not possible (or is it? should be possible to probe) */
+		break;
+
+	case FYMRAT_MMAP:
+		/* check the page size */
+		next = fy_atomic_load(&mran->next);
+		new_size = fy_size_t_align(next, mra->pagesz);
+		if (new_size >= mran->size)
+			break;
+
+#ifdef DEBUG_ARENA
+		fprintf(stderr, "trim: %zu -> %zu\n", mran->size, new_size);
+#endif
+
+#if USE_MREMAP
+		/* failure to shrink a mapping is unthinkable, but check anyway */
+		mem = mremap(mran, mran->size, new_size, 0);
+		if (mem == MAP_FAILED || mem != mran)
+			return -1;
+#else
+		/* we don't shrink, we just unmap over the limit  */
+		rc = munmap((char *)mran + new_size, mran->size - new_size);
+		if (rc)
+			return -1;
+#endif
+		mran->size = new_size;
+		return 0;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	return -1;
+}
+
+static inline struct fy_mremap_tag *
+fy_mremap_tag_from_tag(struct fy_mremap_allocator *mra, int tag)
+{
+	if (!mra)
+		return NULL;
+
+	if ((unsigned int)tag >= mra->tag_count)
+		return NULL;
+
+	if (!fy_id_is_used(mra->ids, mra->tag_id_count, (int)tag))
+		return NULL;
+
+	return &mra->tags[tag];
+}
+
+static void fy_mremap_tag_cleanup(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt)
+{
+	struct fy_mremap_arena *mran;
+#ifdef DEBUG_ARENA
+	size_t total_sys_alloc, total_wasted, next;
+#endif
+
+	if (!mra || !mrt)
+		return;
+
+#ifdef DEBUG_ARENA
+	total_sys_alloc = 0;
+	total_wasted = 0;
+	for (mran = fy_atomic_load(&mrt->arenas); mran; mran = mran->next_arena) {
+		total_sys_alloc += mran->size;
+		next = fy_atomic_load(&mran->next);
+		total_wasted += (mran->size - next);
+	}
+	fprintf(stderr, "total_sys_alloc=%zu total_wasted=%zu\n", total_sys_alloc, total_wasted);
+#endif
+
+#ifdef DEBUG_ARENA
+	fprintf(stderr, "%s: destroying active arenas\n", __func__);
+#endif
+	/* pop and destroy */
+	while ((mran = fy_atomic_load(&mrt->arenas)) != NULL) {
+		if (fy_atomic_compare_exchange_strong(&mrt->arenas, &mran, mran->next_arena))
+			fy_mremap_arena_destroy(mra, mrt, mran);
+	}
+
+	/* nuke it all */
+	memset(mrt, 0, sizeof(*mrt));
+}
+
+static void fy_mremap_tag_trim(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt)
+{
+	struct fy_mremap_arena *mran;
+#ifdef DEBUG_ARENA
+	size_t wasted_before, wasted_after, next;
+#endif
+
+	if (!mra || !mrt)
+		return;
+
+	if (!fy_mremap_arena_type_is_trimmable(mra->arena_type))
+		return;
+
+#ifdef DEBUG_ARENA
+	wasted_before = 0;
+	wasted_after = 0;
+#endif
+	for (mran = fy_atomic_load(&mrt->arenas); mran; mran = mran->next_arena) {
+#ifdef DEBUG_ARENA
+		next = fy_atomic_load(&mran->next);
+		wasted_before += (mran->size - next);
+#endif
+		(void)fy_mremap_arena_trim(mra, mrt, mran);
+#ifdef DEBUG_ARENA
+		next = fy_atomic_load(&mran->next);
+		wasted_after += (mran->size - next);
+#endif
+	}
+
+#ifdef DEBUG_ARENA
+	fprintf(stderr, "wasted_before=%zu wasted_after=%zu\n", wasted_before, wasted_after);
+#endif
+}
+
+static void fy_mremap_tag_reset(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt)
+{
+	struct fy_mremap_arena *mran;
+
+	if (!mra || !mrt)
+		return;
+
+	/* pop and destroy */
+	while ((mran = fy_atomic_load(&mrt->arenas)) != NULL) {
+		if (fy_atomic_compare_exchange_strong(&mrt->arenas, &mran, mran->next_arena))
+			fy_mremap_arena_destroy(mra, mrt, mran);
+	}
+}
+
+static void fy_mremap_tag_setup(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt)
+{
+	assert(mra);
+	assert(mrt);
+
+	memset(mrt, 0, sizeof(*mrt));
+	fy_atomic_store(&mrt->arenas, NULL);
+	fy_atomic_store(&mrt->next_arena_sz, mra->pagesz);
+	fy_atomic_store(&mrt->allocations, 0);
+	fy_atomic_store(&mrt->allocated, 0);
+	fy_atomic_store(&mrt->stores, 0);
+	fy_atomic_store(&mrt->stored, 0);
+}
+
+static void *fy_mremap_tag_alloc(struct fy_mremap_allocator *mra, struct fy_mremap_tag *mrt, size_t size, size_t align)
+{
+	struct fy_mremap_arena *mran, *old_arenas, *start_arenas;
+	size_t next_sz, next_arena_sz, old_next_arena_sz, old_next, new_next, data_pos;
+	uint64_t flags;
+	void *ptr;
+	int rc;
+
+again:
+	start_arenas = fy_atomic_load(&mrt->arenas);
+
+	/* hot path, try to find an arena that fits first */
+	for (mran = start_arenas; mran; mran = mran->next_arena) {
+
+		flags = fy_atomic_load(&mran->flags);
+		if (flags & FYMRAF_FULL)
+			continue;
+
+		if (fy_mremap_arena_check_fit(mran, size, align))
+			goto do_alloc;
+
+		/* if it cant grown and is under the threshold, mark it full */
+		if ((flags & FYMRAF_CANT_GROW) && fy_mremap_arena_available(mran) < mra->empty_threshold)
+			fy_atomic_fetch_or(&mran->flags, FYMRAF_FULL);
+	}
+
+	/* this arena type is not growable, skip growing step */
+	if (!fy_mremap_arena_type_is_growable(mra->arena_type))
+		goto create_arena;
+
+	/* not found space in any arena, try to grow */
+	for (mran = fy_atomic_load(&mrt->arenas); mran; mran = mran->next_arena) {
+
+		flags = fy_atomic_load(&mran->flags);
+		if (flags & (FYMRAF_FULL | FYMRAF_CANT_GROW | FYMRAF_GROWING))
+			continue;
+
+		/* don't even try? */
+		if (!fy_mremap_arena_should_grow(mra, mran, size, align))
+			continue;
+
+		/* try to grab the growing lock */
+		if (!fy_atomic_compare_exchange_strong(&mran->flags, &flags, flags | FYMRAF_GROWING))
+			continue;
+
+		/* try to grow, note that the arena is still available */
+		rc = fy_mremap_arena_grow(mra, mrt, mran, size, align);
+		if (rc) {
+#ifdef DEBUG_ARENA
+			fprintf(stderr, "failed to grow %p\n", mran);
+#endif
+			/* increase by the ratio until we're over */
+			old_next_arena_sz = fy_atomic_load(&mrt->next_arena_sz);
+			next_arena_sz = old_next_arena_sz;
+			while (next_arena_sz < mran->size)
+				next_arena_sz *= 2;
+			/* we don't care about it 'catching' */
+			/* if another thread changes the value we're fine too */
+			(void)fy_atomic_compare_exchange_strong(&mrt->next_arena_sz,
+						&old_next_arena_sz, next_arena_sz);
+
+#ifdef DEBUG_ARENA
+			fprintf(stderr, "mrt=%p next_arena_size=%zu (%zu)\n", mrt, fy_atomic_load(&mrt->next_arena_sz), next_arena_sz);
+#endif
+
+			/* release the lock, and mark it as can't grow */
+			fy_atomic_fetch_or(&mran->flags, FYMRAF_CANT_GROW);
+			fy_atomic_fetch_and(&mran->flags, ~FYMRAF_GROWING);
+
+			continue;
+		}
+
+#ifdef DEBUG_ARENA
+		fprintf(stderr, "grow successful %p mran->size=%zu size=%zu\n", mran, mran->size, size);
+#endif
+
+		/* release the lock */
+		fy_atomic_fetch_and(&mran->flags, ~FYMRAF_GROWING);
+
+		if (fy_mremap_arena_check_fit(mran, size, align))
+			goto do_alloc;
+	}
+
+create_arena:
+	/* everything failed, we have to allocate a new arena */
+
+	/* it's a relatively small allocation, try to resize until we fit */
+	if (!mra->big_alloc_threshold || size < mra->big_alloc_threshold) {
+
+		do {
+			/* increase by the ratio until we're over */
+			old_next_arena_sz = fy_atomic_load(&mrt->next_arena_sz);
+			next_arena_sz = old_next_arena_sz;
+			while (fy_mremap_useable_arena_size(mra, next_arena_sz) < size) {
+				next_sz = (size_t)(next_arena_sz * mra->grow_ratio);
+
+				/* very very unlikely */
+				if (next_sz <= next_arena_sz)
+					goto err_out;
+
+				next_arena_sz = next_sz;
+			}
+
+			/* update to the next possible arena size */
+			next_sz = (size_t)(next_arena_sz * mra->grow_ratio);
+			if (next_sz > next_arena_sz)
+				next_arena_sz = next_sz;
+
+		} while (!fy_atomic_compare_exchange_strong(&mrt->next_arena_sz,
+					&old_next_arena_sz, next_arena_sz));
+	} else
+		next_arena_sz = size;	/* something big, just use it as is */
+
+	/* all failed, just new */
+	mran = fy_mremap_arena_create(mra, mrt, next_arena_sz);
+	if (!mran)
+		goto err_out;
+
+#ifdef DEBUG_ARENA
+	fprintf(stderr, "allocated new %p mran->size=%zu size=%zu\n", mran, mran->size, size);
+#endif
+
+	/* last chance if we're racing with another thread
+	 * if the other thread won updating the arena head just
+	 * drop what we did and try again; chances are there will
+	 * be space available.
+	 */
+	if (fy_atomic_load(&mrt->arenas) != start_arenas) {
+		fy_mremap_arena_destroy(mra, mrt, mran);
+		mran = NULL;
+		goto again;
+	}
+
+	/* NOTE: There's an infidecimal change to add one more arena than needed
+	 * but it's fine, the core can handle it
+	 */
+
+	/* atomically add it */
+	do {
+		old_arenas = fy_atomic_load(&mrt->arenas);
+		mran->next_arena = old_arenas;
+	} while (!fy_atomic_compare_exchange_strong(&mrt->arenas, &old_arenas, mran));
+
+do_alloc:
+
+	do {
+		old_next = fy_atomic_load(&mran->next);
+		data_pos = fy_size_t_align(old_next, align);
+		new_next = data_pos + size;
+		if (new_next > mran->size) {
+#ifdef DEBUG_ARENA
+			fprintf(stderr, "failed new %p mran->size=%zu size=%zu failed to fit!\n", mran, mran->size, size);
+#endif
+			goto again;
+		}
+		ptr = (void *)((char *)mran + data_pos);
+	} while (!fy_atomic_compare_exchange_strong(&mran->next, &old_next, new_next));
+
+	/* malloc arenas need to zero out */
+	if (mra->arena_type == FYMRAT_MALLOC)
+		memset(ptr, 0, size);
+
+#ifdef DEBUG_ARENA
+	fprintf(stderr, "allocated OK %p mran->size=%zu ptr=%p size=%zu align=%zu\n", mran, mran->size, ptr, size, align);
+#endif
+	return ptr;
+
+err_out:
+	return NULL;
+}
+
+static const struct fy_mremap_allocator_cfg default_cfg = {
+	.big_alloc_threshold = MREMAP_ALLOCATOR_DEFAULT_BIG_ALLOC_THRESHOLD,
+	.empty_threshold = MREMAP_ALLOCATOR_DEFAULT_EMPTY_THRESHOLD,
+	.minimum_arena_size = MREMAP_ALLOCATOR_DEFAULT_MINIMUM_ARENA_SIZE,
+	.grow_ratio = MREMAP_ALLOCATOR_DEFAULT_GROW_RATIO,
+	.balloon_ratio = MREMAP_ALLOCATOR_DEFAULT_BALLON_RATIO,
+	.arena_type = MREMAP_ALLOCATOR_DEFAULT_ARENA_TYPE,
+};
+
+static void fy_mremap_cleanup(struct fy_allocator *a)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	unsigned int i;
+
+	if (!a)
+		return;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	for (i = 0; i < mra->tag_count; i++) {
+		mrt = fy_mremap_tag_from_tag(mra, i);
+		if (!mrt)
+			continue;
+		fy_mremap_tag_cleanup(mra, mrt);
+	}
+
+	fy_parent_allocator_free(&mra->a, (void *)mra->ids);
+	fy_parent_allocator_free(&mra->a, mra->tags);
+}
+
+static int fy_mremap_setup(struct fy_allocator *a, struct fy_allocator *parent, int parent_tag, const void *cfg_data)
+{
+	const struct fy_mremap_allocator_cfg *cfg;
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	size_t tmpsz;
+
+	if (!a)
+		return -1;
+
+	cfg = cfg_data ? cfg_data : &default_cfg;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+	memset(mra, 0, sizeof(*mra));
+	mra->a.name = "mremap";
+	mra->a.ops = &fy_mremap_allocator_ops;
+	mra->a.parent = parent;
+	mra->a.parent_tag = parent_tag;
+	mra->cfg = *cfg;
+
+	mra->pagesz = sysconf(_SC_PAGESIZE);
+	/* pagesz is size of 2 find the first set bit */
+	mra->pageshift = fy_bit64_ffs(mra->pagesz);
+
+	mra->big_alloc_threshold = cfg->big_alloc_threshold;
+	if (!mra->big_alloc_threshold)
+		mra->big_alloc_threshold = MREMAP_ALLOCATOR_DEFAULT_BIG_ALLOC_THRESHOLD;
+
+	mra->empty_threshold = cfg->empty_threshold;
+	if (!mra->empty_threshold)
+		mra->empty_threshold = MREMAP_ALLOCATOR_DEFAULT_EMPTY_THRESHOLD;
+
+	mra->minimum_arena_size = cfg->minimum_arena_size;
+	if (!mra->minimum_arena_size)
+		mra->minimum_arena_size = MREMAP_ALLOCATOR_DEFAULT_MINIMUM_ARENA_SIZE;
+
+	mra->grow_ratio = cfg->grow_ratio;
+	if (mra->grow_ratio <= 1)
+		mra->grow_ratio = MREMAP_ALLOCATOR_DEFAULT_GROW_RATIO;
+
+	mra->balloon_ratio = cfg->balloon_ratio;
+	if (mra->balloon_ratio <= 1)
+		mra->balloon_ratio = MREMAP_ALLOCATOR_DEFAULT_BALLON_RATIO;
+
+	mra->arena_type = cfg->arena_type;
+	if (mra->arena_type == FYMRAT_DEFAULT)
+		mra->arena_type = MREMAP_ALLOCATOR_DEFAULT_ARENA_TYPE;
+
+	mra->tag_count = FY_MREMAP_TAG_MAX;
+	mra->tag_id_count = (mra->tag_count + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+
+	tmpsz = mra->tag_id_count * sizeof(*mra->ids);
+	mra->ids = fy_parent_allocator_alloc(&mra->a, tmpsz, _Alignof(fy_id_bits));
+	if (!mra->ids)
+		goto err_out;
+	fy_id_reset(mra->ids, mra->tag_id_count);
+
+	tmpsz = mra->tag_count * sizeof(*mra->tags);
+	mra->tags = fy_parent_allocator_alloc(&mra->a, tmpsz, _Alignof(struct fy_mremap_tag));
+	if (!mra->tags)
+		goto err_out;
+
+	/* start with tag 0 as general use */
+	fy_id_set_used(mra->ids, mra->tag_id_count, 0);
+	mrt = fy_mremap_tag_from_tag(mra, 0);
+	fy_mremap_tag_setup(mra, mrt);
+
+	return 0;
+
+err_out:
+	fy_mremap_cleanup(a);
+	return -1;
+}
+
+struct fy_allocator *fy_mremap_create(struct fy_allocator *parent, int parent_tag, const void *cfg)
+{
+	struct fy_mremap_allocator *mra = NULL;
+	int rc;
+
+	mra = fy_early_parent_allocator_alloc(parent, parent_tag, sizeof(*mra), _Alignof(struct fy_mremap_allocator));
+	if (!mra)
+		goto err_out;
+
+	rc = fy_mremap_setup(&mra->a, parent, parent_tag, cfg);
+	if (rc)
+		goto err_out;
+
+	return &mra->a;
+
+err_out:
+	fy_early_parent_allocator_free(parent, parent_tag, mra);
+	return NULL;
+}
+
+void fy_mremap_destroy(struct fy_allocator *a)
+{
+	struct fy_mremap_allocator *mra;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+	fy_mremap_cleanup(a);
+	fy_parent_allocator_free(a, mra);
+}
+
+void fy_mremap_dump(struct fy_allocator *a)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	struct fy_mremap_arena *mran;
+	size_t count, active_count, full_count, total, system_total;
+	unsigned int i;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	fprintf(stderr, "mremap: ");
+	for (i = 0; i < mra->tag_count; i++) {
+		mrt = fy_mremap_tag_from_tag(mra, i);
+		if (!mrt)
+			continue;
+		fprintf(stderr, "%c", fy_id_is_free(mra->ids, mra->tag_id_count, i) ? '.' : 'x');
+	}
+	fprintf(stderr, "\n");
+
+	for (i = 0; i < mra->tag_count; i++) {
+		mrt = fy_mremap_tag_from_tag(mra, i);
+		if (!mrt)
+			continue;
+
+		count = full_count = active_count = total = system_total = 0;
+		for (mran = fy_atomic_load(&mrt->arenas); mran; mran = mran->next_arena) {
+			total += fy_atomic_load(&mran->next);
+			system_total += mran->size;
+			count++;
+			active_count++;
+			/* XXX full count */
+		}
+
+		fprintf(stderr, "  %d: count %zu (a=%zu/f=%zu) total %zu system %zu overhead %zu (%2.2f%%)\n", i,
+				count, active_count, full_count,
+				total, system_total, system_total - total,
+				100.0 * (double)(system_total - total) / (double)system_total);
+	}
+}
+
+static void *fy_mremap_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	void *ptr;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	mrt = fy_mremap_tag_from_tag(mra, tag);
+	if (!mrt)
+		goto err_out;
+
+	ptr = fy_mremap_tag_alloc(mra, mrt, size, align);
+	if (!ptr)
+		goto err_out;
+
+	if (a->flags & FYAF_KEEP_STATS) {
+		fy_atomic_fetch_add(&mrt->allocations, 1);
+		fy_atomic_fetch_add(&mrt->allocated, size);
+	}
+
+	return ptr;
+
+err_out:
+	return NULL;
+}
+
+static void fy_mremap_free(struct fy_allocator *a, int tag, void *data)
+{
+	/* no frees */
+}
+
+static int fy_mremap_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	mrt = fy_mremap_tag_from_tag(mra, tag);
+	if (!mrt)
+		goto err_out;
+
+	stats->allocations += fy_atomic_get_and_clear_counter(&mrt->allocations);
+	stats->allocated += fy_atomic_get_and_clear_counter(&mrt->allocated);
+	stats->stores += fy_atomic_get_and_clear_counter(&mrt->stores);
+	stats->stored += fy_atomic_get_and_clear_counter(&mrt->stored);
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static const void *fy_mremap_storev(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	void *start;
+	size_t total_size;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	mrt = fy_mremap_tag_from_tag(mra, tag);
+	if (!mrt)
+		goto err_out;
+
+	total_size = fy_iovec_size(iov, iovcnt);
+	if (total_size == SIZE_MAX)
+		goto err_out;
+
+	start = fy_mremap_tag_alloc(mra, mrt, total_size, align);
+	if (!start)
+		goto err_out;
+
+	fy_iovec_copy_from(iov, iovcnt, start);
+
+	if (a->flags & FYAF_KEEP_STATS) {
+		fy_atomic_fetch_add(&mrt->stores, 1);
+		fy_atomic_fetch_add(&mrt->stored, total_size);
+	}
+
+	return start;
+
+err_out:
+	return NULL;
+}
+
+static const void *fy_mremap_lookupv(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	/* no lookups */
+	return NULL;
+}
+
+static void fy_mremap_release(struct fy_allocator *a, int tag, const void *data, size_t size)
+{
+	/* no releases */
+}
+
+static void fy_mremap_release_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	mrt = fy_mremap_tag_from_tag(mra, tag);
+	if (!mrt)
+		return;
+
+	fy_mremap_tag_cleanup(mra, mrt);
+
+	/* must be last */
+	fy_id_free(mra->ids, mra->tag_id_count, tag);
+}
+
+static int fy_mremap_get_tag(struct fy_allocator *a)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	int id = -1;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	/* this is atomic, so safe for multiple threads */
+	id = fy_id_alloc(mra->ids, mra->tag_id_count);
+	if (id < 0)
+		goto err_out;
+
+	mrt = fy_mremap_tag_from_tag(mra, id);
+	if (!mrt)
+		goto err_out;
+
+	fy_mremap_tag_setup(mra, mrt);
+
+	return (int)id;
+
+err_out:
+	if (id >= 0)
+		fy_id_free(mra->ids, mra->tag_id_count, id);
+	return FY_ALLOC_TAG_ERROR;
+}
+
+static int fy_mremap_get_tag_count(struct fy_allocator *a)
+{
+	struct fy_mremap_allocator *mra;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+	return mra->tag_count;
+}
+
+static int fy_mremap_set_tag_count(struct fy_allocator *a, unsigned int count)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_arena *mran;
+	fy_id_bits *ids = NULL;
+	struct fy_mremap_tag *mrt, *mrt_new, *tags = NULL;
+	unsigned int i, tag_count, tag_id_count;
+	size_t tmpsz;
+
+	if (count < 1)
+		return -1;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	if (count == mra->tag_count)
+		return 0;
+
+	tag_count = count;
+	tag_id_count = (tag_count + FY_ID_BITS_BITS - 1) / FY_ID_BITS_BITS;
+
+	/* shrink?, just clip */
+	if (count < mra->tag_count) {
+		for (i = count; i < mra->tag_count; i++) {
+			mrt = fy_mremap_tag_from_tag(mra, i);
+			if (!mrt)
+				continue;
+			fy_mremap_tag_cleanup(mra, mrt);
+			fy_id_free(mra->ids, mra->tag_id_count, i);
+		}
+		tags = mra->tags;
+		ids = mra->ids;
+	} else {
+		/* we need to grow */
+		tmpsz = tag_id_count * sizeof(*mra->ids);
+		ids = fy_parent_allocator_alloc(&mra->a, tmpsz, _Alignof(fy_id_bits));
+		if (!ids)
+			goto err_out;
+		fy_id_reset(ids, tag_id_count);
+
+		tmpsz = tag_count * sizeof(*tags);
+		tags = fy_parent_allocator_alloc(&mra->a, tmpsz, _Alignof(struct fy_mremap_tag));
+		if (!tags)
+			goto err_out;
+
+		/* copy over the old entries */
+		for (i = 0; i < mra->tag_count; i++) {
+
+			mrt = fy_mremap_tag_from_tag(mra, i);
+			if (!mrt)
+				continue;
+
+			mrt_new = &tags[i];
+
+			fy_mremap_tag_setup(mra, mrt_new);
+			do {
+				mran = fy_atomic_load(&mrt->arenas);
+			} while (fy_atomic_compare_exchange_strong(&mrt->arenas, &mran, NULL));
+			fy_atomic_store(&mrt_new->arenas, mran);
+			fy_atomic_store(&mrt_new->next_arena_sz, fy_atomic_load(&mrt->next_arena_sz));
+			fy_atomic_store(&mrt_new->allocations, fy_atomic_load(&mrt->allocations));
+			fy_atomic_store(&mrt_new->allocated, fy_atomic_load(&mrt->allocated));
+			fy_atomic_store(&mrt_new->stores, fy_atomic_load(&mrt->stores));
+			fy_atomic_store(&mrt_new->stored, fy_atomic_load(&mrt->stored));
+
+			/* clean the old entry */
+			fy_mremap_tag_cleanup(mra, mrt);
+
+			fy_id_set_used(ids, tag_id_count, i);
+		}
+	}
+
+	if (mra->tags != tags) {
+		mra->tags = tags;
+		fy_parent_allocator_free(&mra->a, mra->tags);
+	}
+	if (mra->ids != ids) {
+		mra->ids = ids;
+		fy_parent_allocator_free(&mra->a, (void *)mra->ids);
+	}
+	mra->tag_count = tag_count;
+	mra->tag_id_count = tag_id_count;
+	return 0;
+
+err_out:
+	fy_parent_allocator_free(&mra->a, tags);
+	fy_parent_allocator_free(&mra->a, (void *)ids);
+	return -1;
+}
+
+static void fy_mremap_trim_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	mrt = fy_mremap_tag_from_tag(mra, tag);
+	if (!mrt)
+		return;
+
+	fy_mremap_tag_trim(mra, mrt);
+}
+
+static void fy_mremap_reset_tag(struct fy_allocator *a, int tag)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	mrt = fy_mremap_tag_from_tag(mra, tag);
+	if (!mrt)
+		return;
+
+	fy_mremap_tag_reset(mra, mrt);
+}
+
+static struct fy_allocator_info *
+fy_mremap_get_info(struct fy_allocator *a, int tag)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	struct fy_mremap_arena *mran;
+	struct fy_allocator_info *info;
+	struct fy_allocator_tag_info *tag_info;
+	struct fy_allocator_arena_info *arena_info;
+	size_t size, free, used, total;
+	size_t tag_free, tag_used, tag_total;
+	size_t arena_free, arena_used, arena_total;
+	unsigned int num_tags, num_arenas, i;
+	int id;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	/* allocate for the worst case always */
+	num_tags = 0;
+	num_arenas = 0;
+
+	free = 0;
+	used = 0;
+	total = 0;
+
+	/* two passes */
+	for (i = 0; i < 2; i++) {
+
+		if (!i) {
+			tag_info = NULL;
+			arena_info = NULL;
+
+		} else {
+			size = sizeof(*info) +
+                               sizeof(*tag_info) * num_tags +
+			       sizeof(*arena_info) * num_arenas;
+
+			info = malloc(size);
+			if (!info)
+				return NULL;
+			memset(info, 0, sizeof(*info));
+
+			tag_info = (void *)(info + 1);
+			assert(((uintptr_t)tag_info % _Alignof(struct fy_allocator_tag_info)) == 0);
+			arena_info = (void *)(tag_info + num_tags);
+			assert(((uintptr_t)arena_info % _Alignof(struct fy_allocator_arena_info)) == 0);
+
+			info->free = free;
+			info->used = used;
+			info->total = total;
+
+			info->num_tag_infos = 0;
+			info->tag_infos = tag_info;
+		}
+
+		free = 0;
+		used = 0;
+		total = sizeof(*mra);
+
+		for (id = 0; id < (int)mra->tag_count; id++) {
+
+			if (!fy_id_is_used(mra->ids, mra->tag_id_count, id))
+				continue;
+
+			mrt = &mra->tags[id];
+
+			tag_free = 0;
+			tag_used = 0;
+			tag_total = 0;
+
+			if (i) {
+				tag_info->num_arena_infos = 0;
+				tag_info->arena_infos = arena_info;
+			}
+
+			for (mran = fy_atomic_load(&mrt->arenas); mran; mran = mran->next_arena) {
+				arena_free = (size_t)(mran->size - mran->next);
+				arena_used = (size_t)(mran->next - FY_MREMAP_ARENA_OVERHEAD);
+				arena_total = mran->size;
+
+				tag_free += arena_free;
+				tag_used += arena_used;
+				tag_total += arena_total;
+
+				if (!i) {
+					num_arenas++;
+				} else {
+					arena_info->free = arena_free;
+					arena_info->used = arena_used;
+					arena_info->total = arena_total;
+					arena_info->data = (char *)mran + FY_MREMAP_ARENA_OVERHEAD;
+					arena_info->size = arena_info->used;
+					arena_info++;
+					tag_info->num_arena_infos++;
+				}
+			}
+
+			if (!i) {
+				num_tags++;
+			} else {
+
+				/* only store the tag if there's a match */
+				if (tag == FY_ALLOC_TAG_NONE || tag == id) {
+					tag_info->tag = id;
+					tag_info->free = tag_free;
+					tag_info->used = tag_used;
+					tag_info->total = tag_total;
+					tag_info++;
+					info->num_tag_infos++;
+				}
+			}
+
+			free += tag_free;
+			used += tag_used;
+			total += tag_total;
+		}
+	}
+
+	return info;
+}
+
+static enum fy_allocator_cap_flags
+fy_mremap_get_caps(struct fy_allocator *a)
+{
+	return FYACF_CAN_FREE_TAG | FYACF_HAS_EFFICIENT_CONTAINS | \
+	       FYACF_HAS_CONTAINS | FYACF_HAS_TAGS;
+}
+
+static bool mremap_tag_contains(struct fy_mremap_tag *mrt, const void *p)
+{
+	struct fy_mremap_arena *mra;
+
+	for (mra = fy_atomic_load(&mrt->arenas); mra; mra = mra->next_arena) {
+		if (p >= (const void *)mra->mem &&
+		    p < (const void *)((const char *)mra->mem + mra->size))
+			return true;
+	}
+
+	return false;
+}
+
+static bool fy_mremap_contains(struct fy_allocator *a, int tag, const void *ptr)
+{
+	struct fy_mremap_allocator *mra;
+	struct fy_mremap_tag *mrt;
+	int tag_start, tag_end;
+
+	mra = container_of(a, struct fy_mremap_allocator, a);
+
+	if (tag >= 0) {
+		if (tag >= (int)mra->tag_count)
+			return false;
+		tag_start = tag;
+		tag_end = tag + 1;
+	} else {
+		tag_start = 0;
+		tag_end = (int)mra->tag_count;
+	}
+
+	for (tag = tag_start; tag < tag_end; tag++) {
+
+		mrt = fy_mremap_tag_from_tag(mra, tag);
+		if (!mrt)
+			continue;
+
+		if (mremap_tag_contains(mrt, ptr))
+			return true;
+	}
+
+	return false;
+}
+
+const struct fy_allocator_ops fy_mremap_allocator_ops = {
+	.setup = fy_mremap_setup,
+	.cleanup = fy_mremap_cleanup,
+	.create = fy_mremap_create,
+	.destroy = fy_mremap_destroy,
+	.dump = fy_mremap_dump,
+	.alloc = fy_mremap_alloc,
+	.free = fy_mremap_free,
+	.update_stats = fy_mremap_update_stats,
+	.storev = fy_mremap_storev,
+	.lookupv = fy_mremap_lookupv,
+	.release = fy_mremap_release,
+	.get_tag = fy_mremap_get_tag,
+	.release_tag = fy_mremap_release_tag,
+	.get_tag_count = fy_mremap_get_tag_count,
+	.set_tag_count = fy_mremap_set_tag_count,
+	.trim_tag = fy_mremap_trim_tag,
+	.reset_tag = fy_mremap_reset_tag,
+	.get_info = fy_mremap_get_info,
+	.get_caps = fy_mremap_get_caps,
+	.contains = fy_mremap_contains,
+};

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator-mremap.h
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator-mremap.h
@@ -1,0 +1,77 @@
+/*
+ * fy-allocator-mremap.h - the mremap allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ALLOCATOR_MREMAP_H
+#define FY_ALLOCATOR_MREMAP_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "fy-typelist.h"
+#include "fy-id.h"
+
+#include "fy-atomics.h"
+#include "fy-allocator.h"
+
+struct fy_mremap_tag;
+
+#define FY_MREMAP_TAG_MAX	32
+
+static inline bool fy_mremap_arena_type_is_growable(enum fy_mremap_arena_type type)
+{
+	return type == FYMRAT_MMAP;
+}
+
+static inline bool fy_mremap_arena_type_is_trimmable(enum fy_mremap_arena_type type)
+{
+	return type == FYMRAT_MMAP;
+}
+
+#define FYMRAF_FULL		FY_BIT(0)
+#define FYMRAF_GROWING		FY_BIT(1)
+#define FYMRAF_CANT_GROW	FY_BIT(2)
+
+struct fy_mremap_arena {
+	struct fy_mremap_arena *next_arena;
+	size_t size;	/* includes the arena header */
+	FY_ATOMIC(uint64_t) flags;
+	FY_ATOMIC(size_t) next;
+	uint64_t mem[] FY_ALIGNED_TO(16);
+};
+
+#define FY_MREMAP_ARENA_OVERHEAD (offsetof(struct fy_mremap_arena, mem))
+
+struct fy_mremap_tag {
+	FY_ATOMIC(struct fy_mremap_arena *) arenas;
+	FY_ATOMIC(size_t) next_arena_sz;
+	FY_ATOMIC(uint64_t) allocations;
+	FY_ATOMIC(uint64_t) allocated;
+	FY_ATOMIC(uint64_t) stores;
+	FY_ATOMIC(uint64_t) stored;
+};
+
+struct fy_mremap_allocator {
+	struct fy_allocator a;
+	struct fy_mremap_allocator_cfg cfg;
+	size_t pagesz;
+	size_t pageshift;
+	size_t big_alloc_threshold;	/* bigger than that and a new allocation */
+	size_t empty_threshold;		/* less than that and get moved to full */
+	size_t minimum_arena_size;	/* the minimum arena size */
+	float grow_ratio;
+	float balloon_ratio;
+	enum fy_mremap_arena_type arena_type;
+	fy_id_bits *ids;
+	unsigned int tag_id_count;
+	struct fy_mremap_tag *tags;
+	unsigned int tag_count;
+};
+
+extern const struct fy_allocator_ops fy_mremap_allocator_ops;
+
+#endif

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator.c
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator.c
@@ -1,0 +1,779 @@
+/*
+ * fy-allocator.c - allocators
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdalign.h>
+#include <time.h>
+#include <inttypes.h>
+#include <math.h>
+
+#include <stdio.h>
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <pthread.h>
+#endif
+
+/* for container_of */
+#include "fy-list.h"
+#include "fy-utils.h"
+#include "fy-align.h"
+#include "fy-win32.h"
+
+#include "fy-allocator.h"
+#include "fy-allocator-linear.h"
+#include "fy-allocator-malloc.h"
+#include "fy-allocator-mremap.h"
+#include "fy-allocator-dedup.h"
+#include "fy-allocator-auto.h"
+
+static struct fy_registered_allocator_entry_list allocator_registry_list;
+static bool allocator_registry_initialized = false;
+static bool allocator_registry_locked = false;
+
+#ifndef FY_NON_LOCKING_REGISTRY
+
+#if !defined(_WIN32)
+
+static pthread_mutex_t allocator_registry_mutex = PTHREAD_MUTEX_INITIALIZER;
+static inline void allocator_registry_lock(void)
+{
+	int rc FY_DEBUG_UNUSED;
+
+	rc = pthread_mutex_lock(&allocator_registry_mutex);
+	assert(!rc);
+
+	assert(!allocator_registry_locked);
+	allocator_registry_locked = true;
+}
+
+static inline void allocator_registry_unlock(void)
+{
+	int rc FY_DEBUG_UNUSED;
+
+	assert(allocator_registry_locked);
+	allocator_registry_locked = false;
+
+	rc = pthread_mutex_unlock(&allocator_registry_mutex);
+	assert(!rc);
+}
+
+#else	// _WIN32
+
+static CRITICAL_SECTION allocator_registry_mutex;
+static LONG allocator_registry_mutex_initialized = 0;
+static inline void allocator_registry_lock(void)
+{
+	/* Initialize on first use using interlocked operation */
+	if (InterlockedCompareExchange(&allocator_registry_mutex_initialized, 1, 0) == 0)
+		InitializeCriticalSection(&allocator_registry_mutex);
+	EnterCriticalSection(&allocator_registry_mutex);
+	assert(!allocator_registry_locked);
+	allocator_registry_locked = true;
+}
+
+static inline void allocator_registry_unlock(void)
+{
+	assert(allocator_registry_locked);
+	allocator_registry_locked = false;
+	LeaveCriticalSection(&allocator_registry_mutex);
+}
+
+#endif
+
+#else	// FY_NON_LOCKING_REGISTRY
+
+static inline void allocator_registry_lock(void)
+{
+	/* nothing */
+}
+static inline void allocator_registry_unlock(void)
+{
+
+	/* nothing */
+}
+#endif
+
+static inline void allocator_registry_init(void)
+{
+	if (allocator_registry_initialized)
+		return;
+
+	fy_registered_allocator_entry_list_init(&allocator_registry_list);
+
+	allocator_registry_initialized = true;
+}
+
+static struct fy_registered_allocator_entry *
+fy_registered_allocator_entry_create(const char *name, const struct fy_allocator_ops *ops)
+{
+	struct fy_registered_allocator_entry *ae;
+
+	ae = malloc(sizeof(*ae));
+	if (!ae)
+		return NULL;
+	memset(ae, 0, sizeof(*ae));
+	ae->name = name;
+	ae->ops = ops;
+
+	return ae;
+}
+
+static void fy_registered_allocator_entry_destroy(struct fy_registered_allocator_entry *ae)
+{
+	if (!ae)
+		return;
+	free(ae);
+}
+
+static const struct {
+	const char *name;
+	const struct fy_allocator_ops *ops;
+} builtin_allocators[] = {
+	{
+		.name = "linear",
+		.ops = &fy_linear_allocator_ops,
+	}, {
+		.name = "malloc",
+		.ops = &fy_malloc_allocator_ops,
+	}, {
+		.name = "mremap",
+		.ops = &fy_mremap_allocator_ops,
+	}, {
+		.name = "dedup",
+		.ops = &fy_dedup_allocator_ops,
+	}, {
+		.name = "auto",
+		.ops = &fy_auto_allocator_ops,
+	}
+};
+
+int fy_allocator_register(const char *name, const struct fy_allocator_ops *ops)
+{
+	struct fy_registered_allocator_entry *ae;
+	unsigned int i;
+	int ret;
+
+	if (!name || !ops ||
+		!ops->setup ||
+		!ops->cleanup ||
+		!ops->create ||
+		!ops->destroy ||
+		!ops->dump ||
+		!ops->alloc ||
+		!ops->free ||
+		!ops->update_stats ||
+		!ops->storev ||
+		!ops->lookupv ||
+		!ops->release |
+		!ops->get_tag ||
+		!ops->release_tag ||
+		!ops->get_tag_count ||
+		!ops->set_tag_count ||
+		!ops->trim_tag ||
+		!ops->reset_tag ||
+		!ops->get_info ||
+		!ops->get_caps ||
+		!ops->contains)
+		return  -1;
+
+	allocator_registry_lock();
+	allocator_registry_init();
+
+	ret = -1;
+
+	/* must not clash with the builtins */
+	for (i = 0; i < ARRAY_SIZE(builtin_allocators); i++) {
+		if (!strcmp(builtin_allocators[i].name, name))
+			goto out_unlock;
+	}
+
+	/* must not clash with the other entries */
+	for (ae = fy_registered_allocator_entry_list_head(&allocator_registry_list); ae;
+			ae = fy_registered_allocator_entry_next(&allocator_registry_list, ae)) {
+		if (!strcmp(ae->name, name))
+			goto out_unlock;
+	}
+
+	/* OK, create the entry */
+	ae = fy_registered_allocator_entry_create(name, ops);
+	if (!ae)
+		goto out_unlock;
+
+	/* and add it to the list */
+	fy_registered_allocator_entry_list_add(&allocator_registry_list, ae);
+
+	/* all clear */
+	ret = 0;
+
+out_unlock:
+	allocator_registry_unlock();
+
+	return ret;
+}
+
+int fy_allocator_unregister(const char *name)
+{
+	struct fy_registered_allocator_entry *ae;
+	unsigned int i;
+	int ret;
+
+	ret = -1;
+
+	allocator_registry_lock();
+	allocator_registry_init();
+
+	/* must not try to unregister a builtin */
+	for (i = 0; i < ARRAY_SIZE(builtin_allocators); i++) {
+		if (!strcmp(builtin_allocators[i].name, name))
+			goto out_unlock;
+	}
+
+	/* find the entry now */
+	for (ae = fy_registered_allocator_entry_list_head(&allocator_registry_list); ae;
+			ae = fy_registered_allocator_entry_next(&allocator_registry_list, ae)) {
+		if (!strcmp(ae->name, name))
+			break;
+	}
+	if (!ae)
+		goto out_unlock;
+
+	fy_registered_allocator_entry_list_del(&allocator_registry_list, ae);
+
+	/* and destroy it */
+	fy_registered_allocator_entry_destroy(ae);
+
+	ret = 0;
+
+out_unlock:
+	allocator_registry_unlock();
+
+	return ret;
+}
+
+struct fy_allocator *
+fy_allocator_create_internal(const char *name, struct fy_allocator *parent, int parent_tag, const void *cfg)
+{
+	struct fy_registered_allocator_entry *ae;
+	const struct fy_allocator_ops *ops = NULL;
+	unsigned int i;
+
+	if (!name)
+		name = builtin_allocators[0].name;
+
+	allocator_registry_lock();
+	allocator_registry_init();
+
+	/* try the builtins first */
+	for (i = 0; i < ARRAY_SIZE(builtin_allocators); i++) {
+		if (!strcmp(builtin_allocators[i].name, name)) {
+			ops = builtin_allocators[i].ops;
+			break;
+		}
+	}
+
+	/* if not found there, try the registry */
+	if (!ops) {
+		for (ae = fy_registered_allocator_entry_list_head(&allocator_registry_list); ae;
+				ae = fy_registered_allocator_entry_next(&allocator_registry_list, ae)) {
+			if (!strcmp(ae->name, name)) {
+				ops = ae->ops;
+				break;
+			}
+		}
+	}
+	allocator_registry_unlock();
+	if (!ops)
+		return NULL;
+
+	/* XXX just malloc for now */
+	return ops->create(parent, parent_tag, cfg);
+}
+
+struct fy_allocator *fy_allocator_create(const char *name, const void *cfg)
+{
+	/* for now just use internal */
+	return fy_allocator_create_internal(name, NULL, FY_ALLOC_TAG_DEFAULT, cfg);
+}
+
+/* special in place allocator */
+struct fy_allocator *
+fy_linear_allocator_create_in_place(void *buffer, size_t size)
+{
+	const struct fy_allocator_ops *ops = &fy_linear_allocator_ops;
+	struct fy_linear_allocator_cfg cfg = { .buf = buffer, .size = size };
+
+	if (!buffer || size < FY_LINEAR_ALLOCATOR_IN_PLACE_MIN_SIZE)
+		return NULL;
+
+	return ops->create(FY_PARENT_ALLOCATOR_INPLACE, FY_ALLOC_TAG_DEFAULT, &cfg);
+}
+
+struct fy_allocator *
+fy_dedup_allocator_create_in_place(void *buffer, size_t size)
+{
+	struct fy_allocator *pa;
+	struct fy_dedup_allocator_cfg dcfg;
+	size_t dedup_available;
+
+	if (!buffer || size < FY_DEDUP_ALLOCATOR_IN_PLACE_MIN_SIZE)
+		return NULL;
+
+	pa = fy_linear_allocator_create_in_place(buffer, size);
+	if (!pa)
+		return NULL;
+
+	/* try to size the dedup structures to about 10% of the available space */
+	dedup_available = size - FY_LINEAR_ALLOCATOR_IN_PLACE_MIN_SIZE;
+
+	memset(&dcfg, 0, sizeof(dcfg));
+	dcfg.parent_allocator = pa;
+	dcfg.bloom_filter_bits = 0;	/* use default */
+	dcfg.bucket_count_bits = 0;
+	dcfg.estimated_content_size = dedup_available;
+	dcfg.minimum_bucket_occupancy = 1.0;	/* will never grow */
+
+	return fy_allocator_create_internal("dedup", pa, 0, &dcfg);
+}
+
+void fy_allocator_registry_cleanup_internal(bool show_leftovers)
+{
+	struct fy_registered_allocator_entry *ae;
+
+	if (!allocator_registry_initialized)
+		return;
+
+	allocator_registry_lock();
+	while ((ae = fy_registered_allocator_entry_list_pop(&allocator_registry_list)) != NULL) {
+		if (show_leftovers)
+			fprintf(stderr, "%s: destroying %s\n", __func__, ae->name);
+		fy_registered_allocator_entry_destroy(ae);
+	}
+	allocator_registry_unlock();
+}
+
+void fy_allocator_registry_cleanup(void)
+{
+	fy_allocator_registry_cleanup_internal(false);
+}
+
+#ifdef FY_HAS_CONSTRUCTOR
+static FY_CONSTRUCTOR void fy_allocator_registry_constructor(void)
+{
+	allocator_registry_init();
+}
+#endif
+
+#ifdef FY_HAS_DESTRUCTOR
+static FY_DESTRUCTOR void fy_allocator_registry_destructor(void)
+{
+	bool show_leftovers = false;
+
+#ifdef FY_DESTRUCTOR_SHOW_LEFTOVERS
+	show_leftovers = true;
+#endif
+
+	/* make sure the registry is not locked because we will hang */
+	if (allocator_registry_locked) {
+		if (show_leftovers)
+			fprintf(stderr, "%s: refusing to work on locked registry\n", __func__);
+		return;
+	}
+
+	fy_allocator_registry_cleanup_internal(show_leftovers);
+}
+#endif
+
+static const char **create_allocator_array_names(void)
+{
+	unsigned int i, j, count;
+	struct fy_registered_allocator_entry *ae;
+	const char **names = NULL;
+
+	allocator_registry_lock();
+
+	/* two passes */
+	for (j = 0; j < 2; j++) {
+
+		count = 0;
+
+		/* try the builtins first */
+		for (i = 0; i < ARRAY_SIZE(builtin_allocators); i++) {
+			if (j)
+				names[count] = builtin_allocators[i].name;
+			count++;
+
+		}
+		for (ae = fy_registered_allocator_entry_list_head(&allocator_registry_list); ae;
+				ae = fy_registered_allocator_entry_next(&allocator_registry_list, ae)) {
+			if (j)
+				names[count] = ae->name;
+			count++;
+		}
+
+		if (!j) {
+			names = malloc(sizeof(*names) * (count + 1));
+			if (!names)
+				return NULL;
+			memset(names, 0, sizeof(*names) * (count + 1));
+		} else
+			names[count++] = NULL;
+
+	}
+
+	allocator_registry_unlock();
+
+	return names;
+}
+
+const char *fy_allocator_iterate(const char **prevp)
+{
+	unsigned int i;
+	const char **names;
+
+	if (!prevp)
+		return NULL;
+
+	/* yeah, it's not fast, but should be negligible */
+	names = create_allocator_array_names();
+	if (!names)
+		return NULL;
+
+	i = 0;
+	if (*prevp) {
+		while (names[i] && strcmp(*prevp, names[i]))
+			i++;
+		if (names[i])
+			i++;
+	}
+
+	*prevp = names[i];
+
+	free(names);
+
+	return *prevp;
+}
+
+bool fy_allocator_is_available(const char *allocator)
+{
+	const char *name, *prev;
+
+	prev = NULL;
+	while ((name = fy_allocator_iterate(&prev)) != NULL) {
+		if (!strcmp(allocator, name))
+			return true;
+	}
+	return false;
+}
+
+char *fy_allocator_get_names(void)
+{
+	const char *name, *prev;
+	size_t size, len;
+	char *names, *s;
+
+	size = 0;
+	prev = NULL;
+	while ((name = fy_allocator_iterate(&prev)) != NULL)
+		size += strlen(name) + 1;
+
+	names = malloc(size + 1);
+	if (!names)
+		return NULL;
+
+	s = names;
+	prev = NULL;
+	while ((name = fy_allocator_iterate(&prev)) != NULL) {
+		len = strlen(name);
+		assert((size_t)(s + len + 1 - names) <= size);
+		memcpy(s, name, len);
+		s += len;
+		*s++ = ' ';
+	}
+	if (s > names && s[-1] == ' ')
+		s[-1] = '\0';
+	return names;
+}
+
+ssize_t fy_allocator_get_tag_linear_size(struct fy_allocator *a, int tag)
+{
+	struct fy_allocator_info *info;
+	struct fy_allocator_tag_info *tag_info;
+	struct fy_allocator_arena_info *arena_info;
+	unsigned int i, j;
+	size_t size;
+
+	if (!a || tag == FY_ALLOC_TAG_NONE)
+		return -1;
+
+	info = fy_allocator_get_info(a, tag);
+	if (!info)
+		return -1;
+
+	size = 0;
+	for (i = 0; i < info->num_tag_infos; i++) {
+		tag_info = &info->tag_infos[i];
+
+		for (j = 0; j < tag_info->num_arena_infos; j++) {
+			arena_info = &tag_info->arena_infos[j];
+
+			size = fy_size_t_align(size, 16);	/* align at 16 always */
+			size += arena_info->size;
+		}
+	}
+
+	free(info);
+
+	/* too large? really? */
+	if ((ssize_t)size < 0)
+		return -1;
+
+	return (ssize_t)size;
+}
+
+const void *fy_allocator_get_tag_single_linear(struct fy_allocator *a, int tag, size_t *sizep)
+{
+	struct fy_allocator_info *info;
+	struct fy_allocator_arena_info *arena_info;
+	const void *data;
+
+	if (!a || tag == FY_ALLOC_TAG_NONE || !sizep)
+		return NULL;
+
+	*sizep = 0;
+	data = NULL;
+
+	info = fy_allocator_get_info(a, tag);
+	if (!info)
+		return NULL;
+
+	/* this is great, everything is linear */
+	if (info->num_tag_infos == 1 && info->tag_infos[0].num_arena_infos == 1) {
+		arena_info = &info->tag_infos[0].arena_infos[0];
+		data = arena_info->data;
+		*sizep = arena_info->size;
+	}
+
+	free(info);
+
+	return data;
+}
+
+void fy_allocator_destroy(struct fy_allocator *a)
+{
+	if (!a)
+		return;
+	fy_allocator_destroy_nocheck(a);
+}
+
+void fy_allocator_dump(struct fy_allocator *a)
+{
+	if (!a)
+		return;
+	fy_allocator_dump_nocheck(a);
+}
+
+int fy_allocator_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	if (!a || !stats)
+		return -1;
+	return fy_allocator_update_stats_nocheck(a, tag, stats);
+}
+
+void *fy_allocator_alloc(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	if (!a)
+		return NULL;
+	return fy_allocator_alloc_nocheck(a, tag, size, align);
+}
+
+void fy_allocator_free(struct fy_allocator *a, int tag, void *ptr)
+{
+	if (!a || !ptr)
+		return;
+	fy_allocator_free_nocheck(a, tag, ptr);
+}
+
+const void *fy_allocator_storev_hash(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	if (!a || !iov)
+		return NULL;
+	return fy_allocator_storev_hash_nocheck(a, tag, iov, iovcnt, align, hash);
+}
+
+const void *fy_allocator_store(struct fy_allocator *a, int tag, const void *data, size_t size, size_t align)
+{
+	struct iovec iov[1];
+
+	if (!a || !data)
+		return NULL;
+
+	/* just call the storev */
+	iov[0].iov_base = (void *)data;
+	iov[0].iov_len = size;
+
+	return fy_allocator_storev_hash_nocheck(a, tag, iov, 1, align, 0);
+}
+
+const void *fy_allocator_storev(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align)
+{
+	if (!a || !iov)
+		return NULL;
+	return fy_allocator_storev_nocheck(a, tag, iov, iovcnt, align);
+}
+
+const void *fy_allocator_lookupv_hash(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	if (!a || !iov)
+		return NULL;
+	return fy_allocator_lookupv_nocheck(a, tag, iov, iovcnt, align, hash);
+}
+
+const void *fy_allocator_lookupv(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align)
+{
+	if (!a || !iov)
+		return NULL;
+	return fy_allocator_lookupv_nocheck(a, tag, iov, iovcnt, align, 0);
+}
+
+const void *fy_allocator_lookup(struct fy_allocator *a, int tag, const void *data, size_t size, size_t align)
+{
+	struct iovec iov[1];
+
+	if (!a || !data)
+		return NULL;
+
+	/* just call the storev */
+	iov[0].iov_base = (void *)data;
+	iov[0].iov_len = size;
+
+	return fy_allocator_lookupv_nocheck(a, tag, iov, 1, align, 0);
+}
+
+void fy_allocator_release(struct fy_allocator *a, int tag, const void *ptr, size_t size)
+{
+	if (!a || !ptr)
+		return;
+	fy_allocator_release(a, tag, ptr, size);
+}
+
+int fy_allocator_get_tag(struct fy_allocator *a)
+{
+	if (!a)
+		return 0;
+	return fy_allocator_get_tag_nocheck(a);
+}
+
+void fy_allocator_release_tag(struct fy_allocator *a, int tag)
+{
+	if (!a)
+		return;
+	fy_allocator_release_tag_nocheck(a, tag);
+}
+
+int fy_allocator_get_tag_count(struct fy_allocator *a)
+{
+	if (!a)
+		return -1;
+	return fy_allocator_get_tag_count_nocheck(a);
+}
+
+int fy_allocator_set_tag_count(struct fy_allocator *a, unsigned int count)
+{
+	if (!a)
+		return -1;
+	return fy_allocator_set_tag_count_nocheck(a, count);
+}
+
+void fy_allocator_trim_tag(struct fy_allocator *a, int tag)
+{
+	if (!a)
+		return;
+	fy_allocator_trim_tag_nocheck(a, tag);
+}
+
+void fy_allocator_reset_tag(struct fy_allocator *a, int tag)
+{
+	if (!a)
+		return;
+	fy_allocator_reset_tag_nocheck(a, tag);
+}
+
+struct fy_allocator_info *
+fy_allocator_get_info(struct fy_allocator *a, int tag)
+{
+	if (!a)
+		return NULL;
+	return fy_allocator_get_info_nocheck(a, tag);
+}
+
+enum fy_allocator_cap_flags
+fy_allocator_get_caps(struct fy_allocator *a)
+{
+	if (!a)
+		return 0;
+
+	return fy_allocator_get_caps_nocheck(a);
+}
+
+bool
+fy_allocator_contains(struct fy_allocator *a, int tag, const void *ptr)
+{
+	if (!a || !ptr)
+		return false;
+
+	return fy_allocator_contains_nocheck(a, tag, ptr);
+}
+
+/* respects the parent allocator (or uses posix_memalign if NULL) */
+void *fy_early_parent_allocator_alloc(struct fy_allocator *parent, int parent_tag, size_t size, size_t align)
+{
+	/* yeah, not gonna work */
+	if (parent == FY_PARENT_ALLOCATOR_INPLACE)
+		return NULL;
+
+	if (!align)
+		align = _Alignof(max_align_t);
+
+	if (parent)
+		return fy_allocator_alloc(parent, parent_tag, size, align);
+
+	return fy_align_alloc(align, size);
+}
+
+void fy_early_parent_allocator_free(struct fy_allocator *parent, int parent_tag, void *ptr)
+{
+	if (!ptr || parent == FY_PARENT_ALLOCATOR_INPLACE)
+		return;
+
+	if (parent)
+		fy_allocator_free(parent, parent_tag, ptr);
+	else
+		fy_align_free(ptr);
+}
+
+/* respects the parent allocator (or uses posix_memalign if NULL) */
+void *fy_parent_allocator_alloc(struct fy_allocator *a, size_t size, size_t align)
+{
+	if (!a)
+		return NULL;
+
+	return fy_early_parent_allocator_alloc(a->parent, a->parent_tag, size, align);
+}
+
+void fy_parent_allocator_free(struct fy_allocator *a, void *ptr)
+{
+	if (!a || !ptr)
+		return;
+
+	fy_early_parent_allocator_free(a->parent, a->parent_tag, ptr);
+}

--- a/numcosmo/external/libfyaml/src/allocator/fy-allocator.h
+++ b/numcosmo/external/libfyaml/src/allocator/fy-allocator.h
@@ -1,0 +1,287 @@
+/*
+ * fy-allocator.h - allocators
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ALLOCATOR_H
+#define FY_ALLOCATOR_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#ifndef _WIN32
+#include <sys/uio.h>
+#endif
+
+#include "fy-typelist.h"
+#include "fy-utils.h"
+#include "fy-win32.h"
+
+#include <libfyaml.h>
+
+struct fy_allocator;
+struct fy_allocator_stats;
+
+struct fy_allocator_stats;
+struct fy_allocator_info;
+
+struct fy_allocator_ops {
+	int (*setup)(struct fy_allocator *a, struct fy_allocator *parent, int parent_tag, const void *cfg);
+	void (*cleanup)(struct fy_allocator *a);
+	struct fy_allocator *(*create)(struct fy_allocator *parent, int parent_tag, const void *cfg);
+	void (*destroy)(struct fy_allocator *a);
+	void (*dump)(struct fy_allocator *a);
+	void *(*alloc)(struct fy_allocator *a, int tag, size_t size, size_t align);
+	void (*free)(struct fy_allocator *a, int tag, void *data);
+	int (*update_stats)(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats);
+	const void *(*storev)(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash);
+	const void *(*lookupv)(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash);
+	void (*release)(struct fy_allocator *a, int tag, const void *data, size_t size);
+	int (*get_tag)(struct fy_allocator *a);
+	void (*release_tag)(struct fy_allocator *a, int tag);
+	int (*get_tag_count)(struct fy_allocator *a);
+	int (*set_tag_count)(struct fy_allocator *a, unsigned int tag_count);
+	void (*trim_tag)(struct fy_allocator *a, int tag);
+	void (*reset_tag)(struct fy_allocator *a, int tag);
+	struct fy_allocator_info *(*get_info)(struct fy_allocator *a, int tag);
+	enum fy_allocator_cap_flags (*get_caps)(struct fy_allocator *a);	/* Get capability flags (FYACF_*) */
+	bool (*contains)(struct fy_allocator *a, int tag, const void *ptr);
+};
+
+struct fy_allocator_stats {
+	union {
+		struct {
+			uint64_t allocations;
+			uint64_t allocated;
+			uint64_t frees;
+			uint64_t freed;
+			uint64_t stores;
+			uint64_t stored;
+			uint64_t releases;
+			uint64_t released;
+			uint64_t dup_stores;
+			uint64_t dup_saved;
+			uint64_t system_claimed;
+			uint64_t system_free;
+			uint64_t collisions;
+			uint64_t unique_stores;
+		};
+		uint64_t counters[14];
+	};
+};
+
+struct fy_allocator_arena_info {
+	size_t free, used, total;
+	void *data;
+	size_t size;
+};
+
+struct fy_allocator_tag_info {
+	int tag;
+	size_t free, used, total;
+	unsigned int num_arena_infos;
+	struct fy_allocator_arena_info *arena_infos;
+};
+
+struct fy_allocator_info {
+	size_t free, used, total;
+	unsigned int num_tag_infos;
+	struct fy_allocator_tag_info *tag_infos;
+};
+
+enum fy_allocator_flags {
+	FYAF_KEEP_STATS = FY_BIT(0),
+	FYAF_TRACE	= FY_BIT(1),
+};
+
+struct fy_allocator {
+	enum fy_allocator_flags flags;
+	const char *name;
+	const struct fy_allocator_ops *ops;
+	struct fy_allocator *parent;
+	int parent_tag;
+};
+
+/* these private still */
+int fy_allocator_update_stats(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats);
+struct fy_allocator_info *fy_allocator_get_info(struct fy_allocator *a, int tag);
+
+static inline void fy_allocator_set_keep_stats(struct fy_allocator *a, bool keep_flags)
+{
+	if (!a)
+		return;
+
+	if (keep_flags)
+		a->flags |= FYAF_KEEP_STATS;
+	else
+		a->flags &= ~FYAF_KEEP_STATS;
+}
+
+static inline void fy_allocator_set_trace(struct fy_allocator *a, bool trace)
+{
+	if (!a)
+		return;
+
+	if (trace)
+		a->flags |= FYAF_TRACE;
+	else
+		a->flags &= ~FYAF_TRACE;
+}
+
+FY_TYPE_FWD_DECL_LIST(registered_allocator_entry);
+struct fy_registered_allocator_entry {
+	struct list_head node;
+	const char *name;
+	const struct fy_allocator_ops *ops;
+};
+FY_TYPE_DECL_LIST(registered_allocator_entry);
+
+/* these are private still */
+char *fy_allocator_get_names(void);
+int fy_allocator_register(const char *name, const struct fy_allocator_ops *ops);
+int fy_allocator_unregister(const char *name);
+void fy_allocator_release(struct fy_allocator *a, int tag, const void *ptr, size_t size);
+
+/* respects the parent allocator (or uses posix_memalign if NULL) */
+void *fy_early_parent_allocator_alloc(struct fy_allocator *parent, int parent_tag, size_t size, size_t align);
+void fy_early_parent_allocator_free(struct fy_allocator *parent, int parent_tag, void *ptr);
+void *fy_parent_allocator_alloc(struct fy_allocator *a, size_t size, size_t align);
+void fy_parent_allocator_free(struct fy_allocator *a, void *ptr);
+
+#define FY_PARENT_ALLOCATOR_MALLOC	((struct fy_allocator *)NULL)
+#define FY_PARENT_ALLOCATOR_INPLACE	((struct fy_allocator *)(uintptr_t)-1)
+
+static inline struct fy_allocator *
+fy_allocator_get_parent(struct fy_allocator *a)
+{
+	if (!a || !a->parent || a->parent == FY_PARENT_ALLOCATOR_INPLACE)
+		return NULL;
+	return a->parent;
+}
+
+struct fy_allocator *
+fy_allocator_create_internal(const char *name, struct fy_allocator *parent, int parent_tag, const void *cfg);
+
+static inline void fy_allocator_destroy_nocheck(struct fy_allocator *a)
+{
+	a->ops->destroy(a);
+}
+
+static inline void fy_allocator_dump_nocheck(struct fy_allocator *a)
+{
+	a->ops->dump(a);
+}
+
+static inline int fy_allocator_update_stats_nocheck(struct fy_allocator *a, int tag, struct fy_allocator_stats *stats)
+{
+	return a->ops->update_stats(a, tag, stats);
+}
+
+static inline void *fy_allocator_alloc_nocheck(struct fy_allocator *a, int tag, size_t size, size_t align)
+{
+	return a->ops->alloc(a, tag, size, align);
+}
+
+static inline void fy_allocator_free_nocheck(struct fy_allocator *a, int tag, void *ptr)
+{
+	a->ops->free(a, tag, ptr);
+}
+
+static inline const void *fy_allocator_store_nocheck(struct fy_allocator *a, int tag, const void *data, size_t size, size_t align)
+{
+	struct iovec iov[1];
+
+	/* just call the storev */
+	iov[0].iov_base = (void *)data;
+	iov[0].iov_len = size;
+
+	return a->ops->storev(a, tag, iov, 1, align, 0);
+}
+
+static inline const void *fy_allocator_lookup_nocheck(struct fy_allocator *a, int tag, const void *data, size_t size, size_t align)
+{
+	struct iovec iov[1];
+
+	/* just call the storev */
+	iov[0].iov_base = (void *)data;
+	iov[0].iov_len = size;
+
+	return a->ops->lookupv(a, tag, iov, 1, align, 0);
+}
+static inline const void *fy_allocator_lookupv_nocheck(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	return a->ops->lookupv(a, tag, iov, iovcnt, align, hash);
+}
+
+static inline const void *fy_allocator_storev_hash_nocheck(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align, uint64_t hash)
+{
+	return a->ops->storev(a, tag, iov, iovcnt, align, hash);
+}
+
+static inline const void *fy_allocator_storev_nocheck(struct fy_allocator *a, int tag, const struct iovec *iov, int iovcnt, size_t align)
+{
+	return a->ops->storev(a, tag, iov, iovcnt, align, 0);
+}
+
+static inline void fy_allocator_release_nocheck(struct fy_allocator *a, int tag, const void *ptr, size_t size)
+{
+	a->ops->release(a, tag, ptr, size);
+}
+
+static inline int fy_allocator_get_tag_nocheck(struct fy_allocator *a)
+{
+	return a->ops->get_tag(a);
+}
+
+static inline void fy_allocator_release_tag_nocheck(struct fy_allocator *a, int tag)
+{
+	a->ops->release_tag(a, tag);
+}
+
+static inline int fy_allocator_get_tag_count_nocheck(struct fy_allocator *a)
+{
+	return a->ops->get_tag_count(a);
+}
+
+static inline int fy_allocator_set_tag_count_nocheck(struct fy_allocator *a, unsigned int count)
+{
+	return a->ops->set_tag_count(a, count);
+}
+
+static inline void fy_allocator_trim_tag_nocheck(struct fy_allocator *a, int tag)
+{
+	a->ops->trim_tag(a, tag);
+}
+
+static inline void fy_allocator_reset_tag_nocheck(struct fy_allocator *a, int tag)
+{
+	a->ops->reset_tag(a, tag);
+}
+
+static inline struct fy_allocator_info *
+fy_allocator_get_info_nocheck(struct fy_allocator *a, int tag)
+{
+	return a->ops->get_info(a, tag);
+}
+
+static inline enum fy_allocator_cap_flags
+fy_allocator_get_caps_nocheck(struct fy_allocator *a)
+{
+	return a->ops->get_caps(a);
+}
+
+static inline bool
+fy_allocator_contains_nocheck(struct fy_allocator *a, int tag, const void *ptr)
+{
+	return a->ops->contains(a, tag, ptr);
+}
+
+#endif

--- a/numcosmo/external/libfyaml/src/blake3/blake3.c
+++ b/numcosmo/external/libfyaml/src/blake3/blake3.c
@@ -1,0 +1,747 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#ifndef _WIN32
+#include <pthread.h>
+#endif
+
+#include "blake3.h"
+#include "blake3_impl.h"
+#include "blake3_internal.h"
+
+#include "fy-win32.h"
+#include "fy-thread.h"
+
+// GCC gets confused sometimes
+#ifdef GCC_DISABLE_WSTRING_OP_OVERREAD
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
+
+#undef HASHER_OP
+#ifdef HASHER_SUFFIX
+// two levels of indirection required
+#define __HASHER_OP(_name, _sfx) _name ##_ ## _sfx
+#define _HASHER_OP(_name, _sfx) __HASHER_OP(_name, _sfx)
+#define HASHER_OP(_name) _HASHER_OP(_name, HASHER_SUFFIX)
+#else
+#define HASHER_OP(_name) _name
+#endif
+
+#ifndef SIMD_DEGREE
+#define SIMD_DEGREE (hs->simd_degree)
+#endif
+
+#ifndef SIMD_DEGREE_OR_2
+#define SIMD_DEGREE_OR_2	(SIMD_DEGREE >= 2 ? SIMD_DEGREE : 2)
+#endif
+
+// keep the same naming
+#define MAX_SIMD_DEGREE SIMD_DEGREE
+#define MAX_SIMD_DEGREE_OR_2 SIMD_DEGREE_OR_2
+#define blake3_simd_degree() SIMD_DEGREE
+
+// rename to keep the same
+#define blake3_compress_in_place hasher->hs->compress_in_place
+#define blake3_compress_xof hasher->hs->compress_xof
+#define blake3_hash_many self->hs->hash_many
+
+INLINE void chunk_state_init(blake3_chunk_state *self, const uint32_t key[8],
+                             uint8_t flags) {
+  memcpy(self->cv, key, BLAKE3_KEY_LEN);
+  self->chunk_counter = 0;
+  self->buf_len = 0;
+  self->blocks_compressed = 0;
+  self->flags = flags;
+}
+
+INLINE void chunk_state_reset(blake3_chunk_state *self, const uint32_t key[8],
+                              uint64_t chunk_counter) {
+  memcpy(self->cv, key, BLAKE3_KEY_LEN);
+  self->chunk_counter = chunk_counter;
+  self->blocks_compressed = 0;
+  self->buf_len = 0;
+}
+
+INLINE size_t chunk_state_len(const blake3_chunk_state *self) {
+  return (BLAKE3_BLOCK_LEN * (size_t)self->blocks_compressed) +
+         ((size_t)self->buf_len);
+}
+
+INLINE size_t chunk_state_fill_buf(blake3_chunk_state *self,
+                                   const uint8_t *input, size_t input_len) {
+  size_t take = BLAKE3_BLOCK_LEN - ((size_t)self->buf_len);
+  if (take > input_len) {
+    take = input_len;
+  }
+  uint8_t *dest = self->buf + ((size_t)self->buf_len);
+  memcpy(dest, input, take);
+  self->buf_len += (uint8_t)take;
+  return take;
+}
+
+INLINE uint8_t chunk_state_maybe_start_flag(const blake3_chunk_state *self) {
+  if (self->blocks_compressed == 0) {
+    return CHUNK_START;
+  } else {
+    return 0;
+  }
+}
+
+typedef struct {
+  uint32_t input_cv[8] BLAKE3_ALIGN;
+  uint8_t block[BLAKE3_BLOCK_LEN] BLAKE3_ALIGN;
+  uint64_t counter;
+  uint8_t block_len;
+  uint8_t flags;
+} output_t;
+
+INLINE output_t make_output(const uint32_t input_cv[BLAKE3_OUT_WORDS],
+                            const uint8_t block[BLAKE3_BLOCK_LEN],
+                            uint8_t block_len, uint64_t counter,
+                            uint8_t flags) {
+  output_t ret;
+  memcpy(ret.input_cv, input_cv, BLAKE3_OUT_LEN);
+  memcpy(ret.block, block, block_len);
+  ret.block_len = block_len;
+  ret.counter = counter;
+  ret.flags = flags;
+  return ret;
+}
+
+// Chaining values within a given chunk (specifically the compress_in_place
+// interface) are represented as words. This avoids unnecessary bytes<->words
+// conversion overhead in the portable implementation. However, the hash_many
+// interface handles both user input and parent node blocks, so it accepts
+// bytes. For that reason, chaining values in the CV stack are represented as
+// bytes.
+INLINE void output_chaining_value(const blake3_hasher *hasher, output_t *self, uint8_t cv[BLAKE3_OUT_LEN]) {
+  uint32_t cv_words[BLAKE3_OUT_WORDS] BLAKE3_ALIGN;
+  memcpy(cv_words, self->input_cv, BLAKE3_OUT_LEN);
+  memset(self->block + self->block_len, 0, BLAKE3_BLOCK_LEN - self->block_len);
+  blake3_compress_in_place(cv_words, self->block, self->block_len,
+                           self->counter, self->flags);
+  store_cv_words(cv, cv_words);
+}
+
+INLINE void output_root_bytes(const blake3_hasher *hasher, output_t *self, uint64_t seek, uint8_t *out,
+                              size_t out_len) {
+  uint64_t output_block_counter = seek / 64;
+  size_t offset_within_block = seek % 64;
+  uint8_t wide_buf[64] BLAKE3_ALIGN;
+  while (out_len > 0) {
+    memset(self->block + self->block_len, 0, BLAKE3_BLOCK_LEN - self->block_len);
+    blake3_compress_xof(self->input_cv, self->block, self->block_len,
+                        output_block_counter, self->flags | ROOT, wide_buf);
+    size_t available_bytes = 64 - offset_within_block;
+    size_t memcpy_len;
+    if (out_len > available_bytes) {
+      memcpy_len = available_bytes;
+    } else {
+      memcpy_len = out_len;
+    }
+    memcpy(out, wide_buf + offset_within_block, memcpy_len);
+    out += memcpy_len;
+    out_len -= memcpy_len;
+    output_block_counter += 1;
+    offset_within_block = 0;
+  }
+}
+
+INLINE void chunk_state_update(blake3_hasher *hasher, blake3_chunk_state *self, const uint8_t *input,
+                               size_t input_len) {
+  if (self->buf_len > 0) {
+    size_t take = chunk_state_fill_buf(self, input, input_len);
+    input += take;
+    input_len -= take;
+    if (input_len > 0) {
+      blake3_compress_in_place(
+          self->cv, self->buf, BLAKE3_BLOCK_LEN, self->chunk_counter,
+          self->flags | chunk_state_maybe_start_flag(self));
+      self->blocks_compressed += 1;
+      self->buf_len = 0;
+    }
+  }
+
+  while (input_len > BLAKE3_BLOCK_LEN) {
+    blake3_compress_in_place(self->cv, input, BLAKE3_BLOCK_LEN,
+                             self->chunk_counter,
+                             self->flags | chunk_state_maybe_start_flag(self));
+    self->blocks_compressed += 1;
+    input += BLAKE3_BLOCK_LEN;
+    input_len -= BLAKE3_BLOCK_LEN;
+  }
+
+  size_t take = chunk_state_fill_buf(self, input, input_len);
+  input += take;
+  input_len -= take;
+}
+
+INLINE output_t chunk_state_output(const blake3_chunk_state *self) {
+  uint8_t block_flags =
+      self->flags | chunk_state_maybe_start_flag(self) | CHUNK_END;
+  return make_output(self->cv, self->buf, self->buf_len, self->chunk_counter,
+                     block_flags);
+}
+
+INLINE output_t parent_output(const uint8_t block[BLAKE3_BLOCK_LEN],
+                              const uint32_t key[8], uint8_t flags) {
+  return make_output(key, block, BLAKE3_BLOCK_LEN, 0, flags | PARENT);
+}
+
+// Given some input larger than one chunk, return the number of bytes that
+// should go in the left subtree. This is the largest power-of-2 number of
+// chunks that leaves at least 1 byte for the right subtree.
+INLINE size_t left_len(size_t content_len) {
+  // Subtract 1 to reserve at least one byte for the right side. content_len
+  // should always be greater than BLAKE3_CHUNK_LEN.
+  size_t full_chunks = (content_len - 1) / BLAKE3_CHUNK_LEN;
+  return round_down_to_power_of_2(full_chunks) * BLAKE3_CHUNK_LEN;
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE chunks at the same time
+// on a single thread. Write out the chunk chaining values and return the
+// number of chunks hashed. These chunks are never the root and never empty;
+// those cases use a different codepath.
+INLINE size_t compress_chunks_parallel(blake3_hasher *self,
+		                       const uint8_t *input, size_t input_len,
+                                       const uint32_t key[8],
+                                       uint64_t chunk_counter, uint8_t flags,
+                                       uint8_t *out) {
+#if defined(BLAKE3_TESTING)
+  assert(0 < input_len);
+  assert(input_len <= MAX_SIMD_DEGREE * BLAKE3_CHUNK_LEN);
+#endif
+
+  const uint8_t *chunks_array[MAX_SIMD_DEGREE];
+  size_t input_position = 0;
+  size_t chunks_array_len = 0;
+  while (input_len - input_position >= BLAKE3_CHUNK_LEN) {
+    chunks_array[chunks_array_len] = &input[input_position];
+    input_position += BLAKE3_CHUNK_LEN;
+    chunks_array_len += 1;
+  }
+  size_t i = chunks_array_len;
+  while (i < MAX_SIMD_DEGREE)
+	  chunks_array[i++] = NULL;
+
+  blake3_hash_many(chunks_array, chunks_array_len,
+                   BLAKE3_CHUNK_LEN / BLAKE3_BLOCK_LEN, key, chunk_counter,
+                   true, flags, CHUNK_START, CHUNK_END, out);
+
+  // Hash the remaining partial chunk, if there is one. Note that the empty
+  // chunk (meaning the empty message) is a different codepath.
+  if (input_len > input_position) {
+    uint64_t counter = chunk_counter + (uint64_t)chunks_array_len;
+    blake3_chunk_state chunk_state;
+    chunk_state_init(&chunk_state, key, flags);
+    chunk_state.chunk_counter = counter;
+    chunk_state_update(self, &chunk_state, &input[input_position],
+                       input_len - input_position);
+    output_t output = chunk_state_output(&chunk_state);
+    output_chaining_value(self, &output, &out[chunks_array_len * BLAKE3_OUT_LEN]);
+    return chunks_array_len + 1;
+  } else {
+    return chunks_array_len;
+  }
+}
+
+// Use SIMD parallelism to hash up to MAX_SIMD_DEGREE parents at the same time
+// on a single thread. Write out the parent chaining values and return the
+// number of parents hashed. (If there's an odd input chaining value left over,
+// return it as an additional output.) These parents are never the root and
+// never empty; those cases use a different codepath.
+INLINE size_t compress_parents_parallel(blake3_hasher *self,
+					const uint8_t *child_chaining_values,
+                                        size_t num_chaining_values,
+                                        const uint32_t key[8], uint8_t flags,
+                                        uint8_t *out) {
+#if defined(BLAKE3_TESTING)
+  assert(2 <= num_chaining_values);
+  assert(num_chaining_values <= 2 * MAX_SIMD_DEGREE_OR_2);
+#endif
+
+  const uint8_t *parents_array[MAX_SIMD_DEGREE_OR_2];
+  size_t parents_array_len = 0;
+  while (num_chaining_values - (2 * parents_array_len) >= 2) {
+    parents_array[parents_array_len] =
+        &child_chaining_values[2 * parents_array_len * BLAKE3_OUT_LEN];
+    parents_array_len += 1;
+  }
+
+  blake3_hash_many(parents_array, parents_array_len, 1, key,
+                   0, // Parents always use counter 0.
+                   false, flags | PARENT,
+                   0, // Parents have no start flags.
+                   0, // Parents have no end flags.
+                   out);
+
+  // If there's an odd child left over, it becomes an output.
+  if (num_chaining_values > 2 * parents_array_len) {
+    memcpy(&out[parents_array_len * BLAKE3_OUT_LEN],
+           &child_chaining_values[2 * parents_array_len * BLAKE3_OUT_LEN],
+           BLAKE3_OUT_LEN);
+    return parents_array_len + 1;
+  } else {
+    return parents_array_len;
+  }
+}
+
+static size_t blake3_compress_subtree_wide(blake3_hasher *self,
+		                           const uint8_t *input,
+                                           size_t input_len,
+                                           const uint32_t key[8],
+                                           uint64_t chunk_counter,
+                                           uint8_t flags, uint8_t *out);
+
+static bool blake3_compress_subtree_wide_work_check(const void *arg) {
+  const blake3_compress_subtree_state *s = arg;
+
+  /* only off-load to thread if we have enough input */
+  return s->input_len >= s->self->hs->mt_degree * BLAKE3_CHUNK_LEN;
+}
+
+static void blake3_compress_subtree_wide_thread(void *arg) {
+  blake3_compress_subtree_state *s = arg;
+
+  s->n = blake3_compress_subtree_wide(s->self,
+              s->input, s->input_len,
+              s->key,
+              s->chunk_counter,
+              s->flags,
+              s->out);
+}
+
+// The wide helper function returns (writes out) an array of chaining values
+// and returns the length of that array. The number of chaining values returned
+// is the dynamically detected SIMD degree, at most MAX_SIMD_DEGREE. Or fewer,
+// if the input is shorter than that many chunks. The reason for maintaining a
+// wide array of chaining values going back up the tree, is to allow the
+// implementation to hash as many parents in parallel as possible.
+//
+// As a special case when the SIMD degree is 1, this function will still return
+// at least 2 outputs. This guarantees that this function doesn't perform the
+// root compression. (If it did, it would use the wrong flags, and also we
+// wouldn't be able to implement extendable output.) Note that this function is
+// not used when the whole input is only 1 chunk long; that's a different
+// codepath.
+//
+// Why not just have the caller split the input on the first update(), instead
+// of implementing this special rule? Because we don't want to limit SIMD or
+// multi-threading parallelism for that update().
+static size_t blake3_compress_subtree_wide(blake3_hasher *self, const uint8_t *input,
+                                           size_t input_len,
+                                           const uint32_t key[8],
+                                           uint64_t chunk_counter,
+                                           uint8_t flags, uint8_t *out) {
+  // Note that the single chunk case does *not* bump the SIMD degree up to 2
+  // when it is 1. If this implementation adds multi-threading in the future,
+  // this gives us the option of multi-threading even the 2-chunk case, which
+  // can help performance on smaller platforms.
+  if (input_len <= blake3_simd_degree() * BLAKE3_CHUNK_LEN) {
+    return compress_chunks_parallel(self, input, input_len, key, chunk_counter, flags,
+                                    out);
+  }
+
+  // With more than simd_degree chunks, we need to recurse. Start by dividing
+  // the input into left and right subtrees. (Note that this is only optimal
+  // as long as the SIMD degree is a power of 2. If we ever get a SIMD degree
+  // of 3 or something, we'll need a more complicated strategy.)
+  size_t left_input_len = left_len(input_len);
+  size_t right_input_len = input_len - left_input_len;
+  const uint8_t *right_input = &input[left_input_len];
+  uint64_t right_chunk_counter =
+      chunk_counter + (uint64_t)(left_input_len / BLAKE3_CHUNK_LEN);
+
+  // Make space for the child outputs. Here we use MAX_SIMD_DEGREE_OR_2 to
+  // account for the special case of returning 2 outputs when the SIMD degree
+  // is 1.
+  uint8_t cv_array[2 * MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
+  size_t degree = blake3_simd_degree();
+  if (left_input_len > BLAKE3_CHUNK_LEN && degree == 1) {
+    // The special case: We always use a degree of at least two, to make
+    // sure there are two outputs. Except, as noted above, at the chunk
+    // level, where we allow degree=1. (Note that the 1-chunk-input case is
+    // a different codepath.)
+    degree = 2;
+  }
+  uint8_t *right_cvs = &cv_array[degree * BLAKE3_OUT_LEN];
+
+  // Recurse
+  size_t left_n, right_n;
+  if (self->hs->cfg.no_mthread) {
+    left_n = blake3_compress_subtree_wide(self, input, left_input_len, key,
+        chunk_counter, flags, cv_array);
+    right_n = blake3_compress_subtree_wide(self, right_input, right_input_len, key,
+        right_chunk_counter, flags, right_cvs);
+  } else {
+
+    // this is the multi-threaded implementation
+    blake3_compress_subtree_state states[2];
+
+    /* common */
+    states[0].self = states[1].self = self;
+    states[0].key = states[1].key = key;
+    states[0].flags = states[1].flags = flags;
+    states[0].n = states[1].n = 0;
+
+    /* left */
+    states[0].input = input;
+    states[0].input_len = left_input_len;
+    states[0].chunk_counter = chunk_counter;
+    states[0].out = cv_array;
+
+    /* right */
+    states[1].input = right_input;
+    states[1].input_len = right_input_len;
+    states[1].chunk_counter = right_chunk_counter;
+    states[1].out = right_cvs;
+
+    fy_thread_arg_array_join(self->hs->tp,
+        blake3_compress_subtree_wide_thread,
+        blake3_compress_subtree_wide_work_check,
+        states, sizeof(states[0]), 2);
+
+    left_n = states[0].n;
+    right_n = states[1].n;
+  }
+
+  // The special case again. If SIMD_DEGREE=1, then we'll have left_n=1 and
+  // right_n=1. Rather than compressing them into a single output, return
+  // them directly, to make sure we always have at least two outputs.
+  if (left_n == 1) {
+    memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
+    return 2;
+  }
+
+  // Otherwise, do one layer of parent node compression.
+  size_t num_chaining_values = left_n + right_n;
+  return compress_parents_parallel(self, cv_array, num_chaining_values, key, flags,
+                                   out);
+}
+
+// Hash a subtree with compress_subtree_wide(), and then condense the resulting
+// list of chaining values down to a single parent node. Don't compress that
+// last parent node, however. Instead, return its message bytes (the
+// concatenated chaining values of its children). This is necessary when the
+// first call to update() supplies a complete subtree, because the topmost
+// parent node of that subtree could end up being the root. It's also necessary
+// for extended output in the general case.
+//
+// As with compress_subtree_wide(), this function is not used on inputs of 1
+// chunk or less. That's a different codepath.
+INLINE void compress_subtree_to_parent_node(blake3_hasher *self,
+    const uint8_t *input, size_t input_len, const uint32_t key[8],
+    uint64_t chunk_counter, uint8_t flags, uint8_t out[2 * BLAKE3_OUT_LEN]) {
+#if defined(BLAKE3_TESTING)
+  assert(input_len > BLAKE3_CHUNK_LEN);
+#endif
+
+  uint8_t cv_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN];
+  size_t num_cvs = blake3_compress_subtree_wide(self, input, input_len, key,
+                                                chunk_counter, flags, cv_array);
+  assert(num_cvs <= MAX_SIMD_DEGREE_OR_2);
+
+  // If MAX_SIMD_DEGREE is greater than 2 and there's enough input,
+  // compress_subtree_wide() returns more than 2 chaining values. Condense
+  // them into 2 by forming parent nodes repeatedly.
+  uint8_t out_array[MAX_SIMD_DEGREE_OR_2 * BLAKE3_OUT_LEN / 2];
+  // The second half of this loop condition is always true, and we just
+  // asserted it above. But GCC can't tell that it's always true, and if NDEBUG
+  // is set on platforms where MAX_SIMD_DEGREE_OR_2 == 2, GCC emits spurious
+  // warnings here. GCC 8.5 is particularly sensitive, so if you're changing
+  // this code, test it against that version.
+  while (num_cvs > 2 && num_cvs <= MAX_SIMD_DEGREE_OR_2) {
+    num_cvs =
+        compress_parents_parallel(self, cv_array, num_cvs, key, flags, out_array);
+    memcpy(cv_array, out_array, num_cvs * BLAKE3_OUT_LEN);
+  }
+  memcpy(out, cv_array, 2 * BLAKE3_OUT_LEN);
+}
+
+INLINE void hasher_init_base(blake3_host_state *hs, blake3_hasher *self, const uint32_t key[8],
+                             uint8_t flags) {
+  memset(self, 0, sizeof(*self));
+  self->hs = hs;
+  memcpy(self->key, key, BLAKE3_KEY_LEN);
+  chunk_state_init(&self->chunk, key, flags);
+  self->cv_stack_len = 0;
+}
+
+static const uint32_t IV[8] BLAKE3_ALIGN = {
+  B3_IV_0, B3_IV_1, B3_IV_2, B3_IV_3,
+  B3_IV_4, B3_IV_5, B3_IV_6, B3_IV_7,
+};
+
+void HASHER_OP(blake3_hasher_init) (blake3_host_state *hs, blake3_hasher *self) { hasher_init_base(hs, self, IV, 0); }
+
+void HASHER_OP(blake3_hasher_init_keyed) (blake3_host_state *hs, blake3_hasher *self,
+                              const uint8_t key[BLAKE3_KEY_LEN]) {
+  uint32_t key_words[8] BLAKE3_ALIGN;
+  load_key_words(key, key_words);
+  hasher_init_base(hs, self, key_words, KEYED_HASH);
+}
+
+void HASHER_OP(blake3_hasher_init_derive_key_raw) (blake3_host_state *hs, blake3_hasher *self, const void *context,
+                                       size_t context_len) {
+  blake3_hasher context_hasher;
+  hasher_init_base(hs, &context_hasher, IV, DERIVE_KEY_CONTEXT);
+  blake3_hasher_update(&context_hasher, context, context_len);
+  uint8_t context_key[BLAKE3_KEY_LEN];
+  blake3_hasher_finalize(&context_hasher, context_key, BLAKE3_KEY_LEN);
+  uint32_t context_key_words[8];
+  load_key_words(context_key, context_key_words);
+  hasher_init_base(hs, self, context_key_words, DERIVE_KEY_MATERIAL);
+}
+
+void HASHER_OP(blake3_hasher_init_derive_key) (blake3_host_state *hs, blake3_hasher *self, const char *context) {
+  blake3_hasher_init_derive_key_raw(hs, self, context, strlen(context));
+}
+
+// As described in hasher_push_cv() below, we do "lazy merging", delaying
+// merges until right before the next CV is about to be added. This is
+// different from the reference implementation. Another difference is that we
+// aren't always merging 1 chunk at a time. Instead, each CV might represent
+// any power-of-two number of chunks, as long as the smaller-above-larger stack
+// order is maintained. Instead of the "count the trailing 0-bits" algorithm
+// described in the spec, we use a "count the total number of 1-bits" variant
+// that doesn't require us to retain the subtree size of the CV on top of the
+// stack. The principle is the same: each CV that should remain in the stack is
+// represented by a 1-bit in the total number of chunks (or bytes) so far.
+INLINE void hasher_merge_cv_stack(blake3_hasher *self, uint64_t total_len) {
+  size_t post_merge_stack_len = (size_t)popcnt(total_len);
+  while (self->cv_stack_len > post_merge_stack_len) {
+    uint8_t *parent_node =
+        &self->cv_stack[(self->cv_stack_len - 2) * BLAKE3_OUT_LEN];
+    output_t output = parent_output(parent_node, self->key, self->chunk.flags);
+    output_chaining_value(self, &output, parent_node);
+    self->cv_stack_len -= 1;
+  }
+}
+
+// In reference_impl.rs, we merge the new CV with existing CVs from the stack
+// before pushing it. We can do that because we know more input is coming, so
+// we know none of the merges are root.
+//
+// This setting is different. We want to feed as much input as possible to
+// compress_subtree_wide(), without setting aside anything for the chunk_state.
+// If the user gives us 64 KiB, we want to parallelize over all 64 KiB at once
+// as a single subtree, if at all possible.
+//
+// This leads to two problems:
+// 1) This 64 KiB input might be the only call that ever gets made to update.
+//    In this case, the root node of the 64 KiB subtree would be the root node
+//    of the whole tree, and it would need to be ROOT finalized. We can't
+//    compress it until we know.
+// 2) This 64 KiB input might complete a larger tree, whose root node is
+//    similarly going to be the the root of the whole tree. For example, maybe
+//    we have 196 KiB (that is, 128 + 64) hashed so far. We can't compress the
+//    node at the root of the 256 KiB subtree until we know how to finalize it.
+//
+// The second problem is solved with "lazy merging". That is, when we're about
+// to add a CV to the stack, we don't merge it with anything first, as the
+// reference impl does. Instead we do merges using the *previous* CV that was
+// added, which is sitting on top of the stack, and we put the new CV
+// (unmerged) on top of the stack afterwards. This guarantees that we never
+// merge the root node until finalize().
+//
+// Solving the first problem requires an additional tool,
+// compress_subtree_to_parent_node(). That function always returns the top
+// *two* chaining values of the subtree it's compressing. We then do lazy
+// merging with each of them separately, so that the second CV will always
+// remain unmerged. (That also helps us support extendable output when we're
+// hashing an input all-at-once.)
+INLINE void hasher_push_cv(blake3_hasher *self, uint8_t new_cv[BLAKE3_OUT_LEN],
+                           uint64_t chunk_counter) {
+  hasher_merge_cv_stack(self, chunk_counter);
+  memcpy(&self->cv_stack[self->cv_stack_len * BLAKE3_OUT_LEN], new_cv,
+         BLAKE3_OUT_LEN);
+  self->cv_stack_len += 1;
+}
+
+void HASHER_OP(blake3_hasher_update) (blake3_hasher *self, const void *input,
+                          size_t input_len) {
+  // Explicitly checking for zero avoids causing UB by passing a null pointer
+  // to memcpy. This comes up in practice with things like:
+  //   std::vector<uint8_t> v;
+  //   blake3_hasher_update(&hasher, v.data(), v.size());
+  if (input_len == 0) {
+    return;
+  }
+
+  const uint8_t *input_bytes = (const uint8_t *)input;
+
+  // If we have some partial chunk bytes in the internal chunk_state, we need
+  // to finish that chunk first.
+  if (chunk_state_len(&self->chunk) > 0) {
+    size_t take = BLAKE3_CHUNK_LEN - chunk_state_len(&self->chunk);
+    if (take > input_len) {
+      take = input_len;
+    }
+    chunk_state_update(self, &self->chunk, input_bytes, take);
+    input_bytes += take;
+    input_len -= take;
+    // If we've filled the current chunk and there's more coming, finalize this
+    // chunk and proceed. In this case we know it's not the root.
+    if (input_len > 0) {
+      output_t output = chunk_state_output(&self->chunk);
+      uint8_t chunk_cv[32] BLAKE3_ALIGN;
+      output_chaining_value(self, &output, chunk_cv);
+      hasher_push_cv(self, chunk_cv, self->chunk.chunk_counter);
+      chunk_state_reset(&self->chunk, self->key, self->chunk.chunk_counter + 1);
+    } else {
+      return;
+    }
+  }
+
+  // Now the chunk_state is clear, and we have more input. If there's more than
+  // a single chunk (so, definitely not the root chunk), hash the largest whole
+  // subtree we can, with the full benefits of SIMD (and maybe in the future,
+  // multi-threading) parallelism. Two restrictions:
+  // - The subtree has to be a power-of-2 number of chunks. Only subtrees along
+  //   the right edge can be incomplete, and we don't know where the right edge
+  //   is going to be until we get to finalize().
+  // - The subtree must evenly divide the total number of chunks up until this
+  //   point (if total is not 0). If the current incomplete subtree is only
+  //   waiting for 1 more chunk, we can't hash a subtree of 4 chunks. We have
+  //   to complete the current subtree first.
+  // Because we might need to break up the input to form powers of 2, or to
+  // evenly divide what we already have, this part runs in a loop.
+  while (input_len > BLAKE3_CHUNK_LEN) {
+    size_t subtree_len = round_down_to_power_of_2(input_len);
+    uint64_t count_so_far = self->chunk.chunk_counter * BLAKE3_CHUNK_LEN;
+    // Shrink the subtree_len until it evenly divides the count so far. We know
+    // that subtree_len itself is a power of 2, so we can use a bitmasking
+    // trick instead of an actual remainder operation. (Note that if the caller
+    // consistently passes power-of-2 inputs of the same size, as is hopefully
+    // typical, this loop condition will always fail, and subtree_len will
+    // always be the full length of the input.)
+    //
+    // An aside: We don't have to shrink subtree_len quite this much. For
+    // example, if count_so_far is 1, we could pass 2 chunks to
+    // compress_subtree_to_parent_node. Since we'll get 2 CVs back, we'll still
+    // get the right answer in the end, and we might get to use 2-way SIMD
+    // parallelism. The problem with this optimization, is that it gets us
+    // stuck always hashing 2 chunks. The total number of chunks will remain
+    // odd, and we'll never graduate to higher degrees of parallelism. See
+    // https://github.com/BLAKE3-team/BLAKE3/issues/69.
+    while ((((uint64_t)(subtree_len - 1)) & count_so_far) != 0) {
+      subtree_len /= 2;
+    }
+    // The shrunken subtree_len might now be 1 chunk long. If so, hash that one
+    // chunk by itself. Otherwise, compress the subtree into a pair of CVs.
+    uint64_t subtree_chunks = subtree_len / BLAKE3_CHUNK_LEN;
+    if (subtree_len <= BLAKE3_CHUNK_LEN) {
+      blake3_chunk_state chunk_state;
+      chunk_state_init(&chunk_state, self->key, self->chunk.flags);
+      chunk_state.chunk_counter = self->chunk.chunk_counter;
+      chunk_state_update(self, &chunk_state, input_bytes, subtree_len);
+      output_t output = chunk_state_output(&chunk_state);
+      uint8_t cv[BLAKE3_OUT_LEN] BLAKE3_ALIGN;
+      output_chaining_value(self, &output, cv);
+      hasher_push_cv(self, cv, chunk_state.chunk_counter);
+    } else {
+      // This is the high-performance happy path, though getting here depends
+      // on the caller giving us a long enough input.
+      uint8_t cv_pair[2 * BLAKE3_OUT_LEN] BLAKE3_ALIGN;
+      compress_subtree_to_parent_node(self, input_bytes, subtree_len, self->key,
+                                      self->chunk.chunk_counter,
+                                      self->chunk.flags, cv_pair);
+      hasher_push_cv(self, cv_pair, self->chunk.chunk_counter);
+      hasher_push_cv(self, &cv_pair[BLAKE3_OUT_LEN],
+                     self->chunk.chunk_counter + (subtree_chunks / 2));
+    }
+    self->chunk.chunk_counter += subtree_chunks;
+    input_bytes += subtree_len;
+    input_len -= subtree_len;
+  }
+
+  // If there's any remaining input less than a full chunk, add it to the chunk
+  // state. In that case, also do a final merge loop to make sure the subtree
+  // stack doesn't contain any unmerged pairs. The remaining input means we
+  // know these merges are non-root. This merge loop isn't strictly necessary
+  // here, because hasher_push_chunk_cv already does its own merge loop, but it
+  // simplifies blake3_hasher_finalize below.
+  if (input_len > 0) {
+    chunk_state_update(self, &self->chunk, input_bytes, input_len);
+    hasher_merge_cv_stack(self, self->chunk.chunk_counter);
+  }
+}
+
+void HASHER_OP(blake3_hasher_finalize_seek) (const blake3_hasher *self, uint64_t seek,
+                                 uint8_t *out, size_t out_len) {
+  // Explicitly checking for zero avoids causing UB by passing a null pointer
+  // to memcpy. This comes up in practice with things like:
+  //   std::vector<uint8_t> v;
+  //   blake3_hasher_finalize(&hasher, v.data(), v.size());
+  if (out_len == 0) {
+    return;
+  }
+
+  // If the subtree stack is empty, then the current chunk is the root.
+  if (self->cv_stack_len == 0) {
+    output_t output = chunk_state_output(&self->chunk);
+    output_root_bytes(self, &output, seek, out, out_len);
+    return;
+  }
+  // If there are any bytes in the chunk state, finalize that chunk and do a
+  // roll-up merge between that chunk hash and every subtree in the stack. In
+  // this case, the extra merge loop at the end of blake3_hasher_update
+  // guarantees that none of the subtrees in the stack need to be merged with
+  // each other first. Otherwise, if there are no bytes in the chunk state,
+  // then the top of the stack is a chunk hash, and we start the merge from
+  // that.
+  output_t output;
+  size_t cvs_remaining;
+  if (chunk_state_len(&self->chunk) > 0) {
+    cvs_remaining = self->cv_stack_len;
+    output = chunk_state_output(&self->chunk);
+  } else {
+    // There are always at least 2 CVs in the stack in this case.
+    cvs_remaining = self->cv_stack_len - 2;
+    output = parent_output(&self->cv_stack[cvs_remaining * 32], self->key,
+                           self->chunk.flags);
+  }
+  while (cvs_remaining > 0) {
+    cvs_remaining -= 1;
+    uint8_t parent_block[BLAKE3_BLOCK_LEN] BLAKE3_ALIGN;
+    memcpy(parent_block, &self->cv_stack[cvs_remaining * 32], 32);
+    output_chaining_value(self, &output, &parent_block[32]);
+    output = parent_output(parent_block, self->key, self->chunk.flags);
+  }
+  output_root_bytes(self, &output, seek, out, out_len);
+}
+
+void HASHER_OP(blake3_hasher_finalize) (const blake3_hasher *self, uint8_t *out,
+                            size_t out_len) {
+  HASHER_OP(blake3_hasher_finalize_seek) (self, 0, out, out_len);
+}
+
+void HASHER_OP(blake3_hasher_reset) (blake3_hasher *self) {
+  chunk_state_reset(&self->chunk, self->key, 0);
+  self->cv_stack_len = 0;
+}
+#ifdef GCC_DISABLE_WSTRING_OP_OVERREAD
+#pragma GCC diagnostic pop
+#endif
+
+const blake3_hasher_ops HASHER_OP(blake3_hasher_op) = {
+	.hasher_init			= HASHER_OP(blake3_hasher_init),
+	.hasher_init_keyed		= HASHER_OP(blake3_hasher_init_keyed),
+	.hasher_init_derive_key		= HASHER_OP(blake3_hasher_init_derive_key),
+	.hasher_init_derive_key_raw	= HASHER_OP(blake3_hasher_init_derive_key_raw),
+	.hasher_update			= HASHER_OP(blake3_hasher_update),
+	.hasher_finalize		= HASHER_OP(blake3_hasher_finalize),
+	.hasher_finalize_seek		= HASHER_OP(blake3_hasher_finalize_seek),
+	.hasher_reset			= HASHER_OP(blake3_hasher_reset),
+};

--- a/numcosmo/external/libfyaml/src/blake3/blake3.h
+++ b/numcosmo/external/libfyaml/src/blake3/blake3.h
@@ -1,0 +1,163 @@
+#ifndef BLAKE3_H
+#define BLAKE3_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdalign.h>
+
+#define BLAKE3_VERSION_STRING "1.4.1"
+
+#define BLAKE3_KEY_LEN 32
+#define BLAKE3_KEY_WORDS (BLAKE3_KEY_LEN / 4)	// words are 4 bytes
+#define BLAKE3_OUT_LEN 32
+#define BLAKE3_OUT_WORDS (BLAKE3_OUT_LEN / 4)	// words are 4 bytes
+#define BLAKE3_BLOCK_LEN 64
+#define BLAKE3_CHUNK_LEN 1024
+
+struct blake_host_state;
+struct blake_hasher;
+
+const char *blake3_version(void);
+
+/* NOTE: maximum supported backends is 64
+ * and backends are ordered by reverse order
+ * of preference.
+ *
+ * PORTABLE is always available and is the fall-back.
+ */
+
+typedef enum {
+
+	/* just the portable implementation */
+	B3BID_PORTABLE,
+
+	/* x86 */
+	B3BID_SSE2,
+	B3BID_SSE2_ASM,
+	B3BID_SSE41,
+	B3BID_SSE41_ASM,
+	B3BID_AVX2,
+	B3BID_AVX2_ASM,
+	B3BID_AVX512,
+	B3BID_AVX512_ASM,
+
+	/* arm */
+	B3BID_NEON,
+
+	/* gpu */
+	B3BID_VULKAN,
+	B3BID_OPENCL,
+	B3BID_CUDA,
+
+	/* CPU simd (experimental) */
+	B3BID_CPUSIMD,
+
+} blake3_backend_id;
+
+#define B3BID_COUNT	(B3BID_CPUSIMD+1)
+#define B3BID_INVALID	((blake3_backend_id)-1)
+
+#define B3BF_BIT(_x)	((uint64_t)1 << (_x))
+
+#define B3BF_PORTABLE	B3BF_BIT(B3BID_PORTABLE)
+
+#define B3BF_SSE2	B3BF_BIT(B3BID_SSE2)
+#define B3BF_SSE2_ASM	B3BF_BIT(B3BID_SSE2_ASM)
+#define B3BF_SSE41	B3BF_BIT(B3BID_SSE41)
+#define B3BF_SSE41_ASM	B3BF_BIT(B3BID_SSE41_ASM)
+#define B3BF_AVX2	B3BF_BIT(B3BID_AVX2)
+#define B3BF_AVX2_ASM	B3BF_BIT(B3BID_AVX2_ASM)
+#define B3BF_AVX512	B3BF_BIT(B3BID_AVX512)
+#define B3BF_AVX512_ASM	B3BF_BIT(B3BID_AVX512_ASM)
+
+#define B3BF_NEON	B3BF_BIT(B3BID_NEON)
+
+#define B3BF_VULKAN	B3BF_BIT(B3BID_VULKAN)
+#define B3BF_OPENCL	B3BF_BIT(B3BID_OPENCL)
+#define B3BF_CUDA	B3BF_BIT(B3BID_CUDA)
+
+#define B3BF_CPUSIMD	B3BF_BIT(B3BID_CPUSIMD)
+
+uint64_t blake3_get_supported_backends(void);
+uint64_t blake3_get_detected_backends(void);
+uint64_t blake3_get_selectable_backends(void);
+
+typedef enum {
+	B3FID_HASH_MANY,
+	B3FID_COMPRESS_XOF,
+	B3FID_COMPRESS_IN_PLACE,
+} blake3_func_id;
+
+#define B3FID_COUNT	(B3FID_COMPRESS_IN_PLACE+1)
+#define B3FID_INVALID	((blake3_func_id)-1)
+
+#define B3FF_BIT(_x)	((uint64_t)1 << (_x))
+
+#define B3FF_HASH_MANY		B3FF_BIT(B3FID_HASH_MANY)
+#define B3FF_COMPRESS_XOF	B3FF_BIT(B3FID_COMPRESS_XOF)
+#define B3FF_COMPRESS_IN_PLACE	B3FF_BIT(B3FID_COMPRESS_IN_PLACE)
+
+typedef struct blake3_backend_info {
+	blake3_backend_id id;
+	const char *name;
+	const char *description;
+	unsigned int simd_degree;
+	uint64_t funcs;
+} blake3_backend_info;
+
+const blake3_backend_info *blake3_get_backend_info(blake3_backend_id id);
+
+typedef struct blake3_host_config {
+	bool debug;
+	bool no_mthread;
+	bool no_mmap;
+	unsigned int num_threads;
+	unsigned int mt_degree;		// number of chunks to be worth spinning up a thread
+	const char *backend;		// backend selection string, or NULL for default
+	size_t file_io_bufsz;		// buffer size when doing file I/O
+	size_t mmap_min_chunk;		// minimum chunk size for mmap
+	size_t mmap_max_chunk;		// maximum chunk size for mmap
+	struct fy_thread_pool *tp;	// use this thread pool instead of spinning one up
+} blake3_host_config;
+
+struct blake3_host_state *blake3_host_state_create(const blake3_host_config *cfg);
+void blake3_host_state_destroy(struct blake3_host_state *hs);
+
+struct blake3_hasher *blake3_hasher_create(struct blake3_host_state *hs, const uint8_t *key, const void *context, size_t context_len);
+void blake3_hasher_destroy(struct blake3_hasher *self);
+
+/* simple optimized method for file hashing */
+int blake3_hash_file(struct blake3_hasher *hasher, const char *filename, uint8_t output[BLAKE3_OUT_LEN]);
+void blake3_hash(struct blake3_hasher *hasher, const void *mem, size_t size, uint8_t output[BLAKE3_OUT_LEN]);
+
+/* experimental CPUSIMD enable */
+int blake3_backend_cpusimd_setup(unsigned int num_cpus, unsigned int mult_fact);
+void blake3_backend_cpusimd_cleanup(void);
+
+void blake3_hasher_init(struct blake3_host_state *hs, struct blake3_hasher *self);
+void blake3_hasher_init_keyed(struct blake3_host_state *hs, struct blake3_hasher *self, const uint8_t key[BLAKE3_KEY_LEN]);
+void blake3_hasher_init_derive_key(struct blake3_host_state *hs, struct blake3_hasher *self, const char *context);
+void blake3_hasher_init_derive_key_raw(struct blake3_host_state *hs, struct blake3_hasher *self, const void *context, size_t context_len);
+
+void blake3_hasher_update(struct blake3_hasher *self, const void *input, size_t input_len);
+void blake3_hasher_finalize(const struct blake3_hasher *self, uint8_t *out, size_t out_len);
+void blake3_hasher_finalize_seek(const struct blake3_hasher *self, uint64_t seek, uint8_t *out, size_t out_len);
+void blake3_hasher_reset(struct blake3_hasher *self);
+
+typedef struct blake3_hasher_ops {
+	void (*hasher_init)(struct blake3_host_state *hs, struct blake3_hasher *self);
+	void (*hasher_init_keyed)(struct blake3_host_state *hs, struct blake3_hasher *self, const uint8_t key[BLAKE3_KEY_LEN]);
+	void (*hasher_init_derive_key)(struct blake3_host_state *hs, struct blake3_hasher *self, const char *context);
+	void (*hasher_init_derive_key_raw)(struct blake3_host_state *hs, struct blake3_hasher *self, const void *context, size_t context_len);
+
+	void (*hasher_update)(struct blake3_hasher *self, const void *input, size_t input_len);
+	void (*hasher_finalize)(const struct blake3_hasher *self, uint8_t *out, size_t out_len);
+	void (*hasher_finalize_seek)(const struct blake3_hasher *self, uint64_t seek, uint8_t *out, size_t out_len);
+	void (*hasher_reset)(struct blake3_hasher *self);
+} blake3_hasher_ops;
+
+#endif /* BLAKE3_H */

--- a/numcosmo/external/libfyaml/src/blake3/blake3_backend.c
+++ b/numcosmo/external/libfyaml/src/blake3/blake3_backend.c
@@ -1,0 +1,583 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <stdlib.h>
+
+#include "fy-bit64.h"
+
+#include "blake3.h"
+#include "blake3_impl.h"
+#include "blake3_internal.h"
+
+// Declarations for implementation-specific functions.
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags);
+
+void blake3_compress_xof_portable(const uint32_t cv[8],
+                                  const uint8_t block[BLAKE3_BLOCK_LEN],
+                                  uint8_t block_len, uint64_t counter,
+                                  uint8_t flags, uint8_t out[64]);
+
+void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
+                               size_t blocks, const uint32_t key[8],
+                               uint64_t counter, bool increment_counter,
+                               uint8_t flags, uint8_t flags_start,
+                               uint8_t flags_end, uint8_t *out);
+
+/* the portable hasher (can drive the optimized ones, but not optimally) */
+extern const blake3_hasher_ops blake3_hasher_op_portable;
+
+#if defined(IS_X86)
+void blake3_compress_in_place_sse2(uint32_t cv[8],
+                                   const uint8_t block[BLAKE3_BLOCK_LEN],
+                                   uint8_t block_len, uint64_t counter,
+                                   uint8_t flags);
+void blake3_compress_xof_sse2(const uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+void blake3_compress_in_place_sse2_asm(uint32_t cv[8],
+                                   const uint8_t block[BLAKE3_BLOCK_LEN],
+                                   uint8_t block_len, uint64_t counter,
+                                   uint8_t flags);
+void blake3_compress_xof_sse2_asm(const uint32_t cv[8],
+                              const uint8_t block[BLAKE3_BLOCK_LEN],
+                              uint8_t block_len, uint64_t counter,
+                              uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse2_asm(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+
+extern const blake3_hasher_ops blake3_hasher_op_sse2;
+
+void blake3_compress_in_place_sse41(uint32_t cv[8],
+                                    const uint8_t block[BLAKE3_BLOCK_LEN],
+                                    uint8_t block_len, uint64_t counter,
+                                    uint8_t flags);
+void blake3_compress_xof_sse41(const uint32_t cv[8],
+                               const uint8_t block[BLAKE3_BLOCK_LEN],
+                               uint8_t block_len, uint64_t counter,
+                               uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse41(const uint8_t *const *inputs, size_t num_inputs,
+                            size_t blocks, const uint32_t key[8],
+                            uint64_t counter, bool increment_counter,
+                            uint8_t flags, uint8_t flags_start,
+                            uint8_t flags_end, uint8_t *out);
+void blake3_compress_in_place_sse41_asm(uint32_t cv[8],
+                                    const uint8_t block[BLAKE3_BLOCK_LEN],
+                                    uint8_t block_len, uint64_t counter,
+                                    uint8_t flags);
+void blake3_compress_xof_sse41_asm(const uint32_t cv[8],
+                               const uint8_t block[BLAKE3_BLOCK_LEN],
+                               uint8_t block_len, uint64_t counter,
+                               uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_sse41_asm(const uint8_t *const *inputs, size_t num_inputs,
+                            size_t blocks, const uint32_t key[8],
+                            uint64_t counter, bool increment_counter,
+                            uint8_t flags, uint8_t flags_start,
+                            uint8_t flags_end, uint8_t *out);
+
+extern const blake3_hasher_ops blake3_hasher_op_sse41;
+
+void blake3_hash_many_avx2(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+void blake3_hash_many_avx2_asm(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+
+extern const blake3_hasher_ops blake3_hasher_op_avx2;
+
+void blake3_compress_in_place_avx512(uint32_t cv[8],
+                                     const uint8_t block[BLAKE3_BLOCK_LEN],
+                                     uint8_t block_len, uint64_t counter,
+                                     uint8_t flags);
+void blake3_compress_xof_avx512(const uint32_t cv[8],
+                                const uint8_t block[BLAKE3_BLOCK_LEN],
+                                uint8_t block_len, uint64_t counter,
+                                uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_avx512(const uint8_t *const *inputs, size_t num_inputs,
+                             size_t blocks, const uint32_t key[8],
+                             uint64_t counter, bool increment_counter,
+                             uint8_t flags, uint8_t flags_start,
+                             uint8_t flags_end, uint8_t *out);
+void blake3_compress_in_place_avx512_asm(uint32_t cv[8],
+                                     const uint8_t block[BLAKE3_BLOCK_LEN],
+                                     uint8_t block_len, uint64_t counter,
+                                     uint8_t flags);
+void blake3_compress_xof_avx512_asm(const uint32_t cv[8],
+                                const uint8_t block[BLAKE3_BLOCK_LEN],
+                                uint8_t block_len, uint64_t counter,
+                                uint8_t flags, uint8_t out[64]);
+void blake3_hash_many_avx512_asm(const uint8_t *const *inputs, size_t num_inputs,
+                             size_t blocks, const uint32_t key[8],
+                             uint64_t counter, bool increment_counter,
+                             uint8_t flags, uint8_t flags_start,
+                             uint8_t flags_end, uint8_t *out);
+
+extern const blake3_hasher_ops blake3_hasher_op_avx512;
+
+#endif
+
+#if defined(IS_ARM)
+void blake3_hash_many_neon(const uint8_t *const *inputs, size_t num_inputs,
+                           size_t blocks, const uint32_t key[8],
+                           uint64_t counter, bool increment_counter,
+                           uint8_t flags, uint8_t flags_start,
+                           uint8_t flags_end, uint8_t *out);
+
+extern const blake3_hasher_ops blake3_hasher_op_neon;
+#endif
+
+static uint64_t supported_cpusimd_backend(void)
+{
+	const blake3_backend *be = &blake3_backends[B3BID_CPUSIMD];
+	return be->user ? B3BF_CPUSIMD : 0;
+}
+
+static uint64_t detected_cpusimd_backend(void)
+{
+	const blake3_backend *be = &blake3_backends[B3BID_CPUSIMD];
+	return be->user ? B3BF_CPUSIMD : 0;
+}
+
+static uint64_t supported_synthetic_backends(void)
+{
+	uint64_t backends = 0;
+
+	backends |= supported_cpusimd_backend();
+	return backends;
+}
+
+static uint64_t detected_synthetic_backends(void)
+{
+	uint64_t backends = 0;
+
+	backends |= detected_cpusimd_backend();
+	return backends;
+}
+
+static uint64_t supported_gpu_backends(void)
+{
+	return 0;
+}
+
+static uint64_t detected_gpu_backends(void)
+{
+	return 0;
+}
+
+#if defined(IS_X86)
+
+static uint64_t supported_backends_x86(void)
+{
+	uint64_t backends = 0;
+
+#if !defined(BLAKE3_NO_SSE2)
+	backends |= B3BF_SSE2 | B3BF_SSE2_ASM;
+#endif
+#if !defined(BLAKE3_NO_SSE41)
+	backends |= B3BF_SSE41 | B3BF_SSE41_ASM;
+#endif
+#if !defined(BLAKE3_NO_AVX)
+	backends |= B3BF_AVX2 | B3BF_AVX2_ASM;
+#endif
+#if !defined(BLAKE3_NO_AVX512)
+	backends |= B3BF_AVX512 | B3BF_AVX512_ASM;
+#endif
+	return backends;
+}
+
+static inline uint64_t xgetbv(void)
+{
+#if defined(_MSC_VER)
+	return _xgetbv(0);
+#else
+	uint32_t eax = 0, edx = 0;
+	__asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
+	return ((uint64_t)edx << 32) | eax;
+#endif
+}
+
+static inline void cpuid(uint32_t out[4], uint32_t id)
+{
+#if defined(_MSC_VER)
+	__cpuid((int *)out, id);
+#elif defined(__i386__) || defined(_M_IX86)
+	__asm__ __volatile__(
+			"movl %%ebx, %1\n"
+			"cpuid\n"
+			"xchgl %1, %%ebx\n"
+			: "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+			: "a"(id));
+#else
+	__asm__ __volatile__("cpuid\n"
+			: "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+			: "a"(id));
+#endif
+}
+
+static inline void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid)
+{
+#if defined(_MSC_VER)
+	__cpuidex((int *)out, id, sid);
+#elif defined(__i386__) || defined(_M_IX86)
+	__asm__ __volatile__(
+			"movl %%ebx, %1\n"
+			"cpuid\n"
+			"xchgl %1, %%ebx\n"
+			: "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+			: "a"(id), "c"(sid));
+#else
+	__asm__ __volatile__("cpuid\n"
+			: "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+			: "a"(id), "c"(sid));
+#endif
+}
+
+static uint64_t detected_backends_x86(void)
+{
+	uint32_t regs[4] = {0};
+	uint32_t *eax = &regs[0], *ebx = &regs[1], *ecx = &regs[2], *edx = &regs[3];
+	int max_id;
+	uint64_t mask = 0;
+	uint64_t backends = 0;
+
+	(void)edx;
+
+	cpuid(regs, 0);
+	max_id = *eax;
+	cpuid(regs, 1);
+
+#if defined(__amd64__) || defined(_M_X64)
+	backends |= B3BF_SSE2 | B3BF_SSE2_ASM;
+#else
+	if (*edx & (1UL << 26))
+		backends |= B3BF_SSE2 | B3BF_SSE2_ASM;
+#endif
+	if (*ecx & (1UL << 19))
+		backends |= B3BF_SSE41 | B3BF_SSE41_ASM;
+
+	if (*ecx & (1UL << 27)) { // OSXSAVE
+		mask = xgetbv();
+		if ((mask & 6) == 6) { // SSE and AVX states
+			if (max_id >= 7) {
+				cpuidex(regs, 7, 0);
+				if (*ebx & (1UL << 5))
+					backends |= B3BF_AVX2 | B3BF_AVX2_ASM;
+				if ((mask & 224) == 224) { // Opmask, ZMM_Hi256, Hi16_Zmm
+					if ((*ebx & ((1UL << 31) | (1UL << 16))) == ((1UL << 31) | (1UL << 16)))
+						backends |= B3BF_AVX512 | B3BF_AVX512_ASM;	/* AVX412VL+AVX512F  */
+				}
+			}
+		}
+	}
+
+	return backends;
+}
+#endif
+
+#if defined(IS_ARM)
+static uint64_t supported_backends_arm(void)
+{
+	uint64_t backends = 0;
+
+#if defined(IS_AARCH64)
+	backends |= B3BF_NEON;
+#endif
+
+	return backends;
+}
+
+static uint64_t detected_backends_arm(void)
+{
+	uint64_t backends = 0;
+
+#if defined(IS_AARCH64)
+	backends |= B3BF_NEON;
+#endif
+
+	return backends;
+}
+#endif
+
+uint64_t blake3_get_supported_backends(void)
+{
+	uint64_t supported_backends;
+
+	supported_backends = B3BF_PORTABLE;
+
+	supported_backends |= supported_gpu_backends();
+
+#if defined(IS_X86)
+	supported_backends |= supported_backends_x86();
+#endif
+
+#if defined(IS_ARM)
+	supported_backends |= supported_backends_arm();
+#endif
+
+	supported_backends |= supported_synthetic_backends();
+
+	return supported_backends;
+}
+
+uint64_t blake3_get_detected_backends(void)
+{
+	uint64_t detected_backends;
+
+	detected_backends = B3BF_PORTABLE;
+
+	detected_backends |= detected_gpu_backends();
+
+#if defined(IS_X86)
+	detected_backends |= detected_backends_x86();
+#endif
+
+#if defined(IS_ARM)
+	detected_backends |= detected_backends_arm();
+#endif
+
+	detected_backends |= detected_synthetic_backends();
+
+	return detected_backends;
+}
+
+uint64_t blake3_get_selectable_backends(void)
+{
+	return blake3_get_supported_backends() |
+               blake3_get_detected_backends();
+}
+
+blake3_backend blake3_backends[B3BID_COUNT] = {
+	[B3BID_PORTABLE] = {
+		.info = {
+			.id		= B3BID_PORTABLE,
+			.name		= "portable",
+			.description	= "portable C implementation",
+			.simd_degree	= 1,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_portable,
+		.hash_many		= blake3_hash_many_portable,
+		.compress_xof		= blake3_compress_xof_portable,
+		.compress_in_place	= blake3_compress_in_place_portable,
+	},
+#if defined(IS_X86)
+
+#if defined(TARGET_HAS_SSE2) && TARGET_HAS_SSE2
+	[B3BID_SSE2] = {
+		.info = {
+			.id		= B3BID_SSE2,
+			.name		= "sse2",
+			.description	= "x86 SSE2 implementation in C",
+			.simd_degree	= 4,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_sse2,
+		.hash_many		= blake3_hash_many_sse2,
+		.compress_xof		= blake3_compress_xof_sse2,
+		.compress_in_place	= blake3_compress_in_place_sse2,
+	},
+	[B3BID_SSE2_ASM] = {
+		.info = {
+			.id		= B3BID_SSE2_ASM,
+			.name		= "sse2-asm",
+			.description	= "x86 SSE2 implementation in assembly",
+			.simd_degree	= 4,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_sse2,
+		.hash_many		= blake3_hash_many_sse2_asm,
+		.compress_xof		= blake3_compress_xof_sse2_asm,
+		.compress_in_place	= blake3_compress_in_place_sse2_asm,
+	},
+#endif
+
+#if defined(TARGET_HAS_SSE41) && TARGET_HAS_SSE41
+	[B3BID_SSE41] = {
+		.info = {
+			.id		= B3BID_SSE41,
+			.name		= "sse41",
+			.description	= "x86 SSE41 implementation in C",
+			.simd_degree	= 4,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_sse41,
+		.hash_many		= blake3_hash_many_sse41,
+		.compress_xof		= blake3_compress_xof_sse41,
+		.compress_in_place	= blake3_compress_in_place_sse41,
+	},
+	[B3BID_SSE41_ASM] = {
+		.info = {
+			.id		= B3BID_SSE41_ASM,
+			.name		= "sse41-asm",
+			.description	= "x86 SSE41 implementation in assembly",
+			.simd_degree	= 4,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_sse41,
+		.hash_many		= blake3_hash_many_sse41_asm,
+		.compress_xof		= blake3_compress_xof_sse41_asm,
+		.compress_in_place	= blake3_compress_in_place_sse41_asm,
+	},
+#endif
+
+#if defined(TARGET_HAS_AVX2) && TARGET_HAS_AVX2
+	[B3BID_AVX2] = {
+		.info = {
+			.id		= B3BID_AVX2,
+			.name		= "avx2",
+			.description	= "x86 AVX2 implementation in C",
+			.simd_degree	= 8,
+			.funcs		= B3FF_HASH_MANY,
+		},
+		.hasher_ops		= &blake3_hasher_op_avx2,
+		.hash_many		= blake3_hash_many_avx2,
+	},
+	[B3BID_AVX2_ASM] = {
+		.info = {
+			.id		= B3BID_AVX2_ASM,
+			.name		= "avx2-asm",
+			.description	= "x86 AVX2 implementation in assembly",
+			.simd_degree	= 8,
+			.funcs		= B3FF_HASH_MANY,
+		},
+		.hasher_ops		= &blake3_hasher_op_avx2,
+		.hash_many		= blake3_hash_many_avx2_asm,
+	},
+#endif
+#if defined(TARGET_HAS_AVX512) && TARGET_HAS_AVX512
+	[B3BID_AVX512] = {
+		.info = {
+			.id		= B3BID_AVX512,
+			.name		= "avx512",
+			.description	= "x86 AVX512 VL+F implementation in C",
+			.simd_degree	= 16,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_avx512,
+		.hash_many		= blake3_hash_many_avx512,
+		.compress_xof		= blake3_compress_xof_avx512,
+		.compress_in_place	= blake3_compress_in_place_avx512,
+	},
+	[B3BID_AVX512_ASM] = {
+		.info = {
+			.id		= B3BID_AVX512_ASM,
+			.name		= "avx512-asm",
+			.description	= "x86 AVX512 VL+F implementation in assembly",
+			.simd_degree	= 16,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_avx512,
+		.hash_many		= blake3_hash_many_avx512,
+		.compress_xof		= blake3_compress_xof_avx512_asm,
+		.compress_in_place	= blake3_compress_in_place_avx512_asm,
+	},
+#endif
+
+#endif
+
+#if defined(IS_ARM)
+
+#if defined(TARGET_HAS_NEON) && TARGET_HAS_NEON
+	[B3BID_NEON] = {
+		.info = {
+			.id		= B3BID_NEON,
+			.name		= "neon",
+			.description	= "arm NEON implementation",
+			.simd_degree	= 4,
+			.funcs		= B3FF_HASH_MANY | B3FF_COMPRESS_XOF | B3FF_COMPRESS_IN_PLACE,
+		},
+		.hasher_ops		= &blake3_hasher_op_neon,
+		.hash_many		= blake3_hash_many_neon,
+		.compress_xof		= blake3_compress_xof_portable,	/* no NEON for this */
+		.compress_in_place	= blake3_compress_in_place_portable,
+	},
+#endif
+
+#endif
+};
+
+const blake3_backend *blake3_backend_select_function(uint64_t selectable_backends, blake3_func_id fid)
+{
+	const blake3_backend *be;
+	unsigned int i;
+
+	while (selectable_backends) {
+		i = highest_one(selectable_backends);
+		selectable_backends &= ~FY_BIT64(i);
+		be = blake3_backends + i;
+		if (be->info.funcs & FY_BIT64(fid))
+			return be;
+	}
+	/* should never happen because portable is always set */
+	assert(false);
+	return NULL;
+}
+
+const blake3_backend *blake3_get_backend_by_id(blake3_backend_id id)
+{
+	const blake3_backend *be;
+
+	if ((unsigned int)id >= B3BID_COUNT)
+		return NULL;
+
+	be = &blake3_backends[id];
+
+	/* non-enabled backend? */
+	if (be->info.id != id || !be->info.name)
+		return NULL;
+
+	return be;
+}
+
+const blake3_backend *blake3_get_backend_by_name(const char *name)
+{
+	const blake3_backend *be;
+	unsigned int i;
+
+	if (!name)
+		return NULL;
+
+	for (i = 0, be = blake3_backends; i < B3BID_COUNT; i++, be++) {
+		if (be->info.name && !strcmp(be->info.name, name))
+			return be;
+	}
+	return NULL;
+}
+
+const blake3_backend_info *blake3_get_backend_info(blake3_backend_id id)
+{
+	const blake3_backend_info *bei;
+
+	if ((unsigned int)id >= B3BID_COUNT)
+		return NULL;
+
+	bei = &blake3_backends[id].info;
+
+	/* not supported */
+	if (bei->id == B3BID_INVALID || !bei->name)
+		return NULL;
+
+	return bei;
+}

--- a/numcosmo/external/libfyaml/src/blake3/blake3_be_cpusimd.c
+++ b/numcosmo/external/libfyaml/src/blake3/blake3_be_cpusimd.c
@@ -1,0 +1,243 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#include <stdlib.h>
+
+#include "blake3.h"
+#include "blake3_impl.h"
+#include "blake3_internal.h"
+
+#include "fy-thread.h"
+#include "fy-win32.h"
+
+struct cpusimd_data {
+	unsigned int num_cpus;
+	unsigned int simd_cpus;
+	unsigned int be_simd_degree_mult;
+	const blake3_backend *be_best;
+	char *description;
+	struct fy_thread_pool *tp;
+};
+
+static void blake3_cpusimd_hash_many_thread(void *arg)
+{
+	blake3_hash_many_state *s = arg;
+	const blake3_hash_many_common_state *c;
+
+	c = s->common;
+	c->hash_many(s->inputs, s->num_inputs, c->blocks, c->key, s->counter, c->increment_counter, c->flags, c->flags_start, c->flags_end, s->out);
+}
+
+// #define CPUSIMD_CHECK
+
+static void blake3_hash_many_cpusimd(
+		const uint8_t *const *inputs, size_t num_inputs,
+		size_t blocks, const uint32_t key[8],
+		uint64_t counter, bool increment_counter,
+		uint8_t flags, uint8_t flags_start,
+		uint8_t flags_end, uint8_t *out)
+{
+	struct cpusimd_data *d;
+	const blake3_backend *be, *be_best;
+	unsigned int i, stepi, be_simd_degree_mult, simd_degree, count, states_count;
+	blake3_hash_many_state *states, *s;
+	blake3_hash_many_common_state common_local, *common = &common_local;
+	const uint8_t *const *inputsi;
+	uint8_t *outi;
+	uint64_t counteri;
+#ifdef CPUSIMD_CHECK
+	size_t out_size;
+	uint8_t *out_cmp;
+#endif
+
+	(void)simd_degree;
+
+	be = &blake3_backends[B3BID_CPUSIMD];
+	d = be->user;
+	assert(d);
+
+	count = (unsigned int)num_inputs;
+	simd_degree = be->info.simd_degree;
+
+	be_best = d->be_best;
+	be_simd_degree_mult = d->be_simd_degree_mult;
+
+#ifdef CPUSIMD_CHECK
+	/* if less than the underlyind backend degree just do it there */
+	out_size = BLAKE3_OUT_LEN * num_inputs;
+	out_cmp = alloca(out_size);
+	be_best->hash_many(inputs, num_inputs, blocks, key, counter, increment_counter, flags, flags_start, flags_end, out_cmp);
+#endif
+
+	states_count = (count / be_simd_degree_mult) + !!(count % be_simd_degree_mult);
+	states = alloca(sizeof(*states) * states_count);
+
+	/* the common */
+	common->hash_many = be_best->hash_many;
+	common->blocks = blocks;
+	common->key = key;
+	common->increment_counter = increment_counter;
+	common->flags = flags;
+	common->flags_start = flags_start;
+	common->flags_end = flags_end;
+
+	inputsi = inputs;
+	outi = out;
+	counteri = counter;
+	for (i = 0, s = states; i < count; i += stepi, s++) {
+
+		stepi = (i + be_simd_degree_mult) <= count ? be_simd_degree_mult : (count - i);
+
+		s->inputs = inputsi;
+		s->num_inputs = stepi;
+		s->counter = counteri;
+		s->out = outi;
+		s->common = common;
+
+		if (increment_counter)
+			counteri += stepi;
+		inputsi += stepi;
+		outi += BLAKE3_OUT_LEN * stepi;
+	}
+
+	fy_thread_arg_array_join(d->tp, blake3_cpusimd_hash_many_thread, NULL, states, sizeof(states[0]), states_count);
+
+#ifdef CPUSIMD_CHECK
+	for (i = 0; i < count; i += stepi) {
+		stepi = (i + be_simd_degree_mult) <= count ? be_simd_degree_mult : (count - i);
+
+		if (memcmp(out + i * BLAKE3_OUT_LEN, out_cmp + i * BLAKE3_OUT_LEN, BLAKE3_OUT_LEN)) {
+			fprintf(stderr, "%s: differ at #%u\n", __func__, i);
+		}
+	}
+#endif
+}
+
+static void cpusimd_data_free(struct cpusimd_data *d)
+{
+	if (!d)
+		return;
+
+	if (d->description)
+		free(d->description);
+
+	if (d->tp)
+		fy_thread_pool_destroy(d->tp);
+
+	free(d);
+}
+
+int blake3_backend_cpusimd_setup(unsigned int num_cpus, unsigned int mult_fact)
+{
+	blake3_backend *be = &blake3_backends[B3BID_CPUSIMD];
+	const blake3_backend *be_best;
+	struct cpusimd_data *d = NULL;
+	struct fy_thread_pool_cfg tp_cfg;
+	long scval;
+	uint64_t supported_backends, detected_backends, selectable_backends;
+	unsigned int num_simd_cpus;
+	ssize_t n;
+
+	if (!num_cpus) {
+		scval = sysconf(_SC_NPROCESSORS_ONLN);
+		assert(scval > 0);
+		num_cpus = (unsigned int)scval;
+	}
+
+	if (num_cpus <= 1)
+		return 0;
+
+	num_simd_cpus = (unsigned int)round_down_to_power_of_2(num_cpus);
+
+	if (!mult_fact)
+		mult_fact = 1;
+
+	d = malloc(sizeof(*d));
+	if (!d)
+		goto err_out;
+
+	memset(d, 0, sizeof(*d));
+
+	memset(&tp_cfg, 0, sizeof(tp_cfg));
+	tp_cfg.flags = 0;
+	tp_cfg.num_threads = num_simd_cpus;
+	tp_cfg.userdata = NULL;
+
+	d->tp = fy_thread_pool_create(&tp_cfg);
+	if (!d->tp)
+		goto err_out;
+
+	/* probe for available backends */
+	supported_backends = blake3_get_supported_backends();
+	detected_backends = blake3_get_detected_backends();
+	selectable_backends = supported_backends & detected_backends;
+
+	/* remove ourselves (and anything above) */
+	selectable_backends &= B3BF_BIT(B3BID_CPUSIMD) - 1;
+
+	/* select the best one for hash many */
+	be_best = blake3_backend_select_function(selectable_backends, B3FID_HASH_MANY);
+	assert(be_best);
+
+	d->num_cpus = num_cpus;
+	d->simd_cpus = num_simd_cpus;
+	d->be_best = be_best;
+	d->be_simd_degree_mult = be_best->info.simd_degree * mult_fact;
+
+	be->hasher_ops = be_best->hasher_ops;
+
+	d->description = NULL;
+	n = 0;
+	for (;;) {
+		n = snprintf(d->description, n ? (n + 1) : 0, "SIMD like acceleration using %u CPUs (using %s x %u) x %u = total x %u",
+				d->simd_cpus,
+				d->be_best->info.name, d->be_best->info.simd_degree,
+				mult_fact,
+				d->be_simd_degree_mult * d->simd_cpus);
+		if (d->description)
+			break;
+
+		d->description = malloc(n + 1);
+		if (!d->description)
+			goto err_out;
+	}
+
+	be->user = d;
+
+	be->info.id = B3BID_CPUSIMD;
+	be->info.name = "cpusimd";
+	be->info.simd_degree = d->simd_cpus * d->be_best->info.simd_degree * mult_fact;
+	be->info.description = d->description;
+
+	be->hash_many = blake3_hash_many_cpusimd;
+	be->info.funcs = B3FF_HASH_MANY;
+
+	return 0;
+
+err_out:
+	cpusimd_data_free(d);
+	return -1;
+}
+
+void blake3_backend_cpusimd_cleanup(void)
+{
+	blake3_backend *be = &blake3_backends[B3BID_CPUSIMD];
+	struct cpusimd_data *d;
+
+	d = be->user;
+	if (!d)
+		return;
+	cpusimd_data_free(d);
+
+	memset(be, 0, sizeof(*be));
+}

--- a/numcosmo/external/libfyaml/src/blake3/blake3_host_state.c
+++ b/numcosmo/external/libfyaml/src/blake3/blake3_host_state.c
@@ -1,0 +1,576 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#ifndef _WIN32
+#include <pthread.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#endif
+
+#include "fy-bit64.h"
+
+#include "blake3.h"
+#include "blake3_impl.h"
+#include "blake3_internal.h"
+
+#include "fy-thread.h"
+#include "fy-win32.h"
+
+/* 256K threshold for using alloca */
+#define BLAKE3_ALLOCA_BUFFER_SIZE	(256U << 10)
+#define BLAKE3_FILE_IO_BUFFER_SIZE	BLAKE3_ALLOCA_BUFFER_SIZE
+#define BLAKE3_MMAP_MIN_CHUNKSIZE	(1U << 20)	// minimum chunksize is 1MB
+#define BLAKE3_MMAP_MAX_CHUNKSIZE	SIZE_MAX
+
+static int probe_backends(blake3_host_state *hs)
+{
+	hs->supported_backends = blake3_get_supported_backends();
+	hs->detected_backends = blake3_get_detected_backends();
+	hs->selectable_backends = hs->supported_backends & hs->detected_backends;
+
+	return 0;
+}
+
+static int select_backends(blake3_host_state *hs)
+{
+	const blake3_backend *be, *be_portable;
+
+	/* this is the fallback */
+	be_portable = blake3_get_backend_by_id(B3BID_PORTABLE);
+	assert(be_portable);
+
+	/* if there's a backend selected, try to force it */
+	if (hs->cfg.backend && hs->cfg.backend[0] && strcmp(hs->cfg.backend, "auto")) {
+		be = blake3_get_backend_by_name(hs->cfg.backend);
+
+		/* if backend exists and is selectable */
+		if (be && (hs->selectable_backends & FY_BIT64(be->info.id))) {
+			hs->hash_many_be = (be->info.funcs & B3FF_HASH_MANY) ? be : be_portable;
+			hs->compress_xof_be = (be->info.funcs & B3FF_COMPRESS_XOF) ? be : be_portable;
+			hs->compress_in_place_be = (be->info.funcs & B3FF_COMPRESS_IN_PLACE) ? be : be_portable;
+
+			/* and select the ops (piggyback on HASH_MANY) */
+			hs->hasher_ops = (be->info.funcs & B3FF_HASH_MANY) ? be->hasher_ops : be_portable->hasher_ops;
+		}
+	}
+
+	if (!hs->hash_many_be) {
+		hs->hash_many_be = blake3_backend_select_function(hs->selectable_backends, B3FID_HASH_MANY);
+		hs->hasher_ops = hs->hash_many_be->hasher_ops;
+	}
+	if (!hs->compress_xof_be)
+		hs->compress_xof_be = blake3_backend_select_function(hs->selectable_backends, B3FID_COMPRESS_XOF);
+	if (!hs->compress_in_place_be)
+		hs->compress_in_place_be = blake3_backend_select_function(hs->selectable_backends, B3FID_COMPRESS_IN_PLACE);
+
+	/* select methods */
+	hs->hash_many = hs->hash_many_be->hash_many;
+	hs->compress_xof = hs->compress_xof_be->compress_xof;
+	hs->compress_in_place = hs->compress_in_place_be->compress_in_place;
+
+	/* select maximum simd degree */
+	if (hs->simd_degree < hs->hash_many_be->info.simd_degree)
+		hs->simd_degree = hs->hash_many_be->info.simd_degree;
+	if (hs->simd_degree < hs->compress_xof_be->info.simd_degree)
+		hs->simd_degree = hs->compress_xof_be->info.simd_degree;
+	if (hs->simd_degree < hs->compress_in_place_be->info.simd_degree)
+		hs->simd_degree = hs->compress_in_place_be->info.simd_degree;
+
+	return 0;
+}
+
+static void dump_backends(blake3_host_state *hs, uint64_t backends)
+{
+	const blake3_backend *be;
+	int i;
+
+	for (i = 0; i < B3BID_COUNT; i++) {
+		if (!(backends & FY_BIT64(i)))
+			continue;
+		be = blake3_get_backend_by_id(i);
+		assert(be);
+
+		fprintf(stderr, "%sname: %s\n%sdescription: %s\n%ssimd_degree: %u\n%shas_hash_many: %s\n%shas_compress_xof: %s\n%shas_compress_in_place: %s\n",
+				" -", be->info.name,
+				"  ", be->info.description,
+				"  ", be->info.simd_degree,
+				"  ", (be->info.funcs & B3FF_HASH_MANY) ? "true" : "false",
+				"  ", (be->info.funcs & B3FF_COMPRESS_XOF) ? "true" : "false",
+				"  ", (be->info.funcs & B3FF_COMPRESS_IN_PLACE) ? "true" : "false");
+	}
+}
+
+int blake3_host_state_setup(blake3_host_state *hs, const blake3_host_config *cfg)
+{
+	struct fy_thread_pool_cfg tp_cfg;
+	long scval;
+	int rc;
+
+	(void)rc;
+
+	assert(hs);
+	assert(cfg);
+
+	memset(hs, 0, sizeof(*hs));
+	hs->cfg = *cfg;
+
+	scval = sysconf(_SC_NPROCESSORS_ONLN);
+	assert(scval > 0);
+
+	hs->num_cpus = (unsigned int)scval;
+
+	rc = probe_backends(hs);
+	assert(!rc);
+
+	rc = select_backends(hs);
+	assert(!rc);
+
+	hs->mt_degree = hs->cfg.mt_degree > 0 ? hs->cfg.mt_degree : 64;	/* 64K default */
+	hs->tp = NULL;
+
+	if (!hs->cfg.no_mthread) {
+
+		if (!hs->cfg.tp) {
+			memset(&tp_cfg, 0, sizeof(tp_cfg));
+			tp_cfg.flags = FYTPCF_STEAL_MODE;
+			tp_cfg.num_threads = hs->cfg.num_threads ? hs->cfg.num_threads : (hs->num_cpus * 3) / 2;
+			tp_cfg.userdata = NULL;
+			hs->tp = fy_thread_pool_create(&tp_cfg);
+			if (!hs->tp)
+				goto err_out;
+		} else
+			hs->tp = hs->cfg.tp;
+	}
+
+	hs->file_io_bufsz = hs->cfg.file_io_bufsz ? hs->cfg.file_io_bufsz : BLAKE3_FILE_IO_BUFFER_SIZE;
+	hs->mmap_min_chunk = hs->cfg.mmap_min_chunk ? hs->cfg.mmap_min_chunk : BLAKE3_MMAP_MIN_CHUNKSIZE;
+	hs->mmap_max_chunk = hs->cfg.mmap_max_chunk ? hs->cfg.mmap_max_chunk : BLAKE3_MMAP_MAX_CHUNKSIZE;
+
+	if (hs->cfg.debug) {
+
+		fprintf(stderr, "num_cpus: %u\n", hs->num_cpus);
+		fprintf(stderr, "num_threads: %d\n", hs->tp ? fy_thread_pool_get_num_threads(hs->tp) : 0);
+		fprintf(stderr, "simd_degree: %u\n", hs->simd_degree);
+		fprintf(stderr, "mt_degree: %u\n", hs->mt_degree);
+		fprintf(stderr, "file_io_bufsz: %zu\n", hs->file_io_bufsz);
+		fprintf(stderr, "mmap_min_chunk: %zu\n", hs->mmap_min_chunk);
+		fprintf(stderr, "mmap_max_chunk: %zu\n", hs->mmap_max_chunk);
+
+		fprintf(stderr, "supported_backends:\n");
+		dump_backends(hs, hs->supported_backends);
+		fprintf(stderr, "detected_backends:\n");
+		dump_backends(hs, hs->detected_backends);
+
+		fprintf(stderr, "selected-backends:\n");
+		fprintf(stderr, "  hash_many: %s\n", hs->hash_many_be->info.name);
+		fprintf(stderr, "  compress_xof: %s\n", hs->compress_xof_be->info.name);
+		fprintf(stderr, "  compress_in_place: %s\n", hs->compress_in_place_be->info.name);
+
+	}
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+void blake3_host_state_cleanup(blake3_host_state *hs)
+{
+	assert(hs);
+
+	/* destroy the thread pool if we're the ones created it */
+	if (hs->tp && !hs->cfg.tp)
+		fy_thread_pool_destroy(hs->tp);
+}
+
+blake3_host_state *blake3_host_state_create(const blake3_host_config *cfg)
+{
+	blake3_host_state *hs;
+	int rc;
+
+	hs = malloc(sizeof(*hs));
+	if (!hs)
+		return NULL;
+	rc = blake3_host_state_setup(hs, cfg);
+	if (rc)
+		goto err_out;
+
+	return hs;
+
+err_out:
+	if (hs)
+		free(hs);
+	return NULL;
+}
+
+void blake3_host_state_destroy(blake3_host_state *hs)
+{
+	if (!hs)
+		return;
+	blake3_host_state_cleanup(hs);
+	free(hs);
+}
+
+blake3_hasher *blake3_hasher_create(blake3_host_state *hs, const uint8_t *key, const void *context, size_t context_len)
+{
+	blake3_hasher *self;
+
+	self = fy_cacheline_alloc(sizeof(*self));
+	if (!self)
+		return NULL;
+
+	if (!key && !context)
+		blake3_hasher_init(hs, self);
+	else if (key)
+		blake3_hasher_init_keyed(hs, self, key);
+	else if (context_len == 0)
+		blake3_hasher_init_derive_key(hs, self, context);
+	else
+		blake3_hasher_init_derive_key_raw(hs, self, context, context_len);
+	return self;
+}
+
+void blake3_hasher_destroy(blake3_hasher *self)
+{
+	if (!self)
+		return;
+	fy_cacheline_free(self);
+}
+
+#if defined(__linux__)
+
+static int linux_block_dev_is_rotational(dev_t dev)
+{
+	char *path = NULL;
+	int rc, fd;
+	uint8_t c[2];
+	int rotational;
+
+	/* by default it's the filesize */
+	rotational = -1;	/* not found */
+
+	/* read the rotational attribute of the root */
+	rc = asprintf(&path, "/sys/dev/block/%u:%u/queue/rotational", major(dev), 0);
+	if (rc != -1) {
+		fd = open(path, O_RDONLY);
+		if (fd != -1) {
+			if (read(fd, c, 2) == 2)
+				rotational = c[0] == '1' && c[1] == '\n';
+			close(fd);
+		}
+		free(path);
+	}
+
+	return rotational;
+}
+
+static ssize_t linux_file_cached_size(int fd, void *mem, size_t filesize)
+{
+	long pagesize = sysconf(_SC_PAGESIZE);
+	size_t vec_size, resident_size, i;
+	unsigned char *vec;
+	int rc;
+
+	(void)rc;
+	vec_size = (filesize + pagesize - 1) / pagesize;
+	vec = malloc(vec_size + 1);
+	if (!vec)
+		return -1;
+
+	rc = mincore(mem, filesize, vec);
+	assert(!rc);
+
+	/* this could be parallelized */
+	resident_size = 0;
+	for (i = 0; i < vec_size; i++) {
+		if (vec[i] & 1)
+			resident_size += pagesize;
+	}
+
+	free(vec);
+
+	if (resident_size > filesize)
+		resident_size = filesize;
+
+	return (ssize_t)resident_size;
+}
+
+static size_t blake3_mmap_file_chunksize(int fd, dev_t dev, void *mem,
+					 size_t filesize,
+					 size_t mmap_min_chunk, size_t mmap_max_chunk)
+{
+	size_t chunksize;
+	ssize_t cached_size;
+	int rotational;
+
+	if (filesize <= mmap_min_chunk)
+		return filesize;
+
+	/* by default it's the filesize */
+	chunksize = filesize;
+
+	/* starting, check if the rotational attribute exists in this dev */
+	rotational = linux_block_dev_is_rotational(dev);
+	if (rotational == -1) {
+		/* attribute not found? check the non-partition */
+		rotational = linux_block_dev_is_rotational(makedev(major(dev), 0));
+	}
+
+	if (rotational == 1) {
+		/* OK, it's rotational, but is it in cache?
+		 * to avoid checking for the cached status of the whole file
+		 * we just probe the MIN_CHUNKSIZE
+		 * We will thrash in the case where the file is only cached
+		 * for the first few bytes, but this is generally unusual.
+		 */
+		cached_size = linux_file_cached_size(fd, mem, mmap_min_chunk);
+
+		if (cached_size <= 0)
+			chunksize = mmap_min_chunk;
+	}
+
+	if (chunksize > mmap_max_chunk)
+		chunksize = mmap_max_chunk;
+
+	return chunksize;
+}
+
+#else
+
+static size_t blake3_mmap_file_chunksize(int fd, dev_t dev, void *mem,
+					 size_t filesize,
+					 size_t mmap_min_chunk, size_t mmap_max_chunk)
+{
+	if (filesize <= mmap_min_chunk)
+		return filesize;
+
+	if (filesize > mmap_max_chunk)
+		return mmap_max_chunk;
+
+	/* for all others, just use mmap at max */
+	return filesize;
+}
+
+#endif
+
+int blake3_hash_file(blake3_hasher *hasher, const char *filename,
+		     uint8_t output[BLAKE3_OUT_LEN])
+{
+	blake3_host_state *hs;
+	FILE *fp = NULL;
+	void *mem = NULL, *buf = NULL, *p;
+	int fd = -1, ret = -1;
+	size_t rdn, filesize, bufsz = 0, max_chunk, left, chunk;
+	struct stat sb;
+	dev_t dev = 0;
+	int rc;
+
+	if (!hasher || !filename || !output)
+		return -1;
+
+	hs = hasher->hs;
+
+	if (hs->cfg.debug)
+		fprintf(stderr, "processing file %s\n", filename);
+
+	// reset the hasher (do not initialize again)
+	blake3_hasher_reset(hasher);
+
+	if (!strcmp(filename, "-")) {
+		fp = stdin;
+	} else {
+		fp = NULL;
+
+		fd = open(filename, O_RDONLY);
+		if (fd < 0) {
+			if (hs->cfg.debug)
+				fprintf(stderr, "unable to open %s - %s\n",
+					filename, strerror(errno));
+			goto err_out;
+		}
+
+		rc = fstat(fd, &sb);
+		if (rc < 0) {
+			if (hs->cfg.debug)
+				fprintf(stderr, "failed to stat %s - %s\n",
+					filename, strerror(errno));
+			goto err_out;
+		}
+
+		if (!S_ISREG(sb.st_mode)) {
+			if (S_ISDIR(sb.st_mode))
+				errno = EISDIR;
+			else
+				errno = EINVAL;
+			if (hs->cfg.debug)
+				fprintf(stderr, "not a regular file %s - %s\n",
+					filename, strerror(errno));
+			goto err_out;
+		}
+
+		filesize = (size_t)-1;
+
+		/* try to mmap */
+		if (sb.st_size > 0 && !hs->cfg.no_mmap) {
+			filesize = sb.st_size;
+			mem = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+			if (mem != MAP_FAILED) {
+				close(fd);
+				fd = -1;
+				dev = sb.st_dev;
+			} else
+				mem = NULL;
+		}
+
+		/* unable to map? fallback to stream mode */
+		if (!mem) {
+			fp = fdopen(fd, "r");
+			if (!fp) {
+				if (hs->cfg.debug)
+					fprintf(stderr, "unable to fdopen %s - %s\n",
+						filename, strerror(errno));
+				goto err_out;
+			}
+		}
+	}
+
+	/* mmap case, very simple */
+	if (mem) {
+
+		/* if the file is small enough don't bother with the rest */
+		max_chunk = blake3_mmap_file_chunksize(fd, dev, mem, filesize,
+						       hs->mmap_min_chunk, hs->mmap_max_chunk);
+
+		p = mem;
+		left = filesize;
+		while (left > 0) {
+			chunk = left > max_chunk ? max_chunk : left;
+			blake3_hasher_update(hasher, p, chunk);
+			p = (char *)p + chunk;
+			left -= chunk;
+		}
+	} else {
+		/* slow path using file reads */
+
+		assert(fp);
+
+		bufsz = hs->file_io_bufsz;
+
+		/* for less than 8MB alloca */
+		if (bufsz <= BLAKE3_ALLOCA_BUFFER_SIZE) {
+			buf = alloca(bufsz);
+		} else {
+			buf = malloc(bufsz);
+			if (!buf) {
+				if (hs->cfg.debug)
+					fprintf(stderr, "Unable to allocate buffer of %zu bytes\n",
+						bufsz);
+				goto err_out;
+			}
+		}
+
+		do {
+			rdn = fread(buf, 1, bufsz, fp);
+			if (rdn == 0)
+				break;
+			if (rdn > 0)
+				blake3_hasher_update(hasher, buf, rdn);
+		} while (rdn >= bufsz);
+	}
+
+	// Finalize the hash. BLAKE3_OUT_LEN is the default output length, 32 bytes.
+	blake3_hasher_finalize(hasher, output, BLAKE3_OUT_LEN);
+
+	ret = 0;
+
+out:
+	if (mem)
+		munmap(mem, filesize);
+
+	if (fp && fp != stdin)
+		fclose(fp);
+
+	if (fd >= 0)
+		close(fd);
+
+	if (buf && (bufsz > BLAKE3_ALLOCA_BUFFER_SIZE))
+		free(buf);
+
+	return ret;
+
+err_out:
+	ret = -1;
+	goto out;
+}
+
+void blake3_hash(struct blake3_hasher *hasher,
+		 const void *mem, size_t size, uint8_t output[BLAKE3_OUT_LEN])
+{
+	blake3_hasher_reset(hasher);
+	blake3_hasher_update(hasher, mem, size);
+	blake3_hasher_finalize(hasher, output, BLAKE3_OUT_LEN);
+}
+
+const char *blake3_version(void)
+{
+	return BLAKE3_VERSION_STRING;
+}
+
+void blake3_hasher_init(struct blake3_host_state *hs, struct blake3_hasher *self)
+{
+	hs->hasher_ops->hasher_init(hs, self);
+}
+
+void blake3_hasher_init_keyed(struct blake3_host_state *hs, struct blake3_hasher *self, const uint8_t key[BLAKE3_KEY_LEN])
+{
+	hs->hasher_ops->hasher_init_keyed(hs, self, key);
+}
+
+void blake3_hasher_init_derive_key(struct blake3_host_state *hs, struct blake3_hasher *self, const char *context)
+{
+	hs->hasher_ops->hasher_init_derive_key(hs, self, context);
+}
+
+void blake3_hasher_init_derive_key_raw(struct blake3_host_state *hs, struct blake3_hasher *self, const void *context, size_t context_len)
+{
+	hs->hasher_ops->hasher_init_derive_key_raw(hs, self, context, context_len);
+}
+
+void blake3_hasher_update(struct blake3_hasher *self, const void *input, size_t input_len)
+{
+	blake3_host_state *hs = self->hs;
+	hs->hasher_ops->hasher_update(self, input, input_len);
+}
+
+void blake3_hasher_finalize(const struct blake3_hasher *self, uint8_t *out, size_t out_len)
+{
+	blake3_host_state *hs = self->hs;
+	hs->hasher_ops->hasher_finalize(self, out, out_len);
+}
+
+void blake3_hasher_finalize_seek(const struct blake3_hasher *self, uint64_t seek, uint8_t *out, size_t out_len)
+{
+	blake3_host_state *hs = self->hs;
+	hs->hasher_ops->hasher_finalize_seek(self, seek, out, out_len);
+}
+
+void blake3_hasher_reset(struct blake3_hasher *self)
+{
+	blake3_host_state *hs = self->hs;
+	hs->hasher_ops->hasher_reset(self);
+}

--- a/numcosmo/external/libfyaml/src/blake3/blake3_impl.h
+++ b/numcosmo/external/libfyaml/src/blake3/blake3_impl.h
@@ -1,0 +1,236 @@
+#ifndef BLAKE3_IMPL_H
+#define BLAKE3_IMPL_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdatomic.h>
+#include <stdalign.h>
+#include <stdlib.h>
+
+#if defined(__linux__)
+#include <malloc.h>
+#include <sys/sysmacros.h>
+#endif
+
+#include "blake3.h"
+
+#include "fy-endian.h"
+#include "fy-blob.h"
+#include "fy-bit64.h"
+#include "fy-align.h"
+
+#if defined(HAVE_STRING_OP_OVERREAD) && HAVE_STRING_OP_OVERREAD && defined(__GNUC__) && !defined(__clang__)
+#define GCC_DISABLE_WSTRING_OP_OVERREAD
+#endif
+
+/* this is the best alignment for blake3 */
+#if defined(__x86_64__) || defined(_M_X64)
+#define BLAKE3_ALIGNMENT	64
+#else
+#define BLAKE3_ALIGNMENT	32
+#endif
+
+#define BLAKE3_ALIGN	FY_ALIGNED_TO(BLAKE3_ALIGNMENT)
+
+// This C implementation tries to support recent versions of GCC, Clang, and
+// MSVC.
+#if defined(_MSC_VER)
+#define INLINE static __forceinline
+#else
+#define INLINE static inline __attribute__((always_inline))
+#endif
+
+#if defined(__x86_64__) || defined(_M_X64)
+#define IS_X86
+#define IS_X86_64
+#endif
+
+#if defined(__i386__) || defined(_M_IX86)
+#define IS_X86
+#define IS_X86_32
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define IS_AARCH64
+#define IS_ARM
+#endif
+
+#if defined(IS_X86)
+#if defined(_MSC_VER)
+#if defined(__clang__)
+/* clang-cl: intrin.h pulls in mmintrin.h which has vector type bugs
+ * when cross-compiling. Declare only the intrinsics we actually need. */
+unsigned long long _xgetbv(unsigned int);
+void __cpuid(int[4], int);
+#else
+#include <intrin.h>
+#endif
+#endif
+#endif
+
+/* Find index of the highest set bit */
+/* x is assumed to be nonzero.       */
+static inline unsigned int highest_one(uint64_t x)
+{
+#if defined(__GNUC__) || defined(__clang__)
+	return 63 ^ (unsigned int)__builtin_clzll(x);
+#elif defined(_MSC_VER) && defined(IS_X86_64)
+	unsigned long index;
+	_BitScanReverse64(&index, x);
+	return index;
+#elif defined(_MSC_VER) && defined(IS_X86_32)
+	unsigned long index;
+
+	if(x >> 32) {
+		_BitScanReverse(&index, (unsigned long)(x >> 32));
+		index += 32;
+	} else
+		_BitScanReverse(&index, (unsigned long)x);
+	return index;
+#else
+	unsigned int c = 0;
+
+	if (x & 0xffffffff00000000ULL) { x >>= 32; c += 32; }
+	if (x & 0x00000000ffff0000ULL) { x >>= 16; c += 16; }
+	if (x & 0x000000000000ff00ULL) { x >>=  8; c +=  8; }
+	if (x & 0x00000000000000f0ULL) { x >>=  4; c +=  4; }
+	if (x & 0x000000000000000cULL) { x >>=  2; c +=  2; }
+	if (x & 0x0000000000000002ULL) {           c +=  1; }
+	return c;
+#endif
+}
+
+static inline unsigned int lowest_one(uint64_t x)
+{
+#if defined(__GNUC__) || defined(__clang__)
+	return (unsigned int)__builtin_ctzll(x);
+#else
+	unsigned int c = 0;
+
+	if (!(x & 0x00000000ffffffffULL)) { x >>= 32; c += 32; }
+	if (!(x & 0x000000000000ffffULL)) { x >>= 16; c += 16; }
+	if (!(x & 0x00000000000000ffULL)) { x >>=  8; c +=  8; }
+	if (!(x & 0x000000000000000fULL)) { x >>=  4; c +=  4; }
+	if (!(x & 0x0000000000000003ULL)) { x >>=  2; c +=  2; }
+	if (!(x & 0x0000000000000001ULL)) {           c +=  1; }
+	return c;
+#endif
+}
+
+// Count the number of 1 bits.
+static inline unsigned int popcnt(uint64_t x)
+{
+#if defined(__GNUC__) || defined(__clang__)
+	return (unsigned int)__builtin_popcountll(x);
+#else
+	unsigned int count = 0;
+	while (x != 0) {
+		count++;
+		x &= x - 1;
+	}
+	return count;
+#endif
+}
+
+// Largest power of two less than or equal to x. As a special case, returns 1
+// when x is 0.
+static inline uint64_t round_down_to_power_of_2(uint64_t x)
+{
+	return 1ULL << highest_one(x | 1);
+}
+
+static inline uint32_t counter_low(uint64_t counter)
+{
+	return (uint32_t)counter;
+}
+
+static inline uint32_t counter_high(uint64_t counter)
+{
+	return (uint32_t)(counter >> 32);
+}
+
+static inline uint32_t load32(const void *src)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+	return *(const uint32_t *)src;
+#else
+	const uint8_t *p = (const uint8_t *)src;
+	return ((uint32_t)(p[0]) <<  0) | ((uint32_t)(p[1]) <<  8) |
+	       ((uint32_t)(p[2]) << 16) | ((uint32_t)(p[3]) << 24);
+#endif
+}
+
+static inline void load_key_words(const uint8_t key[BLAKE3_KEY_LEN], uint32_t key_words[8])
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+	memcpy(key_words, key, BLAKE3_KEY_LEN);
+#else
+	key_words[0] = load32(&key[0 * 4]);
+	key_words[1] = load32(&key[1 * 4]);
+	key_words[2] = load32(&key[2 * 4]);
+	key_words[3] = load32(&key[3 * 4]);
+	key_words[4] = load32(&key[4 * 4]);
+	key_words[5] = load32(&key[5 * 4]);
+	key_words[6] = load32(&key[6 * 4]);
+	key_words[7] = load32(&key[7 * 4]);
+#endif
+}
+
+static inline void store32(void *dst, uint32_t w)
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+	*(uint32_t *)dst = w;
+#else
+	uint8_t *p = (uint8_t *)dst;
+
+	p[0] = (uint8_t)(w >> 0);
+	p[1] = (uint8_t)(w >> 8);
+	p[2] = (uint8_t)(w >> 16);
+	p[3] = (uint8_t)(w >> 24);
+#endif
+}
+
+static inline void store_cv_words(uint8_t bytes_out[BLAKE3_OUT_LEN], uint32_t cv_words[BLAKE3_OUT_WORDS])
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+	memcpy(bytes_out, cv_words, BLAKE3_KEY_LEN);
+#else
+	store32(&bytes_out[0 * 4], cv_words[0]);
+	store32(&bytes_out[1 * 4], cv_words[1]);
+	store32(&bytes_out[2 * 4], cv_words[2]);
+	store32(&bytes_out[3 * 4], cv_words[3]);
+	store32(&bytes_out[4 * 4], cv_words[4]);
+	store32(&bytes_out[5 * 4], cv_words[5]);
+	store32(&bytes_out[6 * 4], cv_words[6]);
+	store32(&bytes_out[7 * 4], cv_words[7]);
+#endif
+}
+
+/* the IV */
+#define B3_IV_0	((uint32_t)0x6A09E667UL)
+#define B3_IV_1	((uint32_t)0xBB67AE85UL)
+#define B3_IV_2	((uint32_t)0x3C6EF372UL)
+#define B3_IV_3	((uint32_t)0xA54FF53AUL)
+#define B3_IV_4	((uint32_t)0x510E527FUL)
+#define B3_IV_5	((uint32_t)0x9B05688CUL)
+#define B3_IV_6	((uint32_t)0x1F83D9ABUL)
+#define B3_IV_7	((uint32_t)0x5BE0CD19UL)
+
+/* the message schedule definition */
+#define B3_MSG_SCHEDULE_DEF \
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, \
+    {2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8}, \
+    {3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1}, \
+    {10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6}, \
+    {12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4}, \
+    {9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7}, \
+    {11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13}
+
+#endif /* BLAKE3_IMPL_H */

--- a/numcosmo/external/libfyaml/src/blake3/blake3_internal.h
+++ b/numcosmo/external/libfyaml/src/blake3/blake3_internal.h
@@ -1,0 +1,156 @@
+#ifndef BLAKE3_INTERNAL_H
+#define BLAKE3_INTERNAL_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "blake3.h"
+
+#include "blake3_impl.h"
+
+#define BLAKE3_MAX_DEPTH 54
+
+// fwd declaration of opaque types
+struct blake3_host_state;
+struct blake3_hasher;
+struct fy_thread_pool;
+
+// internal flags
+enum blake3_flags {
+	CHUNK_START         = 1 << 0,
+	CHUNK_END           = 1 << 1,
+	PARENT              = 1 << 2,
+	ROOT                = 1 << 3,
+	KEYED_HASH          = 1 << 4,
+	DERIVE_KEY_CONTEXT  = 1 << 5,
+	DERIVE_KEY_MATERIAL = 1 << 6,
+};
+
+typedef struct blake3_chunk_state {
+	uint32_t cv[8] BLAKE3_ALIGN;
+	uint8_t buf[BLAKE3_BLOCK_LEN] BLAKE3_ALIGN;
+	uint64_t chunk_counter;
+	uint8_t buf_len;
+	uint8_t blocks_compressed;
+	uint8_t flags;
+} blake3_chunk_state BLAKE3_ALIGN;
+
+typedef struct blake3_hasher {
+	struct blake3_host_state *hs;
+	uint32_t key[8] BLAKE3_ALIGN;
+	blake3_chunk_state chunk BLAKE3_ALIGN;
+	// The stack size is MAX_DEPTH + 1 because we do lazy merging. For example,
+	// with 7 chunks, we have 3 entries in the stack. Adding an 8th chunk
+	// requires a 4th entry, rather than merging everything down to 1, because we
+	// don't know whether more input is coming. This is different from how the
+	// reference implementation does things.
+	uint8_t cv_stack[(BLAKE3_MAX_DEPTH + 1) * BLAKE3_OUT_LEN] BLAKE3_ALIGN;
+	uint8_t cv_stack_len;
+} blake3_hasher BLAKE3_ALIGN;
+
+typedef void (*blake3_hash_many_f)(const uint8_t *const *inputs, size_t num_inputs,
+				   size_t blocks, const uint32_t key[8], uint64_t counter,
+				   bool increment_counter, uint8_t flags,
+				   uint8_t flags_start, uint8_t flags_end, uint8_t *out);
+
+typedef void (*blake3_compress_xof_f)(const uint32_t cv[8],
+				      const uint8_t block[BLAKE3_BLOCK_LEN],
+				      uint8_t block_len, uint64_t counter, uint8_t flags,
+				      uint8_t out[64]);
+
+typedef void (*blake3_compress_in_place_f)(uint32_t cv[8],
+					   const uint8_t block[BLAKE3_BLOCK_LEN],
+					   uint8_t block_len, uint64_t counter,
+					   uint8_t flags);
+
+typedef struct blake3_backend {
+	const blake3_hasher_ops *hasher_ops;
+	blake3_backend_info info;
+	blake3_hash_many_f hash_many;
+	blake3_compress_xof_f compress_xof;
+	blake3_compress_in_place_f compress_in_place;
+	void *user;	/* per backend data */
+} blake3_backend;
+
+// the state for the thread when doing compress subtree
+typedef struct blake3_compress_subtree_state {
+	struct blake3_hasher *self;
+	// inputs
+	const uint8_t *input;
+	size_t input_len;
+	const uint32_t *key;
+	uint64_t chunk_counter;
+	uint8_t flags;
+	// outputs
+	uint8_t *out;
+	size_t n;
+} blake3_compress_subtree_state;
+
+typedef struct blake3_hash_many_common_state {
+	blake3_hash_many_f hash_many;
+	size_t blocks;
+	const uint32_t *key;
+	bool increment_counter;
+	uint8_t flags, flags_start, flags_end;
+} blake3_hash_many_common_state;
+
+typedef struct blake3_hash_many_state {
+	const blake3_hash_many_common_state *common;
+	const uint8_t *const *inputs;
+	size_t num_inputs;
+	uint64_t counter;
+	uint8_t *out;
+} blake3_hash_many_state;
+
+typedef struct blake3_host_state {
+	blake3_host_config cfg;
+	unsigned int num_cpus;
+	uint64_t supported_backends;
+	uint64_t detected_backends;
+	uint64_t selectable_backends;
+
+	/* backend for hash_many */
+	const blake3_backend *hash_many_be;
+	blake3_hash_many_f hash_many;
+
+	/* backend for compress_xof */
+	const blake3_backend *compress_xof_be;
+	blake3_compress_xof_f compress_xof;
+
+	/* backend for compress_in_place */
+	const blake3_backend *compress_in_place_be;
+	blake3_compress_in_place_f compress_in_place;
+
+	const blake3_hasher_ops *hasher_ops;
+
+	unsigned int simd_degree;
+	unsigned int mt_degree;
+
+	unsigned int num_threads;
+
+	struct fy_thread_pool *tp;
+
+	size_t file_io_bufsz;
+	size_t mmap_min_chunk;
+	size_t mmap_max_chunk;
+
+} blake3_host_state;
+
+int blake3_host_state_setup(blake3_host_state *hs, const blake3_host_config *cfg);
+void blake3_host_state_cleanup(blake3_host_state *hs);
+
+extern blake3_backend blake3_backends[B3BID_COUNT];
+
+const blake3_backend *blake3_backend_select_function(uint64_t selectable_backends, blake3_func_id fid);
+const blake3_backend *blake3_get_backend_by_id(blake3_backend_id id);
+const blake3_backend *blake3_get_backend_by_name(const char *name);
+const blake3_backend_info *blake3_get_backend_info(blake3_backend_id id);
+
+void blake3_cpusimd_setup(unsigned int num_cpus, unsigned int mult_fact);
+void blake3_cpusimd_cleanup(void);
+
+#endif

--- a/numcosmo/external/libfyaml/src/blake3/blake3_portable.c
+++ b/numcosmo/external/libfyaml/src/blake3/blake3_portable.c
@@ -1,0 +1,167 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "blake3_impl.h"
+#include <string.h>
+
+/* define it here instead of the header */
+static const uint8_t MSG_SCHEDULE[7][16] = { B3_MSG_SCHEDULE_DEF };
+
+INLINE uint32_t rotr32(uint32_t w, uint32_t c) {
+  return (w >> c) | (w << (32 - c));
+}
+
+INLINE void g(uint32_t *state, size_t a, size_t b, size_t c, size_t d,
+              uint32_t x, uint32_t y) {
+  state[a] = state[a] + state[b] + x;
+  state[d] = rotr32(state[d] ^ state[a], 16);
+  state[c] = state[c] + state[d];
+  state[b] = rotr32(state[b] ^ state[c], 12);
+  state[a] = state[a] + state[b] + y;
+  state[d] = rotr32(state[d] ^ state[a], 8);
+  state[c] = state[c] + state[d];
+  state[b] = rotr32(state[b] ^ state[c], 7);
+}
+
+INLINE void round_fn(uint32_t state[16], const uint32_t *msg, size_t round) {
+  // Select the message schedule based on the round.
+  const uint8_t *schedule = MSG_SCHEDULE[round];
+
+  // Mix the columns.
+  g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+  g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+  g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+  g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+  // Mix the rows.
+  g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+  g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+  g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+  g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+}
+
+INLINE void compress_pre(uint32_t state[16], const uint32_t cv[8],
+                         const uint8_t block[BLAKE3_BLOCK_LEN],
+                         uint8_t block_len, uint64_t counter, uint8_t flags) {
+  uint32_t block_words[16];
+  block_words[0] = load32(block + 4 * 0);
+  block_words[1] = load32(block + 4 * 1);
+  block_words[2] = load32(block + 4 * 2);
+  block_words[3] = load32(block + 4 * 3);
+  block_words[4] = load32(block + 4 * 4);
+  block_words[5] = load32(block + 4 * 5);
+  block_words[6] = load32(block + 4 * 6);
+  block_words[7] = load32(block + 4 * 7);
+  block_words[8] = load32(block + 4 * 8);
+  block_words[9] = load32(block + 4 * 9);
+  block_words[10] = load32(block + 4 * 10);
+  block_words[11] = load32(block + 4 * 11);
+  block_words[12] = load32(block + 4 * 12);
+  block_words[13] = load32(block + 4 * 13);
+  block_words[14] = load32(block + 4 * 14);
+  block_words[15] = load32(block + 4 * 15);
+
+  state[0] = cv[0];
+  state[1] = cv[1];
+  state[2] = cv[2];
+  state[3] = cv[3];
+  state[4] = cv[4];
+  state[5] = cv[5];
+  state[6] = cv[6];
+  state[7] = cv[7];
+  state[8] = B3_IV_0;
+  state[9] = B3_IV_1;
+  state[10] = B3_IV_2;
+  state[11] = B3_IV_3;
+  state[12] = counter_low(counter);
+  state[13] = counter_high(counter);
+  state[14] = (uint32_t)block_len;
+  state[15] = (uint32_t)flags;
+
+  round_fn(state, &block_words[0], 0);
+  round_fn(state, &block_words[0], 1);
+  round_fn(state, &block_words[0], 2);
+  round_fn(state, &block_words[0], 3);
+  round_fn(state, &block_words[0], 4);
+  round_fn(state, &block_words[0], 5);
+  round_fn(state, &block_words[0], 6);
+}
+
+void blake3_compress_in_place_portable(uint32_t cv[8],
+                                       const uint8_t block[BLAKE3_BLOCK_LEN],
+                                       uint8_t block_len, uint64_t counter,
+                                       uint8_t flags) {
+  uint32_t state[16];
+  compress_pre(state, cv, block, block_len, counter, flags);
+  cv[0] = state[0] ^ state[8];
+  cv[1] = state[1] ^ state[9];
+  cv[2] = state[2] ^ state[10];
+  cv[3] = state[3] ^ state[11];
+  cv[4] = state[4] ^ state[12];
+  cv[5] = state[5] ^ state[13];
+  cv[6] = state[6] ^ state[14];
+  cv[7] = state[7] ^ state[15];
+}
+
+void blake3_compress_xof_portable(const uint32_t cv[8],
+                                  const uint8_t block[BLAKE3_BLOCK_LEN],
+                                  uint8_t block_len, uint64_t counter,
+                                  uint8_t flags, uint8_t out[64]) {
+  uint32_t state[16];
+  compress_pre(state, cv, block, block_len, counter, flags);
+
+  store32(&out[0 * 4], state[0] ^ state[8]);
+  store32(&out[1 * 4], state[1] ^ state[9]);
+  store32(&out[2 * 4], state[2] ^ state[10]);
+  store32(&out[3 * 4], state[3] ^ state[11]);
+  store32(&out[4 * 4], state[4] ^ state[12]);
+  store32(&out[5 * 4], state[5] ^ state[13]);
+  store32(&out[6 * 4], state[6] ^ state[14]);
+  store32(&out[7 * 4], state[7] ^ state[15]);
+  store32(&out[8 * 4], state[8] ^ cv[0]);
+  store32(&out[9 * 4], state[9] ^ cv[1]);
+  store32(&out[10 * 4], state[10] ^ cv[2]);
+  store32(&out[11 * 4], state[11] ^ cv[3]);
+  store32(&out[12 * 4], state[12] ^ cv[4]);
+  store32(&out[13 * 4], state[13] ^ cv[5]);
+  store32(&out[14 * 4], state[14] ^ cv[6]);
+  store32(&out[15 * 4], state[15] ^ cv[7]);
+}
+
+INLINE void hash_one_portable(const uint8_t *input, size_t blocks,
+                              const uint32_t key[8], uint64_t counter,
+                              uint8_t flags, uint8_t flags_start,
+                              uint8_t flags_end, uint8_t out[BLAKE3_OUT_LEN]) {
+  uint32_t cv[8];
+  memcpy(cv, key, BLAKE3_KEY_LEN);
+  uint8_t block_flags = flags | flags_start;
+  while (blocks > 0) {
+    if (blocks == 1) {
+      block_flags |= flags_end;
+    }
+    blake3_compress_in_place_portable(cv, input, BLAKE3_BLOCK_LEN, counter,
+                                      block_flags);
+    input = &input[BLAKE3_BLOCK_LEN];
+    blocks -= 1;
+    block_flags = flags;
+  }
+  store_cv_words(out, cv);
+}
+
+void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
+                               size_t blocks, const uint32_t key[8],
+                               uint64_t counter, bool increment_counter,
+                               uint8_t flags, uint8_t flags_start,
+                               uint8_t flags_end, uint8_t *out) {
+  while (num_inputs > 0) {
+    hash_one_portable(inputs[0], blocks, key, counter, flags, flags_start,
+                      flags_end, out);
+    if (increment_counter) {
+      counter += 1;
+    }
+    inputs += 1;
+    num_inputs -= 1;
+    out = &out[BLAKE3_OUT_LEN];
+  }
+}

--- a/numcosmo/external/libfyaml/src/blake3/fy-blake3.c
+++ b/numcosmo/external/libfyaml/src/blake3/fy-blake3.c
@@ -1,0 +1,171 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include "blake3.h"
+#include "blake3_impl.h"
+
+#include <libfyaml/libfyaml-blake3.h>
+
+struct fy_blake3_hasher {
+	uint8_t output[FY_BLAKE3_OUT_LEN] FY_CACHELINE_ALIGN;
+	struct fy_blake3_hasher_cfg cfg;
+	struct blake3_host_state *hs;
+	struct blake3_hasher *hasher;
+};
+
+struct fy_blake3_hasher *fy_blake3_hasher_create(const struct fy_blake3_hasher_cfg *cfg)
+{
+	struct fy_blake3_hasher *fyh = NULL;
+	blake3_host_config hs_cfg;
+
+	fyh = malloc(sizeof(*fyh));
+	if (!fyh)
+		goto err_out;
+
+	memset(fyh, 0, sizeof(*fyh));
+
+	/* copy config - if it exists */
+	if (cfg)
+		fyh->cfg = *cfg;
+
+	memset(&hs_cfg, 0, sizeof(hs_cfg));
+	hs_cfg.debug = false;
+	hs_cfg.backend = cfg->backend;
+	if (!cfg->tp) {
+		if (cfg->num_threads >= 0)
+			hs_cfg.num_threads = (unsigned int)cfg->num_threads;
+		else
+			hs_cfg.no_mthread = true;
+	} else
+		hs_cfg.tp = cfg->tp;
+	hs_cfg.no_mmap = cfg->no_mmap;
+	hs_cfg.file_io_bufsz = cfg->file_buffer;
+	hs_cfg.mmap_min_chunk = cfg->mmap_min_chunk;
+	hs_cfg.mmap_max_chunk = cfg->mmap_max_chunk;
+	fyh->hs = blake3_host_state_create(&hs_cfg);
+	if (!fyh->hs)
+		goto err_out;
+
+	fyh->hasher = blake3_hasher_create(fyh->hs, fyh->cfg.key, fyh->cfg.context, fyh->cfg.context ? fyh->cfg.context_len : 0);
+	if (!fyh->hasher)
+		goto err_out;
+
+	return fyh;
+
+err_out:
+	fy_blake3_hasher_destroy(fyh);
+	return NULL;
+}
+
+void fy_blake3_hasher_destroy(struct fy_blake3_hasher *fyh)
+{
+	if (!fyh)
+		return;
+	if (fyh->hasher)
+		blake3_hasher_destroy(fyh->hasher);
+	if (fyh->hs)
+		blake3_host_state_destroy(fyh->hs);
+	free(fyh);
+}
+
+void fy_blake3_hasher_update(struct fy_blake3_hasher *fyh, const void *input, size_t input_len)
+{
+	if (!fyh)
+		return;
+	blake3_hasher_update(fyh->hasher, input, input_len);
+}
+
+const uint8_t *fy_blake3_hasher_finalize(struct fy_blake3_hasher *fyh)
+{
+	if (!fyh)
+		return NULL;
+	blake3_hasher_finalize(fyh->hasher, fyh->output, FY_BLAKE3_OUT_LEN);
+	return fyh->output;
+}
+
+void fy_blake3_hasher_reset(struct fy_blake3_hasher *fyh)
+{
+	if (!fyh)
+		return;
+	blake3_hasher_reset(fyh->hasher);
+}
+
+const uint8_t *fy_blake3_hash_file(struct fy_blake3_hasher *fyh, const char *filename)
+{
+	int rc;
+
+	if (!fyh || !filename)
+		return NULL;
+
+	rc = blake3_hash_file(fyh->hasher, filename, fyh->output);
+	if (rc)
+		return NULL;
+
+	return fyh->output;
+}
+
+const uint8_t *fy_blake3_hash(struct fy_blake3_hasher *fyh, const void *mem, size_t size)
+{
+	if (!fyh || !mem)
+		return NULL;
+
+	blake3_hash(fyh->hasher, mem, size, fyh->output);
+
+	return fyh->output;
+}
+
+const char *fy_blake3_backend_iterate(const char **prevp)
+{
+	const char *backend_names[64];	/* maximum 64 backends + 1 for NULL */
+	const blake3_backend_info *bei;
+	uint64_t backends, avail;
+	unsigned int i, count;
+
+	if (!prevp)
+		return NULL;
+
+	avail = blake3_get_selectable_backends() &
+		blake3_get_detected_backends();
+
+	/* first pass, fill the backend name array */
+	for (i = 0, backends = avail, count = 0; backends && i < B3BID_COUNT; i++) {
+		if (!(backends & ((uint64_t)1 << i)))
+			continue;
+		bei = blake3_get_backend_info(i);
+		if (!bei)
+			continue;
+		backends &= ~((uint64_t)1 << i);
+		backend_names[count++] = bei->name;
+	}
+
+	/* start of the iterator */
+	if (!*prevp) {
+		if (!count)
+			return NULL;
+		i = 0;
+
+	} else {
+
+		/* ok, find the current spot */
+		for (i = 0; i < count; i++) {
+			if (!strcmp(*prevp, backend_names[i]))
+				break;
+		}
+
+		/* increase for next, last or not found? */
+		if (++i >= count) {
+			*prevp = NULL;
+			return NULL;
+		}
+	}
+
+	return *prevp = backend_names[i];
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-accel.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-accel.c
@@ -1,0 +1,443 @@
+/*
+ * fy-accel.c - YAML accelerated access methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <limits.h>
+#include <string.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+
+#include "fy-accel.h"
+
+#include "xxhash.h"
+
+/* powers of two and the closest primes before
+ *
+ * pow2:  1 2 4 8 16 32 64 128 256 512 1024 2048 4096 8192 16384 32768 65536
+ * prime: 1 2 3 7 13 31 61 127 251 509 1021 2039 4093 8191 16381 32749 65521
+ *
+ * pow2:  131072 262144 524288
+ * prime: 130657 262051 524201
+ */
+
+/* 64K bucket should be enough for everybody */
+static const uint32_t prime_lt_pow2[] = {
+	1, 2, 3, 7, 13, 31, 61, 127, 251, 509, 1021,
+	2039, 4093, 8191, 16381, 32749, 65521,
+	130657, 262051, 524201
+};
+
+static inline unsigned int
+fy_accel_hash_to_pos(struct fy_accel *xl, const void *hash, unsigned int nbuckets)
+{
+	uint64_t pos;
+
+	switch (xl->hd->size) {
+	case 1:
+		pos = *(const uint8_t *)hash;
+		break;
+	case 2:
+		assert(!((uintptr_t)hash & 1));
+		pos = *(const uint16_t *)hash;
+		break;
+	case 4:
+		assert(!((uintptr_t)hash & 3));
+		pos = *(const uint32_t *)hash;
+		break;
+	case 8:
+		assert(!((uintptr_t)hash & 7));
+		pos = *(const uint64_t *)hash;
+		break;
+	default:
+		/* sigh, what ever */
+		pos = XXH32(hash, xl->hd->size, 0);
+		break;
+	}
+
+	return (unsigned int)(pos % nbuckets);
+}
+
+static inline bool
+fy_accel_hash_eq(struct fy_accel *xl, const void *hash1, const void *hash2)
+{
+	switch (xl->hd->size) {
+	case 1:
+		return *(const uint8_t *)hash1 == *(const uint8_t *)hash2;
+	case 2:
+		assert(!((uintptr_t)hash1 & 1));
+		assert(!((uintptr_t)hash2 & 1));
+		return *(const uint16_t *)hash1 == *(const uint16_t *)hash2;
+	case 4:
+		assert(!((uintptr_t)hash1 & 3));
+		assert(!((uintptr_t)hash2 & 3));
+		return *(const uint32_t *)hash1 == *(const uint32_t *)hash2;
+	case 8:
+		assert(!((uintptr_t)hash1 & 7));
+		assert(!((uintptr_t)hash2 & 7));
+		return *(const uint64_t *)hash1 == *(const uint64_t *)hash2;
+	default:
+		break;
+	}
+
+	return !memcmp(hash1, hash2, xl->hd->size);
+}
+
+int fy_accel_resize(struct fy_accel *xl, unsigned int min_buckets)
+{
+	unsigned int next_pow2, exp, i, nbuckets, pos;
+	struct fy_accel_entry_list *xlel;
+	struct fy_accel_entry *xle;
+	struct fy_accel_entry_list *buckets_new;
+
+	/* get the next power of two larger or equal */
+	next_pow2 = 1;
+	exp = 0;
+	while (next_pow2 < min_buckets &&
+	       exp < sizeof(prime_lt_pow2)/sizeof(prime_lt_pow2[0])) {
+		next_pow2 <<= 1;
+		exp++;
+	}
+
+	nbuckets = prime_lt_pow2[exp];
+	if (nbuckets == xl->nbuckets)
+		return 0;
+
+	buckets_new = malloc(sizeof(*buckets_new) * nbuckets);
+	if (!buckets_new)
+		return -1;
+
+	for (i = 0, xlel = buckets_new; i < nbuckets; i++, xlel++)
+		fy_accel_entry_list_init(xlel);
+
+	if (xl->buckets) {
+		for (i = 0, xlel = xl->buckets; i < xl->nbuckets; i++, xlel++) {
+			while ((xle = fy_accel_entry_list_pop(xlel)) != NULL) {
+				pos = fy_accel_hash_to_pos(xl, xle->hash, nbuckets);
+				fy_accel_entry_list_add_tail(&buckets_new[pos], xle);
+			}
+		}
+		free(xl->buckets);
+	}
+	xl->buckets = buckets_new;
+	xl->nbuckets = nbuckets;
+	xl->next_exp2 = exp;
+
+	return 0;
+}
+
+int fy_accel_grow(struct fy_accel *xl)
+{
+	unsigned int idx;
+
+	if (!xl)
+		return -1;
+
+	/* should not grow indefinetely */
+	idx = xl->next_exp2 + 1;
+	if (idx >= ARRAY_SIZE(prime_lt_pow2))
+		return -1;
+
+	return fy_accel_resize(xl, prime_lt_pow2[idx]);
+}
+
+int fy_accel_shrink(struct fy_accel *xl)
+{
+	if (!xl)
+		return -1;
+
+	/* should not shrink indefinetely */
+	if (xl->next_exp2 <= 0)
+		return -1;
+
+	return fy_accel_resize(xl, prime_lt_pow2[xl->next_exp2 - 1]);
+}
+
+int
+fy_accel_setup(struct fy_accel *xl,
+	       const struct fy_hash_desc *hd,
+	       void *userdata,
+	       unsigned int min_buckets)
+{
+	if (!xl || !hd || !hd->size || !hd->hash)
+		return -1;
+
+	memset(xl, 0, sizeof(*xl));
+	xl->hd = hd;
+	xl->userdata = userdata;
+	xl->count = 0;
+
+	return fy_accel_resize(xl, min_buckets);
+}
+
+void fy_accel_cleanup(struct fy_accel *xl)
+{
+	unsigned int i;
+	struct fy_accel_entry_list *xlel;
+	struct fy_accel_entry *xle;
+
+	if (!xl)
+		return;
+
+	for (i = 0, xlel = xl->buckets; i < xl->nbuckets; i++, xlel++) {
+		while ((xle = fy_accel_entry_list_pop(xlel)) != NULL) {
+			free(xle);
+			assert(xl->count > 0);
+			xl->count--;
+		}
+	}
+
+	free(xl->buckets);
+}
+
+struct fy_accel_entry *
+fy_accel_entry_insert(struct fy_accel *xl, const void *key, const void *value)
+{
+	struct fy_accel_entry *xle, *xlet;
+	struct fy_accel_entry_list *xlel;
+	unsigned int pos, bucket_size;
+	int rc;
+
+	if (!xl)
+		return NULL;
+
+	xle = malloc(sizeof(*xle) + xl->hd->size);
+	if (!xle)
+		goto err_out;
+
+	rc = xl->hd->hash(xl, key, xl->userdata, xle->hash);
+	if (rc)
+		goto err_out;
+	xle->key = key;
+	xle->value = value;
+
+	pos = fy_accel_hash_to_pos(xl, xle->hash, xl->nbuckets);
+	xlel = &xl->buckets[pos];
+
+	fy_accel_entry_list_add_tail(xlel, xle);
+
+	assert(xl->count < UINT_MAX);
+	xl->count++;
+
+	/* if we don't auto-resize, return */
+	if (xl->hd->max_bucket_grow_limit) {
+		bucket_size = 0;
+		for (xlet = fy_accel_entry_list_first(xlel); xlet; xlet = fy_accel_entry_next(xlel, xlet)) {
+			bucket_size++;
+			if (bucket_size >= xl->hd->max_bucket_grow_limit)
+				break;
+		}
+
+		/* we don't really care whether the grow up succeeds or not */
+		if (bucket_size >= xl->hd->max_bucket_grow_limit)
+			(void)fy_accel_grow(xl);
+	}
+
+	return xle;
+err_out:
+	if (xle)
+		free(xle);
+	return NULL;
+}
+
+struct fy_accel_entry *
+fy_accel_entry_lookup(struct fy_accel *xl, const void *key)
+{
+	struct fy_accel_entry_iter xli;
+	struct fy_accel_entry *xle;
+
+	xle = fy_accel_entry_iter_start(&xli, xl, key);
+	if (xle)
+		fy_accel_entry_iter_finish(&xli);
+
+	return xle;
+}
+
+struct fy_accel_entry *
+fy_accel_entry_lookup_key_value(struct fy_accel *xl, const void *key, const void *value)
+{
+	struct fy_accel_entry_iter xli;
+	struct fy_accel_entry *xle, *xle_start;
+
+	xle_start = fy_accel_entry_iter_start(&xli, xl, key);
+	if (!xle_start)
+		return NULL;
+
+	for (xle = xle_start; xle; xle = fy_accel_entry_iter_next(&xli)) {
+
+		if (xle->value == value)
+			break;
+	}
+	fy_accel_entry_iter_finish(&xli);
+
+	return xle;
+}
+
+struct fy_accel_entry *
+fy_accel_entry_lookup_value(struct fy_accel *xl, const void *value)
+{
+	struct fy_accel_entry_list *xlel;
+	struct fy_accel_entry *xle;
+	unsigned int i;
+
+	if (!xl)
+		return NULL;
+
+	for (i = 0, xlel = xl->buckets; i < xl->nbuckets; i++, xlel++) {
+		for (xle = fy_accel_entry_list_first(xlel); xle;
+		     xle = fy_accel_entry_next(xlel, xle)) {
+			if (xle->value == value)
+				return xle;
+		}
+	}
+
+	return NULL;
+}
+
+void
+fy_accel_entry_remove(struct fy_accel *xl, struct fy_accel_entry *xle)
+{
+	unsigned int pos;
+
+	if (!xl || !xle)
+		return;
+
+	pos = fy_accel_hash_to_pos(xl, xle->hash, xl->nbuckets);
+
+	fy_accel_entry_list_del(&xl->buckets[pos], xle);
+
+	assert(xl->count > 0);
+	xl->count--;
+
+	free(xle);
+}
+
+int
+fy_accel_insert(struct fy_accel *xl, const void *key, const void *value)
+{
+	struct fy_accel_entry *xle;
+
+	xle = fy_accel_entry_lookup(xl, key);
+	if (xle)
+		return -1;	/* exists */
+
+	xle = fy_accel_entry_insert(xl, key, value);
+	if (!xle)
+		return -1;	/* failure to insert */
+
+	return 0;
+}
+
+const void *
+fy_accel_lookup(struct fy_accel *xl, const void *key)
+{
+	struct fy_accel_entry *xle;
+
+	xle = fy_accel_entry_lookup(xl, key);
+	return xle ? xle->value : NULL;
+}
+
+int
+fy_accel_remove(struct fy_accel *xl, const void *data)
+{
+	struct fy_accel_entry *xle;
+
+	xle = fy_accel_entry_lookup(xl, data);
+	if (!xle)
+		return -1;
+
+	fy_accel_entry_remove(xl, xle);
+
+	return 0;
+}
+
+struct fy_accel_entry *
+fy_accel_entry_iter_next_internal(struct fy_accel_entry_iter *xli)
+{
+	struct fy_accel *xl;
+	struct fy_accel_entry *xle;
+	struct fy_accel_entry_list *xlel;
+	const void *key;
+	void *hash;
+
+	if (!xli)
+		return NULL;
+
+	xl = xli->xl;
+	hash = xli->hash;
+	xlel = xli->xlel;
+	if (!xl || !hash || !xlel)
+		return NULL;
+	key = xli->key;
+
+	xle = !xli->xle ? fy_accel_entry_list_first(xlel) :
+			  fy_accel_entry_next(xlel, xli->xle);
+	for (; xle; xle = fy_accel_entry_next(xlel, xle)) {
+		if (fy_accel_hash_eq(xl, hash, xle->hash) &&
+		    xl->hd->eq(xl, hash, xle->key, key, xl->userdata))
+			break;
+	}
+	return xli->xle = xle;
+}
+
+struct fy_accel_entry *
+fy_accel_entry_iter_start(struct fy_accel_entry_iter *xli, struct fy_accel *xl, const void *key)
+{
+	unsigned int pos;
+	int rc;
+
+	if (!xli || !xl)
+		return NULL;
+	xli->xl = xl;
+	xli->key = key;
+	if (xl->hd->size <= sizeof(xli->hash_inline))
+		xli->hash = xli->hash_inline;
+	else
+		xli->hash = malloc(xl->hd->size);
+	xli->xlel = NULL;
+
+	if (!xli->hash)
+		goto err_out;
+
+	rc = xl->hd->hash(xl, key, xl->userdata, xli->hash);
+	if (rc)
+		goto err_out;
+
+	pos = fy_accel_hash_to_pos(xl, xli->hash, xl->nbuckets);
+	xli->xlel = &xl->buckets[pos];
+
+	xli->xle = NULL;
+
+	return fy_accel_entry_iter_next_internal(xli);
+
+err_out:
+	fy_accel_entry_iter_finish(xli);
+	return NULL;
+}
+
+void fy_accel_entry_iter_finish(struct fy_accel_entry_iter *xli)
+{
+	if (!xli)
+		return;
+
+	if (xli->hash && xli->hash != xli->hash_inline)
+		free(xli->hash);
+}
+
+struct fy_accel_entry *
+fy_accel_entry_iter_next(struct fy_accel_entry_iter *xli)
+{
+	if (!xli || !xli->xle)
+		return NULL;
+
+	return fy_accel_entry_iter_next_internal(xli);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-accel.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-accel.h
@@ -1,0 +1,94 @@
+/*
+ * fy-accel.h - YAML accelerated access methods
+ *
+ * Copyright (c) 2020 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ACCEL_H
+#define FY_ACCEL_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+#include "fy-typelist.h"
+
+struct fy_accel_entry {
+	struct list_head node;
+	const void *key;
+	const void *value;
+	uint8_t hash[0];
+};
+FY_TYPE_FWD_DECL_LIST(accel_entry);
+FY_TYPE_DECL_LIST(accel_entry);
+
+struct fy_accel;
+
+struct fy_hash_desc {
+	unsigned int size;
+	unsigned int max_bucket_grow_limit;
+	bool unique;
+	int (*hash)(struct fy_accel *xl, const void *key, void *userdata, void *hash);
+	bool (*eq)(struct fy_accel *xl, const void *hash, const void *key1, const void *key2, void *userdata);
+};
+
+struct fy_accel {
+	const struct fy_hash_desc *hd;
+	void *userdata;
+	unsigned int count;
+	unsigned int nbuckets;
+	unsigned int next_exp2;
+	struct fy_accel_entry_list *buckets;
+};
+
+int
+fy_accel_setup(struct fy_accel *xl,
+	       const struct fy_hash_desc *hd,
+	       void *userdata,
+	       unsigned int min_buckets);
+
+void fy_accel_cleanup(struct fy_accel *xl);
+
+int fy_accel_resize(struct fy_accel *xl, unsigned int min_buckets);
+int fy_accel_grow(struct fy_accel *xl);
+int fy_accel_shrink(struct fy_accel *xl);
+
+int fy_accel_insert(struct fy_accel *xl, const void *key, const void *value);
+const void *fy_accel_lookup(struct fy_accel *xl, const void *key);
+int fy_accel_remove(struct fy_accel *xl, const void *key);
+
+struct fy_accel_entry_iter {
+	struct fy_accel *xl;
+	const void *key;
+	void *hash;
+	struct fy_accel_entry_list *xlel;
+	struct fy_accel_entry *xle;
+	uint64_t hash_inline[4];	/* to avoid allocation */
+};
+
+struct fy_accel_entry *
+fy_accel_entry_insert(struct fy_accel *xl, const void *key, const void *value);
+
+struct fy_accel_entry *
+fy_accel_entry_lookup(struct fy_accel *xl, const void *key);
+struct fy_accel_entry *
+fy_accel_entry_lookup_key_value(struct fy_accel *xl, const void *key, const void *value);
+struct fy_accel_entry *
+fy_accel_entry_lookup_value(struct fy_accel *xl, const void *value);
+
+void fy_accel_entry_remove(struct fy_accel *xl, struct fy_accel_entry *xle);
+
+struct fy_accel_entry *
+fy_accel_entry_iter_start(struct fy_accel_entry_iter *xli,
+			  struct fy_accel *xl, const void *key);
+void fy_accel_entry_iter_finish(struct fy_accel_entry_iter *xli);
+struct fy_accel_entry *
+fy_accel_entry_iter_next(struct fy_accel_entry_iter *xli);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-atom.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-atom.c
@@ -1,0 +1,2232 @@
+/*
+ * fy-atom.c - YAML atom methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+#include "fy-input.h"
+
+#include "fy-atom.h"
+
+const char *fy_atom_data(const struct fy_atom *atom)
+{
+	if (!atom)
+		return NULL;
+
+	return (const char *)fy_input_start(atom->fyi) + atom->start_mark.input_pos;
+}
+
+
+struct fy_atom *fy_reader_fill_atom(struct fy_reader *fyr, int advance, struct fy_atom *handle)
+{
+	/* start mark */
+	fy_reader_fill_atom_start(fyr, handle);
+
+	/* advance the given number of characters */
+	if (advance > 0)
+		fy_reader_advance_by(fyr, advance);
+
+	fy_reader_fill_atom_end(fyr, handle);
+
+	return handle;
+}
+
+int fy_reader_advance_mark(struct fy_reader *fyr, int advance, struct fy_mark *m)
+{
+	int c, tabsize, w;
+	bool is_line_break;
+
+	tabsize = fy_reader_tabsize(fyr);
+	while (advance-- > 0) {
+		c = fy_reader_peek_at_offset_width(fyr, m->input_pos, &w);
+		if (c == -1)
+			return -1;
+		m->input_pos += fy_utf8_width(c);
+
+		/* first check for CR/LF */
+		if (c == '\r' &&
+			fy_reader_peek_at_offset(fyr, m->input_pos + (size_t)w) == '\n') {
+			m->input_pos++;
+			is_line_break = true;
+		} else if (fy_reader_is_lb(fyr, c))
+			is_line_break = true;
+		else
+			is_line_break = false;
+
+		if (is_line_break) {
+			m->column = 0;
+			m->line++;
+		} else if (tabsize > 0 && fy_is_tab(c))
+			m->column += (tabsize - (fy_reader_column(fyr) % tabsize));
+		else
+			m->column++;
+	}
+
+	return 0;
+}
+
+struct fy_atom *fy_reader_fill_atom_mark(struct fy_reader *fyr,
+					 const struct fy_mark *start_mark,
+					 const struct fy_mark *end_mark,
+					 struct fy_atom *handle)
+{
+	if (!fyr || !start_mark || !end_mark || !handle)
+		return NULL;
+
+	memset(handle, 0, sizeof(*handle));
+
+	handle->start_mark = *start_mark;
+	handle->end_mark = *end_mark;
+	handle->fyi = fy_reader_current_input(fyr);
+	handle->fyi_generation = fy_reader_current_input_generation(fyr);
+
+	/* default is plain, modify at return */
+	handle->style = FYAS_PLAIN;
+	handle->chomp = FYAC_CLIP;
+	/* by default we don't do storage hints, it's the job of the caller */
+	handle->storage_hint = 0;
+	handle->storage_hint_valid = false;
+
+	return handle;
+}
+
+struct fy_atom *fy_reader_fill_atom_at(struct fy_reader *fyr, int advance, int count, struct fy_atom *handle)
+{
+	struct fy_mark start_mark, end_mark;
+	int rc;
+
+	if (!fyr || !handle || !fyr->current_input)
+		return NULL;
+
+	/* start mark */
+	fy_reader_get_mark(fyr, &start_mark);
+	rc = fy_reader_advance_mark(fyr, advance, &start_mark);
+	(void)rc;
+	/* ignore the return, if the advance failed, it's the end of input */
+
+	/* end mark */
+	end_mark = start_mark;
+	rc = fy_reader_advance_mark(fyr, count, &end_mark);
+	(void)rc;
+	/* ignore the return, if the advance failed, it's the end of input */
+
+	return fy_reader_fill_atom_mark(fyr, &start_mark, &end_mark, handle);
+}
+
+static inline void
+fy_atom_iter_chunk_reset(struct fy_atom_iter *iter)
+{
+	iter->top = 0;
+	iter->read = 0;
+}
+
+static int
+fy_atom_iter_grow_chunk(struct fy_atom_iter *iter)
+{
+	struct fy_atom_iter_chunk *chunks, *c;
+	size_t asz;
+	const char *old_s, *old_e, *ss;
+	unsigned int i;
+	size_t offset;
+
+	old_s = (const char *)iter->chunks;
+	old_e = (const char *)(iter->chunks + iter->alloc);
+
+	asz = sizeof(*chunks) * iter->alloc * 2;
+	chunks = realloc(iter->chunks == iter->startup_chunks ? NULL : iter->chunks, asz);
+	if (!chunks)	/* out of memory */
+		return -1;
+	if (iter->chunks == iter->startup_chunks)
+		memcpy(chunks, iter->startup_chunks, sizeof(iter->startup_chunks));
+
+	/* for chunks that point to the inplace buffer, reassign pointers */
+	for (ss = old_s, c = chunks, i = 0; i < iter->top; ss += sizeof(*c), c++, i++) {
+		if (c->ic.str < old_s || c->ic.str >= old_e ||
+		    c->ic.len > sizeof(c->inplace_buf))
+			continue;
+
+		/* get offset */
+		offset = (size_t)(c->ic.str - ss);
+
+		/* verify that it points to the inplace_buf area */
+		assert(offset >= offsetof(struct fy_atom_iter_chunk, inplace_buf));
+		offset -= offsetof(struct fy_atom_iter_chunk, inplace_buf);
+
+		c->ic.str = c->inplace_buf + offset;
+	}
+
+	iter->alloc *= 2;
+	iter->chunks = chunks;
+
+	return 0;
+}
+
+static int
+_fy_atom_iter_add_chunk(struct fy_atom_iter *iter, const char *str, size_t len)
+{
+	struct fy_atom_iter_chunk *c;
+	int ret;
+
+	if (!len)
+		return 0;
+
+	/* grow iter chunks? */
+	if (iter->top >= iter->alloc) {
+		ret = fy_atom_iter_grow_chunk(iter);
+		if (ret)
+			return ret;
+	}
+	assert(iter->top < iter->alloc);
+	c = &iter->chunks[iter->top++];
+
+	c->ic.str = str;
+	c->ic.len = len;
+
+	return 0;
+}
+
+static int
+_fy_atom_iter_add_chunk_copy(struct fy_atom_iter *iter, const char *str, size_t len)
+{
+	struct fy_atom_iter_chunk *c;
+	int ret;
+
+	if (!len)
+		return 0;
+
+	assert(len <= sizeof(c->inplace_buf));
+
+	if (iter->top >= iter->alloc) {
+		ret = fy_atom_iter_grow_chunk(iter);
+		if (ret)
+			return ret;
+	}
+	assert(iter->top < iter->alloc);
+	c = &iter->chunks[iter->top++];
+
+	memcpy(c->inplace_buf, str, len);
+
+	c->ic.str = c->inplace_buf;
+	c->ic.len = len;
+
+	return 0;
+}
+
+/* optimized linebreaks */
+static int
+_fy_atom_iter_add_lb(struct fy_atom_iter *iter, int c)
+{
+	switch (c) {
+	/* those are generic linebreaks */
+	case '\r':
+	case '\n':
+	case 0x85:
+		return _fy_atom_iter_add_chunk(iter, "\n", 1);
+	/* these are specific linebreaks */
+	case 0x2028:
+		return _fy_atom_iter_add_chunk(iter, "\xe2\x80\xa8", 3);
+	case 0x2029:
+		return _fy_atom_iter_add_chunk(iter, "\xe2\x80\xa9", 3);
+	}
+	/* not a linebreak */
+	return -1;
+}
+
+// #define DEBUG_CHUNK
+
+#ifndef DEBUG_CHUNK
+#define fy_atom_iter_add_chunk _fy_atom_iter_add_chunk
+#define fy_atom_iter_add_chunk_copy _fy_atom_iter_add_chunk_copy
+#define fy_atom_iter_add_lb _fy_atom_iter_add_lb
+#else
+#define fy_atom_iter_add_chunk(_iter, _str, _len) \
+	({ \
+		const char *__str = (_str); \
+		size_t __len2 = (_len); \
+		char *__fy_out = NULL; \
+		int __ret = 0; \
+		\
+		if (__len2 > 0) { \
+			__fy_out = fy_utf8_format_text_alloc(__str, __len2, fyue_doublequote); \
+			assert(__fy_out); \
+			fprintf(stderr, "%s:%d chunk #%zu \"%s\"\n", __func__, __LINE__, __len2, __fy_out); \
+			__ret = _fy_atom_iter_add_chunk((_iter), __str, __len2); \
+			free(__fy_out); \
+		} \
+		__ret; \
+	})
+
+#define fy_atom_iter_add_chunk_copy(_iter, _str, _len) \
+	({ \
+		const char *__str = (_str); \
+		size_t __len2 = (_len); \
+		char *__fy_out = NULL; \
+		int __ret = 0; \
+		\
+		if (__len2 > 0) { \
+			__fy_out = fy_utf8_format_text_alloc(__str, __len2, fyue_doublequote); \
+			assert(__fy_out); \
+			fprintf(stderr, "%s:%d chunk-copy #%zu \"%s\"\n", __func__, __LINE__, __len2, __fy_out); \
+			/* fprintf(stderr, "%s:%d chunk-copy \"%.*s\"\n", __func__, __LINE__, (int)__len, __str); */ \
+			__ret = _fy_atom_iter_add_chunk_copy((_iter), __str, __len2); \
+			free(__fy_out); \
+		} \
+		__ret; \
+	})
+#define fy_atom_iter_add_lb(_iter, _c) \
+	({ \
+		int __c = (_c); \
+		fprintf(stderr, "%s:%d lb 0x%02x\n", __func__, __LINE__, __c); \
+		_fy_atom_iter_add_lb((_iter), (_c)); \
+	})
+#endif
+
+static void
+fy_atom_iter_line_analyze(struct fy_atom_iter *iter, struct fy_atom_iter_line_info *li,
+			  const char *line_start, size_t len)
+{
+	const struct fy_atom *atom = iter->atom;
+	const char *s, *e, *ss;
+	int col, c, cn, w, wn, ts, cws, advws;
+	bool last_was_ws, is_block;
+	int lastc;
+
+	s = line_start;
+	e = line_start + len;
+
+	is_block = fy_atom_style_is_block(atom->style);
+
+	/* short circuit non multiline, non ws atoms */
+	if ((atom->direct_output && !atom->has_lb && !atom->has_ws) ||
+	    (atom->style & FYAS_MANUAL_MARK)) {
+		li->start = s;
+		li->end = e;
+		li->nws_start = s;
+		li->nws_end = e;
+		li->chomp_start = s;
+		li->final = true;
+		li->empty = atom->empty;
+		li->trailing_breaks = 0;
+		li->trailing_breaks_ws = false;
+		li->start_ws = 0;
+		li->end_ws = 0;
+		li->indented = false;
+		li->lb_end = is_block ? atom->ends_with_lb : false;
+		li->final = true;
+		li->actual_lb = -1;
+		li->s_tb = li->e_tb = NULL;
+		li->ends_with_backslash = false;
+		return;
+	}
+
+	li->start = s;
+	li->end = NULL;
+	li->nws_start = NULL;
+	li->nws_end = NULL;
+	li->chomp_start = NULL;
+	li->empty = true;
+	li->trailing_breaks = 0;
+	li->trailing_breaks_ws = false;
+	li->first = false;
+	li->start_ws = (size_t)-1;
+	li->end_ws = (size_t)-1;
+	li->indented = false;
+	li->lb_end = false;
+	li->final = false;
+	li->actual_lb = -1;
+	li->ends_with_backslash = false;
+
+	last_was_ws = false;
+
+	ts = atom->tabsize ? atom->tabsize : 8;	/* pick it up from the atom (if there is) */
+
+	/* consecutive whitespace */
+	cws = 0;
+
+	lastc = -1;
+	li->s_tb = s;
+	for (col = 0, ss = s; (c = fy_utf8_get(ss, (e - ss), &w)) >= 0; ss += w) {
+
+		lastc = c;
+
+		/* mark start of chomp */
+		if (is_block && !li->chomp_start && (unsigned int)col >= iter->chomp) {
+			li->chomp_start = ss;
+
+			/* if the character at the chomp point is whitespace
+			 * then we're indented
+			 */
+			li->indented = fy_is_ws(c);
+
+#if defined(DEBUG_CHUNK)
+			fprintf(stderr, "%s:%d chomp_start=%d\n", __FILE__, __LINE__, (int)(li->chomp_start - li->start));
+#endif
+
+		}
+
+		if (fy_is_lb_m(c, atom->lb_mode)) {
+
+#ifdef DEBUG_CHUNK
+			fprintf(stderr, "%s:%d lb=0x%x\n", __FILE__, __LINE__, c);
+#endif
+
+			col = 0;
+			if (!li->end) {
+
+				li->end = ss;
+				li->end_ws = cws;
+				li->lb_end = true;
+				li->actual_lb = c;
+
+#ifdef DEBUG_CHUNK
+				fprintf(stderr, "%s:%d set actual_lb=0x%x\n", __FILE__, __LINE__, li->actual_lb);
+#endif
+
+				cws = 0;
+			}
+
+			/* no chomp point hit, use whatever we have here */
+			if (is_block && !li->chomp_start) {
+				li->chomp_start = ss;
+#if defined(DEBUG_CHUNK)
+				fprintf(stderr, "%s:%d chomp_start=%d\n", __FILE__, __LINE__, (int)(li->chomp_start - li->start));
+#endif
+
+			}
+
+			if (!last_was_ws) {
+				cws = 0;
+				li->nws_end = ss;
+				last_was_ws = true;
+			}
+
+#if defined(DEBUG_CHUNK)
+			/* special CR/LF handling */
+			if (c == '\r') {
+				cn = ss < e ? fy_utf8_get(ss + w, (e - ss - w), &wn) : FYUG_EOF;
+				if (cn == '\n') {
+					ss += w;
+					w = wn;
+				}
+			}
+#endif
+
+		} else if (fy_is_space(c)) {
+
+			col++;
+			cws++;
+
+			if (!last_was_ws) {
+				li->nws_end = ss;
+				last_was_ws = true;
+			}
+
+		} else if (fy_is_tab(c)) {
+
+			bool can_be_nws_end;
+
+			advws = ts - (col % ts);
+			col += advws;
+
+#if defined(DEBUG_CHUNK)
+			fprintf(stderr, "%s:%d tab col=%d chomp=%d\n", __FILE__, __LINE__, col, (int)(li->chomp_start - li->start));
+#endif
+
+			if (fy_atom_style_is_block(atom->style) && li->chomp_start && col >= (int)(li->chomp_start - li->start)) {
+#if defined(DEBUG_CHUNK)
+				fprintf(stderr, "%s:%d tab col=%d chomp=%d\n", __FILE__, __LINE__, col, (int)(li->chomp_start - li->start));
+#endif
+				goto do_nws;
+			}
+
+			cws += advws;
+
+			can_be_nws_end = true;
+			if (atom->style == FYAS_DOUBLE_QUOTED && ss > li->start && ss[-1] == '\\') {
+				can_be_nws_end = false;
+#ifdef DEBUG_CHUNK
+				fprintf(stderr, "%s:%d backslashed tab\n", __FILE__, __LINE__);
+#endif
+			}
+
+			if (can_be_nws_end && !last_was_ws) {
+				li->nws_end = ss;
+				last_was_ws = true;
+			}
+
+		} else {
+
+			col++;
+do_nws:
+			/* mark start of non whitespace */
+			if (!li->nws_start)
+				li->nws_start = ss;
+
+			if (li->empty)
+				li->empty = false;
+
+			if (li->start_ws == (size_t)-1)
+				li->start_ws = cws;
+
+			last_was_ws = false;
+			cws = 0;
+		}
+
+		/* if we got both break */
+		if (li->end && iter->chomp >= 0)
+			break;
+	}
+	li->e_tb = ss;
+
+	li->final = c < 0;
+
+	if (li->final && atom->ends_with_eof) {
+
+		/* mark start of chomp */
+		if (is_block && !li->chomp_start && (unsigned int)col >= iter->chomp) {
+			li->chomp_start = ss;
+
+			/* if the character at the chomp point is whitespace
+			 * then we're indented
+			 */
+			li->indented = fy_is_ws(lastc);
+#ifdef DEBUG_CHUNK
+			fprintf(stderr, "%s:%d is_block && !li->chomp_start && (unsigned int)col >= iter->chomp\n", __FILE__, __LINE__);
+#endif
+#if defined(DEBUG_CHUNK)
+			fprintf(stderr, "%s:%d chomp_start=%d\n", __FILE__, __LINE__, (int)(li->chomp_start - li->start));
+#endif
+
+		}
+
+		if (!li->end) {
+			li->end = ss;
+			li->end_ws = cws;
+			li->lb_end = true;
+
+#ifdef DEBUG_CHUNK
+			fprintf(stderr, "%s:%d li->final && atom->ends_with_eof && !li->end\n", __FILE__, __LINE__);
+#endif
+			cws = 0;
+		}
+
+		/* no chomp point hit, use whatever we have here */
+		if (is_block && !li->chomp_start) {
+			li->chomp_start = ss;
+#ifdef DEBUG_CHUNK
+			fprintf(stderr, "%s:%d li->final && atom->ends_with_eof && !li->chomp_start\n", __FILE__, __LINE__);
+#endif
+#if defined(DEBUG_CHUNK)
+			fprintf(stderr, "%s:%d chomp_start=%d\n", __FILE__, __LINE__, (int)(li->chomp_start - li->start));
+#endif
+		}
+
+		if (!last_was_ws) {
+			cws = 0;
+			li->nws_end = ss;
+			last_was_ws = true;
+#ifdef DEBUG_CHUNK
+			fprintf(stderr, "%s:%d li->final && atom->ends_with_eof && !last_was_ws\n", __FILE__, __LINE__);
+#endif
+		}
+	}
+
+	if (!last_was_ws)
+		li->nws_end = ss;
+
+	if (!li->nws_start)
+		li->nws_start = ss;
+
+	if (!li->nws_end)
+		li->nws_end = ss;
+
+	/* if we haven't hit the chomp, point use whatever we're now */
+	if (is_block && !li->chomp_start) {
+		li->chomp_start = ss;
+#if defined(DEBUG_CHUNK)
+		fprintf(stderr, "%s:%d chomp_start=%d\n", __FILE__, __LINE__, (int)(li->chomp_start - li->start));
+#endif
+	}
+
+	if (li->start_ws == (size_t)-1)
+		li->start_ws = 0;
+
+	if (li->end_ws == (size_t)-1)
+		li->end_ws = 0;
+
+	/* mark next line to the end if no linebreak found */
+	if (!li->end) {
+		li->end = iter->e;
+		li->last = true;
+		li->end_ws = cws;
+		li->lb_end = false;
+		goto out;
+	}
+
+	/* find out if any trailing breaks exist afterwards */
+	for (; (c = fy_utf8_get(ss, (e - ss), &w)) >= 0 && (fy_is_ws(c) || fy_is_lb_m(c, atom->lb_mode)); ss += w) {
+
+		if (!li->trailing_breaks_ws && is_block && (unsigned int)col > iter->chomp)
+			li->trailing_breaks_ws = true;
+
+		if (fy_is_lb_m(c, atom->lb_mode)) {
+			/* special CRLF handling */
+			if (c == '\r') {
+				cn = ss < e ? fy_utf8_get(ss + w, (e - ss - w), &wn) : FYUG_EOF;
+				if (cn == '\n') {
+#if defined(DEBUG_CHUNK)
+					fprintf(stderr, "%s:%d trailing CRLF\n", __FILE__, __LINE__);
+#endif
+					ss += w;
+					w = wn;
+				}
+			}
+			li->trailing_breaks++;
+			col = 0;
+		} else {
+			/* indented whitespace counts as break */
+			if (fy_is_tab(c))
+				col += (ts - (col % ts));
+			else
+				col++;
+		}
+
+	}
+
+	/* and mark as last if only whitespace and breaks after this point */
+	li->last = ss >= e;
+
+out:
+	assert(li->start);
+	assert(li->end);
+	assert(li->nws_start);
+	assert(li->nws_end);
+	assert(!is_block || li->chomp_start);
+
+	li->ends_with_backslash = atom->style == FYAS_DOUBLE_QUOTED &&
+				  !li->empty &&
+				  (li->nws_end > li->nws_start && li->nws_end[-1] == '\\') &&
+				  ((li->nws_end - li->nws_start) <= 1 || li->nws_end[-2] != '\\');
+#ifdef DEBUG_CHUNK
+	fprintf(stderr, "%s:%d ends_with_backslash=%s\n", __FILE__, __LINE__, li->ends_with_backslash ? "true" : "false");
+#endif
+}
+
+void fy_atom_iter_start(const struct fy_atom *atom, struct fy_atom_iter *iter)
+{
+	struct fy_atom_iter_line_info *li;
+	size_t len;
+
+	if (!atom || !iter)
+		return;
+
+	memset(iter, 0, sizeof(*iter));
+
+	iter->atom = atom;
+	iter->s = fy_atom_data(atom);
+	len = fy_atom_size(atom);
+	iter->e = iter->s + len;
+
+	iter->chomp = atom->increment;
+
+	/* default tab size is 8 */
+	iter->tabsize = atom->tabsize ? atom->tabsize : 8;
+
+	memset(iter->li, 0, sizeof(iter->li));
+	li = &iter->li[1];
+	fy_atom_iter_line_analyze(iter, li, iter->s, len);
+	li->first = true;
+
+	/* if there's single quote at the start of a line ending the atom */
+	iter->dangling_end_quote = atom->end_mark.column == 0;
+	iter->single_line = atom->start_mark.line == atom->end_mark.line;
+	iter->empty = atom->empty;
+	iter->last_ends_with_backslash = li->ends_with_backslash;
+#ifdef DEBUG_CHUNK
+	fprintf(stderr, "%s:%d single_line=%s empty=%s last_ends_with_backslash=%s\n", __FILE__, __LINE__,
+			iter->single_line ? "true" : "false",
+			iter->empty ? "true" : "false",
+			iter->last_ends_with_backslash ? "true" : "false");
+#endif
+
+	/* current is 0, next is 1 */
+	iter->current = 0;
+
+	iter->alloc = sizeof(iter->startup_chunks)/sizeof(iter->startup_chunks[0]);
+	iter->top = 0;
+	iter->read = 0;
+	iter->chunks = iter->startup_chunks;
+
+	iter->done = false;
+
+	iter->unget_c = -1;
+}
+
+void fy_atom_iter_finish(struct fy_atom_iter *iter)
+{
+	if (iter->chunks && iter->chunks != iter->startup_chunks)
+		free(iter->chunks);
+
+	iter->chunks = NULL;
+}
+
+static const struct fy_atom_iter_line_info *
+fy_atom_iter_line(struct fy_atom_iter *iter)
+{
+	const struct fy_atom *atom = iter->atom;
+	struct fy_atom_iter_line_info *li, *nli;
+	const char *ss;
+
+	/* return while there's a next line */
+	if (!iter)
+		return NULL;
+
+	/* make next line the current one */
+	iter->current = !iter->current;
+
+	li = &iter->li[iter->current];
+
+	/* if we're out, we're out */
+	if (li->start >= iter->e)
+		return NULL;
+
+	/* scan next line (special handling for '\r\n') */
+	ss = li->end;
+	if (!ss)
+		return NULL;
+
+	if (ss < iter->e) {
+		if (*ss == '\r' && (ss + 1) < iter->e && ss[1] == '\n')
+			ss += 2;
+		else
+			ss += fy_utf8_width_by_first_octet((uint8_t)*ss);
+	}
+
+	/* get current and next line */
+	fy_atom_iter_line_analyze(iter, &iter->li[!iter->current], ss, iter->e - ss);
+
+	/* if no more, mark the next as NULL */
+	nli = &iter->li[!iter->current];
+	if (nli->start >= iter->e)
+		nli = NULL;
+
+	/* for quoted, output the white space start */
+	if (fy_atom_style_is_quoted(atom->style)) {
+		li->s = li->first ? li->start : li->nws_start;
+		li->e = li->last ? li->end : li->nws_end;
+
+		/* just empty */
+		if (li->empty && li->first && li->last && !iter->single_line)
+			li->s = li->e;
+
+	} else if (fy_atom_style_is_block(atom->style)) {
+		li->s = li->chomp_start;
+		li->e = li->end;
+		if (li->empty && li->first && li->last)
+			li->s = li->e;
+	} else {
+		li->s = li->nws_start;
+		li->e = li->nws_end;
+	}
+
+	/* bah, I hate this, */
+	if (li->s > li->e)
+		li->s = li->e;
+
+	assert(li->s <= li->e);
+
+	/* we never fold LS or PS linebreaks (on yaml 1.1) */
+	li->need_nl = fy_is_lb_LS_PS(li->actual_lb) && fy_is_lb_m(li->actual_lb, iter->atom->lb_mode) && !li->ends_with_backslash;
+	li->need_sep = false;
+
+#ifdef DEBUG_CHUNK
+	fprintf(stderr, "%s:%d need_nl=%s\n", __FILE__, __LINE__, li->need_nl ? "true" : "false");
+#endif
+	if (li->need_nl)
+		return li;
+
+	switch (atom->style) {
+	case FYAS_PLAIN:
+	case FYAS_URI:
+		li->need_nl = !li->last && li->empty;
+		li->need_sep = !li->need_nl && nli && !nli->empty;
+		break;
+
+	case FYAS_COMMENT:
+		li->need_nl = !li->final;
+		li->need_sep = false;
+		break;
+
+	case FYAS_DOUBLE_QUOTED:
+#ifdef DEBUG_CHUNK
+		fprintf(stderr, "%s:%d ends_with_backslash=%s\n", __FILE__, __LINE__, li->ends_with_backslash ? "true" : "false");
+#endif
+		if (li->ends_with_backslash) {
+
+			li->need_nl = false;
+			li->need_sep = false;
+			break;
+		}
+
+		/* fall-through */
+	case FYAS_SINGLE_QUOTED:
+		li->need_nl = (!li->last && !li->first && li->empty) ||
+				(nli && iter->empty && !li->first);
+
+		if (li->need_nl)
+			break;
+
+		li->need_sep = (nli && !nli->empty) ||
+				(!nli && li->last && iter->dangling_end_quote) ||
+				(nli && nli->final && nli->empty);
+
+		break;
+	case FYAS_LITERAL:
+		li->need_nl = true;
+		break;
+	case FYAS_FOLDED:
+		li->need_nl = !li->last && (li->empty || li->indented || li->trailing_breaks_ws || (nli && nli->indented));
+		if (li->need_nl)
+			break;
+		li->need_sep = nli && !nli->indented && !nli->empty;
+		break;
+
+	case FYAS_PLAIN_MANUAL:
+		li->need_nl = false;
+		li->need_sep = false;
+		break;
+
+	case FYAS_SINGLE_QUOTED_MANUAL:
+		li->need_nl = false;
+		li->need_sep = false;
+		break;
+
+	case FYAS_DOUBLE_QUOTED_MANUAL:
+		li->need_nl = false;
+		li->need_sep = false;
+		break;
+
+	case FYAS_LITERAL_MANUAL:
+		li->need_nl = false;
+		li->need_sep = false;
+		break;
+
+	case FYAS_FOLDED_MANUAL:
+		li->need_nl = false;
+		li->need_sep = false;
+		break;
+
+	default:
+		if (atom->style & FYAS_MANUAL_MARK) {
+			li->need_nl = false;
+			li->need_sep = false;
+		}
+		break;
+	}
+
+	return li;
+}
+
+static int
+fy_atom_iter_format(struct fy_atom_iter *iter)
+{
+	const struct fy_atom *atom = iter->atom;
+	const struct fy_atom_iter_line_info *li;
+	const char *s, *e, *t;
+	int value, code_length, ret;
+	uint8_t code[4], *tt;
+	int j, pending_nl;
+	int *pending_lb = NULL, *pending_lb_new = NULL;
+	int pending_lb_size = 0;
+	enum fy_utf8_escape esc_mode;
+	size_t rlen, i;
+
+	/* done? */
+	li = fy_atom_iter_line(iter);
+	if (!li) {
+		iter->done = true;
+		return 0;
+	}
+	if (iter->done)
+		return 0;
+
+	s = li->s;
+	e = li->e;
+
+	switch (atom->style) {
+
+	case FYAS_LITERAL:
+	case FYAS_PLAIN:
+	case FYAS_FOLDED:
+	case FYAS_COMMENT:
+		if (s < e) {
+			ret = fy_atom_iter_add_chunk(iter, s, e - s);
+			if (ret)
+				goto out;
+		}
+
+		break;
+
+	case FYAS_SINGLE_QUOTED:
+		if (li->last)
+			e = li->nws_end;
+		while (s < e) {
+			/* find next single quote */
+			t = memchr(s, '\'', e - s);
+			rlen = (t ? t : e) - s;
+
+			ret = fy_atom_iter_add_chunk(iter, s, rlen);
+			if (ret)
+				goto out;
+
+			/* end of string */
+			if (!t)
+				break;
+
+			s = t;
+			/* next character single quote too */
+			if ((e - s) >= 2 && s[1] == '\'') {
+				fy_atom_iter_add_chunk(iter, s, 1);
+				s += 2;	/* skip over the two single quotes */
+			} else
+				s++;	/* skip over this single quote char */
+		}
+		break;
+
+	case FYAS_DOUBLE_QUOTED:
+		if (li->last)
+			e = li->nws_end;
+
+		esc_mode = atom->json_mode ? fyue_doublequote_json :
+			   atom->lb_mode == fylb_cr_nl ? fyue_doublequote : fyue_doublequote_yaml_1_1;
+
+		while (s < e) {
+			/* find next escape */
+			t = memchr(s, '\\', e - s);
+			/* copy up to there (or end) */
+			rlen = (t ? t : e) - s;
+			ret = fy_atom_iter_add_chunk(iter, s, rlen);
+			if (ret)
+				goto out;
+
+			if (!t || (e - t) < 2)
+				break;
+
+			ret = fy_utf8_parse_escape(&t, e - t, esc_mode);
+			if (ret < 0)
+				goto out;
+			s = t;
+			value = ret;
+
+			tt = fy_utf8_put(code, sizeof(code), value);
+			if (!tt) {
+				ret = -1;
+				goto out;
+			}
+
+			ret = fy_atom_iter_add_chunk_copy(iter, (const char *)code, tt - code);
+			if (ret)
+				goto out;
+		}
+		break;
+
+	case FYAS_URI:
+		while (s < e) {
+			/* find next escape */
+			t = memchr(s, '%', e - s);
+			rlen = (t ? t : e) - s;
+			ret = fy_atom_iter_add_chunk(iter, s, rlen);
+			if (ret)
+				goto out;
+
+			/* end of string */
+			if (!t)
+				break;
+			s = t;
+
+			code_length = sizeof(code);
+			t = fy_uri_esc(s, e - s, code, &code_length);
+			if (!t) {
+				ret = -1;
+				goto out;
+			}
+
+			/* output escaped utf8 */
+			ret = fy_atom_iter_add_chunk_copy(iter, (const char *)code, code_length);
+			if (ret)
+				goto out;
+			s = t;
+		}
+		break;
+
+	case FYAS_PLAIN_MANUAL:
+	case FYAS_SINGLE_QUOTED_MANUAL:
+	case FYAS_DOUBLE_QUOTED_MANUAL:
+	case FYAS_LITERAL_MANUAL:
+	case FYAS_FOLDED_MANUAL:
+		/* manual scalar just goes out */
+		if (s < e) {
+			ret = fy_atom_iter_add_chunk(iter, s, e - s);
+			if (ret)
+				goto out;
+			s = e;
+		}
+		break;
+
+	default:
+		ret = -1;
+		goto out;
+	}
+
+	if (li->last) {
+
+		if (fy_atom_style_is_block(atom->style)) {
+
+			switch (atom->chomp) {
+			case FYAC_STRIP:
+			case FYAC_CLIP:
+
+				pending_lb_size = 16;
+				pending_lb = alloca(sizeof(*pending_lb) * pending_lb_size);
+
+				pending_nl = 0;
+				if (!li->empty) {
+					pending_lb[0] = li->actual_lb > 0 ? li->actual_lb : '\n';
+					pending_nl = 1;
+				}
+				while ((li = fy_atom_iter_line(iter)) != NULL) {
+					if (!iter->empty && li->chomp_start < li->end) {
+						for (j = 0; j < pending_nl; j++) {
+							ret = fy_atom_iter_add_lb(iter, pending_lb[j]);
+							if (ret)
+								goto out;
+						}
+						pending_nl = 0;
+
+						ret = fy_atom_iter_add_chunk(iter, li->chomp_start, li->end - li->chomp_start);
+						if (ret)
+							goto out;
+					}
+					if (li->lb_end && !iter->empty) {
+						if (pending_nl >= pending_lb_size) {
+							pending_lb_new = alloca(sizeof(*pending_lb) * pending_lb_size * 2);
+							memcpy(pending_lb_new, pending_lb, sizeof(*pending_lb) * pending_lb_size);
+							pending_lb_size *= 2;
+							pending_lb = pending_lb_new;
+						}
+						pending_lb[pending_nl] = li->actual_lb > 0 ? li->actual_lb : '\n';
+						pending_nl++;
+					}
+				}
+
+				if (atom->chomp == FYAC_CLIP && (pending_nl || atom->ends_with_eof)) {
+					ret = fy_atom_iter_add_lb(iter, pending_lb[0]);
+					if (ret)
+						goto out;
+				}
+				break;
+			case FYAC_KEEP:
+				if (li->lb_end || atom->ends_with_eof) {
+					ret = fy_atom_iter_add_lb(iter, li->actual_lb > 0 ? li->actual_lb : '\n');
+					if (ret)
+						goto out;
+				}
+
+				/* nothing more if it's an EOF */
+				if (atom->ends_with_eof && atom->empty)
+					break;
+
+				while ((li = fy_atom_iter_line(iter)) != NULL) {
+					if (!iter->empty && li->chomp_start < li->end) {
+						ret = fy_atom_iter_add_chunk(iter, li->chomp_start, li->end - li->chomp_start);
+						if (ret)
+							goto out;
+					}
+					if (li->lb_end) {
+						ret = fy_atom_iter_add_lb(iter, li->actual_lb > 0 ? li->actual_lb : '\n');
+						if (ret)
+							goto out;
+					}
+				}
+				break;
+			}
+
+			iter->done = true;
+
+		} else {
+
+#ifdef DEBUG_CHUNK
+			fprintf(stderr, "%s:%d trailing_breaks=%zu end_ws=%zu empty=%s\n", __func__, __LINE__,
+					li->trailing_breaks, li->end_ws,
+					li->empty ? "true" : "false");
+#endif
+
+			if (li->trailing_breaks == 0 && li->end_ws > 0) {
+				/* end of quote in a non-blank line having white space */
+				ret = fy_atom_iter_add_chunk(iter, li->nws_end, (size_t)(li->e - li->nws_end));
+				if (ret)
+					goto out;
+			} else if (li->trailing_breaks == 1) {
+
+				if (atom->style == FYAS_DOUBLE_QUOTED) {
+#ifdef DEBUG_CHUNK
+					fprintf(stderr, "%s:%d %s <>%d single trailing break %c\n", __FILE__, __LINE__, __func__,
+							(int)(li->s_tb - li->s), li->s_tb[-1]);
+#endif
+				}
+
+				if (!li->ends_with_backslash) {
+					ret = fy_atom_iter_add_chunk(iter, " ", 1);
+					if (ret)
+						goto out;
+				}
+			} else if (li->trailing_breaks > 1) {
+				for (i = 0; i < li->trailing_breaks - 1; i++) {
+					ret = fy_atom_iter_add_lb(iter, '\n');
+					if (ret)
+						goto out;
+				}
+			}
+
+			iter->done = true;
+		}
+
+	} else {
+		if (li->need_sep) {
+			ret = fy_atom_iter_add_chunk(iter, " ", 1);
+			if (ret)
+				goto out;
+		}
+
+		if (li->need_nl) {
+			ret = fy_atom_iter_add_lb(iter, li->actual_lb > 0 ? li->actual_lb : '\n');
+			if (ret)
+				goto out;
+		}
+	}
+
+	/* got more */
+	ret = 1;
+
+out:
+	return ret;
+}
+
+const struct fy_iter_chunk *
+fy_atom_iter_peek_chunk(struct fy_atom_iter *iter)
+{
+	if (iter->read >= iter->top)
+		return NULL;
+
+	return &iter->chunks[iter->read].ic;
+}
+
+void fy_atom_iter_advance(struct fy_atom_iter *iter, size_t len)
+{
+	struct fy_atom_iter_chunk *ac;
+	size_t rlen;
+
+	/* while more and not out */
+	while (len > 0 && iter->read < iter->top) {
+
+		ac = iter->chunks + iter->read;
+
+		/* get next run length */
+		rlen = len > ac->ic.len ? ac->ic.len : len;
+
+		/* remove from chunk */
+		ac->ic.str += rlen;
+		ac->ic.len -= rlen;
+
+		/* advance if out of data */
+		if (ac->ic.len == 0)
+			iter->read++;
+
+		/* remove run from length */
+		len -= rlen;
+	}
+
+	/* reset when everything is gone */
+	if (iter->read >= iter->top)
+		fy_atom_iter_chunk_reset(iter);
+}
+
+const struct fy_iter_chunk *
+fy_atom_iter_chunk_next(struct fy_atom_iter *iter, const struct fy_iter_chunk *curr, int *errp)
+{
+	const struct fy_iter_chunk *ic;
+	int ret;
+
+	ic = fy_atom_iter_peek_chunk(iter);
+	if (curr && curr == ic)
+		fy_atom_iter_advance(iter, ic->len);
+
+	/* need to pull in data? */
+	ic = fy_atom_iter_peek_chunk(iter);
+	if (!curr || !ic) {
+		fy_atom_iter_chunk_reset(iter);
+
+		do {
+			ret = fy_atom_iter_format(iter);
+
+			/* either end or error, means we don't have data */
+			if (ret <= 0) {
+				if (errp)
+					*errp = ret < 0 ? -1 : 0;
+				return NULL;
+			}
+
+		} while (!fy_atom_iter_peek_chunk(iter));
+	}
+	ic = fy_atom_iter_peek_chunk(iter);
+	if (errp)
+		*errp = 0;
+	return ic;
+}
+
+ssize_t fy_atom_format_text_length(struct fy_atom *atom)
+{
+	struct fy_atom_iter iter;
+	const struct fy_iter_chunk *ic;
+	size_t len;
+	int ret;
+
+	if (!atom)
+		return -1;
+
+	if (atom->storage_hint_valid)
+		return (ssize_t)atom->storage_hint;
+
+	len = 0;
+	fy_atom_iter_start(atom, &iter);
+	ic = NULL;
+	while ((ic = fy_atom_iter_chunk_next(&iter, ic, &ret)) != NULL)
+		len += ic->len;
+	fy_atom_iter_finish(&iter);
+
+	/* something funky going on here */
+	if ((ssize_t)len < 0)
+		return -1;
+
+	if (ret != 0)
+		return ret;
+
+	atom->storage_hint = (size_t)len;
+	atom->storage_hint_valid = true;
+	return (ssize_t)len;
+}
+
+const char *fy_atom_format_text(struct fy_atom *atom, char *buf, size_t maxsz)
+{
+	struct fy_atom_iter iter;
+	const struct fy_iter_chunk *ic;
+	char *s, *e;
+	int ret;
+
+	if (!atom || !buf)
+		return NULL;
+
+	s = buf;
+	e = s + maxsz;
+	fy_atom_iter_start(atom, &iter);
+	ic = NULL;
+	while ((ic = fy_atom_iter_chunk_next(&iter, ic, &ret)) != NULL) {
+		/* must fit (something is really off) */
+		if ((size_t)(e - s) < ic->len) {
+			ret = -1;
+			break;
+		}
+		memcpy(s, ic->str, ic->len);
+		s += ic->len;
+	}
+	fy_atom_iter_finish(&iter);
+
+	if (ret != 0 || s >= e)
+		return NULL;
+	*s = '\0';
+
+	return buf;
+}
+
+int fy_atom_format_utf8_length(struct fy_atom *atom)
+{
+	struct fy_atom_iter iter;
+	const struct fy_iter_chunk *ic;
+	const char *s, *e;
+	size_t len, run, rem;
+	int ret, w;
+
+	if (!atom)
+		return -1;
+
+	len = 0;
+	rem = 0;
+	fy_atom_iter_start(atom, &iter);
+	ic = NULL;
+	while ((ic = fy_atom_iter_chunk_next(&iter, ic, &ret)) != NULL) {
+		s = ic->str;
+		e = s + ic->len;
+
+		/* add the remainder */
+		run = (size_t)(e - s) > rem ? rem : (size_t)(e - s);
+		s += run;
+
+		/* count utf8 characters */
+		while (s < e) {
+			w = fy_utf8_width_by_first_octet(*(uint8_t *)s);
+
+			/* how many bytes of this run */
+			run = (e - s) > w ? w : (e - s);
+			/* the remainder of this run */
+			rem = w - run;
+			/* one more character */
+			len++;
+			/* and advance */
+			s += run;
+		}
+	}
+	fy_atom_iter_finish(&iter);
+
+	/* something funky going on here */
+	if ((int)len < 0)
+		return -1;
+
+	if (ret != 0)
+		return ret;
+
+	return (int)len;
+}
+
+
+struct fy_atom_iter *
+fy_atom_iter_create(const struct fy_atom *atom)
+{
+	struct fy_atom_iter *iter;
+
+	iter = malloc(sizeof(*iter));
+	if (!iter)
+		return NULL;
+	if (atom)
+		fy_atom_iter_start(atom, iter);
+	else
+		memset(iter, 0, sizeof(*iter));
+	return iter;
+}
+
+void fy_atom_iter_destroy(struct fy_atom_iter *iter)
+{
+	if (!iter)
+		return;
+
+	fy_atom_iter_finish(iter);
+	free(iter);
+}
+
+ssize_t fy_atom_iter_read(struct fy_atom_iter *iter, void *buf, size_t count)
+{
+	ssize_t nread;
+	size_t nrun;
+	const struct fy_iter_chunk *ic;
+	int ret;
+
+	if (!iter || !buf)
+		return -1;
+
+	ret = 0;
+	nread = 0;
+	while (count > 0) {
+		ic = fy_atom_iter_peek_chunk(iter);
+		if (ic) {
+			nrun = count > ic->len ? ic->len : count;
+			memcpy(buf, ic->str, nrun);
+			nread += nrun;
+			count -= nrun;
+			fy_atom_iter_advance(iter, nrun);
+			continue;
+		}
+
+		fy_atom_iter_chunk_reset(iter);
+		do {
+			ret = fy_atom_iter_format(iter);
+
+			/* either end or error, means we don't have data */
+			if (ret <= 0)
+				return ret == 0 ? nread : -1;
+
+		} while (!fy_atom_iter_peek_chunk(iter));
+	}
+
+	return nread;
+}
+
+int fy_atom_iter_getc(struct fy_atom_iter *iter)
+{
+	uint8_t buf;
+	ssize_t nread;
+	int c;
+
+	if (!iter)
+		return -1;
+
+	/* first try the pushed ungetc */
+	if (iter->unget_c >= 0) {
+		c = iter->unget_c;
+		/* unmatched getc/ungetc */
+		if (fy_utf8_width(c) != 1)
+			return -1;
+		iter->unget_c = -1;
+		return c;
+	}
+
+	/* read first octet */
+	nread = fy_atom_iter_read(iter, &buf, 1);
+	if (nread != 1)
+		return -1;
+
+	return (int)buf & 0xff;
+}
+
+int fy_atom_iter_ungetc(struct fy_atom_iter *iter, int c)
+{
+	if (!iter || c >= 0x80)
+		return -1;
+
+	if (iter->unget_c >= 0)
+		return -1;
+	if (c < 0) {
+		iter->unget_c = -1;
+		return 0;
+	}
+	iter->unget_c = c;
+	return c;
+}
+
+int fy_atom_iter_peekc(struct fy_atom_iter *iter)
+{
+	int c;
+
+	c = fy_atom_iter_getc(iter);
+	if (c == -1)
+		return -1;
+
+	return fy_atom_iter_ungetc(iter, c);
+}
+
+int fy_atom_iter_utf8_get(struct fy_atom_iter *iter)
+{
+	uint8_t buf[4];	/* maximum utf8 is 4 octets */
+	ssize_t nread;
+	int c, w;
+
+	if (!iter)
+		return -1;
+
+	/* first try the pushed ungetc */
+	if (iter->unget_c >= 0) {
+		c = iter->unget_c;
+		iter->unget_c = -1;
+		return c;
+	}
+
+	/* read first octet */
+	nread = fy_atom_iter_read(iter, &buf[0], 1);
+	if (nread != 1)
+		return -1;
+
+	/* get width from it (0 means illegal) */
+	w = fy_utf8_width_by_first_octet(buf[0]);
+	if (!w)
+		return -1;
+
+	/* read the rest octets (if possible) */
+	if (w > 1) {
+		nread = fy_atom_iter_read(iter, buf + 1, w - 1);
+		if (nread != (w - 1))
+			return -1;
+	}
+
+	/* and return the decoded utf8 character */
+	return fy_utf8_get(buf, w, &w);
+}
+
+int fy_atom_iter_utf8_quoted_get(struct fy_atom_iter *iter, size_t *lenp, uint8_t *buf)
+{
+	ssize_t nread;
+	int c, w, ww;
+
+	if (!iter || !lenp || !buf || *lenp < 4)
+		return -1;
+
+	/* first try the pushed ungetc */
+	if (iter->unget_c >= 0) {
+		c = iter->unget_c;
+		iter->unget_c = -1;
+		*lenp = 0;
+		return c;
+	}
+
+	/* read first octet */
+	nread = fy_atom_iter_read(iter, &buf[0], 1);
+	if (nread != 1)
+		return -1;
+
+	/* get width from it (0 means illegal) - return it and mark it */
+	w = fy_utf8_width_by_first_octet(buf[0]);
+	if (!w) {
+		*lenp = 1;
+		return 0;
+	}
+
+	/* read the rest octets (if possible) */
+	if (w > 1) {
+		nread = fy_atom_iter_read(iter, buf + 1, w - 1);
+		if (nread != (w - 1)) {
+			if (nread != -1 && nread < (w - 1))
+				*lenp = nread;
+			return 0;
+		}
+	}
+
+	/* and return the decoded utf8 character */
+	c = fy_utf8_get(buf, w, &ww);
+	if (c >= 0) {
+		*lenp = 0;
+		return c;
+	}
+	*lenp = w;
+	return 0;
+}
+
+int fy_atom_iter_utf8_unget(struct fy_atom_iter *iter, int c)
+{
+	if (!iter)
+		return -1;
+
+	if (iter->unget_c >= 0)
+		return -1;
+	if (c < 0) {
+		iter->unget_c = -1;
+		return 0;
+	}
+	if (!fy_utf8_is_valid(c))
+		return -1;
+	iter->unget_c = c;
+	return c;
+}
+
+int fy_atom_iter_utf8_peek(struct fy_atom_iter *iter)
+{
+	int c;
+
+	c = fy_atom_iter_utf8_get(iter);
+	if (c == -1)
+		return -1;
+
+	return fy_atom_iter_utf8_unget(iter, c);
+}
+
+int fy_atom_memcmp(struct fy_atom *atom, const void *ptr, size_t len)
+{
+	const char *dstr, *str;
+	size_t dlen, tlen;
+	struct fy_atom_iter iter;
+	int c, ct, ret;
+
+	/* empty? just fine */
+	if (!atom && !ptr && !len)
+		return 0;
+
+	/* empty atom but not ptr */
+	if (!atom && (ptr || len))
+		return -1;
+
+	/* non empty atom and empty ptr */
+	if (atom && (!ptr || !len))
+		return 1;
+
+	/* direct output, nice */
+	if (atom->direct_output) {
+		dlen = fy_atom_size(atom);
+		dstr = fy_atom_data(atom);
+		tlen = dlen > len ? len : dlen;
+		ret = memcmp(dstr, ptr, tlen);
+		if (ret)
+			return ret;
+
+		return dlen == len ? 0 : len > dlen ? -1 : 1;
+	}
+
+	str = ptr;
+	ct = -1;
+	fy_atom_iter_start(atom, &iter);
+	while ((c = fy_atom_iter_getc(&iter)) >= 0 && len) {
+		ct = *str & 0xff;
+		if (ct != c)
+			break;
+		str++;
+		len--;
+	}
+	fy_atom_iter_finish(&iter);
+
+	/* out of data on both */
+	if (c == -1 && !len)
+		return 0;
+
+	return ct > c ? -1 : 1;
+}
+
+int fy_atom_strcmp(struct fy_atom *atom, const char *str)
+{
+	size_t len;
+
+	len = str ? strlen(str) : 0;
+
+	return fy_atom_memcmp(atom, str, len);
+}
+
+bool fy_atom_is_number(struct fy_atom *atom)
+{
+	struct fy_atom_iter iter;
+	int c, len, dec, fract, enot;
+	bool first_zero;
+
+	/* empty? just fine */
+	if (!atom || atom->size0)
+		return false;
+
+	len = 0;
+
+	fy_atom_iter_start(atom, &iter);
+
+	/* skip minus sign if it's there */
+	c = fy_atom_iter_utf8_peek(&iter);
+	if (c == '-') {
+		(void)fy_atom_iter_utf8_get(&iter);
+		len++;
+	}
+
+	/* skip digits */
+	first_zero = false;
+	dec = 0;
+	while ((c = fy_atom_iter_utf8_peek(&iter)) >= 0 && fy_is_digit(c)) {
+		if (dec == 0 && c == '0')
+			first_zero = true;
+		else if (dec == 1 && first_zero)
+			goto err_out;	/* 0[0-9] is bad */
+		(void)fy_atom_iter_utf8_get(&iter);
+		dec++;
+		len++;
+	}
+
+	/* no digits is bad */
+	if (!dec)
+		goto err_out;
+
+	fract = 0;
+	/* dot? */
+	c = fy_atom_iter_utf8_peek(&iter);
+	if (c == '.') {
+
+		(void)fy_atom_iter_utf8_get(&iter);
+		len++;
+		/* skip decimal part */
+		while ((c = fy_atom_iter_utf8_peek(&iter)) >= 0 && fy_is_digit(c)) {
+			(void)fy_atom_iter_utf8_get(&iter);
+			len++;
+			fract++;
+		}
+
+		/* . without fractional */
+		if (!fract)
+			goto err_out;
+	}
+
+	enot = 0;
+	/* scientific notation */
+	c = fy_atom_iter_utf8_peek(&iter);
+	if (c == 'e' || c == 'E') {
+		(void)fy_atom_iter_utf8_get(&iter);
+		len++;
+
+		/* skip sign if it's there */
+		c = fy_atom_iter_utf8_peek(&iter);
+		if (c == '+' || c == '-') {
+			(void)fy_atom_iter_utf8_get(&iter);
+			len++;
+		}
+
+		/* skip exponent part */
+		while ((c = fy_atom_iter_utf8_peek(&iter)) >= 0 && fy_is_digit(c)) {
+			(void)fy_atom_iter_utf8_get(&iter);
+			len++;
+			enot++;
+		}
+
+		if (!enot)
+			goto err_out;
+	}
+
+	c = fy_atom_iter_utf8_peek(&iter);
+
+	fy_atom_iter_finish(&iter);
+
+	/* everything must be consumed (and something must) */
+	return c < 0 && len > 0;
+
+err_out:
+	fy_atom_iter_finish(&iter);
+
+	return false;
+}
+
+int fy_atom_cmp(struct fy_atom *atom1, struct fy_atom *atom2)
+{
+	struct fy_atom_iter iter1, iter2;
+	const char *d1, *d2;
+	size_t l1, l2, l;
+	int c1, c2, ret;
+
+	/* handles NULL case too */
+	if (atom1 == atom2)
+		return true;
+
+	/* either null, can't do */
+	if (!atom1 || !atom2)
+		return false;
+
+	/* direct output? */
+	if (atom1->direct_output) {
+		d1 = fy_atom_data(atom1);
+		l1 = fy_atom_size(atom1);
+	} else {
+		d1 = NULL;
+		l1 = 0;
+	}
+	if (atom2->direct_output) {
+		d2 = fy_atom_data(atom2);
+		l2 = fy_atom_size(atom2);
+	} else {
+		d2 = NULL;
+		l2 = 0;
+	}
+
+	/* we have both atoms with direct output */
+	if (d1 && d2) {
+		l = l1 > l2 ? l2 : l1;
+		ret = memcmp(d1, d2, l);
+		if (ret)
+			return ret;
+		return l1 == l2 ? 0 : l2 > l1 ? -1 : 1;
+	}
+
+	/* only atom2 is direct */
+	if (d2)
+		return fy_atom_memcmp(atom1, d2, l2);
+
+	/* only atom1 is direct, (note reversing sign) */
+	if (d1)
+		return -fy_atom_memcmp(atom2, d1, l1);
+
+	/* neither is direct, do it with iterators */
+	fy_atom_iter_start(atom1, &iter1);
+	fy_atom_iter_start(atom2, &iter2);
+	do {
+		c1 = fy_atom_iter_getc(&iter1);
+		c2 = fy_atom_iter_getc(&iter2);
+	} while (c1 == c2 && c1 >= 0 && c2 >= 0);
+	fy_atom_iter_finish(&iter2);
+	fy_atom_iter_finish(&iter1);
+
+	if (c1 == -1 && c2 == -1)
+		return 0;
+
+	return c2 > c1 ? -1 : 1;
+}
+
+const struct fy_raw_line *
+fy_atom_raw_line_iter_next(struct fy_atom_raw_line_iter *iter)
+{
+	struct fy_raw_line *l;
+	int c, w, col, col8, count;
+	unsigned int ts;
+	const char *s;
+
+	if (!iter || !iter->rs || iter->rs > iter->ae)
+		return NULL;
+
+	l = &iter->line;
+
+	ts = iter->atom->tabsize;
+
+	/* track back to the start of the line */
+	s = iter->rs;
+
+	/* we allow a single zero size iteration */
+	if (l->lineno > 0 && iter->rs >= iter->ae)
+		return NULL;
+
+	/* this may happen on illegal utf8 */
+	if (!iter->is)
+		return NULL;
+
+	c = -1;
+	while (s > iter->is) {
+		c = fy_utf8_get_right(iter->is, (size_t)(s - iter->is), &w);
+		if (c <= 0 || fy_is_lb_m(c, iter->atom->lb_mode))
+			break;
+		s -= w;
+	}
+
+	l->line_start = s;
+	col = col8 = 0;
+	count = 0;
+	c = -1;
+	w = 0;
+
+	/* track until the start of the content */
+	while (s < iter->as) {
+		c = fy_utf8_get(s, (size_t)(iter->ae - s), &w);
+		/* we should never hit that */
+		if (c <= 0)
+			return NULL;
+		if (fy_is_tab(c)) {
+			col8 += (8 - (col8 % 8));
+			if (ts)
+				col += (ts - (col % ts));
+			else
+				col++;
+		} else if (!fy_is_lb_m(c, iter->atom->lb_mode)) {
+			col++;
+			col8++;
+		} else
+			return NULL;
+		count++;
+
+		s += w;
+	}
+	/* mark start of content */
+	l->content_start = s;
+	l->content_start_col = col;
+	l->content_start_col8 = col8;
+	l->content_start_count = count;
+
+	/* track until the end of the content (or lb) */
+	while (s < iter->ae) {
+		c = fy_utf8_get(s, (size_t)(iter->ae - s), &w);
+		/* we should never hit that */
+		if (c <= 0)
+			return NULL;
+		if (fy_is_tab(c)) {
+			col8 += (8 - (col8 % 8));
+			if (ts)
+				col += (ts - (col % ts));
+			else
+				col++;
+		} else if (!fy_is_lb_m(c, iter->atom->lb_mode)) {
+			col++;
+			col8++;
+		} else
+			break;
+		count++;
+
+		s += w;
+	}
+
+	l->content_len = (size_t)(s - l->content_start);
+	l->content_count = count - l->content_start_count;
+	l->content_end_col = col;
+	l->content_end_col8 = col8;
+
+	/* if the stop was due to end of the atom */
+	if (s >= iter->ae) {
+		while (s < iter->ie) {
+			c = fy_utf8_get(s, (size_t)(iter->ie - s), &w);
+			/* just end of input */
+			if (c <= 0)
+				break;
+
+			if (fy_is_tab(c)) {
+				col8 += (8 - (col8 % 8));
+				if (ts)
+					col += (ts - (col % ts));
+				else
+					col++;
+			} else if (!fy_is_lb_m(c, iter->atom->lb_mode)) {
+				col++;
+				col8++;
+			} else
+				break;
+			count++;
+
+			s += w;
+		}
+	}
+
+	l->line_len = (size_t)(s - l->line_start);
+	l->line_count = count;
+
+	if (fy_is_lb_m(c, iter->atom->lb_mode)) {
+
+		s += w;
+		/* special case for MSDOS */
+		if (c == '\r' && (s + 1 < iter->ie && s[1] == '\n'))
+			s++;
+		/* len_lb includes the lb */
+		l->line_len_lb = (size_t)(s - l->line_start);
+	} else
+		l->line_len_lb = l->line_len;
+
+	/* start at line #1 */
+	l->lineno++;
+
+	iter->rs = s;
+
+	return l;
+}
+
+void fy_atom_raw_line_iter_start(const struct fy_atom *atom,
+				 struct fy_atom_raw_line_iter *iter)
+{
+	struct fy_input *fyi;
+
+	if (!atom || !iter)
+		return;
+
+	memset(iter, 0, sizeof(*iter));
+
+	fyi = atom->fyi;
+	if (!fyi)
+		return;
+
+	iter->atom = atom;
+
+	iter->as = fy_atom_data(atom);
+	iter->ae = iter->as + fy_atom_size(atom);
+
+	iter->is = fy_input_start(fyi);
+	iter->ie = iter->is + fy_input_size(fyi);
+
+	iter->rs = iter->as;
+}
+
+void fy_atom_raw_line_iter_finish(struct fy_atom_raw_line_iter *iter)
+{
+	/* nothing */
+}
+
+/* returns the line of the atom, marking exactly where the atom is */
+const char *fy_atom_lines_containing(struct fy_atom *atom, size_t *lenp)
+{
+	const struct fy_raw_line *l, *ln;
+	struct fy_atom_raw_line_iter iter;
+	bool first_line, last_line;
+	const char *start, *end;
+
+	if (!atom || !lenp) {
+		if (lenp)
+			*lenp = 0;
+		return NULL;
+	}
+
+	start = end = NULL;
+
+	fy_atom_raw_line_iter_start(atom, &iter);
+	l = fy_atom_raw_line_iter_next(&iter);
+	for (; l != NULL; l = ln) {
+		/* get the next too */
+		ln = fy_atom_raw_line_iter_next(&iter);
+
+		first_line = l->lineno <= 1;
+		last_line = ln == NULL;
+
+		if (first_line)
+			start = l->line_start;
+		if (last_line)
+			end = l->line_start + l->line_count;
+	}
+	fy_atom_raw_line_iter_finish(&iter);
+
+	*lenp = end - start;
+	return start;
+}
+
+unsigned int
+fy_atom_text_analyze(struct fy_atom *handle, enum fy_atom_style style, int *maxspanp, int *maxcolp)
+{
+	unsigned int flags = 0;
+	int c, cn, cnn, cp, col;
+	uint8_t col0si, col0ei;	/* mask for --- ... at indent 0 */
+	int span, maxspan, maxcol;
+	struct fy_atom_iter iter;
+
+	if (maxspanp)
+		*maxspanp = 0;
+	if (maxcolp)
+		*maxcolp = 0;
+
+	flags = FYTTAF_TEXT_TOKEN;
+
+	/* hardwired and fast for regular plain scalars */
+	if (style == FYAS_PLAIN && handle->storage_hint_valid &&
+	    handle->direct_output && !handle->high_ascii &&
+	    !handle->has_lb && !handle->has_ws && !handle->empty) {
+
+		flags |= FYTTAF_DIRECT_OUTPUT;
+
+		maxcol = (int)handle->storage_hint;
+		maxspan = maxcol - 1;
+		flags |=
+			FYTTAF_DIRECT_OUTPUT |
+			FYTTAF_CAN_BE_SIMPLE_KEY |
+			FYTTAF_CAN_BE_PLAIN |
+			FYTTAF_CAN_BE_SINGLE_QUOTED |
+			FYTTAF_CAN_BE_DOUBLE_QUOTED |
+			FYTTAF_CAN_BE_LITERAL |
+			FYTTAF_CAN_BE_PLAIN_FLOW |
+			FYTTAF_CAN_BE_UNQUOTED_PATH_KEY;
+
+		goto done;
+	}
+
+	/* can this token be a simple key initial condition */
+	if (!fy_atom_style_is_block(style) && style != FYAS_URI)
+		flags |= FYTTAF_CAN_BE_SIMPLE_KEY;
+
+	/* can this token be directly output initial condition */
+	if (!fy_atom_style_is_block(style))
+		flags |= FYTTAF_DIRECT_OUTPUT;
+
+	fy_atom_iter_start(handle, &iter);
+
+	col = 0;
+	maxcol = 0;
+	maxspan = 0;
+	span = 0;
+
+	/* get first character */
+	cn = fy_atom_iter_utf8_get(&iter);
+	if (cn < 0) {
+		/* empty? */
+		flags |= FYTTAF_SIZE0 | FYTTAF_EMPTY | FYTTAF_CAN_BE_UNQUOTED_PATH_KEY | FYTTAF_CAN_BE_SIMPLE_KEY;
+		goto out;
+	}
+
+	flags |= FYTTAF_CAN_BE_PLAIN |
+		 FYTTAF_CAN_BE_SINGLE_QUOTED |
+		 FYTTAF_CAN_BE_DOUBLE_QUOTED |
+		 FYTTAF_CAN_BE_LITERAL |
+		 FYTTAF_CAN_BE_FOLDED |
+		 FYTTAF_CAN_BE_PLAIN_FLOW |
+		 FYTTAF_CAN_BE_UNQUOTED_PATH_KEY |
+		 FYTTAF_ALL_WS_LB |
+		 FYTTAF_ALL_PRINT_ASCII |
+		 FYTTAF_EMPTY;
+
+	col0si = col0ei = 0;
+
+	/* disable folded right off the bat, it's a pain */
+	flags &= ~FYTTAF_CAN_BE_FOLDED;
+
+	/* plain scalars can't start with any indicator (or space/lb) */
+	if ((flags & (FYTTAF_CAN_BE_PLAIN | FYTTAF_CAN_BE_PLAIN_FLOW))) {
+		if (fy_is_start_indicator(cn) || fy_atom_is_lb(handle, cn) || fy_is_ws(cn))
+			flags &= ~(FYTTAF_CAN_BE_PLAIN | FYTTAF_CAN_BE_PLAIN_FLOW);
+	}
+
+	/* plain scalars in flow mode can't start with a flow indicator */
+	if ((flags & FYTTAF_CAN_BE_PLAIN_FLOW) &&
+		fy_is_flow_indicator(cn))
+		flags &= ~FYTTAF_CAN_BE_PLAIN_FLOW;
+
+	if ((flags & (FYTTAF_CAN_BE_PLAIN | FYTTAF_CAN_BE_PLAIN_FLOW))) {
+		cnn = fy_atom_iter_utf8_peek(&iter);
+		if (fy_is_blankz_m(cnn, fy_atom_lb_mode(handle)) && fy_is_indicator_before_space(cn))
+			flags &= ~(FYTTAF_CAN_BE_PLAIN | FYTTAF_CAN_BE_PLAIN_FLOW);
+	}
+
+	/* plain unquoted path keys can only start with [a-zA-Z_] */
+	if ((flags & FYTTAF_CAN_BE_UNQUOTED_PATH_KEY) &&
+		!fy_is_first_alpha(cn))
+		flags &= ~FYTTAF_CAN_BE_UNQUOTED_PATH_KEY;
+
+	/* if it starts with white space can't be a plain */
+	if (fy_is_ws(cn)) {
+		flags |= FYTTAF_HAS_START_WS;
+		flags &= ~(FYTTAF_CAN_BE_PLAIN |
+			   FYTTAF_CAN_BE_PLAIN_FLOW);
+	}
+
+	cp = -1;
+	for (c = cn; c >= 0; cp = c, c = cn) {
+
+		if (col <= 2) {
+			if (cn == '-') {
+				col0si |= (uint8_t)1 << col;
+				if (col0si == 7)
+					flags |= FYTTAF_HAS_START_IND | FYTTAF_QUOTE_AT_0;
+			} else if (cn == '.') {
+				col0ei |= (uint8_t)1 << col;
+				if (col0ei == 7)
+					flags |= FYTTAF_HAS_END_IND | FYTTAF_QUOTE_AT_0;
+			}
+		}
+
+		/* can be -1 on end */
+		cn = fy_atom_iter_utf8_get(&iter);
+
+		/* zero can't be output, only in double quoted mode */
+		if (c == 0) {
+			flags &= ~(FYTTAF_DIRECT_OUTPUT |
+				   FYTTAF_CAN_BE_PLAIN |
+				   FYTTAF_CAN_BE_SINGLE_QUOTED |
+				   FYTTAF_CAN_BE_LITERAL |
+				   FYTTAF_CAN_BE_FOLDED |
+				   FYTTAF_CAN_BE_PLAIN_FLOW |
+				   FYTTAF_CAN_BE_UNQUOTED_PATH_KEY |
+				   FYTTAF_ALL_WS_LB |
+				   FYTTAF_ALL_PRINT_ASCII);
+			flags |= FYTTAF_CAN_BE_DOUBLE_QUOTED;
+			flags &= ~FYTTAF_EMPTY;
+			flags |= FYTTAF_HAS_ZERO;
+		} else if (fy_is_ws(c)) {
+
+			flags |= FYTTAF_HAS_WS;
+			if (fy_is_ws(cn)) {
+				flags |= FYTTAF_HAS_CONSECUTIVE_WS;
+
+				/* on a manual ' style we can't have linebreak and then consecutive ws */
+				if (style == FYAS_SINGLE_QUOTED_MANUAL && fy_atom_is_lb(handle, cp))
+					flags &= ~FYTTAF_CAN_BE_SINGLE_QUOTED;
+			}
+
+			/* non printable ascii */
+			flags &= ~FYTTAF_ALL_PRINT_ASCII;
+
+		} else if (fy_atom_is_lb(handle, c)) {
+
+			flags |= FYTTAF_HAS_LB;
+			if (fy_atom_is_lb(handle, cn))
+				flags |= FYTTAF_HAS_CONSECUTIVE_LB;
+
+			/* non printable ascii */
+			flags &= ~FYTTAF_ALL_PRINT_ASCII;
+			flags &= ~FYTTAF_EMPTY;
+
+			/* only non linebreaks can be simple keys */
+			flags &= ~FYTTAF_CAN_BE_SIMPLE_KEY;
+
+			/* anything with linebreaks, can't be direct */
+			flags &= ~FYTTAF_DIRECT_OUTPUT;
+
+			if (c != '\n')
+				flags |= FYTTAF_HAS_NON_NL_LB;
+		} else {
+			flags &= ~FYTTAF_EMPTY;
+			flags &= ~FYTTAF_ALL_WS_LB;
+			/* out of our comfort zone */
+			if (c < '!' || c > '~')
+				flags &= ~FYTTAF_ALL_PRINT_ASCII;
+		}
+
+		if ((flags & FYTTAF_CAN_BE_UNQUOTED_PATH_KEY) && !fy_is_alnum(c))
+			flags &= ~FYTTAF_CAN_BE_UNQUOTED_PATH_KEY;
+
+		/* illegal plain combination */
+		if ((flags & FYTTAF_CAN_BE_PLAIN) &&
+			((c == ':' && fy_is_blankz_m(cn, fy_atom_lb_mode(handle))) ||
+			 (fy_is_blankz_m(c, fy_atom_lb_mode(handle)) && cn == '#') ||
+			 (cp < 0 && c == '#' && cn < 0) ||
+			 !fy_is_print(c))) {
+			flags &= ~(FYTTAF_CAN_BE_PLAIN |
+				   FYTTAF_CAN_BE_PLAIN_FLOW);
+		}
+
+		/* illegal plain flow combination */
+		if ((flags & FYTTAF_CAN_BE_PLAIN_FLOW) &&
+			(fy_is_flow_indicator(c) || (c == ':' && fy_is_flow_indicator(cn))))
+			flags &= ~FYTTAF_CAN_BE_PLAIN_FLOW;
+
+		/* non printable characters, turn off these styles */
+		if (!fy_is_print(c)) {
+			flags &= ~(FYTTAF_CAN_BE_SINGLE_QUOTED | FYTTAF_CAN_BE_LITERAL |
+				   FYTTAF_CAN_BE_FOLDED);
+			flags |= FYTTAF_HAS_NON_PRINT;
+		}
+
+		/* if there's an escape, it can't be direct */
+		if ((flags & FYTTAF_DIRECT_OUTPUT) &&
+		    ((style == FYAS_URI && c == '%') ||
+		     (style == FYAS_SINGLE_QUOTED && c == '\'') ||
+		     (style == FYAS_DOUBLE_QUOTED && c == '\\')))
+			flags &= ~FYTTAF_DIRECT_OUTPUT;
+
+		if (cn < 0 || !c || fy_atom_is_lb(handle, c) || fy_is_ws(c)) {
+			if (span > maxspan)
+				maxspan = span;
+			span = 0;
+		} else
+			span++;
+
+		if (fy_atom_is_lb(handle, c)) {
+			if (col > maxcol)
+				maxcol = col;
+			col = 0;
+			col0si = col0ei = 0;
+		} else
+			col++;
+
+		if (fy_is_any_lb(c))
+			flags |= FYTTAF_HAS_ANY_LB;
+
+		/* last character */
+		if (cn < 0) {
+			/* if ends with whitespace or linebreak, or : can't be plain */
+			if (fy_is_ws(c) || fy_atom_is_lb(handle, c) || c == ':') {
+				flags &= ~(FYTTAF_CAN_BE_PLAIN |
+					   FYTTAF_CAN_BE_PLAIN_FLOW);
+				if (c == ':')
+					flags |= FYTTAF_ENDS_WITH_COLON;
+			}
+		}
+	}
+
+	if (col > maxcol)
+		maxcol = col;
+	if (span > maxspan)
+		maxspan = span;
+
+out:
+	/* if it's got nothing, it can be anything */
+	if (flags & FYTTAF_SIZE0)
+		flags |= FYTTAF_CAN_BE_PLAIN | FYTTAF_CAN_BE_PLAIN_FLOW |
+			 FYTTAF_CAN_BE_SINGLE_QUOTED | FYTTAF_CAN_BE_DOUBLE_QUOTED |
+			 FYTTAF_CAN_BE_LITERAL |  FYTTAF_CAN_BE_FOLDED;
+
+	fy_atom_iter_finish(&iter);
+
+done:
+	if (maxspanp)
+		*maxspanp = maxspan;
+	if (maxcolp)
+		*maxcolp = maxcol;
+	return flags;
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-atom.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-atom.h
@@ -1,0 +1,323 @@
+/*
+ * fy-atom.h - internal YAML atom methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef FY_ATOM_H
+#define FY_ATOM_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+#include "fy-ctype.h"
+
+struct fy_reader;
+struct fy_input;
+struct fy_node;
+
+enum fy_atom_style {
+	/* YAML atoms */
+	FYAS_PLAIN,
+	FYAS_SINGLE_QUOTED,
+	FYAS_DOUBLE_QUOTED,
+	FYAS_LITERAL,
+	FYAS_FOLDED,
+	FYAS_URI,	/* special style for URIs */
+	FYAS_COMMENT,	/* (possibly multi line) comment */
+	FYAS_MANUAL_MARK = FY_BIT(3),
+	FYAS_PLAIN_MANUAL = FYAS_PLAIN | FYAS_MANUAL_MARK,
+	FYAS_SINGLE_QUOTED_MANUAL = FYAS_SINGLE_QUOTED | FYAS_MANUAL_MARK,
+	FYAS_DOUBLE_QUOTED_MANUAL = FYAS_DOUBLE_QUOTED | FYAS_MANUAL_MARK,
+	FYAS_LITERAL_MANUAL = FYAS_LITERAL | FYAS_MANUAL_MARK,
+	FYAS_FOLDED_MANUAL = FYAS_FOLDED | FYAS_MANUAL_MARK,
+};
+
+static inline bool fy_atom_style_is_quoted(enum fy_atom_style style)
+{
+	style &= ~FYAS_MANUAL_MARK;
+	return style == FYAS_SINGLE_QUOTED || style == FYAS_DOUBLE_QUOTED;
+}
+
+static inline bool fy_atom_style_is_block(enum fy_atom_style style)
+{
+	style &= ~FYAS_MANUAL_MARK;
+	return style == FYAS_LITERAL || style == FYAS_FOLDED;
+}
+
+enum fy_atom_chomp {
+	FYAC_STRIP,
+	FYAC_CLIP,
+	FYAC_KEEP,
+};
+
+struct fy_atom {
+	struct fy_mark start_mark;
+	struct fy_mark end_mark;
+	size_t storage_hint;	/* guaranteed to fit in this amount of bytes */
+	struct fy_input *fyi;	/* input on which atom is on */
+	uint64_t fyi_generation;	/* to detect reallocs */
+	unsigned int increment;
+	union {
+		uint64_t tozero;			/* fast way to zero everything here */
+		struct {
+			/* save a little bit of space with bitfields */
+			unsigned int style : 8;	/* enum fy_atom_style, note that it's a big perf win for bytes */
+			unsigned int chomp : 8; /* enum fy_atom_chomp */
+			unsigned int tabsize : 8;
+			int indent_delta : 8;		/* comment column offset from scope indent, clamped to [-128,127] */
+			unsigned int lb_mode : 1; /* enum fy_lb_mode */
+			unsigned int fws_mode : 1; /* enum fy_flow_ws_mode */
+			unsigned int directive0_mode : 1;
+			bool direct_output : 1;		/* can directly output */
+			bool storage_hint_valid : 1;
+			bool empty : 1;			/* atom contains whitespace and linebreaks only if length > 0 */
+			bool has_lb : 1;		/* atom contains at least one linebreak */
+			bool has_ws : 1;		/* atom contains at least one whitespace */
+			bool starts_with_ws : 1;	/* atom starts with whitespace */
+			bool starts_with_lb : 1;	/* atom starts with linebreak */
+			bool ends_with_ws : 1;		/* atom ends with whitespace */
+			bool ends_with_lb : 1;		/* atom ends with linebreak */
+			bool trailing_lb : 1;		/* atom ends with trailing linebreaks > 1 */
+			bool size0 : 1;			/* atom contains absolutely nothing */
+			bool valid_anchor : 1;		/* atom is a valid anchor */
+			bool json_mode : 1;		/* atom was read in json mode */
+			bool ends_with_eof : 1;		/* atom ends at EOF of input */
+			bool is_merge_key: 1;		/* atom is just << */
+			bool simple_key_allowed : 1;	/* atom allows a simple key */
+			bool high_ascii : 1;		/* atom has utf code point >= 0x80 (only for plains) */
+			bool chomp_explicit : 1;	/* chomp was set during block scalar parsing */
+		};
+	};
+};
+
+/* Set indent_delta, clamping to the [-128, 127] range of the 8-bit bitfield */
+static inline void fy_atom_set_indent_delta(struct fy_atom *atom, int delta)
+{
+	atom->indent_delta = delta < -128 ? -128 : (delta > 127 ? 127 : delta);
+}
+
+static inline bool fy_atom_is_set(const struct fy_atom *atom)
+{
+	return atom && atom->fyi;
+}
+
+static inline void fy_atom_reset(struct fy_atom *atom)
+{
+	if (atom)
+		atom->fyi = NULL;
+}
+
+static inline bool fy_atom_json_mode(struct fy_atom *handle)
+{
+	if (!handle)
+		return false;
+
+	return handle->json_mode;
+}
+
+static inline enum fy_lb_mode fy_atom_lb_mode(struct fy_atom *handle)
+{
+	if (!handle)
+		return fylb_cr_nl;
+
+	return handle->lb_mode;
+}
+
+static inline bool fy_atom_is_merge_key(struct fy_atom *handle)
+{
+	return handle && handle->is_merge_key;
+}
+
+static inline enum fy_flow_ws_mode fy_atom_flow_ws_mode(struct fy_atom *handle)
+{
+	if (!handle)
+		return fyfws_space_tab;
+
+	return handle->fws_mode;
+}
+
+/* all atoms are scalars so... */
+static inline bool fy_atom_is_lb(struct fy_atom *handle, int c)
+{
+	return fy_is_generic_lb_m(c, fy_atom_lb_mode(handle));
+}
+
+static inline bool fy_atom_is_flow_ws(struct fy_atom *handle, int c)
+{
+	return fy_is_flow_ws_m(c, fy_atom_flow_ws_mode(handle));
+}
+
+ssize_t fy_atom_format_text_length(struct fy_atom *atom);
+const char *fy_atom_format_text(struct fy_atom *atom, char *buf, size_t maxsz);
+
+int fy_atom_format_utf8_length(struct fy_atom *atom);
+
+static inline void
+fy_atom_reset_storage_hints(struct fy_atom *handle)
+{
+	handle->storage_hint = 0;
+	handle->storage_hint_valid = false;
+}
+
+struct fy_atom *fy_reader_fill_atom(struct fy_reader *fyr, int advance, struct fy_atom *handle);
+struct fy_atom *fy_reader_fill_atom_mark(struct fy_reader *fyr, const struct fy_mark *start_mark,
+					 const struct fy_mark *end_mark, struct fy_atom *handle);
+struct fy_atom *fy_reader_fill_atom_at(struct fy_reader *fyr, int advance, int count, struct fy_atom *handle);
+
+#define fy_reader_fill_atom_a(_fyr, _advance)  fy_reader_fill_atom((_fyr), (_advance), alloca(sizeof(struct fy_atom)))
+
+struct fy_atom *fy_fill_node_atom(struct fy_node *fyn, struct fy_atom *handle);
+
+#define fy_fill_node_atom_a(_fyn)  fy_fill_node_atom((_fyn), alloca(sizeof(struct fy_atom)))
+
+struct fy_atom_iter_line_info {
+	const char *start;
+	const char *end;
+	const char *nws_start;
+	const char *nws_end;
+	const char *chomp_start;
+	bool empty : 1;
+	bool trailing_breaks_ws : 1;
+	bool first : 1;		/* first */
+	bool last : 1;		/* last (only ws/lb afterwards */
+	bool final : 1;		/* the final iterator */
+	bool indented : 1;
+	bool lb_end : 1;
+	bool need_nl : 1;
+	bool need_sep : 1;
+	bool ends_with_backslash : 1;	/* last ended in \\ */
+	size_t trailing_ws;
+	size_t trailing_breaks;
+	size_t start_ws, end_ws;
+	const char *s;
+	const char *e;
+	int actual_lb;		/* the line break */
+	const char *s_tb;	/* start of trailing breaks run */
+	const char *e_tb;	/* end of trailing breaks run */
+};
+
+struct fy_atom_iter_chunk {
+	struct fy_iter_chunk ic;
+	/* note that it is guaranteed for copied chunks to be
+	 * less or equal to 10 characters (the maximum digitbuf
+	 * for double quoted escapes */
+	char inplace_buf[10];	/* small copies in place */
+};
+
+#define NR_STARTUP_CHUNKS	8
+#define SZ_STARTUP_COPY_BUFFER	32
+
+struct fy_atom_iter {
+	const struct fy_atom *atom;
+	const char *s, *e;
+	unsigned int chomp;
+	int tabsize;
+	bool single_line : 1;
+	bool dangling_end_quote : 1;
+	bool last_ends_with_backslash : 1;
+	bool empty : 1;
+	bool current : 1;
+	bool done : 1;	/* last iteration (for block styles) */
+	struct fy_atom_iter_line_info li[2];
+	unsigned int alloc;
+	unsigned int top;
+	unsigned int read;
+	struct fy_atom_iter_chunk *chunks;
+	struct fy_atom_iter_chunk startup_chunks[NR_STARTUP_CHUNKS];
+	int unget_c;
+};
+
+void fy_atom_iter_start(const struct fy_atom *atom, struct fy_atom_iter *iter);
+void fy_atom_iter_finish(struct fy_atom_iter *iter);
+const struct fy_iter_chunk *fy_atom_iter_peek_chunk(struct fy_atom_iter *iter);
+const struct fy_iter_chunk *fy_atom_iter_chunk_next(struct fy_atom_iter *iter, const struct fy_iter_chunk *curr, int *errp);
+void fy_atom_iter_advance(struct fy_atom_iter *iter, size_t len);
+
+struct fy_atom_iter *fy_atom_iter_create(const struct fy_atom *atom);
+void fy_atom_iter_destroy(struct fy_atom_iter *iter);
+ssize_t fy_atom_iter_read(struct fy_atom_iter *iter, void *buf, size_t count);
+int fy_atom_iter_getc(struct fy_atom_iter *iter);
+int fy_atom_iter_ungetc(struct fy_atom_iter *iter, int c);
+int fy_atom_iter_peekc(struct fy_atom_iter *iter);
+int fy_atom_iter_utf8_get(struct fy_atom_iter *iter);
+int fy_atom_iter_utf8_quoted_get(struct fy_atom_iter *iter, size_t *lenp, uint8_t *buf);
+int fy_atom_iter_utf8_unget(struct fy_atom_iter *iter, int c);
+int fy_atom_iter_utf8_peek(struct fy_atom_iter *iter);
+
+int fy_atom_memcmp(struct fy_atom *atom, const void *ptr, size_t len);
+int fy_atom_strcmp(struct fy_atom *atom, const char *str);
+bool fy_atom_is_number(struct fy_atom *atom);
+int fy_atom_cmp(struct fy_atom *atom1, struct fy_atom *atom2);
+
+const char *fy_atom_data(const struct fy_atom *atom);
+
+static inline size_t fy_atom_size(const struct fy_atom *atom)
+{
+	if (!atom)
+		return 0;
+
+	return atom->end_mark.input_pos - atom->start_mark.input_pos;
+}
+
+static inline bool fy_plain_atom_streq(const struct fy_atom *atom, const char *str)
+{
+	size_t size = strlen(str);
+
+	if (!atom || !str || atom->style != FYAS_PLAIN || fy_atom_size(atom) != size)
+		return false;
+
+	return !memcmp(str, fy_atom_data(atom), size);
+}
+
+struct fy_raw_line {
+	int lineno;
+	const char *line_start;
+	size_t line_len;
+	size_t line_len_lb;
+	size_t line_count;
+	const char *content_start;
+	size_t content_len;
+	size_t content_start_count;
+	size_t content_count;
+	int content_start_col;
+	int content_start_col8;	/* this is the tab 8 */
+	int content_end_col;
+	int content_end_col8;
+};
+
+struct fy_atom_raw_line_iter {
+	const struct fy_atom *atom;
+	const char *is, *ie;	/* input start, end */
+	const char *as, *ae;	/* atom start, end */
+	const char *rs;
+	struct fy_raw_line line;
+};
+
+void fy_atom_raw_line_iter_start(const struct fy_atom *atom,
+			     struct fy_atom_raw_line_iter *iter);
+void fy_atom_raw_line_iter_finish(struct fy_atom_raw_line_iter *iter);
+
+const struct fy_raw_line *
+fy_atom_raw_line_iter_next(struct fy_atom_raw_line_iter *iter);
+
+const char *
+fy_atom_lines_containing(struct fy_atom *atom, size_t *lenp);
+
+
+unsigned int
+fy_atom_text_analyze(struct fy_atom *handle, enum fy_atom_style style,
+		     int *maxspanp, int *maxcolp);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-composer-diag.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-composer-diag.c
@@ -1,0 +1,88 @@
+/*
+ * fy-composer-diag.c - composer diagnostics
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-diag.h"
+#include "fy-composer.h"
+
+int fy_composer_vdiag(struct fy_composer *fyc, unsigned int flags,
+		      const char *file, int line, const char *func,
+		      const char *fmt, va_list ap)
+{
+	struct fy_diag_ctx fydc;
+	int rc;
+
+	if (!fyc || !fmt || !fyc->cfg.diag)
+		return -1;
+
+	/* perform the enable tests early to avoid the overhead */
+	if ((int)((flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT) < (int)fyc->cfg.diag->cfg.level)
+		return 0;
+
+	/* fill in fy_diag_ctx */
+	memset(&fydc, 0, sizeof(fydc));
+
+	fydc.level = (flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT;
+	fydc.module = (flags & FYDF_MODULE_MASK) >> FYDF_MODULE_SHIFT;
+	fydc.source_file = file;
+	fydc.source_line = line;
+	fydc.source_func = func;
+	fydc.line = -1;
+	fydc.column = -1;
+
+	rc = fy_vdiag(fyc->cfg.diag, &fydc, fmt, ap);
+
+	return rc;
+}
+
+int fy_composer_diag(struct fy_composer *fyc, unsigned int flags,
+		     const char *file, int line, const char *func,
+		     const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_composer_vdiag(fyc, flags, file, line, func, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+void fy_composer_diag_vreport(struct fy_composer *fyc,
+			      const struct fy_diag_report_ctx *fydrc,
+			      const char *fmt, va_list ap)
+{
+	if (!fyc || !fyc->cfg.diag || !fydrc || !fmt)
+		return;
+
+	fy_diag_vreport(fyc->cfg.diag, fydrc, fmt, ap);
+}
+
+void fy_composer_diag_report(struct fy_composer *fyc,
+			     const struct fy_diag_report_ctx *fydrc,
+			     const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_composer_diag_vreport(fyc, fydrc, fmt, ap);
+	va_end(ap);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-composer.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-composer.c
@@ -1,0 +1,445 @@
+/*
+ * fy-composer.c - Composer support
+ *
+ * Copyright (c) 2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+
+#include "fy-utils.h"
+
+struct fy_composer *
+fy_composer_create(struct fy_composer_cfg *cfg)
+{
+	struct fy_composer *fyc;
+	struct fy_path *fypp;
+
+	/* verify configuration and mandatory ops */
+	if (!cfg || !cfg->ops ||
+	    !cfg->ops->process_event)
+		return NULL;
+
+	fyc = malloc(sizeof(*fyc));
+	if (!fyc)
+		return NULL;
+	memset(fyc, 0, sizeof(*fyc));
+	fyc->cfg = *cfg;
+
+	fy_path_list_init(&fyc->paths);
+	fypp = fy_path_create();
+	if (!fypp)
+		goto err_no_path;
+	fy_path_list_add_tail(&fyc->paths, fypp);
+
+	return fyc;
+
+err_no_path:
+	free(fyc);
+	return NULL;
+}
+
+void fy_composer_destroy(struct fy_composer *fyc)
+{
+	struct fy_path *fypp;
+
+	if (!fyc)
+		return;
+
+	fy_diag_unref(fyc->cfg.diag);
+	while ((fypp = fy_path_list_pop(&fyc->paths)) != NULL)
+		fy_path_destroy(fypp);
+	free(fyc);
+}
+
+static enum fy_composer_return
+fy_composer_process_event_private(struct fy_composer *fyc, struct fy_event *fye, struct fy_path *fypp)
+{
+	const struct fy_composer_ops *ops;
+	struct fy_eventp *fyep;
+	struct fy_path_component *fypc, *fypc_last;
+	struct fy_path *fyppt;
+	struct fy_document *fyd;
+	bool is_collection, is_map, is_start, is_end;
+	int rc = 0;
+	enum fy_composer_return ret;
+	bool stop_req = false;
+
+	assert(fyc);
+	assert(fye);
+	assert(fypp);
+
+	fyep = container_of(fye, struct fy_eventp, e);
+
+	ops = fyc->cfg.ops;
+	assert(ops);
+
+	rc = 0;
+
+	switch (fye->type) {
+	case FYET_MAPPING_START:
+		is_collection = true;
+		is_start = true;
+		is_end = false;
+		is_map = true;
+		break;
+
+	case FYET_MAPPING_END:
+		is_collection = true;
+		is_start = false;
+		is_end = true;
+		is_map = true;
+		break;
+
+	case FYET_SEQUENCE_START:
+		is_collection = true;
+		is_start = true;
+		is_end = false;
+		is_map = false;
+		break;
+
+	case FYET_SEQUENCE_END:
+		is_collection = true;
+		is_start = false;
+		is_end = true;
+		is_map = false;
+		break;
+
+	case FYET_SCALAR:
+		is_collection = false;
+		is_start = true;
+		is_end = true;
+		is_map = false;
+		break;
+
+	case FYET_ALIAS:
+		is_collection = false;
+		is_start = true;
+		is_end = true;
+		is_map = false;
+		break;
+
+	case FYET_STREAM_START:
+	case FYET_STREAM_END:
+	case FYET_DOCUMENT_START:
+	case FYET_DOCUMENT_END:
+		return ops->process_event(fyc, fypp, fye);
+
+	default:
+		return FYCR_OK_CONTINUE;
+	}
+
+	fypc_last = fy_path_component_list_tail(&fypp->components);
+
+	if (fy_path_component_is_mapping(fypc_last) && fypc_last->map.accumulating_complex_key) {
+
+		/* get the next one */
+		fyppt = fy_path_next(&fyc->paths, fypp);
+		assert(fyppt);
+		assert(fyppt != fypp);
+		assert(fyppt->parent == fypp);
+
+		/* and pass along */
+		ret = fy_composer_process_event_private(fyc, fye, fyppt);
+		if (!fy_composer_return_is_ok(ret)) {
+			/* XXX TODO handle skip */
+			return ret;
+		}
+		if (!stop_req)
+			stop_req = ret == FYCR_OK_STOP;
+
+		rc = fy_document_builder_process_event(fypp->fydb, fyep ? &fyep->e : NULL);
+		if (rc == 0)
+			return FYCR_OK_CONTINUE;
+		fyc_error_check(fyc, rc > 0, err_out,
+				"fy_document_builder_process_event() failed\n");
+
+		/* get the document */
+		fyd = fy_document_builder_take_document(fypp->fydb);
+		fyc_error_check(fyc, fyd, err_out,
+				"fy_document_builder_take_document() failed\n");
+
+		fy_document_builder_destroy(fypp->fydb);
+		fypp->fydb = NULL;
+
+		fypc_last->map.is_complex_key = true;
+		fypc_last->map.accumulating_complex_key = false;
+		fypc_last->map.complex_key = fyd;
+		fypc_last->map.has_key = true;
+		fypc_last->map.await_key = false;
+		fypc_last->map.complex_key_complete = true;
+		fypc_last->map.root = false;
+
+		fyppt = fy_path_list_pop_tail(&fyc->paths);
+		assert(fyppt);
+
+		fy_path_destroy(fyppt);
+
+		fyc_error_check(fyc, rc >= 0, err_out,
+				"fy_path_component_build_text() failed\n");
+
+		return !stop_req ? FYCR_OK_CONTINUE : FYCR_OK_STOP;
+	}
+
+	/* start of something on a mapping */
+	if (is_start && fy_path_component_is_mapping(fypc_last) && fypc_last->map.await_key && is_collection) {
+
+		/* the configuration must support a document builder for complex keys */
+		FYC_TOKEN_ERROR_CHECK(fyc, fy_event_get_token(fye), FYEM_DOC,
+				ops->create_document_builder, err_out,
+				"composer configuration does not support complex keys");
+
+		/* call out for creating the document builder */
+		fypp->fydb = ops->create_document_builder(fyc);
+		fyc_error_check(fyc, fypp->fydb, err_out,
+				"ops->create_document_builder() failed\n");
+
+		/* and pass the current event; must return 0 since we know it's a collection start */
+		rc = fy_document_builder_process_event(fypp->fydb, fyep ? &fyep->e : NULL);
+		fyc_error_check(fyc, !rc, err_out,
+				"fy_document_builder_process_event() failed\n");
+
+		fypc_last->map.is_complex_key = true;
+		fypc_last->map.accumulating_complex_key = true;
+		fypc_last->map.complex_key = NULL;
+		fypc_last->map.complex_key_complete = false;
+
+		/* create new path */
+		fyppt = fy_path_create();
+		fyc_error_check(fyc, fyppt, err_out,
+				"fy_path_create() failed\n");
+
+		/* append it to the end */
+		fyppt->parent = fypp;
+		fy_path_list_add_tail(&fyc->paths, fyppt);
+
+		/* and pass along */
+		ret = fy_composer_process_event_private(fyc, fye, fyppt);
+		if (!fy_composer_return_is_ok(ret)) {
+			/* XXX TODO handle skip */
+			return ret;
+		}
+		if (!stop_req)
+			stop_req = ret == FYCR_OK_STOP;
+
+		return !stop_req ? FYCR_OK_CONTINUE : FYCR_OK_STOP;
+	}
+
+	if (is_start && fy_path_component_is_sequence(fypc_last)) {	/* start in a sequence */
+
+		if (fypc_last->seq.idx < 0)
+			fypc_last->seq.idx = 0;
+		else
+			fypc_last->seq.idx++;
+	}
+
+	if (is_collection && is_start) {
+
+		/* collection start */
+		if (is_map) {
+			fypc = fy_path_component_create_mapping(fypp);
+			fyc_error_check(fyc, fypc, err_out,
+					"fy_path_component_create_mapping() failed\n");
+		} else {
+			fypc = fy_path_component_create_sequence(fypp);
+			fyc_error_check(fyc, fypc, err_out,
+					"fy_path_component_create_sequence() failed\n");
+		}
+
+		/* append to the tail */
+		fy_path_component_list_add_tail(&fypp->components, fypc);
+
+	} else if (is_collection && is_end) {
+
+		/* collection end */
+		assert(fypc_last);
+		fy_path_component_clear_state(fypc_last);
+
+	} else if (!is_collection && fy_path_component_is_mapping(fypc_last) && fypc_last->map.await_key) {
+
+		fypc_last->map.is_complex_key = false;
+		fypc_last->map.scalar.tag = fy_token_ref(fy_event_get_tag_token(fye));
+		fypc_last->map.scalar.key = fy_token_ref(fy_event_get_token(fye));
+		fypc_last->map.has_key = true;
+		fypc_last->map.root = false;
+
+	}
+
+	/* process the event */
+	ret = ops->process_event(fyc, fypp, fye);
+	if (!fy_composer_return_is_ok(ret)) {
+		/* XXX TODO handle skip */
+		return ret;
+	}
+	if (!stop_req)
+		stop_req = ret == FYCR_OK_STOP;
+
+	if (is_collection && is_end) {
+		/* for the end of a collection, pop the last component */
+		fypc = fy_path_component_list_pop_tail(&fypp->components);
+		assert(fypc);
+
+		assert(fypc == fypc_last);
+
+		fy_path_component_recycle(fypp, fypc);
+
+		/* and get the new last */
+		fypc_last = fy_path_component_list_tail(&fypp->components);
+	}
+
+	/* at the end of something */
+	if (is_end && fy_path_component_is_mapping(fypc_last)) {
+		if (!fypc_last->map.await_key) {
+			fy_path_component_clear_state(fypc_last);
+			fypc_last->map.await_key = true;
+		} else
+			fypc_last->map.await_key = false;
+	}
+
+	return !stop_req ? FYCR_OK_CONTINUE : FYCR_OK_STOP;
+
+err_out:
+	return FYCR_ERROR;
+}
+
+void
+fy_composer_halt_one(struct fy_composer *fyc, struct fy_path *fypp, enum fy_composer_return rc)
+{
+	const struct fy_composer_ops *ops;
+	struct fy_eventp ev_none;
+	struct fy_path_component *fypc;
+
+	/* for normal stop, we don't teardown */
+	if (rc == FYCR_OK_STOP)
+		return;
+
+	ops = fyc->cfg.ops;
+	assert(ops);
+
+	memset(&ev_none, 0, sizeof(ev_none));
+	ev_none.e.type = FYET_NONE;
+
+	/* pump FYET_NONEs to clean the stack */
+
+	while ((fypc = fy_path_component_list_tail(&fypp->components)) != NULL) {
+
+		ops->process_event(fyc, fypp, &ev_none.e);
+
+		fy_path_component_list_del(&fypp->components, fypc);
+		fy_path_component_free(fypc);
+	}
+
+	/* and the final one to clean the root */
+	ops->process_event(fyc, fypp, &ev_none.e);
+}
+
+void fy_composer_halt(struct fy_composer *fyc, enum fy_composer_return rc)
+{
+	struct fy_path *fypp;
+
+	/* for normal stop, we don't teardown */
+	if (rc == FYCR_OK_STOP)
+		return;
+
+	for (fypp = fy_path_list_head(&fyc->paths); fypp; fypp = fy_path_next(&fyc->paths, fypp))
+		fy_composer_halt_one(fyc, fypp, rc);
+}
+
+enum fy_composer_return
+fy_composer_process_event(struct fy_composer *fyc, struct fy_event *fye)
+{
+	struct fy_path *fypp;
+	int rc;
+
+	if (!fyc || !fye)
+		return FYCR_ERROR;
+
+	/* start at the head */
+	fypp = fy_path_list_head(&fyc->paths);
+
+	/* no top? something's very out of order */
+	if (!fypp)
+		return FYCR_ERROR;
+
+	rc = fy_composer_process_event_private(fyc, fye, fypp);
+
+	if (rc == FYCR_ERROR || rc == FYCR_OK_STOP)
+		fy_composer_halt(fyc, rc);
+
+	return rc;
+}
+
+struct fy_composer_cfg *fy_composer_get_cfg(struct fy_composer *fyc)
+{
+	if (!fyc)
+		return NULL;
+	return &fyc->cfg;
+}
+
+void *fy_composer_get_cfg_userdata(struct fy_composer *fyc)
+{
+	if (!fyc)
+		return NULL;
+	return fyc->cfg.userdata;
+}
+
+struct fy_diag *fy_composer_get_diag(struct fy_composer *fyc)
+{
+	if (!fyc)
+		return NULL;
+	return fyc->cfg.diag;
+}
+
+struct fy_path *fy_composer_get_root_path(struct fy_composer *fyc)
+{
+	if (!fyc)
+		return NULL;
+	return fy_path_list_head(&fyc->paths);
+}
+
+struct fy_path *fy_composer_get_next_path(struct fy_composer *fyc, struct fy_path *fypp)
+{
+	if (!fyc || !fypp)
+		return NULL;
+	return fy_path_next(&fyc->paths, fypp);
+}
+
+struct fy_path *fy_composer_get_path(struct fy_composer *fyc)
+{
+	struct fy_path *fypp, *fyppt;
+	struct fy_path_component *fypc_last;
+
+	if (!fyc)
+		return NULL;
+
+	fypp = fy_path_list_head(&fyc->paths);
+	if (!fypp)
+		return NULL;
+
+	/* traverse until we find the last non complex key acculating */
+	for (;;) {
+		fypc_last = fy_path_component_list_tail(&fypp->components);
+		if (!fy_path_component_is_mapping(fypc_last) || !fypc_last->map.accumulating_complex_key)
+			break;
+		fyppt = fy_path_next(&fyc->paths, fypp);
+		if (!fyppt)
+			break;
+		fypp = fyppt;
+	}
+
+	return fypp;
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-composer.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-composer.h
@@ -1,0 +1,137 @@
+/*
+ * fy-composer.h - YAML composer
+ *
+ * Copyright (c) 2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_COMPOSER_H
+#define FY_COMPOSER_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+#include "fy-typelist.h"
+
+#include "fy-emit-accum.h"
+#include "fy-path.h"
+
+#include "fy-diag.h"
+
+struct fy_composer;
+struct fy_token;
+struct fy_diag;
+struct fy_event;
+struct fy_eventp;
+struct fy_document_builder;
+
+struct fy_composer {
+	struct fy_composer_cfg cfg;
+	struct fy_path_list paths;
+};
+
+void fy_composer_halt_one(struct fy_composer *fyc, struct fy_path *fypp, enum fy_composer_return rc);
+void fy_composer_halt(struct fy_composer *fyc, enum fy_composer_return rc);
+
+/* diagnostics */
+
+static inline bool
+fyc_debug_log_level_is_enabled(struct fy_composer *fyc, enum fy_error_module module)
+{
+	return fyc && fy_diag_log_level_is_enabled(fyc->cfg.diag, FYET_DEBUG, module);
+}
+
+int fy_composer_vdiag(struct fy_composer *fyc, unsigned int flags,
+		      const char *file, int line, const char *func,
+		      const char *fmt, va_list ap);
+
+int fy_composer_diag(struct fy_composer *fyc, unsigned int flags,
+		     const char *file, int line, const char *func,
+		     const char *fmt, ...)
+	FY_FORMAT(printf, 6, 7);
+
+void fy_composer_diag_vreport(struct fy_composer *fyc,
+			      const struct fy_diag_report_ctx *fydrc,
+			      const char *fmt, va_list ap);
+void fy_composer_diag_report(struct fy_composer *fyc,
+			     const struct fy_diag_report_ctx *fydrc,
+			     const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+#ifdef FY_DEVMODE
+
+#define fyc_debug(_fyc, _module, _fmt, ...) \
+	do { \
+		struct fy_composer *__fyc = (_fyc); \
+		enum fy_error_module __module = (_module); \
+		\
+		if (fyc_debug_log_level_is_enabled(__fyc, __module)) \
+			fy_composer_diag(__fyc, FYET_DEBUG | FYDF_MODULE(_module), \
+					__FILE__, __LINE__, __func__, \
+					(_fmt) , ## __VA_ARGS__); \
+	} while(0)
+#else
+
+#define fyc_debug(_fyc, _module, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fyc_info(_fyc, _fmt, ...) \
+	fy_composer_diag((_fyc), FYET_INFO, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyc_notice(_fyc, _fmt, ...) \
+	fy_composer_diag((_fyc), FYET_NOTICE, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyc_warning(_fyc, _fmt, ...) \
+	fy_composer_diag((_fyc), FYET_WARNING, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyc_error(_fyc, _fmt, ...) \
+	fy_composer_diag((_fyc), FYET_ERROR, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+
+#define fyc_error_check(_fyc, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			fyc_error((_fyc), _fmt, ## __VA_ARGS__); \
+			goto _label ; \
+		} \
+	} while(0)
+
+#define _FYC_TOKEN_DIAG(_fyc, _fyt, _type, _module, _fmt, ...) \
+	do { \
+		struct fy_diag_report_ctx _drc; \
+		memset(&_drc, 0, sizeof(_drc)); \
+		_drc.type = (_type); \
+		_drc.module = (_module); \
+		_drc.fyt = (_fyt); \
+		fy_composer_diag_report((_fyc), &_drc, (_fmt) , ## __VA_ARGS__); \
+	} while(0)
+
+#define FYC_TOKEN_DIAG(_fyc, _fyt, _type, _module, _fmt, ...) \
+	_FYC_TOKEN_DIAG(_fyc, fy_token_ref(_fyt), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYC_NODE_DIAG(_fyc, _fyn, _type, _module, _fmt, ...) \
+	_FYC_TOKEN_DIAG(_fyc, fy_node_token(_fyn), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYC_TOKEN_ERROR(_fyc, _fyt, _module, _fmt, ...) \
+	FYC_TOKEN_DIAG(_fyc, _fyt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYC_TOKEN_ERROR_CHECK(_fyc, _fyt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYC_TOKEN_ERROR(_fyc, _fyt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYC_TOKEN_WARNING(_fyc, _fyt, _module, _fmt, ...) \
+	FYC_TOKEN_DIAG(_fyc, _fyt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-diag.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-diag.c
@@ -1,0 +1,1170 @@
+/*
+ * fy-diag.c - diagnostics
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-diag.h"
+
+#include "fy-parse.h"
+#include "fy-input.h"
+
+static const char *error_type_txt[] = {
+	[FYET_DEBUG]   = "debug",
+	[FYET_INFO]    = "info",
+	[FYET_NOTICE]  = "notice",
+	[FYET_WARNING] = "warning",
+	[FYET_ERROR]   = "error",
+};
+
+const char *fy_error_type_to_string(enum fy_error_type type)
+{
+
+	if ((unsigned int)type >= FYET_MAX)
+		return "";
+	return error_type_txt[type];
+}
+
+enum fy_error_type fy_string_to_error_type(const char *str)
+{
+	unsigned int i;
+	int level;
+
+	if (!str)
+		return FYET_MAX;
+
+	if (isdigit((unsigned char)*str)) {
+		level = atoi(str);
+		if (level >= 0 && level < FYET_MAX)
+			return (enum fy_error_type)level;
+	}
+
+	for (i = 0; i < FYET_MAX; i++) {
+		if (!strcmp(str, error_type_txt[i]))
+			return (enum fy_error_type)i;
+	}
+
+	return FYET_MAX;
+}
+
+static const char *error_module_txt[] = {
+	[FYEM_UNKNOWN]			= "unknown",
+	[FYEM_ATOM]			= "atom",
+	[FYEM_SCAN]			= "scan",
+	[FYEM_PARSE]			= "parse",
+	[FYEM_DOC]			= "doc",
+	[FYEM_BUILD]			= "build",
+	[FYEM_INTERNAL]			= "internal",
+	[FYEM_SYSTEM]			= "system",
+	[FYEM_EMIT]			= "emit",
+	[FYEM_TYPESET]			= "typeset",
+	[FYEM_DECODE]			= "decode",
+	[FYEM_ENCODE]			= "encode",
+};
+
+const char *fy_error_module_to_string(enum fy_error_module module)
+{
+
+	if ((unsigned int)module >= FYEM_MAX)
+		return "";
+	return error_module_txt[module];
+}
+
+enum fy_error_module fy_string_to_error_module(const char *str)
+{
+	unsigned int i;
+
+	if (!str)
+		return FYEM_MAX;
+
+	for (i = 0; i < FYEM_MAX; i++) {
+		if (!strcmp(str, error_module_txt[i]))
+			return (enum fy_error_module)i;
+	}
+
+	return FYEM_MAX;
+}
+
+static const char *fy_error_level_str(enum fy_error_type level)
+{
+	static const char *txt[] = {
+		[FYET_DEBUG]   = "DBG",
+		[FYET_INFO]    = "INF",
+		[FYET_NOTICE]  = "NOT",
+		[FYET_WARNING] = "WRN",
+		[FYET_ERROR]   = "ERR",
+	};
+
+	if ((unsigned int)level >= FYET_MAX)
+		return "*unknown*";
+	return txt[level];
+}
+
+static const char *fy_error_module_str(enum fy_error_module module)
+{
+	static const char *txt[] = {
+		[FYEM_UNKNOWN]			= "UNKWN",
+		[FYEM_ATOM]			= "ATOM ",
+		[FYEM_SCAN]			= "SCAN ",
+		[FYEM_PARSE]			= "PARSE",
+		[FYEM_DOC]			= "DOC  ",
+		[FYEM_BUILD]			= "BUILD",
+		[FYEM_INTERNAL]			= "INTRL",
+		[FYEM_SYSTEM]			= "SYSTM",
+		[FYEM_EMIT]			= "EMIT ",
+		[FYEM_TYPESET]			= "TYPES",
+		[FYEM_DECODE]			= "DEC  ",
+		[FYEM_ENCODE]			= "ENC  ",
+	};
+
+	if ((unsigned int)module >= FYEM_MAX)
+		return "*unknown*";
+	return txt[module];
+}
+
+/* really concervative options */
+static const struct fy_diag_term_info default_diag_term_info_template = {
+	.rows		= 25,
+	.columns	= 80
+};
+
+static const struct fy_diag_cfg default_diag_cfg_template = {
+	.fp		= NULL,	/* must be overriden */
+	.level		= FYET_INFO,
+	.module_mask	= (1U << FYEM_MAX) - 1,	/* all modules */
+	.show_source	= false,
+	.show_position	= false,
+	.show_type	= true,
+	.show_module	= false,
+	.colorize	= false, /* can be overriden */
+	.source_width	= 50,
+	.position_width	= 10,
+	.type_width	= 5,
+	.module_width	= 6,
+};
+
+void fy_diag_cfg_default(struct fy_diag_cfg *cfg)
+{
+	if (!cfg)
+		return;
+
+	*cfg = default_diag_cfg_template;
+	cfg->fp = stderr;
+	cfg->colorize = isatty(fileno(stderr)) == 1;
+}
+
+void fy_diag_cfg_from_parser_flags(struct fy_diag_cfg *cfg, enum fy_parse_cfg_flags pflags)
+{
+	/* nothing */
+}
+
+static bool fy_diag_isatty(struct fy_diag *diag)
+{
+	return diag && diag->cfg.fp && isatty(fileno(diag->cfg.fp));
+}
+
+static void fy_diag_update_term_info(struct fy_diag *diag)
+{
+	int fd, rows, columns, ret;
+
+	/* start by setting things to the default */
+	diag->term_info = default_diag_term_info_template;
+
+	fd = diag->cfg.fp && isatty(fileno(diag->cfg.fp)) ?
+		fileno(diag->cfg.fp) : -1;
+
+	if (fd == -1)
+		goto out;
+
+	rows = columns = 0;
+	ret = fy_term_query_size(fd, &rows, &columns);
+	if (ret != 0)
+		goto out;
+
+	if (rows > 0 && columns > 0) {
+		diag->term_info.rows = rows;
+		diag->term_info.columns = columns;
+	}
+out:
+	diag->terminal_probed = true;
+}
+
+void fy_diag_errorp_free(struct fy_diag_errorp *errp)
+{
+	if (errp->space)
+		free(errp->space);
+	fy_token_unref(errp->e.fyt);
+	free(errp);
+}
+
+struct fy_diag *fy_diag_create(const struct fy_diag_cfg *cfg)
+{
+	struct fy_diag *diag;
+
+	diag = malloc(sizeof(*diag));
+	if (!diag)
+		return NULL;
+	memset(diag, 0, sizeof(*diag));
+
+	if (!cfg)
+		fy_diag_cfg_default(&diag->cfg);
+	else
+		diag->cfg = *cfg;
+	diag->on_error = false;
+	diag->refs = 1;
+
+	diag->terminal_probed = false;
+	if (!fy_diag_isatty(diag))
+		fy_diag_update_term_info(diag);
+
+	fy_diag_errorp_list_init(&diag->errors);
+
+	return diag;
+}
+
+void fy_diag_destroy(struct fy_diag *diag)
+{
+	struct fy_diag_errorp *errp;
+
+	if (!diag)
+		return;
+
+	diag->destroyed = true;
+
+	/* free everything */
+	while ((errp = fy_diag_errorp_list_pop(&diag->errors)) != NULL)
+		fy_diag_errorp_free(errp);
+
+	fy_diag_unref(diag);
+}
+
+bool fy_diag_got_error(struct fy_diag *diag)
+{
+	return diag && diag->on_error;
+}
+
+void fy_diag_set_error(struct fy_diag *diag, bool on_error)
+{
+	if (diag)
+		diag->on_error = on_error;
+}
+
+void fy_diag_reset_error(struct fy_diag *diag)
+{
+	struct fy_diag_errorp *errp;
+
+	if (!diag)
+		return;
+
+	diag->on_error = false;
+
+	while ((errp = fy_diag_errorp_list_pop(&diag->errors)) != NULL)
+		fy_diag_errorp_free(errp);
+}
+
+void fy_diag_set_collect_errors(struct fy_diag *diag, bool collect_errors)
+{
+	struct fy_diag_errorp *errp;
+
+	if (!diag || diag->destroyed)
+		return;
+
+	diag->collect_errors = collect_errors;
+
+	/* clear collected errors on disable */
+	if (!diag->collect_errors) {
+		while ((errp = fy_diag_errorp_list_pop(&diag->errors)) != NULL)
+			fy_diag_errorp_free(errp);
+	}
+}
+
+bool fy_diag_get_collect_errors(struct fy_diag *diag)
+{
+	if (!diag || diag->destroyed)
+		return false;
+
+	return diag->collect_errors;
+}
+
+struct fy_diag_error *fy_diag_errors_iterate(struct fy_diag *diag, void **prevp)
+{
+	struct fy_diag_errorp *errp;
+
+	if (!diag || !prevp)
+		return NULL;
+
+	if (!*prevp)
+		errp = fy_diag_errorp_list_head(&diag->errors);
+	else {
+		errp = *prevp;
+		errp = fy_diag_errorp_next(&diag->errors, errp);
+	}
+
+	if (!errp)
+		return NULL;
+	*prevp = errp;
+	return &errp->e;
+}
+
+void fy_diag_free(struct fy_diag *diag)
+{
+	if (!diag)
+		return;
+	free(diag);
+}
+
+const struct fy_diag_cfg *fy_diag_get_cfg(struct fy_diag *diag)
+{
+	if (!diag)
+		return NULL;
+	return &diag->cfg;
+}
+
+void fy_diag_set_cfg(struct fy_diag *diag, const struct fy_diag_cfg *cfg)
+{
+	if (!diag)
+		return;
+
+	if (!cfg)
+		fy_diag_cfg_default(&diag->cfg);
+	else
+		diag->cfg = *cfg;
+
+	fy_diag_update_term_info(diag);
+}
+
+void fy_diag_set_level(struct fy_diag *diag, enum fy_error_type level)
+{
+	if (!diag || (unsigned int)level >= FYET_MAX)
+		return;
+	diag->cfg.level = level;
+}
+
+void fy_diag_set_colorize(struct fy_diag *diag, bool colorize)
+{
+	if (!diag)
+		return;
+	diag->cfg.colorize = colorize;
+}
+
+struct fy_diag *fy_diag_ref(struct fy_diag *diag)
+{
+	if (!diag)
+		return NULL;
+
+	assert(diag->refs + 1 > 0);
+	diag->refs++;
+
+	return diag;
+}
+
+void fy_diag_unref(struct fy_diag *diag)
+{
+	if (!diag)
+		return;
+
+	assert(diag->refs > 0);
+
+	if (diag->refs == 1)
+		fy_diag_free(diag);
+	else
+		diag->refs--;
+}
+
+ssize_t fy_diag_write(struct fy_diag *diag, const void *buf, size_t count)
+{
+	size_t ret;
+
+	if (!diag || !buf)
+		return -1;
+
+	/* no more output */
+	if (diag->destroyed)
+		return 0;
+
+	ret = 0;
+	if (diag->cfg.fp) {
+		ret = fwrite(buf, 1, count, diag->cfg.fp);
+	} else if (diag->cfg.output_fn) {
+		diag->cfg.output_fn(diag, diag->cfg.user, buf, count);
+		ret = count;
+	}
+
+	return ret == count ? (ssize_t)count : -1;
+}
+
+int fy_diag_vprintf(struct fy_diag *diag, const char *fmt, va_list ap)
+{
+	char *buf;
+	int rc;
+
+	if (!diag || !fmt)
+		return -1;
+
+	/* no more output */
+	if (diag->destroyed)
+		return 0;
+
+	if (diag->cfg.fp)
+		return vfprintf(diag->cfg.fp, fmt, ap);
+
+	if (diag->cfg.output_fn) {
+		rc = vasprintf(&buf, fmt, ap);
+		if (rc < 0)
+			return rc;
+		diag->cfg.output_fn(diag, diag->cfg.user, buf, (size_t)rc);
+		free(buf);
+		return rc;
+	}
+
+	return -1;
+}
+
+int fy_diag_printf(struct fy_diag *diag, const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_diag_vprintf(diag, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+int fy_vdiag(struct fy_diag *diag, const struct fy_diag_ctx *fydc,
+	     const char *fmt, va_list ap)
+{
+	char *msg = NULL;
+	char *source = NULL, *position = NULL, *typestr = NULL, *modulestr = NULL;
+	const char *file_stripped = NULL;
+	const char *color_start = NULL, *color_end = NULL;
+	enum fy_error_type level;
+	int rc;
+
+	if (!diag || !fydc || !fmt)
+		return -1;
+
+	level = fydc->level;
+
+	/* turn errors into debugs while not reset */
+	if (level >= FYET_ERROR && diag->on_error)
+		level = FYET_DEBUG;
+
+	if (!fy_diag_log_level_is_enabled(diag, level, fydc->module)) {
+		rc = 0;
+		goto out;
+	}
+
+	msg = fy_vsprintfa(fmt, ap);
+	fy_strip_trailing_nl(msg);
+
+	/* source part */
+	if (diag->cfg.show_source) {
+		if (fydc->source_file) {
+			file_stripped = strrchr(fydc->source_file, '/');
+			if (!file_stripped)
+				file_stripped = fydc->source_file;
+			else
+				file_stripped++;
+		} else
+			file_stripped = "";
+		source = fy_sprintfa("%s:%d @%s()%s",
+				file_stripped, fydc->source_line, fydc->source_func, " ");
+	}
+
+	/* position part */
+	if (diag->cfg.show_position && fydc->line >= 0 && fydc->column >= 0)
+		position = fy_sprintfa("<%3d:%2d>%s", fydc->line, fydc->column, ": ");
+
+	/* type part */
+	if (diag->cfg.show_type)
+		typestr = fy_sprintfa("[%s]%s", fy_error_level_str(level), ": ");
+
+	/* module part */
+	if (diag->cfg.show_module)
+		modulestr = fy_sprintfa("<%s>%s", fy_error_module_str(fydc->module), ": ");
+
+	if (diag->cfg.colorize) {
+		switch (level) {
+		case FYET_DEBUG:
+			color_start = "\x1b[37m";	/* normal white */
+			break;
+		case FYET_INFO:
+			color_start = "\x1b[37;1m";	/* bright white */
+			break;
+		case FYET_NOTICE:
+			color_start = "\x1b[34;1m";	/* bright blue */
+			break;
+		case FYET_WARNING:
+			color_start = "\x1b[33;1m";	/* bright yellow */
+			break;
+		case FYET_ERROR:
+			color_start = "\x1b[31;1m";	/* bright red */
+			break;
+		default:	/* handles FYET_MAX */
+			break;
+		}
+		if (color_start)
+			color_end = "\x1b[0m";
+	}
+
+	rc = fy_diag_printf(diag, "%s" "%*s" "%*s" "%*s" "%*s" "%s" "%s\n",
+			color_start ? color_start : "",
+			source    ? diag->cfg.source_width : 0, source ? source : "",
+			position  ? diag->cfg.position_width : 0, position ? position : "",
+			typestr   ? diag->cfg.type_width : 0, typestr ? typestr : "",
+			modulestr ? diag->cfg.module_width : 0, modulestr ? modulestr : "",
+			msg,
+			color_end ? color_end : "");
+
+	if (rc > 0)
+		rc++;
+
+out:
+	/* if it's the first error we're generating set the
+	 * on_error flag until the top caller clears it
+	 */
+	if (!diag->on_error && fydc->level >= FYET_ERROR)
+		diag->on_error = true;
+
+	return rc;
+}
+
+int fy_diagf(struct fy_diag *diag, const struct fy_diag_ctx *fydc,
+	     const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_vdiag(diag, fydc, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+static void fy_diag_get_error_colors(struct fy_diag *diag, enum fy_error_type type,
+				     const char **start, const char **end, const char **white)
+{
+	if (!diag->cfg.colorize) {
+		*start = *end = *white = "";
+		return;
+	}
+
+	switch (type) {
+	case FYET_DEBUG:
+		*start = "\x1b[37m";	/* normal white */
+		break;
+	case FYET_INFO:
+		*start = "\x1b[37;1m";	/* bright white */
+		break;
+	case FYET_NOTICE:
+		*start = "\x1b[34;1m";	/* bright blue */
+		break;
+	case FYET_WARNING:
+		*start = "\x1b[33;1m";	/* bright yellow */
+		break;
+	case FYET_ERROR:
+		*start = "\x1b[31;1m";	/* bright red */
+		break;
+	default:
+		*start = "\x1b[0m";	/* catch-all reset */
+		break;
+	}
+	*end = "\x1b[0m";
+	*white = "\x1b[37;1m";
+}
+
+void fy_diag_error_atom_display(struct fy_diag *diag, enum fy_error_type type, struct fy_atom *atom)
+{
+	const struct fy_raw_line *l, *ln;
+	struct fy_raw_line l_tmp;
+	struct fy_atom_raw_line_iter iter;
+	int content_start_col, content_end_col, content_width;
+	int pass, cols, min_col, max_col, max_line_count, max_line_col8, max_width;
+	int start_col, end_col;
+	const char *color_start, *color_end, *white;
+	bool first_line, last_line;
+	const char *display;
+	int display_len, line_shift;
+	char first_mark;
+	char *rowbuf = NULL, *rbs = NULL, *rbe = NULL;
+	const char *s, *e;
+	int col8, c, w;
+	int tab8_len, tilde_start, tilde_width, tilde_width_m1;
+	size_t rowbufsz;
+
+	(void)end_col;
+
+	if (!diag || !atom)
+		return;
+
+	fy_diag_get_error_colors(diag, type, &color_start, &color_end, &white);
+
+	/* pacify compilers that think these are uninitialized */
+	cols = 0;
+	rowbufsz = 0;
+
+	/* two passes, first one collects extents */
+
+	start_col = -1;
+	end_col = -1;
+	min_col = -1;
+	max_col = -1;
+	max_line_count = -1;
+	max_line_col8 = -1;
+	line_shift = -1;
+	for (pass = 0; pass < 2; pass++) {
+
+		/* on the start of the second pass */
+		if (pass > 0) {
+
+			cols = 0;
+
+			/* if it's probed, use what's there */
+			if (diag->terminal_probed && diag->term_info.columns > 0)
+				cols = diag->term_info.columns;
+
+			/* heuristic, avoid probing terminal size if maximum column is less than 80
+			 * columns. This is faster and avoid problems with terminals...
+			 */
+			if (!cols && max_line_col8 < 80)
+				cols = 80;
+
+			/* no choice but to probe */
+			if (!cols) {
+				/* only need the terminal width when outputting an error */
+				if (!diag->terminal_probed && fy_diag_isatty(diag))
+					fy_diag_update_term_info(diag);
+
+				cols = diag->term_info.columns;
+			}
+
+			/* worse case utf8 + 2 color sequences + zero terminated */
+			rowbufsz = cols * 4 + 2 * 16 + 1;
+			rowbuf = alloca(rowbufsz);
+			rbe = rowbuf + rowbufsz;
+
+			/* if the maximum column number is less than the terminal
+			 * width everything fits, and we're fine */
+			if (max_line_col8 < cols) {
+				line_shift = 0;
+			} else {
+				max_width = max_col - min_col;
+
+				/* try to center */
+				line_shift = min_col + (max_width - cols) / 2;
+
+				/* the start of the content must always be included */
+				if (start_col < line_shift)
+					line_shift = start_col;
+			}
+		}
+
+		fy_atom_raw_line_iter_start(atom, &iter);
+		l = fy_atom_raw_line_iter_next(&iter);
+		for (; l != NULL; l = ln) {
+
+			/* save it */
+			l_tmp = *l;
+			l = &l_tmp;
+
+			/* get the next too */
+			ln = fy_atom_raw_line_iter_next(&iter);
+
+			first_line = l->lineno <= 1;
+			last_line = ln == NULL;
+
+			content_start_col = l->content_start_col8;
+			content_end_col = l->content_end_col8;
+
+			content_width = content_end_col - content_start_col;
+
+			if (pass == 0) {
+
+				if (min_col < 0 || content_start_col < min_col)
+					min_col = content_start_col;
+				if (max_col < 0 || content_end_col > max_col)
+					max_col = content_end_col;
+				if (max_line_count < 0 || (int)l->line_count > max_line_count)
+					max_line_count = (int)l->line_count;
+				if (first_line)
+					start_col = content_start_col;
+				if (last_line)
+					end_col = content_end_col;
+
+				/* optimize by using the content end as a starting point */
+				s = l->content_start + l->content_len;
+				e = l->line_start + l->line_count;
+
+				/* guard against something stupid */
+				if (s > e)
+					s = e;
+
+				col8 = l->content_end_col8;
+				while ((c = fy_utf8_get(s, (e - s), &w)) >= 0) {
+					s += w;
+					if (fy_is_tab(c))
+						col8 += 8 - (col8 % 8);
+					else
+						col8++;
+				}
+				/* update the max column number of the lines */
+				if (max_line_col8 < 0 || col8 > max_line_col8)
+					max_line_col8 = col8;
+
+				continue;
+			}
+
+			/* output pass */
+
+			/* the defaults if everything fits */
+			first_mark = first_line ? '^' : '~';
+
+			tab8_len = 0;
+
+			/* find the starting point */
+			s = l->line_start;
+			e = s + l->line_len;
+			col8 = 0;
+			while (col8 < line_shift && (c = fy_utf8_get(s, (e - s), &w)) >= 0) {
+				if (fy_is_tab(c))
+					col8 += 8 - (col8 % 8);
+				else
+					col8++;
+				s += w;
+			}
+			if (col8 > line_shift)
+				tab8_len = col8 - line_shift;	/* the remaining of the tab */
+			else
+				tab8_len = 0;
+
+			/* start filling the row buffer */
+			assert(rowbuf);
+			rbs = rowbuf;
+			rbe = rowbuf + rowbufsz;
+
+			/* remaining tabs */
+			while (tab8_len > 0) {
+				*rbs++ = ' ';
+				tab8_len--;
+			}
+
+			/* go forward until end of line or cols */
+			while (col8 < (line_shift + cols) && (c = fy_utf8_get(s, (e - s), &w)) >= 0 && rbs < rbe) {
+				if (fy_is_tab(c)) {
+					s++;
+					tab8_len = 8 - (col8 % 8);
+					col8 += tab8_len;
+					while (tab8_len > 0 && rbs < rbe) {
+						*rbs++ = ' ';
+						tab8_len--;
+					}
+				} else {
+					while (w > 0 && rbs < rbe) {
+						*rbs++ = *s++;
+						w--;
+					}
+					col8++;
+				}
+			}
+			display = rowbuf;
+			display_len = (int)(rbs - rowbuf);
+
+			tilde_start = content_start_col - line_shift;
+			tilde_width = content_width;
+			if (tilde_start + tilde_width > cols)
+				tilde_width = cols - tilde_start;
+			if ((size_t)tilde_width >= rowbufsz)
+				tilde_width = (int)(rowbufsz - 1);	/* guard */
+			tilde_width_m1 = tilde_width > 0 ? (tilde_width - 1) : 0;
+
+			/* output the line */
+			fy_diag_write(diag, display, display_len);
+
+			/* set the tildes */
+			assert((int)rowbufsz > tilde_width_m1 + 1);
+			memset(rowbuf, '~', tilde_width_m1);
+			rowbuf[tilde_width_m1] = '\0';
+
+			fy_diag_printf(diag, "\n%*s%s%c%.*s%s\n",
+				       tilde_start, "",
+				       color_start, first_mark, tilde_width_m1, rowbuf, color_end);
+
+		}
+		fy_atom_raw_line_iter_finish(&iter);
+	}
+}
+
+void fy_diag_error_token_display(struct fy_diag *diag, enum fy_error_type type, struct fy_token *fyt)
+{
+	struct fy_atom style_handle;
+
+	if (!diag || !fyt)
+		return;
+
+	fy_token_get_style_atom(fyt, &style_handle);
+	fy_diag_error_atom_display(diag, type, &style_handle);
+	fy_input_unref(style_handle.fyi);
+}
+
+void fy_diag_vreport(struct fy_diag *diag,
+		     const struct fy_diag_report_ctx *fydrc,
+		     const char *fmt, va_list ap)
+{
+	const char *name, *color_start = NULL, *color_end = NULL, *white = NULL;
+	char *msg_str = NULL, *name_str = NULL;
+	const struct fy_mark *start_mark;
+	int line, column;
+	struct fy_diag_errorp *errp;
+	struct fy_diag_error *err;
+	size_t spacesz, msgsz, filesz;
+	char *s;
+
+	if (!diag || !fydrc || !fmt || !fydrc->fyt)
+		return;
+
+	start_mark = fy_token_start_mark(fydrc->fyt);
+
+	if (fydrc->has_override) {
+		name = fydrc->override_file;
+		line = fydrc->override_line;
+		column = fydrc->override_column;
+	} else {
+		name = fy_input_get_filename(fy_token_get_input(fydrc->fyt));
+		line = start_mark->line + 1;
+		column = start_mark->column + 1;
+	}
+
+	/* it will strip trailing newlines */
+	msg_str = fy_vsprintfa(fmt, ap);
+	fy_strip_trailing_nl(msg_str);
+
+	/* get the colors */
+	fy_diag_get_error_colors(diag, fydrc->type, &color_start, &color_end, &white);
+
+	if (name || (line > 0 && column > 0))
+		name_str = (line > 0 && column > 0) ?
+			fy_sprintfa("%s%s:%d:%d: ", white, name, line, column) :
+			fy_sprintfa("%s%s: ", white, name);
+
+	if (!diag->collect_errors) {
+		fy_diag_printf(diag, "%s" "%s%s: %s" "%s\n",
+			name_str ? name_str : "",
+			color_start, fy_error_type_to_string(fydrc->type), color_end,
+			msg_str);
+
+		fy_diag_error_token_display(diag, fydrc->type, fydrc->fyt);
+
+		fy_token_unref(fydrc->fyt);
+
+	} else if ((errp = malloc(sizeof(*errp))) != NULL) {
+
+		msgsz = strlen(msg_str) + 1;
+		filesz = strlen(name) + 1;
+		spacesz = msgsz + filesz;
+
+		errp->space = malloc(spacesz);
+		if (!errp->space) {
+			free(errp);
+			goto out;
+		}
+		s = errp->space;
+
+		err = &errp->e;
+		memset(err, 0, sizeof(*err));
+		err->type = fydrc->type;
+		err->module = fydrc->module;
+		err->fyt = fydrc->fyt;
+		err->msg = s;
+		memcpy(s, msg_str, msgsz);
+		s += msgsz;
+		err->file = s;
+		memcpy(s, name, filesz);
+		s += filesz;
+		err->line = line;
+		err->column = column;
+
+		fy_diag_errorp_list_add_tail(&diag->errors, errp);
+	}
+out:
+	if (!diag->on_error && fydrc->type == FYET_ERROR)
+		diag->on_error = true;
+}
+
+void fy_diag_report(struct fy_diag *diag,
+		    const struct fy_diag_report_ctx *fydrc,
+		    const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_diag_vreport(diag, fydrc, fmt, ap);
+	va_end(ap);
+}
+
+void fy_diag_token_vreport(struct fy_diag *diag, struct fy_token *fyt,
+			  enum fy_error_type type, const char *fmt, va_list ap)
+{
+	struct fy_diag_report_ctx drc;
+	bool save_on_error;
+
+	if (!fyt || !diag)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = false;
+
+	memset(&drc, 0, sizeof(drc));
+	drc.type = type;
+	drc.module = FYEM_UNKNOWN;
+	drc.fyt = fyt;
+	fy_diag_vreport(diag, &drc, fmt, ap);
+
+	diag->on_error = save_on_error;
+}
+
+void fy_diag_token_report(struct fy_diag *diag, struct fy_token *fyt,
+			 enum fy_error_type type, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_diag_token_vreport(diag, fyt, type, fmt, ap);
+	va_end(ap);
+}
+
+void fy_diag_token_override_vreport(struct fy_diag *diag, struct fy_token *fyt,
+				   enum fy_error_type type, const char *file,
+				   int line, int column,
+				   const char *fmt, va_list ap)
+{
+	struct fy_diag_report_ctx drc;
+	bool save_on_error;
+
+	if (!fyt || !diag)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = false;
+
+	memset(&drc, 0, sizeof(drc));
+	drc.type = type;
+	drc.module = FYEM_UNKNOWN;
+	drc.fyt = fyt;
+	drc.has_override = true;
+	drc.override_file = file;
+	drc.override_line = line;
+	drc.override_column = column;
+	fy_diag_vreport(diag, &drc, fmt, ap);
+
+	diag->on_error = save_on_error;
+}
+
+void fy_diag_token_override_report(struct fy_diag *diag, struct fy_token *fyt,
+				  enum fy_error_type type, const char *file,
+				  int line, int column, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_diag_token_override_vreport(diag, fyt, type, file, line, column, fmt, ap);
+	va_end(ap);
+}
+
+void fy_diag_node_vreport(struct fy_diag *diag, struct fy_node *fyn,
+			  enum fy_error_type type, const char *fmt, va_list ap)
+{
+	struct fy_diag_report_ctx drc;
+	bool save_on_error;
+
+	if (!fyn || !diag)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = false;
+
+	memset(&drc, 0, sizeof(drc));
+	drc.type = type;
+	drc.module = FYEM_UNKNOWN;
+	drc.fyt = fy_node_token(fyn);
+	fy_diag_vreport(diag, &drc, fmt, ap);
+
+	diag->on_error = save_on_error;
+}
+
+void fy_diag_node_report(struct fy_diag *diag, struct fy_node *fyn,
+			 enum fy_error_type type, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_diag_node_vreport(diag, fyn, type, fmt, ap);
+	va_end(ap);
+}
+
+void fy_diag_node_override_vreport(struct fy_diag *diag, struct fy_node *fyn,
+				   enum fy_error_type type, const char *file,
+				   int line, int column,
+				   const char *fmt, va_list ap)
+{
+	struct fy_diag_report_ctx drc;
+	bool save_on_error;
+
+	if (!fyn || !diag)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = false;
+
+	memset(&drc, 0, sizeof(drc));
+	drc.type = type;
+	drc.module = FYEM_UNKNOWN;
+	drc.fyt = fy_node_token(fyn);
+	drc.has_override = true;
+	drc.override_file = file;
+	drc.override_line = line;
+	drc.override_column = column;
+	fy_diag_vreport(diag, &drc, fmt, ap);
+
+	diag->on_error = save_on_error;
+}
+
+void fy_diag_node_override_report(struct fy_diag *diag, struct fy_node *fyn,
+				  enum fy_error_type type, const char *file,
+				  int line, int column, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_diag_node_override_vreport(diag, fyn, type, file, line, column, fmt, ap);
+	va_end(ap);
+}
+
+void fy_node_vreport(struct fy_node *fyn, enum fy_error_type type,
+		     const char *fmt, va_list ap)
+{
+	if (!fyn || !fyn->fyd)
+		return;
+
+	fy_diag_node_vreport(fyn->fyd->diag, fyn, type, fmt, ap);
+}
+
+void fy_node_report(struct fy_node *fyn, enum fy_error_type type,
+		    const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_node_vreport(fyn, type, fmt, ap);
+	va_end(ap);
+}
+
+void fy_node_override_vreport(struct fy_node *fyn, enum fy_error_type type,
+			      const char *file, int line, int column,
+			      const char *fmt, va_list ap)
+{
+	if (!fyn || !fyn->fyd)
+		return;
+
+	fy_diag_node_override_vreport(fyn->fyd->diag, fyn, type,
+				      file, line, column, fmt, ap);
+}
+
+void fy_node_override_report(struct fy_node *fyn, enum fy_error_type type,
+			     const char *file, int line, int column,
+			     const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_node_override_vreport(fyn, type, file, line, column, fmt, ap);
+	va_end(ap);
+}
+
+void fy_diag_event_vreport(struct fy_diag *diag, struct fy_event *fye,
+			   enum fy_event_part fyep, enum fy_error_type type,
+			   const char *fmt, va_list ap)
+{
+	struct fy_diag_report_ctx drc;
+	struct fy_token *fyt;
+	bool save_on_error;
+
+	if (!fye || !diag)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = false;
+
+	memset(&drc, 0, sizeof(drc));
+	drc.type = type;
+	drc.module = FYEM_UNKNOWN;
+	drc.fyt = NULL;
+	switch (fyep) {
+	case FYEP_VALUE:
+		fyt = fy_event_get_token(fye);
+		break;
+	case FYEP_TAG:
+		fyt = fy_event_get_tag_token(fye);
+		break;
+	case FYEP_ANCHOR:
+		fyt = fy_event_get_anchor_token(fye);
+		break;
+	default:
+		fyt = NULL;
+		break;
+	}
+	drc.fyt = fy_token_ref(fyt);
+	fy_diag_vreport(diag, &drc, fmt, ap);
+
+	diag->on_error = save_on_error;
+}
+
+void fy_diag_event_report(struct fy_diag *diag, struct fy_event *fye,
+			  enum fy_event_part fyep, enum fy_error_type type,
+			  const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_diag_event_vreport(diag, fye, fyep, type, fmt, ap);
+	va_end(ap);
+}
+
+void fy_event_vreport(struct fy_parser *fyp, struct fy_event *fye,
+		      enum fy_event_part fyep, enum fy_error_type type,
+		      const char *fmt, va_list ap)
+{
+	if (fye)
+		fy_diag_event_vreport(fyp->diag, fye, fyep, type, fmt, ap);
+	else
+		fy_parser_vlog(fyp, type, fmt, ap);
+}
+
+void
+fy_event_report(struct fy_parser *fyp, struct fy_event *fye,
+		enum fy_event_part fyep, enum fy_error_type type,
+		const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_event_vreport(fyp, fye, fyep, type, fmt, ap);
+	va_end(ap);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-diag.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-diag.h
@@ -1,0 +1,133 @@
+/*
+ * fy-diag.h - diagnostics
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_DIAG_H
+#define FY_DIAG_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-utils.h"
+
+#include "fy-list.h"
+#include "fy-token.h"
+
+/* error flags (above 0x100 is library specific) */
+#define FYEF_SOURCE	0x0001
+#define FYEF_POSITION	0x0002
+#define FYEF_TYPE	0x0004
+#define FYEF_USERSTART	0x0100
+
+#define FYDF_LEVEL_SHIFT	0
+#define FYDF_LEVEL_MASK		(0x0f << FYDF_LEVEL_SHIFT)
+#define FYDF_LEVEL(x)		(((unsigned int)(x) << FYDF_LEVEL_SHIFT) & FYDF_LEVEL_MASK)
+#define FYDF_DEBUG		FYDF_LEVEL(FYET_DEBUG)
+#define FYDF_INFO		FYDF_LEVEL(FYET_INFO)
+#define FYDF_NOTICE		FYDF_LEVEL(FYET_NOTICE)
+#define FYDF_WARNING		FYDF_LEVEL(FYET_WARNING)
+#define FYDF_ERROR		FYDF_LEVEL(FYET_ERROR)
+
+#define FYDF_MODULE_SHIFT	4
+#define FYDF_MODULE_MASK	(0x0f << FYDF_MODULE_SHIFT)
+#define FYDF_MODULE(x)		(((unsigned int)(x) << FYDF_MODULE_SHIFT) & FYDF_MODULE_MASK)
+#define FYDF_ATOM		FYDF_MODULE(FYEM_ATOM)
+#define FYDF_SCANNER		FYDF_MODULE(FYEM_SCANNER)
+#define FYDF_PARSER		FYDF_MODULE(FYEM_PARSE)
+#define FYDF_DOC		FYDF_MODULE(FYEM_DOC)
+#define FYDF_BUILD		FYDF_MODULE(FYEM_BUILD)
+#define FYDF_INTERNAL		FYDF_MODULE(FYEM_INTERNAL)
+#define FYDF_SYSTEM		FYDF_MODULE(FYEM_SYSTEM)
+#define FYDF_MODULE_USER_MASK	7
+#define FYDF_MODULE_USER(x)	FYDF_MODULE(8 + ((x) & FYDF_MODULE_USER_MASK))
+
+struct fy_diag_term_info {
+	int rows;
+	int columns;
+};
+
+struct fy_diag_report_ctx {
+	enum fy_error_type type;
+	enum fy_error_module module;
+	struct fy_token *fyt;
+	bool has_override;
+	const char *override_file;
+	int override_line;
+	int override_column;
+};
+
+FY_TYPE_FWD_DECL_LIST(diag_errorp);
+struct fy_diag_errorp {
+	struct list_head node;
+	char *space;
+	struct fy_diag_error e;
+};
+FY_TYPE_DECL_LIST(diag_errorp);
+
+struct fy_diag {
+	struct fy_diag_cfg cfg;
+	int refs;
+	bool on_error : 1;
+	bool destroyed : 1;
+	bool collect_errors : 1;
+	bool terminal_probed : 1;
+	struct fy_diag_term_info term_info;
+	struct fy_diag_errorp_list errors;
+};
+
+void fy_diag_free(struct fy_diag *diag);
+
+void fy_diag_vreport(struct fy_diag *diag,
+		     const struct fy_diag_report_ctx *fydrc,
+		     const char *fmt, va_list ap);
+void fy_diag_report(struct fy_diag *diag,
+		    const struct fy_diag_report_ctx *fydrc,
+		    const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+static inline bool
+fy_diag_log_level_is_enabled(struct fy_diag *diag, enum fy_error_type level, enum fy_error_module module)
+{
+	if (!diag)
+		return false;
+
+	/* check level */
+	if ((unsigned int)level < FYET_MAX) {
+
+		/* turn errors into debugs while not reset */
+		if (level >= FYET_ERROR && diag->on_error)
+			level = FYET_DEBUG;
+
+		if (level < diag->cfg.level)
+			return false;
+	}
+
+	/* check module enable mask */
+	if ((unsigned int)module < FYEM_MAX) {
+		if (!(diag->cfg.module_mask & FY_BIT(module)))
+			return false;
+	}
+
+	/* ok, clear to generate */
+	return true;
+}
+
+void fy_diag_error_atom_display(struct fy_diag *diag, enum fy_error_type type,
+				 struct fy_atom *atom);
+void fy_diag_error_token_display(struct fy_diag *diag, enum fy_error_type type,
+				 struct fy_token *fyt);
+
+void fy_diag_cfg_from_parser_flags(struct fy_diag_cfg *cfg, enum fy_parse_cfg_flags pflags);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-doc-diag.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-doc-diag.c
@@ -1,0 +1,88 @@
+/*
+ * fy-doc-diag.c - document diagnostics
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-diag.h"
+#include "fy-doc.h"
+
+int fy_document_vdiag(struct fy_document *fyd, unsigned int flags,
+		      const char *file, int line, const char *func,
+		      const char *fmt, va_list ap)
+{
+	struct fy_diag_ctx fydc;
+	int rc;
+
+	if (!fyd || !fmt || !fyd->diag)
+		return -1;
+
+	/* perform the enable tests early to avoid the overhead */
+	if ((int)((flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT) < (int)fyd->diag->cfg.level)
+		return 0;
+
+	/* fill in fy_diag_ctx */
+	memset(&fydc, 0, sizeof(fydc));
+
+	fydc.level = (flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT;
+	fydc.module = (flags & FYDF_MODULE_MASK) >> FYDF_MODULE_SHIFT;
+	fydc.source_file = file;
+	fydc.source_line = line;
+	fydc.source_func = func;
+	fydc.line = -1;
+	fydc.column = -1;
+
+	rc = fy_vdiag(fyd->diag, &fydc, fmt, ap);
+
+	return rc;
+}
+
+int fy_document_diag(struct fy_document *fyd, unsigned int flags,
+		     const char *file, int line, const char *func,
+		     const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_document_vdiag(fyd, flags, file, line, func, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+void fy_document_diag_vreport(struct fy_document *fyd,
+			      const struct fy_diag_report_ctx *fydrc,
+			      const char *fmt, va_list ap)
+{
+	if (!fyd || !fyd->diag || !fydrc || !fmt)
+		return;
+
+	fy_diag_vreport(fyd->diag, fydrc, fmt, ap);
+}
+
+void fy_document_diag_report(struct fy_document *fyd,
+			     const struct fy_diag_report_ctx *fydrc,
+			     const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_document_diag_vreport(fyd, fydrc, fmt, ap);
+	va_end(ap);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-doc.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-doc.c
@@ -1,0 +1,8011 @@
+/*
+ * fy-doc.c - YAML document methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+
+#include "fy-utils.h"
+
+#include "xxhash.h"
+
+static const struct fy_hash_desc hd_anchor;
+static const struct fy_hash_desc hd_nanchor;
+static const struct fy_hash_desc hd_mapping;
+
+int fy_node_hash_uint(struct fy_node *fyn, unsigned int *hashp);
+
+static struct fy_node *
+fy_node_by_path_internal(struct fy_node *fyn,
+			 const char *path, size_t pathlen,
+		         enum fy_node_walk_flags flags);
+
+#define FY_NODE_PATH_WALK_DEPTH_DEFAULT	16
+
+static inline unsigned int
+fy_node_walk_max_depth_from_flags(enum fy_node_walk_flags flags)
+{
+	unsigned int max_depth;
+
+	max_depth = ((unsigned int)flags >> FYNWF_MAXDEPTH_SHIFT) & FYNWF_MAXDEPTH_MASK;
+	if (max_depth == 0)
+		max_depth = FY_NODE_PATH_WALK_DEPTH_DEFAULT;
+
+	return max_depth;
+}
+
+static inline unsigned int
+fy_node_walk_marker_from_flags(enum fy_node_walk_flags flags)
+{
+	return ((unsigned int)flags >> FYNWF_MARKER_SHIFT) & FYNWF_MARKER_MASK;
+}
+
+/* internal simple key to optimize string lookups */
+static inline bool is_simple_key(const char *str, size_t len)
+{
+	const char *s, *e;
+	char c;
+
+	if (!str)
+		return false;
+
+	if (len == (size_t)-1)
+		len = strlen(str);
+
+	for (s = str, e = s + len; s < e; s++) {
+
+		c = *s;
+
+		/* note no isalpha() it's locale specific */
+		if (!((c >= 'A' && c <= 'Z') ||
+		      (c >= 'a' && c <= 'z') ||
+		      (c >= '0' && c <= '9') ||
+		      (c == '_')))
+			break;
+	}
+
+	return s == e;
+}
+
+static void fy_resolve_parent_node(struct fy_document *fyd, struct fy_node *fyn, struct fy_node *fyn_parent);
+
+void fy_anchor_destroy(struct fy_anchor *fya)
+{
+	if (!fya)
+		return;
+	fy_token_unref(fya->anchor);
+	free(fya);
+}
+
+struct fy_anchor *fy_anchor_create(struct fy_document *fyd,
+		struct fy_node *fyn, struct fy_token *anchor)
+{
+	struct fy_anchor *fya = NULL;
+
+	fya = malloc(sizeof(*fya));
+	if (!fya)
+		return NULL;
+
+	fya->fyn = fyn;
+	fya->anchor = anchor;
+	fya->multiple = false;
+
+	return fya;
+}
+
+struct fy_anchor *fy_document_anchor_iterate(struct fy_document *fyd, void **prevp)
+{
+	struct fy_anchor_list *fyal;
+
+	if (!fyd || !prevp)
+		return NULL;
+
+	fyal = &fyd->anchors;
+
+	return *prevp = *prevp ? fy_anchor_next(fyal, *prevp) : fy_anchor_list_head(fyal);
+}
+
+#define FYDSAF_COPY		FY_BIT(0)
+#define FYDSAF_MALLOCED		FY_BIT(1)
+
+static int fy_document_set_anchor_internal(struct fy_document *fyd, struct fy_node *fyn, const char *text, size_t len,
+					   unsigned int flags)
+{
+	const bool copy = !!(flags & FYDSAF_COPY);
+	const bool malloced = !!(flags & FYDSAF_MALLOCED);
+	struct fy_anchor *fya = NULL, *fyam = NULL;
+	struct fy_input *fyi = NULL;
+	struct fy_token *fyt = NULL;
+	struct fy_accel_entry *xle;
+	struct fy_atom handle;
+	char *data_copy = NULL;
+	const char *origtext;
+	size_t origlen;
+	int rc;
+
+	if (!fyd || !fyn || fyn->fyd != fyd)
+		return -1;
+
+	if (text && len == (size_t)-1)
+		len = strlen(text);
+
+	fya = fy_document_lookup_anchor_by_node(fyd, fyn);
+
+	if (!text) {
+		/* no anchor, and trying to delete? OK */
+		if (!fya)
+			return 0;
+
+		/* remove the anchor */
+		fy_anchor_list_del(&fyd->anchors, fya);
+
+			if (fy_document_is_accelerated(fyd)) {
+				xle = fy_accel_entry_lookup_value(fyd->axl, fya);
+				fy_accel_entry_remove(fyd->axl, xle);
+
+				xle = fy_accel_entry_lookup_value(fyd->naxl, fya);
+				fy_accel_entry_remove(fyd->naxl, xle);
+			}
+
+		fy_anchor_destroy(fya);
+		return 0;
+	}
+
+	/* trying to add duplicate anchor */
+	if (fya) {
+		origtext = fy_token_get_text(fya->anchor, &origlen);
+		fyd_error_check(fyd, origtext, err_out,
+				"fy_token_get_text() failed");
+
+		FYD_NODE_ERROR(fyd, fyn, FYEM_DOC,
+				"cannot set anchor %.*s (anchor %.*s already exists)",
+				(int)len, text, (int)origlen, origtext);
+		if (malloced && text)
+			free((void *)text);
+		fya = NULL;
+		goto err_out;
+	}
+
+	if (copy) {
+		data_copy = malloc(len);
+		fyd_error_check(fyd, data_copy, err_out,
+				"malloc() failed");
+		memcpy(data_copy, text, len);
+	} else if (malloced)
+		data_copy = (char *)text;
+	else
+		data_copy = NULL;
+
+	if (data_copy)
+		fyi = fy_input_from_malloc_data(data_copy, len, &handle, true);
+	else
+		fyi = fy_input_from_data(text, len, &handle, true);
+	fyd_error_check(fyd, fyi, err_out,
+			"fy_input_from_data() failed");
+	data_copy = NULL;
+
+	/* it must not be something funky */
+	if (!handle.valid_anchor)
+		goto err_out;
+
+	fyt = fy_token_create(FYTT_ANCHOR, &handle);
+	if (!fyt)
+		goto err_out;
+
+	fya = fy_anchor_create(fyd, fyn, fyt);
+	if (!fya)
+		goto err_out;
+
+	fy_anchor_list_add(&fyd->anchors, fya);
+	if (fy_document_is_accelerated(fyd)) {
+		xle = fy_accel_entry_lookup(fyd->axl, fya->anchor);
+		if (xle) {
+			fyam = (void *)xle->value;
+			/* multiple */
+			if (!fyam->multiple)
+				fyam->multiple = true;
+			fya->multiple = true;
+
+			fyd_debug(fyd, "register anchor %.*s is multiple", (int)len, text);
+		}
+
+		xle = fy_accel_entry_insert(fyd->axl, fya->anchor, fya);
+		fyd_error_check(fyd, xle, err_out,
+				"fy_accel_entry_insert() fyd->axl failed");
+	}
+
+	if (fy_document_is_accelerated(fyd)) {
+		rc = fy_accel_insert(fyd->naxl, fyn, fya);
+		fyd_error_check(fyd, !rc, err_out_rc,
+				"fy_accel_insert() fyd->naxl failed");
+	}
+
+	/* take away the input reference */
+	fy_input_unref(fyi);
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	if (data_copy)
+		free(data_copy);
+	fy_anchor_destroy(fya);
+	fy_token_unref(fyt);
+	fy_input_unref(fyi);
+	fyd->diag->on_error = false;
+	return rc;
+}
+
+int fy_document_set_anchor(struct fy_document *fyd, struct fy_node *fyn, const char *text, size_t len)
+{
+	return fy_document_set_anchor_internal(fyd, fyn, text, len, 0);
+}
+
+int fy_node_set_anchor(struct fy_node *fyn, const char *text, size_t len)
+{
+	if (!fyn)
+		return -1;
+	return fy_document_set_anchor_internal(fyn->fyd, fyn, text, len, 0);
+}
+
+int fy_node_set_anchor_copy(struct fy_node *fyn, const char *text, size_t len)
+{
+	if (!fyn)
+		return -1;
+	return fy_document_set_anchor_internal(fyn->fyd, fyn, text, len, FYDSAF_COPY);
+}
+
+int fy_node_set_vanchorf(struct fy_node *fyn, const char *fmt, va_list ap)
+{
+	if (!fyn || !fmt)
+		return -1;
+
+	return fy_document_set_anchor_internal(fyn->fyd, fyn, fy_vsprintfa(fmt, ap), FY_NT, FYDSAF_COPY);
+}
+
+int fy_node_set_anchorf(struct fy_node *fyn, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = fy_node_set_vanchorf(fyn, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+int fy_node_remove_anchor(struct fy_node *fyn)
+{
+	return fy_node_set_anchor(fyn, NULL, 0);
+}
+
+struct fy_anchor *fy_node_get_anchor(struct fy_node *fyn)
+{
+	if (!fyn)
+		return NULL;
+
+	return fy_document_lookup_anchor_by_node(fyn->fyd, fyn);
+}
+
+struct fy_anchor *fy_node_get_nearest_anchor(struct fy_node *fyn)
+{
+	struct fy_anchor *fya;
+	struct fy_node *fynt;
+
+	while ((fya = fy_node_get_anchor(fyn)) == NULL && (fynt = fy_node_get_parent(fyn)))
+		fyn = fynt;
+
+	return fya;
+}
+
+struct fy_node *fy_node_get_nearest_child_of(struct fy_node *fyn_base,
+					     struct fy_node *fyn)
+{
+        struct fy_node *fynp;
+
+        if (!fyn)
+                return NULL;
+        if (!fyn_base)
+                fyn_base = fy_document_root(fy_node_document(fyn));
+        if (!fyn_base)
+                return NULL;
+
+        /* move up until we hit a node that's a child of fyn_base */
+        fynp = fyn;
+        while (fyn && (fynp = fy_node_get_parent(fyn)) != NULL && fyn_base != fynp)
+                fyn = fynp;
+
+        return fyn;
+}
+
+void fy_parse_document_destroy(struct fy_parser *fyp, struct fy_document *fyd)
+{
+	struct fy_node *fyn;
+
+	if (!fyd)
+		return;
+
+	fy_document_cleanup_path_expr_data(fyd);
+
+	fyn = fyd->root;
+	fyd->root = NULL;
+	fy_node_detach_and_free(fyn);
+
+	fy_document_purge_anchors(fyd);
+
+	fy_document_state_unref(fyd->fyds);
+
+	fy_diag_unref(fyd->diag);
+
+	free(fyd);
+}
+
+struct fy_document *fy_parse_document_create(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_document *fyd = NULL;
+	struct fy_document_state *fyds;
+	struct fy_event *fye = NULL;
+	int rc;
+
+	if (!fyp || !fyep)
+		return NULL;
+
+	fye = &fyep->e;
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fy_event_get_token(fye), FYEM_DOC,
+			fye->type == FYET_DOCUMENT_START, err_out,
+			"invalid start of event stream");
+
+	fyd = malloc(sizeof(*fyd));
+	fyp_error_check(fyp, fyd, err_out,
+		"malloc() failed");
+
+	memset(fyd, 0, sizeof(*fyd));
+
+	fyd->diag = fy_diag_ref(fyp->diag);
+	fyd->parse_cfg = fyp->cfg;
+
+	fy_anchor_list_init(&fyd->anchors);
+	if (fy_document_can_be_accelerated(fyd)) {
+		fyd->axl = malloc(sizeof(*fyd->axl));
+		fyp_error_check(fyp, fyd->axl, err_out,
+				"malloc() failed");
+
+		/* start with a very small bucket list */
+		rc = fy_accel_setup(fyd->axl, &hd_anchor, fyd, 8);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_accel_setup() failed");
+
+		fyd->naxl = malloc(sizeof(*fyd->naxl));
+		fyp_error_check(fyp, fyd->axl, err_out,
+				"malloc() failed");
+
+		/* start with a very small bucket list */
+		rc = fy_accel_setup(fyd->naxl, &hd_nanchor, fyd, 8);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_accel_setup() failed");
+	}
+
+	fyd->root = NULL;
+
+	fyds = fye->document_start.document_state;
+	fye->document_start.document_state = NULL;
+
+	/* and we're done with this event */
+	fy_parse_eventp_recycle(fyp, fyep);
+
+	/* drop the old reference */
+	fy_document_state_unref(fyd->fyds);
+
+	/* note that we keep the reference */
+	fyd->fyds = fyds;
+
+	fy_document_list_init(&fyd->children);
+
+	return fyd;
+
+err_out:
+	fy_parse_document_destroy(fyp, fyd);
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyd->diag->on_error = false;
+	return NULL;
+}
+
+const struct fy_parse_cfg *fy_document_get_cfg(struct fy_document *fyd)
+{
+	if (!fyd)
+		return NULL;
+	return &fyd->parse_cfg;
+}
+
+struct fy_diag *fy_document_get_diag(struct fy_document *fyd)
+{
+	if (!fyd || !fyd->diag)
+		return NULL;
+	return fy_diag_ref(fyd->diag);
+}
+
+int fy_document_set_diag(struct fy_document *fyd, struct fy_diag *diag)
+{
+	struct fy_diag_cfg dcfg;
+
+	if (!fyd)
+		return -1;
+
+	/* default? */
+	if (!diag) {
+		fy_diag_cfg_default(&dcfg);
+		diag = fy_diag_create(&dcfg);
+		if (!diag)
+			return -1;
+	}
+
+	fy_diag_unref(fyd->diag);
+	fyd->diag = fy_diag_ref(diag);
+
+	return 0;
+}
+
+struct fy_document *fy_node_document(struct fy_node *fyn)
+{
+	return fyn ? fyn->fyd : NULL;
+}
+
+static inline struct fy_anchor *
+fy_document_accel_lookup_anchor_by_token(struct fy_document *fyd, struct fy_token *fyt)
+{
+	assert(fyd);
+	assert(fyd->axl);
+	return (void *)fy_accel_lookup(fyd->axl, fyt);
+}
+
+static inline struct fy_anchor *
+fy_document_accel_lookup_anchor_by_node(struct fy_document *fyd, struct fy_node *fyn)
+{
+	assert(fyd);
+	assert(fyd->naxl);
+	return (void *)fy_accel_lookup(fyd->naxl, fyn);
+}
+
+static inline struct fy_node_pair *
+fy_node_accel_lookup_by_node(struct fy_node *fyn, struct fy_node *fyn_key)
+{
+	assert(fyn);
+	assert(fyn->xl);
+
+	return (void *)fy_accel_lookup(fyn->xl, (const void *)fyn_key);
+}
+
+struct fy_anchor *
+fy_document_lookup_anchor(struct fy_document *fyd, const char *anchor, size_t len)
+{
+	struct fy_anchor *fya;
+	struct fy_anchor_list *fyal;
+	struct fy_input *fyi;
+	struct fy_atom handle;
+	struct fy_token *fyt;
+	const char *text;
+	size_t text_len;
+
+	if (!fyd || !anchor)
+		return NULL;
+
+	if (len == (size_t)-1)
+		len = strlen(anchor);
+
+	if (fy_document_is_accelerated(fyd)) {
+		fyi = fy_input_from_data(anchor, len, &handle, true);
+		if (!fyi)
+			return NULL;
+
+		fyt = fy_token_create(FYTT_ANCHOR, &handle);
+
+		if (!fyt) {
+			fy_input_unref(fyi);
+			return NULL;
+		}
+
+		fya = fy_document_accel_lookup_anchor_by_token(fyd, fyt);
+
+		fy_input_unref(fyi);
+		fy_token_unref(fyt);
+
+		if (!fya)
+			return NULL;
+
+		/* single anchor? return it */
+		if (!fya->multiple)
+			return fya;
+
+		/* multiple anchors, fall-through */
+	}
+
+	/* note that we're performing the lookup in reverse creation order
+	 * so that we pick the most recent
+	 */
+	fyal = &fyd->anchors;
+	for (fya = fy_anchor_list_tail(fyal); fya; fya = fy_anchor_prev(fyal, fya)) {
+		text = fy_anchor_get_text(fya, &text_len);
+		if (!text)
+			return NULL;
+
+		if (len == text_len && !memcmp(anchor, text, len))
+			return fya;
+	}
+
+	return NULL;
+}
+
+struct fy_anchor *
+fy_document_lookup_anchor_by_token(struct fy_document *fyd,
+				   struct fy_token *anchor)
+{
+	struct fy_anchor *fya, *fya_found, *fya_found2;
+	struct fy_anchor_list *fyal;
+	const char *anchor_text, *text;
+	size_t anchor_len, text_len;
+	int count;
+
+	if (!fyd || !anchor)
+		return NULL;
+
+	/* first try direct match (it's faster and the common case) */
+	if (fy_document_is_accelerated(fyd)) {
+		fya = fy_document_accel_lookup_anchor_by_token(fyd, anchor);
+		if (!fya)
+			return NULL;
+
+		/* single anchor? return it */
+		if (!fya->multiple)
+			return fya;
+
+		/* multiple anchors, fall-through */
+	}
+
+	anchor_text = fy_token_get_text(anchor, &anchor_len);
+	if (!anchor_text)
+		return NULL;
+
+	fyal = &fyd->anchors;
+
+	/* first pass, try with a single match */
+	count = 0;
+	fya_found = NULL;
+	for (fya = fy_anchor_list_head(fyal); fya; fya = fy_anchor_next(fyal, fya)) {
+		text = fy_anchor_get_text(fya, &text_len);
+		if (!text)
+			return NULL;
+
+		if (anchor_len == text_len && !memcmp(anchor_text, text, anchor_len)) {
+			count++;
+			fya_found = fya;
+		}
+	}
+
+	/* not found */
+	if (!count)
+		return NULL;
+
+	/* single one? fine */
+	if (count == 1)
+		return fya_found;
+
+	/* multiple ones, must pick the one that's the last one before
+	 * the requesting token */
+	/* fyd_notice(fyd, "multiple anchors for %.*s", (int)anchor_len, anchor_text); */
+
+	/* only try the ones on the same input
+	 * we don't try to cover the case where the label is referenced
+	 * by other constructed documents
+	 */
+	fya_found2 = NULL;
+	for (fya = fy_anchor_list_head(fyal); fya; fya = fy_anchor_next(fyal, fya)) {
+
+		/* only on the same input */
+		if (fy_token_get_input(fya->anchor) != fy_token_get_input(anchor))
+			continue;
+
+		text = fy_anchor_get_text(fya, &text_len);
+		if (!text)
+			return NULL;
+
+		if (anchor_len == text_len && !memcmp(anchor_text, text, anchor_len) &&
+		    fy_token_start_pos(fya->anchor) < fy_token_start_pos(anchor)) {
+			fya_found2 = fya;
+		}
+	}
+
+	/* just return the one find earlier */
+	if (!fya_found2)
+		return fya_found;
+
+	/* return the one that was the latest */
+	return fya_found2;
+}
+
+struct fy_anchor *fy_document_lookup_anchor_by_node(struct fy_document *fyd, struct fy_node *fyn)
+{
+	struct fy_anchor *fya;
+	struct fy_anchor_list *fyal;
+
+	if (!fyd || !fyn)
+		return NULL;
+
+	if (fy_document_is_accelerated(fyd)) {
+		fya = fy_document_accel_lookup_anchor_by_node(fyd, fyn);
+	} else {
+		fyal = &fyd->anchors;
+		for (fya = fy_anchor_list_head(fyal); fya; fya = fy_anchor_next(fyal, fya)) {
+			if (fya->fyn == fyn)
+				break;
+		}
+	}
+
+	return fya;
+}
+
+const char *fy_anchor_get_text(struct fy_anchor *fya, size_t *lenp)
+{
+	if (!fya || !lenp)
+		return NULL;
+	return fy_token_get_text(fya->anchor, lenp);
+}
+
+struct fy_node *fy_anchor_node(struct fy_anchor *fya)
+{
+	if (!fya)
+		return NULL;
+	return fya->fyn;
+}
+
+int fy_node_pair_free(struct fy_node_pair *fynp)
+{
+	int rc, rc_ret = 0;
+
+	if (!fynp)
+		return 0;
+
+	rc = fy_node_free(fynp->key);
+	if (rc)
+		rc_ret = -1;
+	rc = fy_node_free(fynp->value);
+	if (rc)
+		rc_ret = -1;
+
+	free(fynp);
+
+	return rc_ret;
+}
+
+void fy_node_pair_detach_and_free(struct fy_node_pair *fynp)
+{
+	if (!fynp)
+		return;
+
+	fy_node_detach_and_free(fynp->key);
+	fy_node_detach_and_free(fynp->value);
+	free(fynp);
+}
+
+struct fy_node_pair *fy_node_pair_alloc(struct fy_document *fyd)
+{
+	struct fy_node_pair *fynp = NULL;
+
+	fynp = malloc(sizeof(*fynp));
+	if (!fynp)
+		return NULL;
+
+	fynp->key = NULL;
+	fynp->value = NULL;
+	fynp->fyd = fyd;
+	fynp->parent = NULL;
+	return fynp;
+}
+
+int fy_node_free(struct fy_node *fyn)
+{
+	struct fy_document *fyd;
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp;
+	struct fy_anchor *fya, *fyan;
+		struct fy_accel_entry_iter xli;
+	struct fy_accel_entry *xle, *xlen;
+
+	if (!fyn)
+		return 0;
+
+	/* a document must exist */
+	fyd = fyn->fyd;
+	if (!fyd)
+		return -1;
+
+	if (fyn->attached)
+		return -1;
+
+	if (fy_document_is_accelerated(fyd)) {
+		for (xle = fy_accel_entry_iter_start(&xli, fyd->naxl, fyn);
+		     xle; xle = xlen) {
+			xlen = fy_accel_entry_iter_next(&xli);
+
+			fya = (void *)xle->value;
+
+			fy_anchor_list_del(&fyd->anchors, fya);
+
+			xle = fy_accel_entry_lookup_value(fyd->axl, fya);
+			fy_accel_entry_remove(fyd->axl, xle);
+
+			xle = fy_accel_entry_lookup_value(fyd->naxl, fya);
+			fy_accel_entry_remove(fyd->naxl, xle);
+
+			fy_anchor_destroy(fya);
+		}
+		fy_accel_entry_iter_finish(&xli);
+	} else {
+		/* remove anchors that are located on this node */
+		for (fya = fy_anchor_list_head(&fyd->anchors); fya; fya = fyan) {
+			fyan = fy_anchor_next(&fyd->anchors, fya);
+			if (fya->fyn == fyn) {
+				fy_anchor_list_del(&fyd->anchors, fya);
+				fy_anchor_destroy(fya);
+			}
+		}
+	}
+
+	/* clear the meta data of this node */
+	fy_node_clear_meta(fyn);
+
+	fy_token_unref(fyn->tag);
+	fyn->tag = NULL;
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fy_token_unref(fyn->scalar);
+		fyn->scalar = NULL;
+		break;
+	case FYNT_SEQUENCE:
+		while ((fyni = fy_node_list_pop(&fyn->sequence)) != NULL)
+			fy_node_detach_and_free(fyni);
+		fy_token_unref(fyn->sequence_start);
+		fy_token_unref(fyn->sequence_end);
+		fyn->sequence_start = NULL;
+		fyn->sequence_end = NULL;
+		break;
+	case FYNT_MAPPING:
+		while ((fynp = fy_node_pair_list_pop(&fyn->mapping)) != NULL)
+			fy_node_pair_detach_and_free(fynp);
+		fy_token_unref(fyn->mapping_start);
+		fy_token_unref(fyn->mapping_end);
+		fyn->mapping_start = NULL;
+		fyn->mapping_end = NULL;
+		break;
+	}
+
+	if (fyn->xl) {
+		fy_accel_cleanup(fyn->xl);
+		free(fyn->xl);
+	}
+
+	fy_node_cleanup_path_expr_data(fyn);
+
+	free(fyn);
+
+	return 0;
+}
+
+void fy_node_detach_and_free(struct fy_node *fyn)
+{
+	int rc __FY_DEBUG_UNUSED__;
+
+	if (!fyn || !fyn->fyd)
+		return;
+
+	fyn->attached = false;
+
+	/* it must always succeed */
+	rc = fy_node_free(fyn);
+	assert(!rc);
+}
+
+struct fy_node *fy_node_alloc(struct fy_document *fyd, enum fy_node_type type)
+{
+	struct fy_node *fyn = NULL;
+	int rc;
+
+	fyn = malloc(sizeof(*fyn));
+	if (!fyn)
+		return NULL;
+
+	memset(fyn, 0, sizeof(*fyn));
+
+	fyn->style = FYNS_ANY;
+	fyn->fyd = fyd;
+	fyn->type = type;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		fy_node_list_init(&fyn->sequence);
+		break;
+	case FYNT_MAPPING:
+		fy_node_pair_list_init(&fyn->mapping);
+
+		if (fy_document_is_accelerated(fyd)) {
+			fyn->xl = malloc(sizeof(*fyn->xl));
+			fyd_error_check(fyd, fyn->xl, err_out,
+					"malloc() failed");
+
+			/* start with a very small bucket list */
+			rc = fy_accel_setup(fyn->xl, &hd_mapping, fyd, 8);
+			fyd_error_check(fyd, !rc, err_out,
+					"fy_accel_setup() failed");
+		}
+		break;
+	}
+	return fyn;
+
+err_out:
+	if (fyn) {
+		if (fyn->xl) {
+			fy_accel_cleanup(fyn->xl);
+			free(fyn->xl);
+		}
+		free(fyn);
+	}
+	return NULL;
+}
+
+struct fy_token *fy_node_non_synthesized_token(struct fy_node *fyn)
+{
+	struct fy_token *fyt_start = NULL, *fyt_end = NULL;
+	struct fy_token *fyt;
+	struct fy_input *fyi;
+	struct fy_atom handle;
+	unsigned int aflags;
+	const char *s, *e;
+	size_t size;
+	bool simple;
+
+	if (!fyn)
+		return NULL;
+
+	fyi = fy_node_get_input(fyn);
+	if (!fyi)
+		return NULL;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		return fy_token_ref(fyn->scalar);
+
+	case FYNT_SEQUENCE:
+		fyt_start = fyn->sequence_start;
+		fyt_end = fyn->sequence_end;
+		break;
+
+	case FYNT_MAPPING:
+		fyt_start = fyn->mapping_start;
+		fyt_end = fyn->mapping_end;
+		break;
+
+	}
+
+	if (!fyt_start || !fyt_end)
+		return NULL;
+
+	s = (const char *)fy_input_start(fyi) + fyt_start->handle.start_mark.input_pos;
+	e = (const char *)fy_input_start(fyi) + fyt_end->handle.end_mark.input_pos;
+	size = (size_t)(e - s);
+
+	if (size > 0)
+		aflags = fy_analyze_scalar_content(s, size,
+				fy_token_atom_json_mode(fyt_start),
+				fy_token_atom_lb_mode(fyt_start),
+				fy_token_atom_flow_ws_mode(fyt_start));
+	else
+		aflags = FYACF_EMPTY | FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN;
+
+	memset(&handle, 0, sizeof(handle));
+	handle.start_mark = fyt_start->handle.start_mark;
+	handle.end_mark = fyt_end->handle.end_mark;
+
+	simple = (aflags & (FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN | FYACF_LB | FYACF_ENDS_WITH_COLON))
+			== (FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN);
+	/* if it's plain, all is good */
+	if (simple) {
+		handle.storage_hint = size;	/* maximum */
+		handle.storage_hint_valid = false;
+		handle.direct_output = !!(aflags & FYACF_JSON_ESCAPE);	/* direct only when no json escape */
+		handle.style = FYAS_PLAIN;
+	} else {
+		handle.storage_hint = 0;	/* just calculate */
+		handle.storage_hint_valid = false;
+		handle.direct_output = false;
+		handle.style = FYAS_DOUBLE_QUOTED_MANUAL;
+	}
+	handle.empty = !!(aflags & FYACF_EMPTY);
+	handle.has_lb = !!(aflags & FYACF_LB);
+	handle.has_ws = !!(aflags & FYACF_WS);
+	handle.starts_with_ws = !!(aflags & FYACF_STARTS_WITH_WS);
+	handle.starts_with_lb = !!(aflags & FYACF_STARTS_WITH_LB);
+	handle.ends_with_ws = !!(aflags & FYACF_ENDS_WITH_WS);
+	handle.ends_with_lb = !!(aflags & FYACF_ENDS_WITH_LB);
+	handle.trailing_lb = !!(aflags & FYACF_TRAILING_LB);
+	handle.size0 = !!(aflags & FYACF_SIZE0);
+	handle.valid_anchor = !!(aflags & FYACF_VALID_ANCHOR);
+	handle.json_mode = false;		/* always false */
+	handle.lb_mode = fylb_cr_nl;		/* always \r\n */
+	handle.fws_mode = fyfws_space_tab;	/* always space + tab */
+	handle.directive0_mode = false;
+
+	handle.chomp = FYAC_STRIP;
+	handle.increment = 0;
+	handle.fyi = fyi;
+	handle.tabsize = 0;
+
+	fyt = fy_token_create(FYTT_INPUT_MARKER, &handle);
+	if (!fyt)
+		return NULL;
+
+	return fyt;
+}
+
+struct fy_token *fy_node_token(struct fy_node *fyn)
+{
+	struct fy_atom atom;
+	struct fy_input *fyi = NULL;
+	struct fy_token *fyt = NULL;
+	char *buf = NULL;
+
+	if (!fyn)
+		return NULL;
+
+	/* if it's non synthetic we can use the node extends */
+	if (!fy_node_is_synthetic(fyn))
+		return fy_node_non_synthesized_token(fyn);
+
+	/* emit to a string and create the token there */
+	buf = fy_emit_node_to_string(fyn, FYECF_MODE_FLOW_ONELINE | FYECF_WIDTH_INF);
+	if (!buf)
+		goto err_out;
+
+	fyi = fy_input_from_malloc_data(buf, FY_NT, &atom, true);
+	if (!fyi)
+		goto err_out;
+
+	fyt = fy_token_create(FYTT_INPUT_MARKER, &atom);
+	if (!fyt)
+		goto err_out;
+
+	/* take away the input reference */
+	fy_input_unref(fyi);
+
+	return fyt;
+
+err_out:
+	fy_input_unref(fyi);
+	if (buf)
+		free(buf);
+	return NULL;
+}
+
+bool fy_node_uses_single_input_only(struct fy_node *fyn, struct fy_input *fyi)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp;
+
+	if (!fyn || !fyi)
+		return false;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		return fy_token_get_input(fyn->scalar) == fyi;
+
+	case FYNT_SEQUENCE:
+		if (fy_token_get_input(fyn->sequence_start) != fyi)
+			return false;
+
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+		     fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			if (!fy_node_uses_single_input_only(fyni, fyi))
+				return false;
+		}
+
+		if (fy_token_get_input(fyn->sequence_end) != fyi)
+			return false;
+		break;
+
+	case FYNT_MAPPING:
+		if (fy_token_get_input(fyn->mapping_start) != fyi)
+			return false;
+
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp;
+		     fynp = fy_node_pair_next(&fyn->mapping, fynp)) {
+
+			if (fynp->key && !fy_node_uses_single_input_only(fynp->key, fyi))
+				return false;
+
+			if (fynp->value && !fy_node_uses_single_input_only(fynp->value, fyi))
+				return false;
+		}
+
+		if (fy_token_get_input(fyn->mapping_end) != fyi)
+			return false;
+
+		break;
+	}
+
+	return true;
+}
+
+struct fy_input *fy_node_get_first_input(struct fy_node *fyn)
+{
+	if (!fyn)
+		return NULL;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		return fy_token_get_input(fyn->scalar);
+
+	case FYNT_SEQUENCE:
+		return fy_token_get_input(fyn->sequence_start);
+
+	case FYNT_MAPPING:
+		return fy_token_get_input(fyn->mapping_start);
+	}
+
+	/* should never happen */
+	return NULL;
+}
+
+/* a node is synthetic if any of it's tokens reside in
+ * different inputs, or any sequence/mapping has been
+ * created via the manual sequence/mapping creation methods
+ */
+bool fy_node_is_synthetic(struct fy_node *fyn)
+{
+	return fyn && fyn->synthetic;
+}
+
+/* map this node and all of it's parents synthetic */
+void fy_node_mark_synthetic(struct fy_node *fyn)
+{
+	if (!fyn)
+		return;
+	fyn->synthetic = true;
+	while ((fyn = fy_node_get_document_parent(fyn)) != NULL)
+		fyn->synthetic = true;
+}
+
+struct fy_input *fy_node_get_input(struct fy_node *fyn)
+{
+	struct fy_input *fyi = NULL;
+
+	fyi = fy_node_get_first_input(fyn);
+	if (!fyi)
+		return NULL;
+
+	return fy_node_uses_single_input_only(fyn, fyi) ? fyi : NULL;
+}
+
+int fy_document_register_anchor(struct fy_document *fyd,
+				struct fy_node *fyn, struct fy_token *anchor)
+{
+	struct fy_anchor *fya, *fyam;
+	struct fy_accel_entry *xle;
+	const char *text FY_DEBUG_UNUSED;
+	size_t text_len FY_DEBUG_UNUSED;
+	int rc;
+
+	fya = fy_anchor_create(fyd, fyn, anchor);
+	fyd_error_check(fyd, fya, err_out,
+			"fy_anchor_create() failed");
+
+	fy_anchor_list_add_tail(&fyd->anchors, fya);
+	if (fy_document_is_accelerated(fyd)) {
+		xle = fy_accel_entry_lookup(fyd->axl, fya->anchor);
+		if (xle) {
+			fyam = (void *)xle->value;
+			/* multiple */
+			if (!fyam->multiple)
+				fyam->multiple = true;
+			fya->multiple = true;
+
+			text = fy_anchor_get_text(fya, &text_len);
+			assert(text);
+			assert(text_len > 0);
+			fyd_debug(fyd, "register anchor %.*s is multiple", (int)text_len, text);
+		}
+
+		xle = fy_accel_entry_insert(fyd->axl, fya->anchor, fya);
+		fyd_error_check(fyd, xle, err_out,
+				"fy_accel_entry_insert() fyd->axl failed");
+	}
+
+	if (fy_document_is_accelerated(fyd)) {
+		rc = fy_accel_insert(fyd->naxl, fyn, fya);
+		fyd_error_check(fyd, !rc, err_out_rc,
+				"fy_accel_insert() fyd->naxl failed");
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	fyd->diag->on_error = false;
+	return rc;
+}
+
+struct fy_node_cmp_arg {
+	fy_node_scalar_compare_fn cmp_fn;
+	void *arg;
+};
+
+static int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
+				      struct fy_node *fyn_b,
+				      void *arg);
+
+static int fy_node_mapping_sort_cmp_default(const struct fy_node_pair *fynp_a,
+					    const struct fy_node_pair *fynp_b,
+					    void *arg);
+
+bool fy_node_compare_user(struct fy_node *fyn1, struct fy_node *fyn2,
+			 fy_node_mapping_sort_fn sort_fn, void *sort_fn_arg,
+			 fy_node_scalar_compare_fn cmp_fn, void *cmp_fn_arg)
+{
+	struct fy_node *fyni1, *fyni2;
+	struct fy_node_pair *fynp1, *fynp2;
+	bool ret, null1, null2;
+	struct fy_node_pair **fynpp1, **fynpp2;
+	int i, count1, count2;
+	bool alias1, alias2;
+	struct fy_node_cmp_arg def_arg;
+
+	if (!cmp_fn) {
+		cmp_fn = fy_node_scalar_cmp_default;
+		cmp_fn_arg = NULL;
+	}
+	if (!sort_fn) {
+		sort_fn = fy_node_mapping_sort_cmp_default;
+		def_arg.cmp_fn = cmp_fn;
+		def_arg.arg = cmp_fn_arg;
+		sort_fn_arg = &def_arg;
+	} else {
+		def_arg.cmp_fn = NULL;
+		def_arg.arg = NULL;
+	}
+	/* equal pointers? */
+	if (fyn1 == fyn2)
+		return true;
+
+	null1 = !fyn1 || (fyn1->type == FYNT_SCALAR && fy_token_get_text_length(fyn1->scalar) == 0);
+	null2 = !fyn2 || (fyn2->type == FYNT_SCALAR && fy_token_get_text_length(fyn2->scalar) == 0);
+
+	/* both null */
+	if (null1 && null2)
+		return true;
+
+	/* either is NULL, no match */
+	if (null1 || null2)
+		return false;
+
+	/* types must match */
+	if (fyn1->type != fyn2->type)
+		return false;
+
+	ret = true;
+
+	switch (fyn1->type) {
+	case FYNT_SEQUENCE:
+		fyni1 = fy_node_list_head(&fyn1->sequence);
+		fyni2 = fy_node_list_head(&fyn2->sequence);
+		while (fyni1 && fyni2) {
+
+			ret = fy_node_compare_user(fyni1, fyni2, sort_fn, sort_fn_arg, cmp_fn, cmp_fn_arg);
+			if (!ret)
+				break;
+
+			fyni1 = fy_node_next(&fyn1->sequence, fyni1);
+			fyni2 = fy_node_next(&fyn2->sequence, fyni2);
+		}
+		if (ret && fyni1 != fyni2 && (!fyni1 || !fyni2))
+			ret = false;
+
+		break;
+
+	case FYNT_MAPPING:
+		count1 = fy_node_mapping_item_count(fyn1);
+		count2 = fy_node_mapping_item_count(fyn2);
+
+		/* mapping counts must match */
+		if (count1 != count2) {
+			ret = false;
+			break;
+		}
+
+		fynpp1 = alloca(sizeof(*fynpp1) * (count1 + 1));
+		fy_node_mapping_fill_array(fyn1, fynpp1, count1);
+		fy_node_mapping_perform_sort(fyn1, sort_fn, sort_fn_arg, fynpp1, count1);
+
+		fynpp2 = alloca(sizeof(*fynpp2) * (count2 + 1));
+		fy_node_mapping_fill_array(fyn2, fynpp2, count2);
+		fy_node_mapping_perform_sort(fyn2, sort_fn, sort_fn_arg, fynpp2, count2);
+
+		for (i = 0; i < count1; i++) {
+			fynp1 = fynpp1[i];
+			fynp2 = fynpp2[i];
+
+			ret = fy_node_compare_user(fynp1->key, fynp2->key, sort_fn, sort_fn_arg, cmp_fn, cmp_fn_arg);
+			if (!ret)
+				break;
+
+			ret = fy_node_compare_user(fynp1->value, fynp2->value, sort_fn, sort_fn_arg, cmp_fn, cmp_fn_arg);
+			if (!ret)
+				break;
+		}
+		if (i >= count1)
+			ret = true;
+
+		break;
+
+	case FYNT_SCALAR:
+		alias1 = fy_node_is_alias(fyn1);
+		alias2 = fy_node_is_alias(fyn2);
+
+		/* either both must be aliases or both not */
+		if (alias1 != alias2)
+			return false;
+
+		ret = !cmp_fn(fyn1, fyn2, cmp_fn_arg);
+		break;
+	}
+
+	return ret;
+}
+
+bool fy_node_compare(struct fy_node *fyn1, struct fy_node *fyn2)
+{
+	return fy_node_compare_user(fyn1, fyn2, NULL, NULL, NULL, NULL);
+}
+
+bool fy_node_compare_string(struct fy_node *fyn, const char *str, size_t len)
+{
+	struct fy_document *fyd = NULL;
+	bool ret;
+
+	fyd = fy_document_build_from_string(NULL, str, len);
+	if (!fyd)
+		return false;
+
+	ret = fy_node_compare(fyn, fy_document_root(fyd));
+
+	fy_document_destroy(fyd);
+
+	return ret;
+}
+
+bool fy_node_compare_token(struct fy_node *fyn, struct fy_token *fyt)
+{
+	/* check if there's NULL */
+	if (!fyn || !fyt)
+		return false;
+
+	/* only valid for scalars */
+	if (!fy_node_is_scalar(fyn) || fyt->type != FYTT_SCALAR)
+		return false;
+
+	return fy_token_cmp(fyn->scalar, fyt) == 0;
+}
+
+bool fy_node_compare_text(struct fy_node *fyn, const char *text, size_t len)
+{
+	const char *textn;
+	size_t lenn;
+
+	if (!fyn || !text)
+		return false;
+
+	textn = fy_node_get_scalar(fyn, &lenn);
+	if (!textn)
+		return false;
+
+	if (len == FY_NT)
+		len = strlen(text);
+
+	if (len != lenn)
+		return false;
+
+	return memcmp(text, textn, len) == 0;
+}
+
+struct fy_node_pair *fy_node_mapping_lookup_pair(struct fy_node *fyn, struct fy_node *fyn_key)
+{
+	struct fy_node_pair *fynpi, *fynp;
+
+	/* sanity check */
+	if (!fy_node_is_mapping(fyn))
+		return NULL;
+
+	fynp = NULL;
+
+
+	if (fyn->xl) {
+		fynp = fy_node_accel_lookup_by_node(fyn, fyn_key);
+	} else {
+		for (fynpi = fy_node_pair_list_head(&fyn->mapping); fynpi;
+			fynpi = fy_node_pair_next(&fyn->mapping, fynpi)) {
+			if (fy_node_compare(fynpi->key, fyn_key)) {
+				fynp = fynpi;
+				break;
+			}
+		}
+	}
+
+	return fynp;
+}
+
+int fy_node_mapping_get_pair_index(struct fy_node *fyn, const struct fy_node_pair *fynp)
+{
+	struct fy_node_pair *fynpi;
+	int i;
+
+	if (!fy_node_is_mapping(fyn))
+		return -1;
+
+	for (i = 0, fynpi = fy_node_pair_list_head(&fyn->mapping); fynpi;
+		fynpi = fy_node_pair_next(&fyn->mapping, fynpi), i++) {
+
+		if (fynpi == fynp)
+			return i;
+	}
+
+	return -1;
+}
+
+bool fy_node_mapping_key_is_duplicate(struct fy_node *fyn, struct fy_node *fyn_key)
+{
+	return fy_node_mapping_lookup_pair(fyn, fyn_key) != NULL;
+}
+
+static int
+fy_parse_document_load_node(struct fy_parser *fyp, struct fy_document *fyd,
+			    struct fy_eventp *fyep, struct fy_node **fynp,
+			    int *depthp);
+
+int fy_parse_document_load_alias(struct fy_parser *fyp, struct fy_document *fyd, struct fy_eventp *fyep, struct fy_node **fynp)
+{
+	*fynp = NULL;
+
+	fyp_doc_debug(fyp, "in %s", __func__);
+
+	/* TODO verify aliases etc */
+	fy_parse_eventp_recycle(fyp, fyep);
+	return 0;
+}
+
+static int
+fy_parse_document_load_scalar(struct fy_parser *fyp, struct fy_document *fyd,
+			      struct fy_eventp *fyep, struct fy_node **fynp,
+			      int *depthp)
+{
+	struct fy_node *fyn = NULL;
+	struct fy_event *fye;
+	int rc;
+
+	if (!fyd)
+		return -1;
+
+	fyp_error_check(fyp, fyep || !fyp->stream_error, err_out,
+			"no event to process");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 0, FYEM_DOC,
+			fyep, err_out,
+			"premature end of event stream");
+
+	fyp_doc_debug(fyp, "in %s [%s]", __func__, fy_event_type_txt[fyep->e.type]);
+
+	*fynp = NULL;
+
+	fye = &fyep->e;
+
+	/* we don't free nodes that often, so no need for recycling */
+	fyn = fy_node_alloc(fyd, FYNT_SCALAR);
+	fyp_error_check(fyp, fyn, err_out,
+			"fy_node_alloc() failed");
+
+	if (fye->type == FYET_SCALAR) {
+
+		/* move the tags and value to the node */
+		if (fye->scalar.value)
+			fyn->style = fy_node_style_from_scalar_style(fye->scalar.value->scalar.style);
+		else
+			fyn->style = FYNS_PLAIN;
+		fyn->tag = fye->scalar.tag;
+		fye->scalar.tag = NULL;
+
+		fyn->scalar = fye->scalar.value;
+		fye->scalar.value = NULL;
+
+		if (fye->scalar.anchor) {
+			rc = fy_document_register_anchor(fyd, fyn, fye->scalar.anchor);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_document_register_anchor() failed");
+			fye->scalar.anchor = NULL;
+		}
+
+	} else if (fye->type == FYET_ALIAS) {
+		fyn->style = FYNS_ALIAS;
+		fyn->scalar = fye->alias.anchor;
+		fye->alias.anchor = NULL;
+	} else
+		FY_IMPOSSIBLE_ABORT();
+
+	*fynp = fyn;
+	fyn = NULL;
+
+	/* everything OK */
+	fy_parse_eventp_recycle(fyp, fyep);
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyd->diag->on_error = false;
+	return rc;
+}
+
+static int
+fy_parse_document_load_sequence(struct fy_parser *fyp, struct fy_document *fyd,
+				struct fy_eventp *fyep, struct fy_node **fynp,
+				int *depthp)
+{
+	struct fy_node *fyn = NULL, *fyn_item = NULL;
+	struct fy_event *fye = NULL;
+	struct fy_token *fyt_ss = NULL;
+	int rc;
+
+	fyp_error_check(fyp, fyep || !fyp->stream_error, err_out,
+			"no event to process");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 0, FYEM_DOC,
+			fyep, err_out,
+			"premature end of event stream");
+
+	fyp_doc_debug(fyp, "in %s [%s]", __func__, fy_event_type_txt[fyep->e.type]);
+
+	*fynp = NULL;
+
+	fye = &fyep->e;
+
+	fyt_ss = fye->sequence_start.sequence_start;
+
+	/* we don't free nodes that often, so no need for recycling */
+	fyn = fy_node_alloc(fyd, FYNT_SEQUENCE);
+	fyp_error_check(fyp, fyn, err_out,
+			"fy_node_alloc() failed");
+
+	fyn->style = fyt_ss && fyt_ss->type == FYTT_FLOW_SEQUENCE_START ? FYNS_FLOW : FYNS_BLOCK;
+
+	fyn->tag = fye->sequence_start.tag;
+	fye->sequence_start.tag = NULL;
+
+	if (fye->sequence_start.anchor) {
+		rc = fy_document_register_anchor(fyd, fyn, fye->sequence_start.anchor);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_document_register_anchor() failed");
+		fye->sequence_start.anchor = NULL;
+	}
+
+	if (fye->sequence_start.sequence_start) {
+		fyn->sequence_start = fye->sequence_start.sequence_start;
+		fye->sequence_start.sequence_start = NULL;
+	} else
+		fyn->sequence_start = NULL;
+
+	assert(fyn->sequence_start);
+
+	/* done with this */
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyep = NULL;
+
+	while ((fyep = fy_parse_private(fyp)) != NULL) {
+		fye = &fyep->e;
+		if (fye->type == FYET_SEQUENCE_END)
+			break;
+
+		rc = fy_parse_document_load_node(fyp, fyd, fyep, &fyn_item, depthp);
+		fyep = NULL;
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_document_load_node() failed");
+
+		fy_node_list_add_tail(&fyn->sequence, fyn_item);
+		fyn_item->attached = true;
+		fyn_item = NULL;
+	}
+
+	if (!fyep)
+		goto err_out;
+
+	if (fye->sequence_end.sequence_end) {
+		fyn->sequence_end = fye->sequence_end.sequence_end;
+		fye->sequence_end.sequence_end = NULL;
+	} else
+		fyn->sequence_end = NULL;
+
+	assert(fyn->sequence_end);
+
+	*fynp = fyn;
+	fyn = NULL;
+
+	fy_parse_eventp_recycle(fyp, fyep);
+	return 0;
+
+	/* fallthrough */
+err_out:
+	rc = -1;
+err_out_rc:
+	fy_parse_eventp_recycle(fyp, fyep);
+	fy_node_detach_and_free(fyn_item);
+	fy_node_detach_and_free(fyn);
+	return rc;
+}
+
+static int
+fy_parse_document_load_mapping(struct fy_parser *fyp, struct fy_document *fyd,
+			       struct fy_eventp *fyep, struct fy_node **fynp,
+			       int *depthp)
+{
+	struct fy_node *fyn = NULL, *fyn_key = NULL, *fyn_value = NULL;
+	struct fy_node_pair *fynp_item = NULL;
+	struct fy_event *fye = NULL;
+	struct fy_token *fyt_ms = NULL;
+	bool duplicate;
+	int rc;
+
+	fyp_error_check(fyp, fyep || !fyp->stream_error, err_out,
+			"no event to process");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 0, FYEM_DOC,
+			fyep, err_out,
+			"premature end of event stream");
+
+	fyp_doc_debug(fyp, "in %s [%s]", __func__, fy_event_type_txt[fyep->e.type]);
+
+	*fynp = NULL;
+
+	fye = &fyep->e;
+
+	fyt_ms = fye->mapping_start.mapping_start;
+
+	/* we don't free nodes that often, so no need for recycling */
+	fyn = fy_node_alloc(fyd, FYNT_MAPPING);
+	fyp_error_check(fyp, fyn, err_out,
+			"fy_node_alloc() failed");
+
+	fyn->style = fyt_ms && fyt_ms->type == FYTT_FLOW_MAPPING_START ? FYNS_FLOW : FYNS_BLOCK;
+
+	fyn->tag = fye->mapping_start.tag;
+	fye->mapping_start.tag = NULL;
+
+	if (fye->mapping_start.anchor) {
+		rc = fy_document_register_anchor(fyd, fyn, fye->mapping_start.anchor);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_document_register_anchor() failed");
+		fye->mapping_start.anchor = NULL;
+	}
+
+	if (fye->mapping_start.mapping_start) {
+		fyn->mapping_start = fye->mapping_start.mapping_start;
+		fye->mapping_start.mapping_start = NULL;
+	}
+
+	assert(fyn->mapping_start);
+
+	/* done with this */
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyep = NULL;
+
+	while ((fyep = fy_parse_private(fyp)) != NULL) {
+		fye = &fyep->e;
+		if (fye->type == FYET_MAPPING_END)
+			break;
+
+		fynp_item = fy_node_pair_alloc(fyd);
+		fyp_error_check(fyp, fynp_item, err_out,
+				"fy_node_pair_alloc() failed");
+
+		fyn_key = NULL;
+		fyn_value = NULL;
+
+		rc = fy_parse_document_load_node(fyp, fyd,
+						 fyep, &fyn_key, depthp);
+		fyep = NULL;
+
+		assert(fyn_key);
+
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_document_load_node() failed");
+
+		/* if we don't allow duplicate keys */
+		if (!(fyd->parse_cfg.flags & FYPCF_ALLOW_DUPLICATE_KEYS)) {
+
+			/* make sure we don't add an already existing key */
+			duplicate = fy_node_mapping_key_is_duplicate(fyn, fyn_key);
+
+			FYP_NODE_ERROR_CHECK(fyp, fyn_key, FYEM_DOC,
+					!duplicate, err_out,
+					"duplicate key");
+		}
+
+		fyep = fy_parse_private(fyp);
+
+		fyp_error_check(fyp, fyep || !fyp->stream_error, err_out,
+				"fy_parse_private() failed");
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 0, FYEM_DOC,
+				fyep, err_out,
+				"missing mapping value");
+
+		fye = &fyep->e;
+
+		rc = fy_parse_document_load_node(fyp, fyd,
+						 fyep, &fyn_value, depthp);
+		fyep = NULL;
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_document_load_node() failed");
+
+		assert(fyn_value);
+
+		fynp_item->key = fyn_key;
+		fynp_item->value = fyn_value;
+		fyn_key = NULL;
+		fyn_value = NULL;
+		if (fyn->xl) {
+			rc = fy_accel_insert(fyn->xl, fynp_item->key, fynp_item);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_accel_insert() failed");
+		}
+
+		fy_node_pair_list_add_tail(&fyn->mapping, fynp_item);
+		if (fynp_item->key)
+			fynp_item->key->attached = true;
+		if (fynp_item->value)
+			fynp_item->value->attached = true;
+		fynp_item = NULL;
+	}
+
+	if (!fyep)
+		goto err_out;
+
+	if (fye->mapping_end.mapping_end) {
+		fyn->mapping_end = fye->mapping_end.mapping_end;
+		fye->mapping_end.mapping_end = NULL;
+	}
+
+	assert(fyn->mapping_end);
+
+	*fynp = fyn;
+	fyn = NULL;
+
+	fy_parse_eventp_recycle(fyp, fyep);
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	fy_parse_eventp_recycle(fyp, fyep);
+	fy_node_pair_free(fynp_item);
+	fy_node_detach_and_free(fyn_key);
+	fy_node_detach_and_free(fyn_value);
+	fy_node_detach_and_free(fyn);
+	return rc;
+}
+
+static int
+fy_parse_document_load_node(struct fy_parser *fyp, struct fy_document *fyd,
+			    struct fy_eventp *fyep, struct fy_node **fynp,
+			    int *depthp)
+{
+	struct fy_event *fye;
+	enum fy_event_type type;
+	int ret;
+
+	*fynp = NULL;
+
+	fyp_error_check(fyp, fyep || !fyp->stream_error, err_out,
+			"no event to process");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 0, FYEM_DOC,
+			fyep, err_out,
+			"premature end of event stream");
+
+	fyp_doc_debug(fyp, "in %s [%s]", __func__, fy_event_type_txt[fyep->e.type]);
+
+	fye = &fyep->e;
+
+	type = fye->type;
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fy_event_get_token(fye), FYEM_DOC,
+			type == FYET_ALIAS || type == FYET_SCALAR ||
+			type == FYET_SEQUENCE_START || type == FYET_MAPPING_START, err_out,
+			"bad event");
+
+	(*depthp)++;
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fy_event_get_token(fye), FYEM_DOC,
+			((fyp->cfg.flags & FYPCF_DISABLE_DEPTH_LIMIT) ||
+				*depthp <= fy_depth_limit()), err_out,
+			"depth limit exceeded");
+
+	switch (type) {
+
+	case FYET_ALIAS:
+	case FYET_SCALAR:
+		ret = fy_parse_document_load_scalar(fyp, fyd,
+						     fyep, fynp, depthp);
+		break;
+
+	case FYET_SEQUENCE_START:
+		ret = fy_parse_document_load_sequence(fyp, fyd,
+						       fyep, fynp, depthp);
+		break;
+
+	case FYET_MAPPING_START:
+		ret = fy_parse_document_load_mapping(fyp, fyd,
+						      fyep, fynp, depthp);
+		break;
+
+	default:
+		ret = 0;
+		break;
+	}
+
+	--(*depthp);
+	return ret;
+
+err_out:
+	fy_parse_eventp_recycle(fyp, fyep);
+	return -1;
+}
+
+int fy_parse_document_load_end(struct fy_parser *fyp, struct fy_document *fyd, struct fy_eventp *fyep)
+{
+	struct fy_event *fye;
+	int rc;
+
+	fyp_error_check(fyp, fyep || !fyp->stream_error, err_out,
+			"no event to process");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 0, FYEM_DOC,
+			fyep, err_out,
+			"premature end of event stream");
+
+	fyp_doc_debug(fyp, "in %s [%s]", __func__, fy_event_type_txt[fyep->e.type]);
+
+	fye = &fyep->e;
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fy_event_get_token(fye), FYEM_DOC,
+			fye->type == FYET_DOCUMENT_END, err_out,
+			"bad event");
+
+	/* recycle the document end event */
+	fy_parse_eventp_recycle(fyp, fyep);
+
+	return 0;
+err_out:
+	rc = -1;
+	fy_parse_eventp_recycle(fyp, fyep);
+	return rc;
+}
+
+struct fy_document *fy_parse_load_document_recursive(struct fy_parser *fyp)
+{
+	struct fy_document *fyd = NULL;
+	struct fy_eventp *fyep = NULL;
+	struct fy_event *fye = NULL;
+	int rc, depth;
+	bool was_stream_start;
+
+again:
+	was_stream_start = false;
+	do {
+		/* get next event */
+		fyep = fy_parse_private(fyp);
+
+		/* no more */
+		if (!fyep)
+			return NULL;
+
+		was_stream_start = fyep->e.type == FYET_STREAM_START;
+
+		if (was_stream_start) {
+			fy_parse_eventp_recycle(fyp, fyep);
+			fyep = NULL;
+		}
+
+	} while (was_stream_start);
+
+	fye = &fyep->e;
+
+	/* STREAM_END */
+	if (fye->type == FYET_STREAM_END) {
+		fy_parse_eventp_recycle(fyp, fyep);
+
+		/* final STREAM_END? */
+		if (fyp->state == FYPS_END)
+			return NULL;
+
+		/* multi-stream */
+		goto again;
+	}
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fy_event_get_token(fye), FYEM_DOC,
+			fye->type == FYET_DOCUMENT_START, err_out,
+			"bad event");
+
+	fyd = fy_parse_document_create(fyp, fyep);
+	fyep = NULL;
+
+	fyp_error_check(fyp, fyd, err_out,
+			"fy_parse_document_create() failed");
+
+	fyp_doc_debug(fyp, "calling load_node() for root");
+	depth = 0;
+	rc = fy_parse_document_load_node(fyp, fyd, fy_parse_private(fyp),
+					 &fyd->root, &depth);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parse_document_load_node() failed");
+
+	rc = fy_parse_document_load_end(fyp, fyd, fy_parse_private(fyp));
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parse_document_load_node() failed");
+
+	/* always resolve parents */
+	fy_resolve_parent_node(fyd, fyd->root, NULL);
+
+	if (fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT) {
+		rc = fy_document_resolve(fyd);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_document_resolve() failed");
+	}
+
+	return fyd;
+
+err_out:
+	fy_parse_eventp_recycle(fyp, fyep);
+	fy_parse_document_destroy(fyp, fyd);
+	return NULL;
+}
+
+struct fy_document *fy_parse_load_document_with_builder(struct fy_parser *fyp)
+{
+	struct fy_document_builder_cfg cfg;
+	struct fy_document *fyd;
+	int rc;
+
+	if (!fyp)
+		return NULL;
+
+	if (!fyp->fydb) {
+		memset(&cfg, 0, sizeof(cfg));
+		cfg.parse_cfg = fyp->cfg;
+		cfg.userdata = fyp;
+		cfg.diag = fy_diag_ref(fyp->diag);
+
+		fyp->fydb = fy_document_builder_create(&cfg);
+		if (!fyp->fydb)
+			return NULL;
+	}
+
+	fyd = fy_document_builder_load_document(fyp->fydb, fyp);
+	if (!fyd)
+		return NULL;
+
+	if (fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT) {
+		rc = fy_document_resolve(fyd);
+		if (rc) {
+			fy_document_destroy(fyd);
+			fyp->stream_error = true;
+			return NULL;
+		}
+	}
+
+	return fyd;
+}
+
+struct fy_document *fy_parse_load_document(struct fy_parser *fyp)
+{
+	if (!fyp)
+		return NULL;
+
+	return !(fyp->cfg.flags & FYPCF_PREFER_RECURSIVE) ?
+		fy_parse_load_document_with_builder(fyp) :
+		fy_parse_load_document_recursive(fyp);
+}
+
+struct fy_node *fy_node_copy_internal(struct fy_document *fyd, struct fy_node *fyn_from,
+				      struct fy_node *fyn_parent, int depth)
+{
+	struct fy_document *fyd_from;
+	struct fy_node *fyn = NULL, *fyni = NULL, *fynit = NULL;
+	struct fy_node_pair *fynp = NULL, *fynpt = NULL;
+	struct fy_anchor *fya, *fya_from;
+	const char *anchor;
+	size_t anchor_len;
+	int rc;
+
+	if (!fyd || !fyn_from || !fyn_from->fyd)
+		return NULL;
+
+	FYD_NODE_ERROR_CHECK(fyd, fyn_from, FYEM_DOC,
+			depth < FY_NODE_PATH_WALK_DEPTH_DEFAULT, err_out,
+			"maximum node copy depth exceeded %d (max %d)",
+			depth, FY_NODE_PATH_WALK_DEPTH_DEFAULT);
+
+	fyd_from = fyn_from->fyd;
+
+	fyn = fy_node_alloc(fyd, fyn_from->type);
+	fyd_error_check(fyd, fyn, err_out,
+			"fy_node_alloc() failed");
+
+	fyn->tag = fy_token_ref(fyn_from->tag);
+	fyn->style = fyn_from->style;
+	fyn->parent = fyn_parent;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fyn->scalar = fy_token_ref(fyn_from->scalar);
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn_from->sequence); fyni;
+				fyni = fy_node_next(&fyn_from->sequence, fyni)) {
+
+			fynit = fy_node_copy_internal(fyd, fyni, fyn, depth + 1);
+			fyd_error_check(fyd, fynit, err_out,
+					"fy_node_copy_internal() failed");
+
+			fy_node_list_add_tail(&fyn->sequence, fynit);
+			fynit->attached = true;
+			fynit = NULL;
+		}
+
+		break;
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn_from->mapping); fynp;
+				fynp = fy_node_pair_next(&fyn_from->mapping, fynp)) {
+
+			fynpt = fy_node_pair_alloc(fyd);
+			fyd_error_check(fyd, fynpt, err_out,
+					"fy_node_pair_alloc() failed");
+
+			if (fynp->key) {
+				fynpt->key = fy_node_copy_internal(fyd, fynp->key, fyn, depth + 1);
+				fyd_error_check(fyd, fynpt->key, err_out,
+						"fy_node_copy_internal() key failed");
+			}
+			if (fynp->value) {
+				fynpt->value = fy_node_copy_internal(fyd, fynp->value, fyn, depth + 1);
+				fyd_error_check(fyd, fynpt->value, err_out,
+						"fy_node_copy_internal() key failed");
+			}
+			fynpt->parent = fyn;
+
+			if (fynpt->key) {
+				fynpt->key->attached = true;
+				fynpt->key->key_root = true;
+			}
+			if (fynpt->value)
+				fynpt->value->attached = true;
+
+			fy_node_pair_list_add_tail(&fyn->mapping, fynpt);
+			if (fyn->xl) {
+				rc = fy_accel_insert(fyn->xl, fynpt->key, fynpt);
+				fynpt = NULL;
+				fyd_error_check(fyd, !rc, err_out,
+						"fy_accel_insert() failed");
+			}
+			fynpt = NULL;
+		}
+		break;
+	}
+
+	/* drop an anchor to the copy */
+	for (fya_from = fy_anchor_list_head(&fyd_from->anchors); fya_from;
+			fya_from = fy_anchor_next(&fyd_from->anchors, fya_from)) {
+		if (fyn_from == fya_from->fyn)
+			break;
+	}
+
+	/* source node has an anchor */
+	if (fya_from) {
+		fya = fy_document_lookup_anchor_by_token(fyd, fya_from->anchor);
+		if (!fya) {
+			fyd_doc_debug(fyd, "new anchor");
+			/* update the new anchor position */
+			rc = fy_document_register_anchor(fyd, fyn, fya_from->anchor);
+			fyd_error_check(fyd, !rc, err_out,
+					"fy_document_register_anchor() failed");
+
+			fy_token_ref(fya_from->anchor);
+		} else {
+			anchor = fy_anchor_get_text(fya, &anchor_len);
+			fyd_error_check(fyd, anchor, err_out,
+					"fy_anchor_get_text() failed");
+			fyd_doc_debug(fyd, "not overwritting anchor %.*s", (int)anchor_len, anchor);
+		}
+	}
+
+	return fyn;
+
+err_out:
+	fy_node_free(fynit);
+	fy_node_pair_free(fynpt);
+	fy_node_free(fyn);
+	return NULL;
+}
+
+struct fy_node *fy_node_copy(struct fy_document *fyd, struct fy_node *fyn_from)
+{
+	struct fy_node *fyn;
+
+	if (!fyd)
+		return NULL;
+
+	fyn = fy_node_copy_internal(fyd, fyn_from, NULL, 0);
+	if (!fyn) {
+		fyd->diag->on_error = false;
+		return NULL;
+	}
+
+	return fyn;
+}
+
+struct fy_document *fy_document_clone(struct fy_document *fydsrc)
+{
+	struct fy_document *fyd = NULL;
+
+	if (!fydsrc)
+		return NULL;
+
+	fyd = fy_document_create(&fydsrc->parse_cfg);
+	if (!fyd)
+		return NULL;
+
+	/* drop the default document state */
+	fy_document_state_unref(fyd->fyds);
+	/* and use the source document state (and ref it) */
+	fyd->fyds = fy_document_state_ref(fydsrc->fyds);
+	assert(fyd->fyds);
+
+	if (fydsrc->root) {
+		fyd->root = fy_node_copy(fyd, fydsrc->root);
+		if (!fyd->root)
+			goto err_out;
+	}
+
+	return fyd;
+err_out:
+	fy_document_destroy(fyd);
+	return NULL;
+}
+
+int fy_node_copy_to_scalar(struct fy_document *fyd, struct fy_node *fyn_to, struct fy_node *fyn_from)
+{
+	struct fy_node *fyn, *fyni;
+	struct fy_node_pair *fynp;
+	struct fy_accel_entry_iter xli;
+	struct fy_accel_entry *xle, *xlen;
+	struct fy_anchor_list *fyal;
+	struct fy_anchor *fya;
+
+	fyn = fy_node_copy(fyd, fyn_from);
+	if (!fyn)
+		return -1;
+
+	/* the node is guaranteed to be a scalar */
+	fy_token_unref(fyn_to->tag);
+	fyn_to->tag = NULL;
+	fy_token_unref(fyn_to->scalar);
+	fyn_to->scalar = NULL;
+
+	fyn_to->type = fyn->type;
+	fyn_to->tag = fy_token_ref(fyn->tag);
+	fyn_to->style = fyn->style;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fyn_to->scalar = fyn->scalar;
+		fyn->scalar = NULL;
+		break;
+	case FYNT_SEQUENCE:
+		fy_node_list_init(&fyn_to->sequence);
+		fyn_to->sequence_start = fyn->sequence_start;
+		fyn->sequence_start = NULL;
+		fyn_to->sequence_end = fyn->sequence_end;
+		fyn->sequence_end = NULL;
+		while ((fyni = fy_node_list_pop(&fyn->sequence)) != NULL) {
+			fyni->parent = fyn_to;
+			fy_node_list_add_tail(&fyn_to->sequence, fyni);
+		}
+		break;
+	case FYNT_MAPPING:
+		fy_node_pair_list_init(&fyn_to->mapping);
+		/* fy_node_copy_to_scalar() is only used to replace alias scalars. */
+		assert(!fyn_to->xl);
+		fyn_to->mapping_start = fyn->mapping_start;
+		fyn->mapping_start = NULL;
+		fyn_to->mapping_end = fyn->mapping_end;
+		fyn->mapping_end = NULL;
+		fyn_to->xl = fyn->xl;
+		fyn->xl = NULL;
+		while ((fynp = fy_node_pair_list_pop(&fyn->mapping)) != NULL) {
+			fynp->parent = fyn_to;
+			if (fynp->key)
+				fynp->key->parent = fyn_to;
+			if (fynp->value)
+				fynp->value->parent = fyn_to;
+			fy_node_pair_list_add_tail(&fyn_to->mapping, fynp);
+		}
+		break;
+	}
+
+	/* update any anchors pointing to the temporary copy (fyn) to now
+	 * point to fyn_to, since we've moved all of fyn's data into fyn_to */
+	if (fy_document_is_accelerated(fyd)) {
+		for (xle = fy_accel_entry_iter_start(&xli, fyd->naxl, fyn);
+		     xle; xle = xlen) {
+			xlen = fy_accel_entry_iter_next(&xli);
+
+			fya = (void *)xle->value;
+			fy_accel_entry_remove(fyd->naxl, xle);
+			fya->fyn = fyn_to;
+			fy_accel_insert(fyd->naxl, fyn_to, fya);
+		}
+		fy_accel_entry_iter_finish(&xli);
+	} else {
+		fyal = &fyd->anchors;
+		for (fya = fy_anchor_list_head(fyal); fya;
+		     fya = fy_anchor_next(fyal, fya)) {
+			if (fya->fyn == fyn)
+				fya->fyn = fyn_to;
+		}
+	}
+
+	/* and free */
+	fy_node_free(fyn);
+
+	return 0;
+}
+
+static int fy_document_node_update_tags(struct fy_document *fyd, struct fy_node *fyn)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi;
+	struct fy_token *fyt_td;
+	const char *handle;
+	size_t handle_size;
+	int rc;
+
+	if (!fyd || !fyn)
+		return 0;
+
+	/* replace tag reference with the one that the document contains */
+	if (fyn->tag) {
+		fyd_error_check(fyd, fyn->tag->type == FYTT_TAG, err_out,
+				"bad node tag");
+
+		handle = fy_tag_directive_token_handle(fyn->tag->tag.fyt_td, &handle_size);
+		fyd_error_check(fyd, handle, err_out,
+				"bad tag directive token");
+
+		fyt_td = fy_document_state_lookup_tag_directive(fyd->fyds, handle, handle_size);
+		fyd_error_check(fyd, fyt_td, err_out,
+				"Missing tag directive with handle=%.*s", (int)handle_size, handle);
+
+		/* need to replace this */
+		if (fyt_td != fyn->tag->tag.fyt_td) {
+			fy_token_unref(fyn->tag->tag.fyt_td);
+			fyn->tag->tag.fyt_td = fy_token_ref(fyt_td);
+
+		}
+	}
+
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			rc = fy_document_node_update_tags(fyd, fyni);
+			if (rc)
+				goto err_out_rc;
+		}
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			/* the parent of the key is always NULL */
+			rc = fy_document_node_update_tags(fyd, fynp->key);
+			if (rc)
+				goto err_out_rc;
+
+			rc = fy_document_node_update_tags(fyd, fynp->value);
+			if (rc)
+				goto err_out_rc;
+		}
+		break;
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_node_insert(struct fy_node *fyn_to, struct fy_node *fyn_from)
+{
+	struct fy_document *fyd;
+	struct fy_node *fyn_parent, *fyn_cpy, *fyni, *fyn_prev;
+	struct fy_node_pair *fynp, *fynpi, *fynpj;
+	int rc;
+
+	if (!fyn_to || !fyn_to->fyd)
+		return -1;
+
+	fyd = fyn_to->fyd;
+	assert(fyd);
+
+	fyn_parent = fy_node_get_document_parent(fyn_to);
+	fynp = NULL;
+	if (fyn_parent) {
+		fyd_error_check(fyd, fyn_parent->type != FYNT_SCALAR, err_out,
+				    "Illegal scalar parent node type");
+
+		if (fyn_parent->type == FYNT_MAPPING) {
+			/* find mapping pair that contains the `to` node */
+			for (fynp = fy_node_pair_list_head(&fyn_parent->mapping); fynp;
+					fynp = fy_node_pair_next(&fyn_parent->mapping, fynp)) {
+				if (fynp->value == fyn_to)
+					break;
+			}
+		}
+	}
+
+	/* deleting target */
+	if (!fyn_from) {
+		fyn_to->parent = NULL;
+
+		if (!fyn_parent) {
+			fyd_doc_debug(fyd, "Deleting %s node", fyd->root == fyn_to ? "root" : "unattached");
+			fy_node_detach_and_free(fyn_to);
+
+			/* if destination was the root, remove it */
+			if (fyn_to == fyd->root)
+				fyd->root = NULL;
+		} else if (fyn_parent->type == FYNT_SEQUENCE) {
+			fyd_doc_debug(fyd, "Deleting sequence node");
+			fy_node_list_del(&fyn_parent->sequence, fyn_to);
+			fy_node_detach_and_free(fyn_to);
+		} else {
+			fyd_doc_debug(fyd, "Deleting mapping node");
+			/* should never happen, it's checked right above, but play safe */
+			assert(fyn_parent->type == FYNT_MAPPING);
+
+			fyd_error_check(fyd, fynp, err_out,
+					"Illegal mapping node found");
+
+			fy_node_pair_list_del(&fyn_parent->mapping, fynp);
+			if (fyn_parent->xl)
+				fy_accel_remove(fyn_parent->xl, fynp->key);
+			/* this will also delete fyn_to */
+			fy_node_pair_detach_and_free(fynp);
+		}
+		return 0;
+	}
+
+	/*
+	 * from: scalar
+	 *
+	 * to: another-scalar -> scalar
+	 * to: { key: value } -> scalar
+	 * to: [ seq0, seq1 ] -> scalar
+	 *
+	 * from: [ seq2 ]
+	 * to: scalar -> [ seq2 ]
+	 * to: { key: value } -> [ seq2 ]
+	 * to: [ seq0, seq1 ] -> [ seq0, seq1, sec2 ]
+	 *
+	 * from: { another-key: another-value }
+	 * to: scalar -> { another-key: another-value }
+	 * to: { key: value } -> { key: value, another-key: another-value }
+	 * to: [ seq0, seq1 ] -> { another-key: another-value }
+	 *
+	 * from: { key: another-value }
+	 * to: scalar -> { key: another-value }
+	 * to: { key: value } -> { key: another-value }
+	 * to: [ seq0, seq1 ] -> { key: another-value }
+	 *
+	 */
+
+	/* if types of `from` and `to` differ (or it's a scalar), it's a replace */
+	if (fyn_from->type != fyn_to->type || fyn_from->type == FYNT_SCALAR) {
+
+		fyn_cpy = fy_node_copy(fyd, fyn_from);
+		fyd_error_check(fyd, fyn_cpy, err_out,
+				"fy_node_copy() failed");
+
+		if (!fyn_parent) {
+			fyd_doc_debug(fyd, "Replacing root node");
+			fy_node_detach_and_free(fyd->root);
+			fyd->root = fyn_cpy;
+		} else if (fyn_parent->type == FYNT_SEQUENCE) {
+			fyd_doc_debug(fyd, "Replacing sequence node");
+
+			/* get previous */
+			fyn_prev = fy_node_prev(&fyn_parent->sequence, fyn_to);
+
+			/* delete */
+			fy_node_list_del(&fyn_parent->sequence, fyn_to);
+			fy_node_detach_and_free(fyn_to);
+
+			/* if there's no previous insert to head */
+			if (!fyn_prev)
+				fy_node_list_add(&fyn_parent->sequence, fyn_cpy);
+			else
+				fy_node_list_insert_after(&fyn_parent->sequence, fyn_prev, fyn_cpy);
+		} else {
+			fyd_doc_debug(fyd, "Replacing mapping node value");
+			/* should never happen, it's checked right above, but play safe */
+			assert(fyn_parent->type == FYNT_MAPPING);
+			fyd_error_check(fyd, fynp, err_out,
+					"Illegal mapping node found");
+
+			fy_node_detach_and_free(fynp->value);
+			fynp->value = fyn_cpy;
+		}
+
+		return 0;
+	}
+
+	/* types match, if it's a sequence append */
+	if (fyn_to->type == FYNT_SEQUENCE) {
+
+		fyd_doc_debug(fyd, "Appending to sequence node");
+
+		for (fyni = fy_node_list_head(&fyn_from->sequence); fyni;
+				fyni = fy_node_next(&fyn_from->sequence, fyni)) {
+
+			fyn_cpy = fy_node_copy(fyd, fyni);
+			fyd_error_check(fyd, fyn_cpy, err_out,
+					"fy_node_copy() failed");
+
+			fy_node_list_add_tail(&fyn_to->sequence, fyn_cpy);
+			fyn_cpy->attached = true;
+		}
+	} else {
+		/* only mapping is possible here */
+
+		/* iterate over all the keys in the `from` */
+		for (fynpi = fy_node_pair_list_head(&fyn_from->mapping); fynpi;
+			fynpi = fy_node_pair_next(&fyn_from->mapping, fynpi)) {
+
+			if (fyn_to->xl) {
+				fynpj = fy_node_accel_lookup_by_node(fyn_to, fynpi->key);
+			} else {
+				/* find whether the key already exists */
+				for (fynpj = fy_node_pair_list_head(&fyn_to->mapping); fynpj;
+					fynpj = fy_node_pair_next(&fyn_to->mapping, fynpj)) {
+
+					if (fy_node_compare(fynpi->key, fynpj->key))
+						break;
+				}
+			}
+
+			if (!fynpj) {
+				fyd_doc_debug(fyd, "Appending to mapping node");
+
+				/* not found? append it */
+				fynpj = fy_node_pair_alloc(fyd);
+				fyd_error_check(fyd, fynpj, err_out,
+						"fy_node_pair_alloc() failed");
+
+				fynpj->key = fy_node_copy(fyd, fynpi->key);
+				fyd_error_check(fyd, !fynpi->key || fynpj->key, err_out,
+						"fy_node_copy() failed");
+				fynpj->value = fy_node_copy(fyd, fynpi->value);
+				fyd_error_check(fyd, !fynpi->value || fynpj->value, err_out,
+						"fy_node_copy() failed");
+
+				fy_node_pair_list_add_tail(&fyn_to->mapping, fynpj);
+				if (fyn_to->xl)
+					fy_accel_insert(fyn_to->xl, fynpj->key, fynpj);
+
+				if (fynpj->key)
+					fynpj->key->attached = true;
+				if (fynpj->value)
+					fynpj->value->attached = true;
+
+			} else {
+				fyd_doc_debug(fyd, "Updating mapping node value (deep merge)");
+
+				rc = fy_node_insert(fynpj->value, fynpi->value);
+				fyd_error_check(fyd, !rc, err_out_rc,
+						"fy_node_insert() failed");
+			}
+		}
+	}
+
+	/* adjust parents */
+	switch (fyn_to->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn_to->sequence); fyni;
+				fyni = fy_node_next(&fyn_to->sequence, fyni)) {
+
+			fyni->parent = fyn_to;
+		}
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn_to->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn_to->mapping, fynp);
+
+			if (fynp->key) {
+				fynp->key->parent = fyn_to;
+				fynp->key->key_root = true;
+			}
+			if (fynp->value)
+				fynp->value->parent = fyn_to;
+			fynp->parent = fyn_to;
+		}
+		break;
+	}
+
+	/* if the documents differ, merge their states */
+	if (fyn_to->fyd != fyn_from->fyd) {
+		rc = fy_document_state_merge(fyn_to->fyd->fyds, fyn_from->fyd->fyds);
+		fyd_error_check(fyd, !rc, err_out_rc,
+				"fy_document_state_merge() failed");
+
+		rc = fy_document_node_update_tags(fyd, fy_document_root(fyd));
+		fyd_error_check(fyd, !rc, err_out_rc,
+				"fy_document_node_update_tags() failed");
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_node_delete(struct fy_node *fyn)
+{
+	if (!fyn)
+		return 0;
+	return fy_node_insert(fyn, NULL);
+}
+
+int fy_document_insert_at(struct fy_document *fyd,
+			  const char *path, size_t pathlen,
+			  struct fy_node *fyn)
+{
+	int rc;
+	struct fy_node *fyn2;
+
+	fyn2 = fy_node_by_path(fy_document_root(fyd), path, pathlen, FYNWF_DONT_FOLLOW);
+	rc = fy_node_insert(fyn2, fyn);
+
+	fy_node_free(fyn);
+
+	return rc;
+}
+
+struct fy_token *fy_document_tag_directive_iterate(struct fy_document *fyd, void **prevp)
+{
+	struct fy_token_list *fytl;
+
+	if (!fyd || !fyd->fyds || !prevp)
+		return NULL;
+
+	fytl = &fyd->fyds->fyt_td;
+
+	return *prevp = *prevp ? fy_token_next(fytl, *prevp) : fy_token_list_head(fytl);
+}
+
+struct fy_token *fy_document_tag_directive_lookup(struct fy_document *fyd, const char *handle)
+{
+	struct fy_token *fyt;
+	void *iter;
+	const char *h;
+	size_t h_size, len;
+
+	if (!fyd || !handle)
+		return NULL;
+	len = strlen(handle);
+
+	iter = NULL;
+	while ((fyt = fy_document_tag_directive_iterate(fyd, &iter)) != NULL) {
+		h = fy_tag_directive_token_handle(fyt, &h_size);
+		if (!h)
+			continue;
+		if (h_size == len && !memcmp(h, handle, len))
+			return fyt;
+	}
+	return NULL;
+}
+
+int fy_document_tag_directive_add(struct fy_document *fyd, const char *handle, const char *prefix)
+{
+	struct fy_token *fyt;
+
+	if (!fyd || !fyd->fyds || !handle || !prefix)
+		return -1;
+
+	/* it must not exist */
+	fyt = fy_document_tag_directive_lookup(fyd, handle);
+	if (fyt)
+		return -1;
+
+	return fy_document_state_append_tag(fyd->fyds, handle, prefix, false);
+}
+
+int fy_document_tag_directive_remove(struct fy_document *fyd, const char *handle)
+{
+	struct fy_token *fyt;
+
+	if (!fyd || !fyd->fyds || !handle)
+		return -1;
+
+	/* it must not exist */
+	fyt = fy_document_tag_directive_lookup(fyd, handle);
+	if (!fyt || fyt->refs != 1)
+		return -1;
+
+	fy_token_list_del(&fyd->fyds->fyt_td, fyt);
+	fy_token_unref(fyt);
+
+	return 0;
+}
+
+static int fy_resolve_alias(struct fy_document *fyd, struct fy_node *fyn)
+{
+	struct fy_node *fyn_copy = NULL;
+	int rc;
+
+	fyn_copy = fy_node_resolve_alias(fyn);
+	FYD_NODE_ERROR_CHECK(fyd, fyn, FYEM_DOC,
+			fyn_copy, err_out,
+			"invalid alias");
+
+	rc = fy_node_copy_to_scalar(fyd, fyn, fyn_copy);
+	fyd_error_check(fyd, !rc, err_out,
+			"fy_node_copy_to_scalar() failed");
+
+	return 0;
+
+err_out:
+	fyd->diag->on_error = false;
+	return -1;
+}
+
+static struct fy_node *
+fy_node_follow_alias(struct fy_node *fyn, enum fy_node_walk_flags flags)
+{
+	enum fy_node_walk_flags ptr_flags;
+	struct fy_anchor *fya;
+	const char *anchor_text, *s, *e, *p, *path;
+	size_t anchor_len, path_len;
+	struct fy_node *fyn_path_root;
+	unsigned int marker;
+
+	if (!fyn || !fy_node_is_alias(fyn))
+		return NULL;
+
+	ptr_flags = flags & FYNWF_PTR(FYNWF_PTR_MASK);
+	if (ptr_flags == FYNWF_PTR_YPATH)
+		return fy_node_alias_resolve_by_ypath(fyn);
+
+	/* try regular label target */
+	fya = fy_document_lookup_anchor_by_token(fyn->fyd, fyn->scalar);
+	if (fya)
+		return fya->fyn;
+
+	anchor_text = fy_token_get_text(fyn->scalar, &anchor_len);
+	if (!anchor_text)
+		return NULL;
+
+	s = anchor_text;
+	e = s + anchor_len;
+
+	fyn_path_root = NULL;
+
+	if (ptr_flags == FYNWF_PTR_YAML && (p = memchr(s, '/', e - s)) != NULL) {
+		/* fyd_notice(fyn->fyd, "%s: alias contains a path component %.*s",
+				__func__, (int)(e - p - 1), p + 1); */
+
+		if (p > s) {
+
+			fya = fy_document_lookup_anchor(fyn->fyd, s, p - s);
+			if (!fya) {
+				/* fyd_notice(fyn->fyd, "%s: unable to resolve alias %.*s @%s",
+						__func__, (int)(p - s), s, fy_node_get_path(fya->fyn)); */
+				return NULL;
+			}
+
+			/* fyd_notice(fyn->fyd, "%s: alias base %.*s @%s",
+					__func__, (int)(p - s), s, fy_node_get_path(fya->fyn)); */
+			path = ++p;
+			path_len = e - p;
+
+			fyn_path_root = fya->fyn;
+
+		} else {
+			/* fyd_notice(fyn->fyd, "%s: absolute %.*s @%s",
+					__func__, (int)(p - s), s, fy_node_get_path(fya->fyn)); */
+			path = s;
+			path_len = e - s;
+
+			fyn_path_root = fyn->fyd->root;
+		}
+	}
+
+	if (!fyn_path_root)
+		return NULL;
+
+	marker = fy_node_walk_marker_from_flags(flags);
+	if (marker >= FYNWF_MAX_USER_MARKER)
+		return NULL;
+
+	/* use the next marker */
+	flags &= ~FYNWF_MARKER(FYNWF_MARKER_MASK);
+	flags |= FYNWF_MARKER(marker + 1);
+
+	return fy_node_by_path_internal(fyn_path_root, path, path_len, flags);
+}
+
+static bool fy_node_pair_is_merge_key(struct fy_node_pair *fynp)
+{
+	struct fy_node *fyn = fynp->key;
+
+	return fyn && fyn->type == FYNT_SCALAR && fyn->style == FYNS_PLAIN &&
+	       fy_plain_atom_streq(fy_token_atom(fyn->scalar), "<<");
+}
+
+static struct fy_node *fy_alias_get_merge_mapping(struct fy_document *fyd, struct fy_node *fyn)
+{
+	struct fy_anchor *fya;
+
+	/* must be an alias */
+	if (!fy_node_is_alias(fyn))
+		return NULL;
+
+	/* anchor must exist */
+	fya = fy_document_lookup_anchor_by_token(fyd, fyn->scalar);
+	if (!fya)
+		return NULL;
+
+	/* and it must be a mapping */
+	if (fya->fyn->type != FYNT_MAPPING)
+		return NULL;
+
+	return fya->fyn;
+}
+
+static bool fy_node_pair_is_valid_merge_key(struct fy_document *fyd, struct fy_node_pair *fynp)
+{
+	struct fy_node *fyn, *fyni, *fynm;
+
+	fyn = fynp->value;
+
+	/* value must exist */
+	if (!fyn)
+		return false;
+
+	/* scalar alias */
+	fynm = fy_alias_get_merge_mapping(fyd, fyn);
+	if (fynm)
+		return true;
+
+	/* it must be a sequence then */
+	if (fyn->type != FYNT_SEQUENCE)
+		return false;
+
+	/* the sequence must only contain valid aliases for mapping */
+	for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+			fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+		/* sequence of aliases only! */
+		fynm = fy_alias_get_merge_mapping(fyd, fyni);
+		if (!fynm)
+			return false;
+
+	}
+
+	return true;
+}
+
+static int fy_resolve_merge_key_populate(struct fy_document *fyd, struct fy_node *fyn,
+					  struct fy_node_pair *fynp, struct fy_node *fynm)
+{
+	struct fy_node_pair *fynpi, *fynpn;
+
+	if (!fyd)
+		return -1;
+
+	fyd_error_check(fyd,
+			fyn && fynp && fynm && fyn->type == FYNT_MAPPING && fynm->type == FYNT_MAPPING,
+			err_out, "bad inputs to %s", __func__);
+
+	for (fynpi = fy_node_pair_list_head(&fynm->mapping); fynpi;
+		fynpi = fy_node_pair_next(&fynm->mapping, fynpi)) {
+
+		/* if we don't allow duplicate keys */
+		if (!(fyd->parse_cfg.flags & FYPCF_ALLOW_DUPLICATE_KEYS)) {
+
+			/* make sure we don't override an already existing key */
+			if (fy_node_mapping_key_is_duplicate(fyn, fynpi->key))
+				continue;
+		}
+
+		fynpn = fy_node_pair_alloc(fyd);
+		fyd_error_check(fyd, fynpn, err_out,
+				"fy_node_pair_alloc() failed");
+
+		fynpn->key = fy_node_copy(fyd, fynpi->key);
+		fynpn->value = fy_node_copy(fyd, fynpi->value);
+
+		fy_node_pair_list_insert_after(&fyn->mapping, fynp, fynpn);
+		if (fyn->xl)
+			fy_accel_insert(fyn->xl, fynpn->key, fynpn);
+	}
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+static int fy_resolve_merge_key(struct fy_document *fyd, struct fy_node *fyn, struct fy_node_pair *fynp)
+{
+	struct fy_node *fynv, *fyni, *fynm;
+	int rc;
+
+	/* it must be a valid merge key value */
+	FYD_NODE_ERROR_CHECK(fyd, fynp->value, FYEM_DOC,
+			fy_node_pair_is_valid_merge_key(fyd, fynp), err_out,
+			"invalid merge key value");
+
+	fynv = fynp->value;
+	fynm = fy_alias_get_merge_mapping(fyd, fynv);
+	if (fynm) {
+		rc = fy_resolve_merge_key_populate(fyd, fyn, fynp, fynm);
+		fyd_error_check(fyd, !rc, err_out_rc,
+				"fy_resolve_merge_key_populate() failed");
+
+		return 0;
+	}
+
+	/* it must be a sequence then */
+	fyd_error_check(fyd, fynv->type == FYNT_SEQUENCE, err_out,
+			"invalid node type to use for merge key");
+
+	/* the sequence must only contain valid aliases for mapping */
+	for (fyni = fy_node_list_head(&fynv->sequence); fyni;
+			fyni = fy_node_next(&fynv->sequence, fyni)) {
+
+		fynm = fy_alias_get_merge_mapping(fyd, fyni);
+		fyd_error_check(fyd, fynm, err_out,
+				"invalid merge key sequence item (not an alias)");
+
+		rc = fy_resolve_merge_key_populate(fyd, fyn, fynp, fynm);
+		fyd_error_check(fyd, !rc, err_out_rc,
+				"fy_resolve_merge_key_populate() failed");
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+/* the anchors are scalars that have the FYNS_ALIAS style */
+static int fy_resolve_anchor_node(struct fy_document *fyd, struct fy_node *fyn)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi, *fynpit;
+	int rc, ret_rc = 0;
+	struct fy_token *fyt;
+
+	if (!fyn)
+		return 0;
+
+	if (fy_node_is_alias(fyn))
+		return fy_resolve_alias(fyd, fyn);
+
+	if (fyn->type == FYNT_SEQUENCE) {
+
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			rc = fy_resolve_anchor_node(fyd, fyni);
+			if (rc && !ret_rc)
+				ret_rc = rc;
+		}
+
+	} else if (fyn->type == FYNT_MAPPING) {
+
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			if (fy_node_pair_is_merge_key(fynp)) {
+				rc = fy_resolve_merge_key(fyd, fyn, fynp);
+				if (rc && !ret_rc)
+					ret_rc = rc;
+
+				/* remove this node pair */
+				if (!rc) {
+					fy_node_pair_list_del(&fyn->mapping, fynp);
+					if (fyn->xl)
+						fy_accel_remove(fyn->xl, fynp->key);
+					fy_node_pair_detach_and_free(fynp);
+				}
+
+			} else {
+
+				rc = fy_resolve_anchor_node(fyd, fynp->key);
+
+				if (!rc) {
+
+					/* check whether the keys are duplicate */
+					for (fynpit = fy_node_pair_list_head(&fyn->mapping); fynpit;
+						fynpit = fy_node_pair_next(&fyn->mapping, fynpit)) {
+
+						/* skip this node pair */
+						if (fynpit == fynp)
+							continue;
+
+						if (!fy_node_compare(fynpit->key, fynp->key))
+							continue;
+
+						/* whoops, duplicate key after resolution */
+						fyt = NULL;
+						switch (fyn->type) {
+						case FYNT_SCALAR:
+							fyt = fyn->scalar;
+							break;
+						case FYNT_SEQUENCE:
+							fyt = fyn->sequence_start;
+							break;
+						case FYNT_MAPPING:
+							fyt = fyn->mapping_start;
+							break;
+						}
+
+						FYD_TOKEN_ERROR_CHECK(fyd, fyt, FYEM_DOC,
+								false, err_out,
+								"duplicate key after resolving");
+
+					}
+
+				}
+
+				if (rc && !ret_rc)
+					ret_rc = rc;
+
+				rc = fy_resolve_anchor_node(fyd, fynp->value);
+				if (rc && !ret_rc)
+					ret_rc = rc;
+
+			}
+		}
+	}
+
+	return ret_rc;
+
+err_out:
+	return -1;
+}
+
+static void fy_resolve_parent_node(struct fy_document *fyd, struct fy_node *fyn, struct fy_node *fyn_parent)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi;
+
+	if (!fyn)
+		return;
+
+	fyn->parent = fyn_parent;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			fy_resolve_parent_node(fyd, fyni, fyn);
+		}
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			fy_resolve_parent_node(fyd, fynp->key, fyn);
+			fy_resolve_parent_node(fyd, fynp->value, fyn);
+			fynp->parent = fyn;
+		}
+		break;
+	}
+}
+
+void fy_document_purge_anchors(struct fy_document *fyd)
+{
+	struct fy_anchor *fya;
+	struct fy_anchor *fyan;
+	struct fy_accel_entry *xle;
+
+	/* remove all anchors */
+	for (fya = fy_anchor_list_head(&fyd->anchors); fya; fya = fyan) {
+		fyan = fy_anchor_next(&fyd->anchors, fya);
+		fy_anchor_list_del(&fyd->anchors, fya);
+
+			if (fy_document_is_accelerated(fyd)) {
+				xle = fy_accel_entry_lookup_value(fyd->axl, fya);
+				fy_accel_entry_remove(fyd->axl, xle);
+
+				xle = fy_accel_entry_lookup_value(fyd->naxl, fya);
+				fy_accel_entry_remove(fyd->naxl, xle);
+			}
+
+		fy_anchor_destroy(fya);
+	}
+
+	if (fy_document_is_accelerated(fyd)) {
+		fy_accel_cleanup(fyd->axl);
+		free(fyd->axl);
+		fyd->axl = NULL;
+
+		fy_accel_cleanup(fyd->naxl);
+		free(fyd->naxl);
+		fyd->naxl = NULL;
+	}
+}
+
+typedef void (*fy_node_applyf)(struct fy_node *fyn, void *user);
+
+void fy_node_apply(struct fy_node *fyn, fy_node_applyf func, void *user)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp;
+
+	if (!fyn || !func)
+		return;
+
+	(*func)(fyn, user);
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni))
+			fy_node_apply(fyni, func, user);
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp;
+				fynp = fy_node_pair_next(&fyn->mapping, fynp)) {
+
+			fy_node_apply(fynp->key, func, user);
+			fy_node_apply(fynp->value, func, user);
+		}
+		break;
+	}
+}
+
+static void clear_system_marks(struct fy_node *fyn, void *user)
+{
+	fyn->marks &= ~FYNWF_SYSTEM_MARKS;
+}
+
+/* clear all the system markers */
+void fy_node_clear_system_marks(struct fy_node *fyn)
+{
+	fy_node_apply(fyn, clear_system_marks, NULL);
+}
+
+static void count_aliases(struct fy_node *fyn, void *user)
+{
+	int *countp = user;
+
+	if (fyn->style == FYNS_ALIAS)
+		(*countp)++;
+}
+
+int fy_node_count_aliases(struct fy_node *fyn)
+{
+	int count;
+
+	count = 0;
+
+	fy_node_apply(fyn, count_aliases, &count);
+
+	return count;
+}
+
+int fy_document_resolve(struct fy_document *fyd)
+{
+	int rc, num_aliases, num_aliases_prev;
+	bool ret;
+
+	if (!fyd)
+		return 0;
+
+	num_aliases_prev = INT_MAX;
+	do {
+		fy_node_clear_system_marks(fyd->root);
+
+		/* for resolution to work, no reference loops should exist */
+		ret = fy_check_ref_loop(fyd, fyd->root,
+				FYNWF_MAXDEPTH_DEFAULT | FYNWF_FOLLOW, NULL, 0);
+
+		fy_node_clear_system_marks(fyd->root);
+
+		if (ret)
+			goto err_out;
+
+		/* now resolve any anchor nodes */
+		rc = fy_resolve_anchor_node(fyd, fyd->root);
+		if (rc)
+			goto err_out_rc;
+
+		/* redo parent resolution */
+		fy_resolve_parent_node(fyd, fyd->root, NULL);
+
+		/* count the remaining aliases */
+		num_aliases = fy_node_count_aliases(fyd->root);
+		if (num_aliases == num_aliases_prev)
+			goto err_out;
+
+	} while (num_aliases > 0);
+
+	/* remove all anchors after resolution */
+	fy_document_purge_anchors(fyd);
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	fyd->diag->on_error = false;
+	return rc;
+}
+
+void fy_document_free_nodes(struct fy_document *fyd)
+{
+	struct fy_document *fyd_child;
+
+	for (fyd_child = fy_document_list_first(&fyd->children); fyd_child;
+	     fyd_child = fy_document_next(&fyd->children, fyd_child))
+		fy_document_free_nodes(fyd_child);
+
+	fy_node_detach_and_free(fyd->root);
+	fyd->root = NULL;
+}
+
+void fy_document_destroy(struct fy_document *fyd)
+{
+	struct fy_document *fyd_child;
+
+	/* both the document and the parser object must exist */
+	if (!fyd)
+		return;
+
+	/* we have to free the nodes first */
+	fy_document_free_nodes(fyd);
+
+	/* recursively delete children */
+	while ((fyd_child = fy_document_list_pop(&fyd->children)) != NULL) {
+		fyd_child->parent = NULL;
+		fy_document_destroy(fyd_child);
+	}
+
+	fy_parse_document_destroy(NULL, fyd);
+}
+
+int fy_document_set_parent(struct fy_document *fyd, struct fy_document *fyd_child)
+{
+
+	if (!fyd || !fyd_child || fyd_child->parent)
+		return -1;
+
+	fyd_child->parent = fyd;
+	fy_document_list_add_tail(&fyd->children, fyd_child);
+
+	return 0;
+}
+
+static const struct fy_parse_cfg doc_parse_default_cfg = {
+	.flags = FYPCF_DEFAULT_DOC,
+};
+
+struct fy_document *fy_document_create(const struct fy_parse_cfg *cfg)
+{
+	struct fy_document *fyd = NULL;
+	struct fy_diag *diag;
+	int rc;
+
+	if (!cfg)
+		cfg = &doc_parse_default_cfg;
+
+	fyd = malloc(sizeof(*fyd));
+	if (!fyd)
+		goto err_out;
+
+	memset(fyd, 0, sizeof(*fyd));
+	fyd->parse_cfg = *cfg;
+
+	diag = cfg->diag;
+	if (!diag) {
+		diag = fy_diag_create(NULL);
+		if (!diag)
+			goto err_out;
+	} else
+		fy_diag_ref(diag);
+
+	fyd->diag = diag;
+
+	fy_anchor_list_init(&fyd->anchors);
+	if (fy_document_is_accelerated(fyd)) {
+		fyd->axl = malloc(sizeof(*fyd->axl));
+		fyd_error_check(fyd, fyd->axl, err_out,
+				"malloc() failed");
+
+		/* start with a very small bucket list */
+		rc = fy_accel_setup(fyd->axl, &hd_anchor, fyd, 8);
+		fyd_error_check(fyd, !rc, err_out,
+				"fy_accel_setup() failed");
+
+		fyd->naxl = malloc(sizeof(*fyd->naxl));
+		fyd_error_check(fyd, fyd->axl, err_out,
+				"malloc() failed");
+
+		/* start with a very small bucket list */
+		rc = fy_accel_setup(fyd->naxl, &hd_nanchor, fyd, 8);
+		fyd_error_check(fyd, !rc, err_out,
+				"fy_accel_setup() failed");
+	}
+	fyd->root = NULL;
+
+	/* we don't do document create version setting,
+	 * perhaps we should in the future
+	 */
+	fyd->fyds = fy_document_state_default(NULL, NULL);
+	fyd_error_check(fyd, fyd->fyds, err_out,
+			"fy_document_state_default() failed");
+
+	/* turn on JSON mode if it's forced */
+	fyd->fyds->json_mode = (cfg->flags &
+			(FYPCF_JSON_MASK << FYPCF_JSON_SHIFT)) == FYPCF_JSON_FORCE;
+
+	fy_document_list_init(&fyd->children);
+
+	return fyd;
+
+err_out:
+	fy_parse_document_destroy(NULL, fyd);
+	return NULL;
+}
+
+struct fy_document_build_string_ctx {
+	const char *str;
+	size_t len;
+};
+
+static int parser_setup_from_string(struct fy_parser *fyp, void *user)
+{
+	struct fy_document_build_string_ctx *ctx = user;
+
+	return fy_parser_set_string(fyp, ctx->str, ctx->len);
+}
+
+struct fy_document_build_malloc_string_ctx {
+	char *str;
+	size_t len;
+};
+
+static int parser_setup_from_malloc_string(struct fy_parser *fyp, void *user)
+{
+	struct fy_document_build_malloc_string_ctx *ctx = user;
+
+	return fy_parser_set_malloc_string(fyp, ctx->str, ctx->len);
+}
+
+struct fy_document_build_file_ctx {
+	const char *file;
+};
+
+static int parser_setup_from_file(struct fy_parser *fyp, void *user)
+{
+	struct fy_document_build_file_ctx *ctx = user;
+
+	return fy_parser_set_input_file(fyp, ctx->file);
+}
+
+struct fy_document_build_fp_ctx {
+	const char *name;
+	FILE *fp;
+};
+
+static int parser_setup_from_fp(struct fy_parser *fyp, void *user)
+{
+	struct fy_document_build_fp_ctx *ctx = user;
+
+	return fy_parser_set_input_fp(fyp, ctx->name, ctx->fp);
+}
+
+struct fy_document_vbuildf_ctx {
+	const char *fmt;
+	va_list ap;
+};
+
+static int parser_setup_from_fmt_ap(struct fy_parser *fyp, void *user)
+{
+	struct fy_document_vbuildf_ctx *vctx = user;
+	va_list ap, ap_orig;
+	int size, sizew;
+	char *buf;
+
+	/* first try without allocating */
+	va_copy(ap_orig, vctx->ap);
+	size = vsnprintf(NULL, 0, vctx->fmt, ap_orig);
+	va_end(ap_orig);
+
+	fyp_error_check(fyp, size >= 0, err_out,
+			"vsnprintf() failed");
+
+	buf = malloc(size + 1);
+	fyp_error_check(fyp, buf, err_out,
+			"malloc() failed");
+
+	va_copy(ap, vctx->ap);
+	sizew = vsnprintf(buf, size + 1, vctx->fmt, ap);
+	fyp_error_check(fyp, sizew == size, err_out,
+			"vsnprintf() failed");
+	va_end(ap);
+
+	buf[size] = '\0';
+
+	return fy_parser_set_malloc_string(fyp, buf, size);
+
+err_out:
+	return -1;
+}
+
+static struct fy_document *fy_document_build_internal(const struct fy_parse_cfg *cfg,
+		int (*parser_setup)(struct fy_parser *fyp, void *user),
+		void *user)
+{
+	struct fy_parser fyp_data, *fyp = &fyp_data;
+	struct fy_document *fyd = NULL;
+	struct fy_eventp *fyep;
+	bool got_stream_end;
+	int rc;
+
+	if (!parser_setup)
+		return NULL;
+
+	if (!cfg)
+		cfg = &doc_parse_default_cfg;
+
+	rc = fy_parse_setup(fyp, cfg);
+	if (rc)
+		return NULL;
+
+	rc = (*parser_setup)(fyp, user);
+	fyp_error_check(fyp, !rc, err_out,
+			"parser_setup() failed");
+
+	fyd = fy_parse_load_document(fyp);
+
+	/* we're going to handle stream errors from now */
+	if (!fyd)
+		fyp->stream_error = false;
+
+	/* if we collect diagnostics, we can continue */
+	if (!fyd && !(fyp->cfg.flags & FYPCF_COLLECT_DIAG))
+		goto err_out;
+
+	/* no document, but we're collecting diagnostics */
+	if (!fyd) {
+
+		if (fyp->cfg.flags & FYPCF_COLLECT_DIAG)
+			fyp_error(fyp, "fy_parse_load_document() failed");
+
+		fyp->stream_error = false;
+		fyd = fy_parse_document_create(fyp, NULL);
+		fyp_error_check(fyp, fyd, err_out,
+				"fy_parse_document_create() failed");
+		fyd->parse_error = true;
+
+		/* XXX */
+		goto out;
+	}
+
+	got_stream_end = false;
+	while (!got_stream_end && (fyep = fy_parse_private(fyp)) != NULL) {
+		if (fyep->e.type == FYET_STREAM_END)
+			got_stream_end = true;
+		fy_parse_eventp_recycle(fyp, fyep);
+	}
+
+	if (got_stream_end) {
+		fyep = fy_parse_private(fyp);
+		fyp_error_check(fyp, !fyep, err_out,
+				"more events after stream end");
+		fy_parse_eventp_recycle(fyp, fyep);
+	}
+
+out:
+	fy_parse_cleanup(fyp);
+	return fyd;
+
+err_out:
+	fy_document_destroy(fyd);
+	fy_parse_cleanup(fyp);
+	return NULL;
+}
+
+struct fy_document *fy_document_build_from_string(const struct fy_parse_cfg *cfg,
+						  const char *str, size_t len)
+{
+	struct fy_document_build_string_ctx ctx = {
+		.str = str,
+		.len = len,
+	};
+
+	return fy_document_build_internal(cfg, parser_setup_from_string, &ctx);
+}
+
+struct fy_document *fy_document_build_from_malloc_string(const struct fy_parse_cfg *cfg,
+							 char *str, size_t len)
+{
+	struct fy_document_build_malloc_string_ctx ctx = {
+		.str = str,
+		.len = len,
+	};
+
+	return fy_document_build_internal(cfg, parser_setup_from_malloc_string, &ctx);
+}
+
+struct fy_document *fy_document_build_from_file(const struct fy_parse_cfg *cfg,
+						const char *file)
+{
+	struct fy_document_build_file_ctx ctx = {
+		.file = file,
+	};
+
+	return fy_document_build_internal(cfg, parser_setup_from_file, &ctx);
+}
+
+struct fy_document *fy_document_build_from_fp(const struct fy_parse_cfg *cfg,
+					      FILE *fp)
+{
+	struct fy_document_build_fp_ctx ctx = {
+		.name = NULL,
+		.fp = fp,
+	};
+
+	return fy_document_build_internal(cfg, parser_setup_from_fp, &ctx);
+}
+
+enum fy_node_type fy_node_get_type(struct fy_node *fyn)
+{
+	/* a NULL is a plain scalar node */
+	return fyn ? fyn->type : FYNT_SCALAR;
+}
+
+enum fy_node_style fy_node_get_style(struct fy_node *fyn)
+{
+	/* a NULL is a plain scalar node */
+	return fyn ? fyn->style : FYNS_PLAIN;
+}
+
+enum fy_node_style fy_node_set_style(struct fy_node *fyn, enum fy_node_style style)
+{
+	const struct fy_token_analysis *ta;
+
+	/* a NULL node is always plain */
+	if (!fyn)
+		return FYNS_PLAIN;
+
+	/* same style */
+	if (style == fyn->style)
+		return style;
+
+	/* can't change an alias style */
+	if (fyn->style == FYNS_ALIAS)
+		return fyn->style;
+
+	/* any is easy... */
+	if (style == FYNS_ANY) {
+		fyn->style = style;
+		return style;
+	}
+
+	/* for a collection the choices are limited */
+	if (fyn->type == FYNT_MAPPING ||
+	    fyn->type == FYNT_SEQUENCE) {
+
+		/* only flow/block style is allowed */
+		if (style == FYNS_FLOW || style == FYNS_BLOCK)
+			fyn->style = style;
+
+		return fyn->style;
+	}
+
+	/* a scalar, analyze it */
+	ta = fy_token_text_analyze(fyn->scalar);
+	switch (style) {
+	case FYNS_PLAIN:
+		if (ta->flags & FYTTAF_CAN_BE_PLAIN)
+			fyn->style = style;
+		break;
+	case FYNS_SINGLE_QUOTED:
+		if (ta->flags & FYTTAF_CAN_BE_SINGLE_QUOTED)
+			fyn->style = style;
+		break;
+
+	case FYNS_DOUBLE_QUOTED:
+		if (ta->flags & FYTTAF_CAN_BE_DOUBLE_QUOTED)
+			fyn->style = style;
+		break;
+
+	case FYNS_LITERAL:
+		if (ta->flags & FYTTAF_CAN_BE_LITERAL)
+			fyn->style = style;
+		break;
+
+	case FYNS_FOLDED:
+		/* we never support changing style to folded
+		 * it is never emitted and frankly not worth the effort.
+		 */
+		break;
+
+	default:
+		/* anything else, doesn't take */
+		break;
+
+	}
+
+	/* NOTE even if the style has 'taken' the emitter is free to change it
+	 * since the style might not be possible at a given state. For example
+	 * setting a literal style when the emitter is in flow mode obviously
+	 * will not work.
+	 */
+	return fyn->style;
+}
+
+struct fy_token *fy_node_get_start_token(struct fy_node *fyn)
+{
+        if (!fyn)
+                return NULL;
+
+        switch (fyn->type) {
+        case FYNT_MAPPING:
+                return fyn->mapping_start;
+        case FYNT_SEQUENCE:
+                return fyn->sequence_start;
+        case FYNT_SCALAR:
+                return fyn->scalar;
+	default:
+		/* should not happen, but play it safe */
+		break;
+        }
+	return NULL;
+}
+
+struct fy_token *fy_node_get_end_token(struct fy_node *fyn)
+{
+        if (!fyn)
+                return NULL;
+
+        switch (fyn->type) {
+        case FYNT_MAPPING:
+                return fyn->mapping_end;
+        case FYNT_SEQUENCE:
+                return fyn->sequence_end;
+        case FYNT_SCALAR:
+                return fyn->scalar;
+	default:
+		/* should not happen, but play it safe */
+		break;
+        }
+	return NULL;
+}
+
+bool fy_node_is_null(struct fy_node *fyn)
+{
+	if (!fyn)
+		return true;
+
+	if (fyn->type != FYNT_SCALAR)
+		return false;
+
+	return fyn->scalar == NULL || fyn->scalar->scalar.is_null;
+}
+
+bool fy_node_is_attached(struct fy_node *fyn)
+{
+	if (!fyn)
+		return false;
+
+	if (fyn->attached)
+		return true;
+
+	/* finally root is attached (although the property is not set) */
+	return fyn->fyd && fyn->fyd->root == fyn;
+}
+
+struct fy_node *fy_node_get_parent(struct fy_node *fyn)
+{
+	return fyn && !fyn->key_root ? fyn->parent : NULL;
+}
+
+struct fy_node *fy_node_get_document_parent(struct fy_node *fyn)
+{
+	return fyn ? fyn->parent : NULL;
+}
+
+struct fy_token *fy_node_get_tag_token(struct fy_node *fyn)
+{
+	return fyn ? fyn->tag : NULL;
+}
+
+struct fy_token *fy_node_get_scalar_token(struct fy_node *fyn)
+{
+	return fyn && fyn->type == FYNT_SCALAR ? fyn->scalar : NULL;
+}
+
+struct fy_node *fy_node_pair_key(struct fy_node_pair *fynp)
+{
+	return fynp ? fynp->key : NULL;
+}
+
+struct fy_node *fy_node_pair_value(struct fy_node_pair *fynp)
+{
+	return fynp ? fynp->value : NULL;
+}
+
+int fy_node_pair_set_key(struct fy_node_pair *fynp, struct fy_node *fyn)
+{
+	struct fy_node *fyn_map;
+	struct fy_node_pair *fynpi;
+
+	if (!fynp)
+		return -1;
+
+	/* the node must not be attached */
+	if (fyn && fyn->attached)
+		return -1;
+
+	/* sanity check and duplication check */
+	fyn_map = fynp->parent;
+	if (fyn_map) {
+
+		/* (in)sanity check */
+		if (!fy_node_is_mapping(fyn_map))
+			return -1;
+
+		if (fyn_map->xl) {
+			/* either we're already on the parent list (and it's OK) */
+			/* or we're not and we have a duplicate key */
+			fynpi = fy_node_accel_lookup_by_node(fyn_map, fyn);
+			if (fynpi && fynpi != fynp)
+				return -1;
+			/* remove that key */
+			fy_accel_remove(fyn_map->xl, fynp->key);
+		} else {
+			/* check whether the key is a duplicate
+			* skipping ourselves since our key gets replaced
+			*/
+			for (fynpi = fy_node_pair_list_head(&fyn_map->mapping); fynpi;
+				fynpi = fy_node_pair_next(&fyn_map->mapping, fynpi)) {
+
+				if (fynpi != fynp && fy_node_compare(fynpi->key, fyn))
+					return -1;
+			}
+		}
+
+		fy_node_mark_synthetic(fyn_map);
+	}
+
+	fy_node_detach_and_free(fynp->key);
+	fynp->key = fyn;
+
+	if (fyn_map && fyn_map->xl)
+		fy_accel_insert(fyn_map->xl, fynp->key, fynp);
+
+	fyn->attached = true;
+
+	return 0;
+}
+
+int fy_node_pair_set_value(struct fy_node_pair *fynp, struct fy_node *fyn)
+{
+	if (!fynp)
+		return -1;
+	/* the node must not be attached */
+	if (fyn && fyn->attached)
+		return -1;
+	fy_node_detach_and_free(fynp->value);
+	fynp->value = fyn;
+	fyn->attached = true;
+
+	if (fynp->parent)
+		fy_node_mark_synthetic(fynp->parent);
+
+	return 0;
+}
+
+struct fy_node *fy_document_root(struct fy_document *fyd)
+{
+	if (!fyd)
+		return NULL;
+
+	return fyd->root;
+}
+
+const char *fy_node_get_tag(struct fy_node *fyn, size_t *lenp)
+{
+	size_t tmplen;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyn || !fyn->tag) {
+		*lenp = 0;
+		return NULL;
+	}
+
+	return fy_token_get_text(fyn->tag, lenp);
+}
+
+const char *fy_node_get_tag0(struct fy_node *fyn)
+{
+	if (!fyn || !fyn->tag)
+		return NULL;
+
+	return fy_token_get_text0(fyn->tag);
+}
+
+size_t fy_node_get_tag_length(struct fy_node *fyn)
+{
+
+	if (!fyn || !fyn->tag)
+		return 0;
+
+	return fy_token_get_text_length(fyn->tag);
+}
+
+const char *fy_node_get_scalar(struct fy_node *fyn, size_t *lenp)
+{
+	size_t tmplen;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyn || fyn->type != FYNT_SCALAR) {
+		*lenp = 0;
+		return NULL;
+	}
+
+	return fy_token_get_text(fyn->scalar, lenp);
+}
+
+const char *fy_node_get_scalar0(struct fy_node *fyn)
+{
+	if (!fyn || fyn->type != FYNT_SCALAR)
+		return NULL;
+
+	return fy_token_get_text0(fyn->scalar);
+}
+
+size_t fy_node_get_scalar_length(struct fy_node *fyn)
+{
+
+	if (!fyn || fyn->type != FYNT_SCALAR)
+		return 0;
+
+	return fy_token_get_text_length(fyn->scalar);
+}
+
+size_t fy_node_get_scalar_utf8_length(struct fy_node *fyn)
+{
+
+	if (!fyn || fyn->type != FYNT_SCALAR)
+		return 0;
+
+	return fy_token_format_utf8_length(fyn->scalar);
+}
+
+struct fy_node *fy_node_sequence_iterate(struct fy_node *fyn, void **prevp)
+{
+	if (!fyn || fyn->type != FYNT_SEQUENCE || !prevp)
+		return NULL;
+
+	return *prevp = *prevp ? fy_node_next(&fyn->sequence, *prevp) : fy_node_list_head(&fyn->sequence);
+}
+
+struct fy_node *fy_node_sequence_reverse_iterate(struct fy_node *fyn, void **prevp)
+{
+	if (!fyn || fyn->type != FYNT_SEQUENCE || !prevp)
+		return NULL;
+
+	return *prevp = *prevp ? fy_node_prev(&fyn->sequence, *prevp) : fy_node_list_tail(&fyn->sequence);
+}
+
+int fy_node_sequence_item_count(struct fy_node *fyn)
+{
+	struct fy_node *fyni;
+	int count;
+
+	if (!fyn || fyn->type != FYNT_SEQUENCE)
+		return -1;
+
+	count = 0;
+	for (fyni = fy_node_list_head(&fyn->sequence); fyni; fyni = fy_node_next(&fyn->sequence, fyni))
+		count++;
+	return count;
+}
+
+bool fy_node_sequence_is_empty(struct fy_node *fyn)
+{
+	return !fyn || fyn->type != FYNT_SEQUENCE || fy_node_list_empty(&fyn->sequence);
+}
+
+struct fy_node *fy_node_sequence_get_by_index(struct fy_node *fyn, int index)
+{
+	struct fy_node *fyni;
+	void *iterp = NULL;
+
+	if (!fyn || fyn->type != FYNT_SEQUENCE)
+		return NULL;
+
+	if (index >= 0) {
+		do {
+			fyni = fy_node_sequence_iterate(fyn, &iterp);
+		} while (fyni && --index >= 0);
+	} else {
+		do {
+			fyni = fy_node_sequence_reverse_iterate(fyn, &iterp);
+		} while (fyni && ++index < 0);
+	}
+
+	return fyni;
+}
+
+struct fy_node_pair *fy_node_mapping_iterate(struct fy_node *fyn, void **prevp)
+{
+	if (!fyn || fyn->type != FYNT_MAPPING || !prevp)
+		return NULL;
+
+	return *prevp = *prevp ? fy_node_pair_next(&fyn->mapping, *prevp) : fy_node_pair_list_head(&fyn->mapping);
+}
+
+struct fy_node_pair *fy_node_mapping_reverse_iterate(struct fy_node *fyn, void **prevp)
+{
+	if (!fyn || fyn->type != FYNT_MAPPING || !prevp)
+		return NULL;
+
+	return *prevp = *prevp ? fy_node_pair_prev(&fyn->mapping, *prevp) : fy_node_pair_list_tail(&fyn->mapping);
+}
+
+struct fy_node *fy_node_collection_iterate(struct fy_node *fyn, void **prevp)
+{
+	struct fy_node_pair *fynp;
+
+	if (!fyn || !prevp)
+		return NULL;
+
+	switch (fyn->type) {
+	case FYNT_SEQUENCE:
+		return fy_node_sequence_iterate(fyn, prevp);
+
+	case FYNT_MAPPING:
+		fynp = fy_node_mapping_iterate(fyn, prevp);
+		if (!fynp)
+			return NULL;
+		return fynp->value;
+
+	case FYNT_SCALAR:
+		fyn = !*prevp ? fyn : NULL;
+		*prevp = fyn;
+		return fyn;
+	}
+
+	return NULL;
+}
+
+
+int fy_node_mapping_item_count(struct fy_node *fyn)
+{
+	struct fy_node_pair *fynpi;
+	int count;
+
+	if (!fyn || fyn->type != FYNT_MAPPING)
+		return -1;
+
+	count = 0;
+	for (fynpi = fy_node_pair_list_head(&fyn->mapping); fynpi; fynpi = fy_node_pair_next(&fyn->mapping, fynpi))
+		count++;
+	return count;
+}
+
+bool fy_node_mapping_is_empty(struct fy_node *fyn)
+{
+	return !fyn || fyn->type != FYNT_MAPPING || fy_node_pair_list_empty(&fyn->mapping);
+}
+
+struct fy_node_pair *fy_node_mapping_get_by_index(struct fy_node *fyn, int index)
+{
+	struct fy_node_pair *fynpi;
+	void *iterp = NULL;
+
+	if (!fyn || fyn->type != FYNT_MAPPING)
+		return NULL;
+
+	if (index >= 0) {
+		do {
+			fynpi = fy_node_mapping_iterate(fyn, &iterp);
+		} while (fynpi && --index >= 0);
+	} else {
+		do {
+			fynpi = fy_node_mapping_reverse_iterate(fyn, &iterp);
+		} while (fynpi && ++index < 0);
+	}
+
+	return fynpi;
+}
+
+struct fy_node_pair *
+fy_node_mapping_lookup_pair_by_simple_key(struct fy_node *fyn,
+					  const char *key, size_t len)
+{
+	struct fy_node_pair *fynpi;
+	struct fy_node *fyn_scalar;
+
+	if (!fyn || fyn->type != FYNT_MAPPING || !key)
+		return NULL;
+
+	if (len == (size_t)-1)
+		len = strlen(key);
+
+	if (fyn->xl) {
+		fyn_scalar = fy_node_create_scalar(fyn->fyd, key, len);
+		if (!fyn_scalar)
+			return NULL;
+
+		fynpi = fy_node_accel_lookup_by_node(fyn, fyn_scalar);
+
+		fy_node_free(fyn_scalar);
+
+		if (fynpi)
+			return fynpi;
+	} else {
+		for (fynpi = fy_node_pair_list_head(&fyn->mapping); fynpi;
+			fynpi = fy_node_pair_next(&fyn->mapping, fynpi)) {
+
+			if (!fy_node_is_scalar(fynpi->key) || fy_node_is_alias(fynpi->key))
+				continue;
+
+			if (!fynpi->key && len == 0)
+				return fynpi;
+
+			if (fynpi->key && !fy_token_memcmp(fynpi->key->scalar, key, len))
+				return fynpi;
+		}
+	}
+
+	return NULL;
+}
+
+struct fy_node *
+fy_node_mapping_lookup_value_by_simple_key(struct fy_node *fyn,
+					   const char *key, size_t len)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_lookup_pair_by_simple_key(fyn, key, len);
+	return fynp ? fy_node_pair_value(fynp) : NULL;
+}
+
+struct fy_node_pair *
+fy_node_mapping_lookup_pair_by_null_key(struct fy_node *fyn)
+{
+	struct fy_node_pair *fynpi;
+
+	if (!fyn || fyn->type != FYNT_MAPPING)
+		return NULL;
+
+	/* no acceleration for NULLs */
+	for (fynpi = fy_node_pair_list_head(&fyn->mapping); fynpi;
+		fynpi = fy_node_pair_next(&fyn->mapping, fynpi)) {
+
+		if (fy_node_is_null(fynpi->key))
+			return fynpi;
+	}
+
+	return NULL;
+}
+
+struct fy_node *
+fy_node_mapping_lookup_value_by_null_key(struct fy_node *fyn)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_lookup_pair_by_null_key(fyn);
+	return fynp ? fy_node_pair_value(fynp) : NULL;
+}
+
+const char *
+fy_node_mapping_lookup_scalar_by_simple_key(struct fy_node *fyn, size_t *lenp,
+					    const char *key, size_t keylen)
+{
+	struct fy_node *fyn_value;
+
+	fyn_value = fy_node_mapping_lookup_value_by_simple_key(fyn, key, keylen);
+	if (!fyn_value || !fy_node_is_scalar(fyn_value))
+		return NULL;
+	return fy_node_get_scalar(fyn_value, lenp);
+}
+
+const char *
+fy_node_mapping_lookup_scalar0_by_simple_key(struct fy_node *fyn,
+					     const char *key, size_t keylen)
+{
+	struct fy_node *fyn_value;
+
+	fyn_value = fy_node_mapping_lookup_value_by_simple_key(fyn, key, keylen);
+	if (!fyn_value || !fy_node_is_scalar(fyn_value))
+		return NULL;
+	return fy_node_get_scalar0(fyn_value);
+}
+
+struct fy_node *fy_node_mapping_lookup_value_by_key(struct fy_node *fyn, struct fy_node *fyn_key)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_lookup_pair(fyn, fyn_key);
+	return fynp ? fynp->value : NULL;
+}
+
+struct fy_node *fy_node_mapping_lookup_key_by_key(struct fy_node *fyn, struct fy_node *fyn_key)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_lookup_pair(fyn, fyn_key);
+	return fynp ? fynp->key : NULL;
+}
+
+struct fy_node_pair *
+fy_node_mapping_lookup_pair_by_string(struct fy_node *fyn, const char *key, size_t len)
+{
+	struct fy_document *fyd;
+	struct fy_node_pair *fynp;
+
+	/* try quick and dirty simple scan */
+	if (is_simple_key(key, len))
+		return fy_node_mapping_lookup_pair_by_simple_key(fyn, key, len);
+
+	fyd = fy_document_build_from_string(NULL, key, len);
+	if (!fyd)
+		return NULL;
+
+	fynp = fy_node_mapping_lookup_pair(fyn, fy_document_root(fyd));
+
+	fy_document_destroy(fyd);
+
+	return fynp;
+}
+
+struct fy_node *
+fy_node_mapping_lookup_by_string(struct fy_node *fyn,
+				 const char *key, size_t len)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_lookup_pair_by_string(fyn, key, len);
+	return fynp ? fynp->value : NULL;
+}
+
+struct fy_node *
+fy_node_mapping_lookup_value_by_string(struct fy_node *fyn,
+				       const char *key, size_t len)
+{
+	return fy_node_mapping_lookup_by_string(fyn, key, len);
+}
+
+struct fy_node *
+fy_node_mapping_lookup_key_by_string(struct fy_node *fyn,
+				     const char *key, size_t len)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_lookup_pair_by_string(fyn, key, len);
+	return fynp ? fynp->key : NULL;
+}
+
+bool fy_node_is_empty(struct fy_node *fyn)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp;
+	struct fy_atom *atom;
+
+	/* skip if no value node or token */
+	if (!fyn)
+		return true;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		atom = fy_token_atom(fyn->scalar);
+		if (atom && !atom->size0 && !atom->empty)
+			return false;
+		break;
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+			if (!fy_node_is_empty(fyni))
+				return false;
+		}
+		break;
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp;
+				fynp = fy_node_pair_next(&fyn->mapping, fynp)) {
+			if (!fy_node_is_empty(fynp->value))
+				return false;
+		}
+		break;
+	}
+	return true;
+}
+
+#ifdef _MSC_VER
+/* MSVC version - use _alloca with helper function */
+static __inline struct fy_node_walk_ctx *
+fy_node_walk_ctx_init_impl(struct fy_node_walk_ctx *ctx, unsigned int max_depth, unsigned int mark)
+{
+	ctx->max_depth = max_depth;
+	ctx->next_slot = 0;
+	ctx->mark = mark;
+	return ctx;
+}
+#define fy_node_walk_ctx_create_a(_max_depth, _mark) \
+	fy_node_walk_ctx_init_impl( \
+		(struct fy_node_walk_ctx *)_alloca(sizeof(struct fy_node_walk_ctx) + sizeof(struct fy_node *) * (_max_depth)), \
+		(_max_depth), \
+		(_mark))
+#else
+#define fy_node_walk_ctx_create_a(_max_depth, _mark) \
+	({ \
+		unsigned int __max_depth = (_max_depth); \
+		struct fy_node_walk_ctx *_ctx; \
+		\
+		_ctx = alloca(sizeof(*_ctx) + sizeof(struct fy_node *) * __max_depth); \
+		_ctx->max_depth = _max_depth; \
+		_ctx->next_slot = 0; \
+		_ctx->mark = (_mark); \
+		_ctx; \
+	})
+#endif
+
+static inline void fy_node_walk_mark_start(struct fy_node_walk_ctx *ctx)
+{
+	ctx->next_slot = 0;
+}
+
+static inline void fy_node_walk_mark_end(struct fy_node_walk_ctx *ctx)
+{
+	struct fy_node *fyn;
+
+	while (ctx->next_slot > 0) {
+		fyn = ctx->marked[--ctx->next_slot];
+		fyn->marks &= ~ctx->mark;
+	}
+}
+
+/* fyn is guaranteed to be non NULL and an alias */
+static inline bool fy_node_walk_mark(struct fy_node_walk_ctx *ctx, struct fy_node *fyn)
+{
+	struct fy_document *fyd = fyn->fyd;
+	struct fy_token *fyt = NULL;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fyt = fyn->scalar;
+		break;
+	case FYNT_SEQUENCE:
+		fyt = fyn->sequence_start;
+		break;
+	case FYNT_MAPPING:
+		fyt = fyn->mapping_start;
+		break;
+	}
+
+	/* depth error */
+	FYD_TOKEN_ERROR_CHECK(fyd, fyt, FYEM_DOC,
+		ctx->next_slot < ctx->max_depth, err_out,
+		"max recursion depth exceeded (%u)", ctx->max_depth);
+
+	/* mark found, loop */
+	FYD_TOKEN_ERROR_CHECK(fyd, fyt, FYEM_DOC,
+		!(fyn->marks & ctx->mark), err_out,
+		"cyclic reference detected");
+
+	fyn->marks |= ctx->mark;
+	ctx->marked[ctx->next_slot++] = fyn;
+
+	return true;
+
+err_out:
+	return false;
+}
+
+static struct fy_node *
+fy_node_follow_aliases(struct fy_node *fyn, enum fy_node_walk_flags flags, bool single)
+{
+	enum fy_node_walk_flags ptr_flags;
+	struct fy_ptr_node_list nl;
+	struct fy_ptr_node *fypn;
+
+	if (!fyn || !fy_node_is_alias(fyn) || !(flags & FYNWF_FOLLOW))
+		return fyn;
+
+	ptr_flags = flags & FYNWF_PTR(FYNWF_PTR_MASK);
+	if (ptr_flags != FYNWF_PTR_YAML && ptr_flags != FYNWF_PTR_YPATH)
+		return fyn;
+
+	fy_ptr_node_list_init(&nl);
+
+	while (fyn && fy_node_is_alias(fyn)) {
+
+		// fprintf(stderr, "%s: %s\n", __func__, fy_node_get_path_alloca(fyn));
+
+		/* check for loops */
+		if (fy_ptr_node_list_contains(&nl, fyn)) {
+			fyn = NULL;
+			break;
+		}
+
+		/* out of memory? */
+		fypn = fy_ptr_node_create(fyn);
+		if (!fypn) {
+			fyn = NULL;
+			break;
+		}
+		fy_ptr_node_list_add_tail(&nl, fypn);
+
+		fyn = fy_node_follow_alias(fyn, flags);
+
+		if (single)
+			break;
+	}
+
+	/* release */
+	while ((fypn = fy_ptr_node_list_pop(&nl)) != NULL)
+		fy_ptr_node_destroy(fypn);
+
+	return fyn;
+}
+
+struct fy_node *fy_node_resolve_alias(struct fy_node *fyn)
+{
+	enum fy_node_walk_flags flags;
+
+	if (!fyn)
+		return NULL;
+
+	flags = FYNWF_FOLLOW | FYNWF_MAXDEPTH_DEFAULT | FYNWF_MARKER_DEFAULT;
+	if (fyn->fyd->parse_cfg.flags & FYPCF_YPATH_ALIASES)
+		flags |= FYNWF_PTR_YPATH;
+	else
+		flags |= FYNWF_PTR_YAML;
+	return fy_node_follow_aliases(fyn, flags, false);
+}
+
+struct fy_node *fy_node_dereference(struct fy_node *fyn)
+{
+	enum fy_node_walk_flags flags;
+
+	if (!fyn || !fy_node_is_alias(fyn))
+		return NULL;
+
+	flags = FYNWF_FOLLOW | FYNWF_MAXDEPTH_DEFAULT | FYNWF_MARKER_DEFAULT;
+	if (fyn->fyd->parse_cfg.flags & FYPCF_YPATH_ALIASES)
+		flags |= FYNWF_PTR_YPATH;
+	else
+		flags |= FYNWF_PTR_YAML;
+	return fy_node_follow_aliases(fyn, flags, true);
+}
+
+static struct fy_node *
+fy_node_by_path_internal(struct fy_node *fyn,
+			 const char *path, size_t pathlen,
+		         enum fy_node_walk_flags flags)
+{
+	enum fy_node_walk_flags ptr_flags;
+	struct fy_node *fynt, *fyni;
+	const char *s, *e, *ss, *ee;
+	char *end_idx, *json_key, *t, *p, *uri_path;
+	char c;
+	char idx_buf[13];
+	size_t idx_buf_sz;
+	int idx;
+	size_t len, rlen, json_key_len, uri_path_len;
+	bool has_json_key_esc;
+	uint8_t code[4];
+	int code_length;
+	bool trailing_slash;
+
+	if (!fyn || !path)
+		return NULL;
+
+	ptr_flags = flags & FYNWF_PTR(FYNWF_PTR_MASK);
+	if (ptr_flags == FYNWF_PTR_YPATH)
+		return fy_node_by_ypath(fyn, path, pathlen);
+
+	s = path;
+	if (pathlen == (size_t)-1)
+		pathlen = strlen(path);
+	e = s + pathlen;
+
+	/* a trailing slash works just like unix and symbolic links
+	 * if it does not exist no symbolic link lookups are performed
+	 * at the end of the operation.
+	 * if it exists they are followed upon resolution
+	 */
+	trailing_slash = pathlen > 0 && path[pathlen - 1] == '/';
+
+	/* and continue on path lookup with the rest */
+
+	/* skip all prefixed / */
+	switch (ptr_flags) {
+	default:
+	case FYNWF_PTR_YAML:
+		while (s < e && *s == '/')
+			s++;
+		/* for a last component / always match this one */
+		if (s >= e)
+			goto out;
+		break;
+
+	case FYNWF_PTR_JSON:
+		/* "" -> everything here */
+		if (s == e)
+			return fyn;
+		/* it must have a separator here */
+		if (*s != '/')
+			return NULL;
+		s++;
+		break;
+
+	case FYNWF_PTR_RELJSON:
+		break;
+	}
+
+	/* fyd_notice(fyn->fyd, "%s:%d following alias @%s \"%.*s\"",
+			__func__, __LINE__, fy_node_get_path(fyn), (int)(e - s), s); */
+	fyn = fy_node_follow_aliases(fyn, flags, true);
+
+	/* scalar can be only last element in the path (it has no key) */
+	if (fy_node_is_scalar(fyn)) {
+		if (s < e && *s)
+			fyn = NULL;	/* not end of the path - fail */
+		goto out;
+	}
+
+	/* for a sequence the only allowed key is [n] where n is the index to follow */
+	if (fy_node_is_sequence(fyn)) {
+
+		c = -1;
+		switch (ptr_flags) {
+		default:
+		case FYNWF_PTR_YAML:
+			while (s < e && isspace((unsigned char)*s))
+				s++;
+
+			c = *s;
+			if (c == '[')
+				s++;
+			else if (!isdigit(c) && c != '-')
+				return NULL;
+
+			/* copy to temp buffer */
+			idx_buf_sz = (size_t)(e - s);
+			if (idx_buf_sz >= sizeof(idx_buf) - 1)
+				idx_buf_sz = sizeof(idx_buf) - 1;
+			memcpy(idx_buf, s, idx_buf_sz);
+			idx_buf[idx_buf_sz] = '\0';
+
+			idx = (int)strtol(idx_buf, &end_idx, 10);
+
+			/* no digits found at all */
+			if (idx == 0 && end_idx == idx_buf)
+				return NULL;
+
+			s += (size_t)(end_idx - idx_buf);
+
+			while (s < e && isspace((unsigned char)*s))
+				s++;
+
+			if (c == '[' && *s++ != ']')
+				return NULL;
+
+			while (s < e && isspace((unsigned char)*s))
+				s++;
+
+			break;
+
+		case FYNWF_PTR_JSON:
+		case FYNWF_PTR_RELJSON:
+
+			/* special array end - always fails */
+			if (*s == '-')
+				return NULL;
+
+			/* copy to temp buffer */
+			idx_buf_sz = (size_t)(e - s);
+			if (idx_buf_sz >= sizeof(idx_buf) - 1)
+				idx_buf_sz = sizeof(idx_buf) - 1;
+			memcpy(idx_buf, s, idx_buf_sz);
+			idx_buf[idx_buf_sz] = '\0';
+
+			idx = (int)strtol(idx_buf, &end_idx, 10);
+
+			/* no digits found at all */
+			if (idx == 0 && end_idx == idx_buf)
+				return NULL;
+
+			/* no negatives */
+			if (idx < 0)
+				return NULL;
+
+			s += (size_t)(end_idx - idx_buf);
+
+			if (s < e && *s == '/')
+				s++;
+
+			break;
+		}
+
+		len = e - s;
+
+		fyn = fy_node_sequence_get_by_index(fyn, idx);
+		if (trailing_slash)
+			fyn = fy_node_follow_aliases(fyn, flags, false);
+		fyn = fy_node_by_path_internal(fyn, s, len, flags);
+		goto out;
+	}
+
+	/* be a little bit paranoid */
+	assert(fy_node_is_mapping(fyn));
+
+	path = s;
+	pathlen = (size_t)(e - s);
+
+	switch (ptr_flags) {
+	default:
+	case FYNWF_PTR_YAML:
+
+		/* scan ahead for the end of the path component
+		* note that we don't do UTF8 here, because all the
+		* escapes are regular ascii characters, i.e.
+		* '/', '*', '&', '.', '{', '}', '[', ']' and '\\'
+		*/
+
+		while (s < e) {
+			c = *s;
+			/* end of path component? */
+			if (c == '/')
+				break;
+			s++;
+
+			if (c == '\\') {
+				/* it must be a valid escape */
+				if (s >= e || !strchr("/*&.{}[]\\", *s))
+					return NULL;
+				s++;
+			} else if (c == '"') {
+				while (s < e && *s != '"') {
+					c = *s++;
+					if (c == '\\' && (s < e && *s == '"'))
+						s++;
+				}
+				/* not a normal double quote end */
+				if (s >= e || *s != '"')
+					return NULL;
+				s++;
+			} else if (c == '\'') {
+				while (s < e && *s != '\'') {
+					c = *s++;
+					if (c == '\'' && (s < e && *s == '\''))
+						s++;
+				}
+				/* not a normal single quote end */
+				if (s >= e || *s != '\'')
+					return NULL;
+				s++;
+			}
+		}
+		len = s - path;
+
+		fynt = fyn;
+		fyn = fy_node_mapping_lookup_by_string(fyn, path, len);
+
+		/* failed! last ditch attempt, is there a merge key? */
+		if (!fyn && fynt && (flags & FYNWF_FOLLOW) && ptr_flags == FYNWF_PTR_YAML) {
+			fyn = fy_node_mapping_lookup_by_string(fynt, "<<", 2);
+			if (!fyn)
+				goto out;
+
+			if (fy_node_is_alias(fyn)) {
+
+				/* single alias '<<: *foo' */
+				fyn = fy_node_mapping_lookup_by_string(
+						fy_node_follow_aliases(fyn, flags, false), path, len);
+
+			} else if (fy_node_is_sequence(fyn)) {
+
+				/* multi aliases '<<: [ *foo, *bar ]' */
+				fynt = fyn;
+				for (fyni = fy_node_list_head(&fynt->sequence); fyni;
+						fyni = fy_node_next(&fynt->sequence, fyni)) {
+					if (!fy_node_is_alias(fyni))
+						continue;
+					fyn = fy_node_mapping_lookup_by_string(
+							fy_node_follow_aliases(fyni, flags, false),
+							path, len);
+					if (fyn)
+						break;
+				}
+			} else
+				fyn = NULL;
+		}
+		break;
+
+	case FYNWF_PTR_JSON:
+	case FYNWF_PTR_RELJSON:
+
+		has_json_key_esc = false;
+		while (s < e) {
+			c = *s;
+			/* end of path component? */
+			if (c == '/')
+				break;
+			s++;
+			if (c == '~')
+				has_json_key_esc = true;
+		}
+		len = s - path;
+
+		if (has_json_key_esc) {
+			/* note that the escapes reduce the length, so allocating the
+			 * same size is guaranteed safe */
+			json_key = alloca(len + 1);
+
+			ss = path;
+			ee = s;
+			t = json_key;
+			while (ss < ee) {
+				if (*ss != '~') {
+					*t++ = *ss++;
+					continue;
+				}
+				/* unterminated ~ escape, or neither ~0, ~1 */
+				if (ss + 1 >= ee || (ss[1] != '0' && ss[1] != '1'))
+					return NULL;
+				*t++ = ss[1] == '0' ? '~' : '/';
+				ss += 2;
+			}
+			json_key_len = t - json_key;
+
+			path = json_key;
+			len = json_key_len;
+		}
+
+		/* URI encoded escaped */
+		if ((flags & FYNWF_URI_ENCODED) && memchr(path, '%', len)) {
+			/* escapes shrink, so safe to allocate as much */
+			uri_path = alloca(len + 1);
+
+			ss = path;
+			ee = path + len;
+			t = uri_path;
+			while (ss < ee) {
+				/* copy run until '%' or end */
+				p = memchr(ss, '%', ee - ss);
+				rlen = (size_t)((p ? p : ee) - ss);
+				memcpy(t, ss, rlen);
+				ss += rlen;
+				t += rlen;
+
+				/* if end, break */
+				if (!p)
+					break;
+
+				/* collect a utf8 character sequence */
+				code_length = sizeof(code);
+				ss = fy_uri_esc(ss, ee - ss, code, &code_length);
+				if (!ss) {
+					/* bad % escape sequence */
+					return NULL;
+				}
+				memcpy(t, code, code_length);
+				t += code_length;
+			}
+			uri_path_len = t - uri_path;
+
+			path = uri_path;
+			len = uri_path_len;
+		}
+
+		fynt = fyn;
+		fyn = fy_node_mapping_lookup_value_by_simple_key(fyn, path, len);
+		break;
+	}
+
+	len = e - s;
+
+	if (len > 0 && trailing_slash) {
+		/* fyd_notice(fyn->fyd, "%s:%d following alias @%s \"%.*s\"",
+				__func__, __LINE__, fy_node_get_path(fyn), (int)(e - s), s); */
+		fyn = fy_node_follow_aliases(fyn, flags, true);
+	}
+
+	fyn = fy_node_by_path_internal(fyn, s, len, flags);
+
+out:
+	len = e - s;
+
+	if (len > 0 && trailing_slash) {
+		/* fyd_notice(fyn->fyd, "%s:%d following alias @%s \"%.*s\"",
+				__func__, __LINE__, fy_node_get_path(fyn), (int)(e - s), s); */
+		fyn = fy_node_follow_aliases(fyn, flags, true);
+	}
+
+	return fyn;
+}
+
+struct fy_node *fy_node_by_path(struct fy_node *fyn,
+				const char *path, size_t len,
+				enum fy_node_walk_flags flags)
+{
+	struct fy_document *fyd;
+	struct fy_anchor *fya;
+	const char *s, *e, *t, *anchor;
+	size_t alen;
+	char c;
+	char idx_buf[13];
+	size_t idx_buf_sz;
+	int idx, w;
+	char *end_idx;
+
+	if (!fyn || !path)
+		return NULL;
+
+	if (len == (size_t)-1)
+		len = strlen(path);
+
+	/* verify that the path string is well formed UTF8 */
+	s = path;
+	e = s + len;
+
+	fyd = fyn->fyd;
+	while (s < e) {
+		c = fy_utf8_get(s, e - s, &w);
+		if (c < 0) {
+			fyd_error(fyd, "fy_node_by_path() malformed path string\n");
+			return NULL;
+		}
+		s += w;
+	}
+
+	/* rewind */
+	s = path;
+
+	/* if it's a YPATH, just punt to that method */
+	if ((flags & FYNWF_PTR(FYNWF_PTR_MASK)) == FYNWF_PTR_YPATH)
+		return fy_node_by_ypath(fyn, path, len);
+
+	/* fyd_notice(fyn->fyd, "%s: %.*s", __func__, (int)(len), s); */
+
+	/* first path component may be an alias */
+	if ((flags & FYNWF_FOLLOW) && fyn && path) {
+		while (s < e && isspace((unsigned char)*s))
+			s++;
+
+		if (s >= e || *s != '*')
+			goto regular_path_lookup;
+
+		s++;
+
+		c = -1;
+		for (t = s; t < e; t++) {
+			c = *t;
+			/* it ends on anything non alias */
+			if (c == '[' || c == ']' ||
+				c == '{' || c == '}' ||
+				c == ',' || c == ' ' || c == '\t' ||
+				c == '/')
+				break;
+		}
+
+		/* bad alias form for path */
+		if (c == '[' || c == ']' || c == '{' || c == '}' || c == ',')
+			return NULL;
+
+		anchor = s;
+		alen = t - s;
+
+		if (alen) {
+			/* we must be terminated by '/' or space followed by '/' */
+			/* strip until spaces and '/' end */
+			while (t < e && (*t == ' ' || *t == '\t'))
+				t++;
+
+			while (t < e && *t == '/')
+				t++;
+
+			/* update path */
+			path = t;
+			len = e - t;
+
+			/* fyd_notice(fyn->fyd, "%s: looking up anchor=%.*s", __func__, (int)(alen), anchor); */
+
+			/* lookup anchor */
+			fya = fy_document_lookup_anchor(fyn->fyd, anchor, alen);
+			if (!fya) {
+				/* fyd_notice(fyn->fyd, "%s: failed to lookup anchor=%.*s", __func__, (int)(alen), anchor); */
+				return NULL;
+			}
+
+			/* fyd_notice(fyn->fyd, "%s: found anchor=%.*s at %s",
+					__func__, (int)(alen), anchor, fy_node_get_path(fya->fyn)); */
+
+			/* nothing more? we're done */
+			if (*path == '\0')
+				return fya->fyn;
+
+			/* anchor found... all good */
+
+			fyn = fya->fyn;
+		} else {
+			/* no anchor it must be of the form *\/ */
+
+			path = s;
+			len = e - s;
+		}
+
+		/* fyd_notice(fyn->fyd, "%s: continuing looking for %.*s",
+				__func__, (int)(len), path); */
+
+	}
+
+regular_path_lookup:
+
+	/* if it's a relative json pointer... */
+	if ((flags & FYNWF_PTR(FYNWF_PTR_MASK)) == FYNWF_PTR_RELJSON) {
+
+		/* it must at least be one digit */
+		if (len == 0)
+			return NULL;
+
+		/* copy to temp buffer */
+		s = path;
+		idx_buf_sz = (size_t)(e - s);
+		if (idx_buf_sz >= sizeof(idx_buf) - 1)
+			idx_buf_sz = sizeof(idx_buf) - 1;
+		memcpy(idx_buf, s, idx_buf_sz);
+		idx_buf[idx_buf_sz] = '\0';
+
+		idx = (int)strtol(idx_buf, &end_idx, 10);
+
+		/* at least one digit must exist */
+		if (idx == 0 && end_idx == idx_buf)
+			return NULL;
+
+		s += (size_t)(end_idx - idx_buf);
+
+		len = e - s;
+		path = s;
+
+		/* we don't do the trailing # here */
+		if (len == 1 && *path == '#')
+			return NULL;
+
+		while (idx-- > 0)
+			fyn = fy_node_get_parent(fyn);
+
+		/* convert to regular json pointer from now on */
+		flags &= ~FYNWF_PTR(FYNWF_PTR_MASK);
+		flags |= FYNWF_PTR_JSON;
+	}
+
+	return fy_node_by_path_internal(fyn, path, len, flags);
+}
+
+static char *
+fy_node_get_reference_internal(struct fy_node *fyn_base, struct fy_node *fyn, bool near)
+{
+	struct fy_anchor *fya;
+	const char *path;
+	char *path2, *path3;
+	const char *text;
+	size_t len;
+
+	if (!fyn)
+		return NULL;
+
+	path2 = NULL;
+
+	/* if the node has an anchor use it (ie return *foo) */
+	if (!fyn_base && (fya = fy_node_get_anchor(fyn)) != NULL) {
+		text = fy_anchor_get_text(fya, &len);
+		if (!text)
+			return NULL;
+		path2 = alloca(1 + len + 1);
+		path2[0] = '*';
+		memcpy(path2 + 1, text, len);
+		path2[len + 1] = '\0';
+
+	} else {
+
+		fya = fyn_base ? fy_node_get_anchor(fyn_base) : NULL;
+		if (!fya && near)
+			fya = fy_node_get_nearest_anchor(fyn);
+		if (!fya) {
+			/* no anchor, direct reference (ie return *\/foo\/bar */
+			path = fy_node_get_path_alloca(fyn);
+			if (!*path)
+				return NULL;
+			path2 = alloca(1 + strlen(path) + 1);
+			path2[0] = '*';
+			strcpy(path2 + 1, path);
+		} else {
+			text = fy_anchor_get_text(fya, &len);
+			if (!text)
+				return NULL;
+			if (fy_anchor_node(fya) != fyn) {
+				path = fy_node_get_path_relative_to_alloca(fy_anchor_node(fya), fyn);
+				if (*path) {
+					/* we have a relative path */
+					path2 = alloca(1 + len + 1 + strlen(path) + 1);
+					path2[0] = '*';
+					memcpy(path2 + 1, text, len);
+					path2[len + 1] = '/';
+					memcpy(1 + path2 + len + 1, path, strlen(path) + 1);
+				} else {
+					/* absolute path */
+					path = fy_node_get_path_alloca(fyn);
+					if (!*path)
+						return NULL;
+					path2 = alloca(1 + strlen(path) + 1);
+					path2[0] = '*';
+					strcpy(path2 + 1, path);
+				}
+			} else {
+				path2 = alloca(1 + len + 1);
+				path2[0] = '*';
+				memcpy(path2 + 1, text, len);
+				path2[len + 1] = '\0';
+			}
+		}
+	}
+
+	if (!path2)
+		return NULL;
+
+	path3 = strdup(path2);
+	if (!path3)
+		return NULL;
+
+	return path3;
+}
+
+char *fy_node_get_reference(struct fy_node *fyn)
+{
+	return fy_node_get_reference_internal(NULL, fyn, false);
+}
+
+struct fy_node *fy_node_create_reference(struct fy_node *fyn)
+{
+	struct fy_node *fyn_ref;
+	char *path, *alias;
+
+	path = fy_node_get_reference(fyn);
+	if (!path)
+		return NULL;
+
+	alias = path;
+	if (*alias == '*')
+		alias++;
+
+	fyn_ref = fy_node_create_alias_copy(fy_node_document(fyn), alias, FY_NT);
+
+	free(path);
+
+	return fyn_ref;
+}
+
+char *fy_node_get_relative_reference(struct fy_node *fyn_base, struct fy_node *fyn)
+{
+	return fy_node_get_reference_internal(fyn_base, fyn, false);
+}
+
+struct fy_node *fy_node_create_relative_reference(struct fy_node *fyn_base, struct fy_node *fyn)
+{
+	struct fy_node *fyn_ref;
+	char *path, *alias;
+
+	path = fy_node_get_relative_reference(fyn_base, fyn);
+	if (!path)
+		return NULL;
+
+	alias = path;
+	if (*alias == '*')
+		alias++;
+
+	fyn_ref = fy_node_create_alias_copy(fy_node_document(fyn), alias, FY_NT);
+
+	free(path);
+
+	return fyn_ref;
+}
+
+bool
+fy_check_ref_loop(struct fy_document *fyd, struct fy_node *fyn,
+		  enum fy_node_walk_flags flags,
+		  struct fy_node_walk_ctx *ctx,
+		  unsigned int depth)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi;
+	struct fy_node_walk_ctx *ctxn;
+	bool ret;
+
+	if (!fyn)
+		return false;
+
+	/* over depth? */
+	if (depth > fy_node_walk_max_depth_from_flags(flags))
+		return true;
+
+	/* visited? no need to check */
+	if (fyn->marks & FY_BIT(FYNWF_VISIT_MARKER))
+		return false;
+
+	/* marked node, it's a loop */
+	if (ctx && !fy_node_walk_mark(ctx, fyn))
+		return true;
+
+	ret = false;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+
+		/* if it's not an alias, we're done */
+		if (!fy_node_is_alias(fyn))
+			break;
+
+		ctxn = ctx;
+		if (!ctxn)
+			ctxn = fy_node_walk_ctx_create_a(
+				fy_node_walk_max_depth_from_flags(flags), FYNWF_REF_MARKER);
+
+
+		if (!ctx) {
+			fy_node_walk_mark_start(ctxn);
+
+			/* mark this node */
+			fy_node_walk_mark(ctxn, fyn);
+		}
+
+		fyni = fy_node_follow_alias(fyn, flags);
+
+		ret = fy_check_ref_loop(fyd, fyni, flags, ctxn, depth + 1);
+
+		if (!ctx)
+			fy_node_walk_mark_end(ctxn);
+
+		if (ret)
+			break;
+
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			ret = fy_check_ref_loop(fyd, fyni, flags, ctx, depth + 1);
+			if (ret)
+				break;
+		}
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			ret = fy_check_ref_loop(fyd, fynp->key, flags, ctx, depth + 1);
+			if (ret)
+				break;
+
+			ret = fy_check_ref_loop(fyd, fynp->value, flags, ctx, depth + 1);
+			if (ret)
+				break;
+		}
+		break;
+	}
+
+	/* mark as visited */
+	fyn->marks |= FY_BIT(FYNWF_VISIT_MARKER);
+
+	return ret;
+}
+
+char *fy_node_get_parent_address(struct fy_node *fyn)
+{
+	struct fy_node *parent, *fyni;
+	struct fy_node_pair *fynp;
+	struct fy_node *fyna;
+	char *path = NULL;
+	const char *str;
+	size_t len;
+	int idx;
+	bool is_key_root;
+	int ret;
+	const char *fmt;
+	char *new_path, *old_path;
+
+	if (!fyn)
+		return NULL;
+
+	parent = fy_node_get_document_parent(fyn);
+	if (!parent)
+		return NULL;
+
+	if (fy_node_is_sequence(parent)) {
+
+		/* for a sequence, find the index */
+		idx = 0;
+		for (fyni = fy_node_list_head(&parent->sequence); fyni;
+				fyni = fy_node_next(&parent->sequence, fyni)) {
+			if (fyni == fyn)
+				break;
+			idx++;
+		}
+
+		if (!fyni)
+			return NULL;
+
+		ret = asprintf(&path, "%d", idx);
+		if (ret == -1)
+			return NULL;
+	}
+
+	if (fy_node_is_mapping(parent)) {
+
+		is_key_root = fyn->key_root;
+
+		idx = 0;
+		fyna = NULL;
+		for (fynp = fy_node_pair_list_head(&parent->mapping); fynp;
+				fynp = fy_node_pair_next(&parent->mapping, fynp)) {
+
+			if ((!is_key_root && fynp->value == fyn) || (is_key_root && fynp->key == fyn))
+				break;
+			idx++;
+		}
+
+		if (!fynp)
+			return NULL;
+
+		fyna = fynp->key;
+		if (!fyna)
+			return NULL;
+
+		/* if key is a plain scalar try to not use a complex style (even for quoted) */
+		if (fyna && fy_node_is_scalar(fyna) && !fy_node_is_alias(fyna) &&
+				(str = fy_token_get_scalar_path_key(fyna->scalar, &len)) != NULL) {
+
+			fmt = !is_key_root ? "%.*s" : ".key(%.*s)";
+			ret = asprintf(&path, fmt, (int)len, str);
+			if (ret == -1)
+				return NULL;
+
+		} else {
+
+			/* something complex, emit it */
+			path = fy_emit_node_to_string(fyna,
+				FYECF_MODE_FLOW_ONELINE | FYECF_WIDTH_INF |
+				FYECF_STRIP_LABELS	| FYECF_STRIP_TAGS |
+				FYECF_NO_ENDING_NEWLINE);
+			if (!path)
+				return NULL;
+
+			if (is_key_root) {
+				old_path = path;
+				ret = asprintf(&new_path, ".key(%s)", path);
+				if (ret == -1) {
+					free(path);
+					return NULL;
+				}
+				free(old_path);
+				path = new_path;
+			}
+		}
+	}
+
+	return path;
+}
+
+char *fy_node_get_path(struct fy_node *fyn)
+{
+	struct path_track {
+		struct path_track *prev;
+		char *path;
+	};
+	struct path_track *track, *newtrack;
+	char *path, *s, *path_mem;
+	size_t len;
+	struct fy_node *parent;
+
+	if (!fyn)
+		return NULL;
+
+	/* easy on the root */
+	parent = fy_node_get_document_parent(fyn);
+	if (!parent) {
+		path_mem = strdup("/");
+		return path_mem;
+	}
+
+	track = NULL;
+	len = 0;
+	while ((path = fy_node_get_parent_address(fyn))) {
+		newtrack = alloca(sizeof(*newtrack));
+		newtrack->prev = track;
+		newtrack->path = path;
+
+		track = newtrack;
+
+		len += strlen(path) + 1;
+
+		fyn = fy_node_get_document_parent(fyn);
+	}
+	len += 2;
+
+	path_mem = malloc(len);
+
+	s = path_mem;
+
+	while (track) {
+		len = strlen(track->path);
+		if (s) {
+			*s++ = '/';
+			memcpy(s, track->path, len);
+			s += len;
+		}
+		free(track->path);
+		track = track->prev;
+	}
+
+	if (s)
+		*s = '\0';
+
+	return path_mem;
+}
+
+char *fy_node_get_path_relative_to(struct fy_node *fyn_parent, struct fy_node *fyn)
+{
+	char *path, *ppath, *path2, *path_ret;
+	size_t pathlen, ppathlen;
+	struct fy_node *ni, *nj;
+
+	if (!fyn)
+		return NULL;
+
+	/* must be on the same document */
+	if (fyn_parent && (fyn_parent->fyd != fyn->fyd))
+		return NULL;
+
+	if (!fyn_parent)
+		fyn_parent = fyn->fyd->root;
+
+	/* verify that it's a parent */
+	ni = fyn;
+	while ((nj = fy_node_get_parent(ni)) != NULL && nj != fyn_parent)
+		ni = nj;
+
+	/* not a parent, illegal */
+	if (!nj)
+		return NULL;
+
+	/* here we go... */
+	path = "";
+	pathlen = 0;
+
+	ni = fyn;
+	while ((nj = fy_node_get_parent(ni)) != NULL) {
+		ppath = fy_node_get_parent_address(ni);
+		if (!ppath)
+			return NULL;
+
+		ppathlen = strlen(ppath);
+
+		if (pathlen > 0) {
+			path2 = alloca(pathlen + 1 + ppathlen + 1);
+			memcpy(path2, ppath, ppathlen);
+			path2[ppathlen] = '/';
+			memcpy(path2 + ppathlen + 1, path, pathlen);
+			path2[ppathlen + 1 + pathlen] = '\0';
+		} else {
+			path2 = alloca(ppathlen + 1);
+			memcpy(path2, ppath, ppathlen);
+			path2[ppathlen] = '\0';
+		}
+
+		path = path2;
+		pathlen = strlen(path);
+
+		free(ppath);
+		ni = nj;
+
+		if (ni == fyn_parent)
+			break;
+	}
+
+	path_ret = strdup(path);
+	return path_ret;
+}
+
+char *fy_node_get_short_path(struct fy_node *fyn)
+{
+	struct fy_node *fyn_anchor;
+	struct fy_anchor *fya;
+	const char *text;
+	size_t len;
+	char *str, *path;
+
+	if (!fyn)
+		return NULL;
+
+	/* get the nearest anchor traversing upwards */
+	fya = fy_node_get_nearest_anchor(fyn);
+	if (!fya)
+		return fy_node_get_path(fyn);
+
+	fyn_anchor = fy_anchor_node(fya);
+
+	text = fy_anchor_get_text(fya, &len);
+	if (!text)
+		return NULL;
+
+	if (fyn_anchor == fyn)
+		str = fy_sprintfa("*%.*s", (int)len, text);
+	else
+		str = fy_sprintfa("*%.*s/%s", (int)len, text,
+				fy_node_get_path_relative_to_alloca(fyn_anchor, fyn));
+	fy_strip_trailing_nl(str);
+
+	path = strdup(str);
+	return path;
+}
+
+static struct fy_node *
+fy_document_load_node(struct fy_document *fyd, struct fy_parser *fyp,
+		      struct fy_document_state **fydsp)
+{
+	struct fy_eventp *fyep = NULL;
+	struct fy_event *fye = NULL;
+	struct fy_node *fyn = NULL;
+	int rc, depth;
+	bool was_stream_start;
+
+	if (!fyd || !fyp)
+		return NULL;
+
+	/* only single documents */
+	fy_parser_set_next_single_document(fyp);
+	fy_parser_set_default_document_state(fyp, fyd->fyds);
+
+again:
+	was_stream_start = false;
+	do {
+		/* get next event */
+		fyep = fy_parse_private(fyp);
+
+		/* no more */
+		if (!fyep)
+			return NULL;
+
+		was_stream_start = fyep->e.type == FYET_STREAM_START;
+
+		if (was_stream_start) {
+			fy_parse_eventp_recycle(fyp, fyep);
+			fyep = NULL;
+		}
+
+	} while (was_stream_start);
+
+	fye = &fyep->e;
+
+	/* STREAM_END */
+	if (fye->type == FYET_STREAM_END) {
+		fy_parse_eventp_recycle(fyp, fyep);
+
+		/* final STREAM_END? */
+		if (fyp->state == FYPS_END)
+			return NULL;
+
+		/* multi-stream */
+		goto again;
+	}
+
+	FYD_TOKEN_ERROR_CHECK(fyd, fy_event_get_token(fye), FYEM_DOC,
+			fye->type == FYET_DOCUMENT_START, err_out,
+			"bad event");
+
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyep = NULL;
+	fye = NULL;
+
+	fyd_doc_debug(fyd, "calling load_node() for root");
+	depth = 0;
+	rc = fy_parse_document_load_node(fyp, fyd, fy_parse_private(fyp), &fyn, &depth);
+	fyd_error_check(fyd, !rc, err_out,
+			"fy_parse_document_load_node() failed");
+
+	rc = fy_parse_document_load_end(fyp, fyd, fy_parse_private(fyp));
+	fyd_error_check(fyd, !rc, err_out,
+			"fy_parse_document_load_node() failed");
+
+	/* always resolve parents */
+	fy_resolve_parent_node(fyd, fyn, NULL);
+
+	if (fydsp)
+		*fydsp = fy_document_state_ref(fyp->current_document_state);
+
+	return fyn;
+
+err_out:
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyd->diag->on_error = false;
+	fy_node_detach_and_free(fyn);
+	return NULL;
+}
+
+static struct fy_node *
+fy_node_build_internal(struct fy_document *fyd,
+		int (*parser_setup)(struct fy_parser *fyp, void *user),
+		void *user)
+{
+	struct fy_document_state *fyds = NULL;
+	struct fy_node *fyn = NULL;
+	struct fy_parser fyp_data, *fyp = &fyp_data;
+	struct fy_parse_cfg cfg;
+	struct fy_eventp *fyep;
+	int rc;
+	bool got_stream_end;
+
+	if (!fyd || !parser_setup)
+		return NULL;
+
+	cfg = fyd->parse_cfg;
+	cfg.diag = fyd->diag;
+	rc = fy_parse_setup(fyp, &cfg);
+	if (rc) {
+		fyd->diag->on_error = false;
+		return NULL;
+	}
+
+	rc = (*parser_setup)(fyp, user);
+	fyd_error_check(fyd, !rc, err_out,
+			"parser_setup() failed");
+
+	fyn = fy_document_load_node(fyd, fyp, &fyds);
+	fyd_error_check(fyd, fyn, err_out,
+			"fy_document_load_node() failed");
+
+	got_stream_end = false;
+	while (!got_stream_end && (fyep = fy_parse_private(fyp)) != NULL) {
+		if (fyep->e.type == FYET_STREAM_END)
+			got_stream_end = true;
+		fy_parse_eventp_recycle(fyp, fyep);
+	}
+
+	if (got_stream_end) {
+		fyep = fy_parse_private(fyp);
+
+		FYD_TOKEN_ERROR_CHECK(fyd, fy_event_get_token(&fyep->e), FYEM_DOC,
+				!fyep, err_out,
+				"trailing events after the last");
+
+		fy_parse_eventp_recycle(fyp, fyep);
+	}
+
+	rc = fy_document_state_merge(fyd->fyds, fyds);
+	fyd_error_check(fyd, !rc, err_out,
+			"fy_document_state_merge() failed");
+
+	fy_document_state_unref(fyds);
+
+	fy_parse_cleanup(fyp);
+
+	return fyn;
+
+err_out:
+	fy_node_detach_and_free(fyn);
+	fy_document_state_unref(fyds);
+	fy_parse_cleanup(fyp);
+	fyd->diag->on_error = false;
+	return NULL;
+}
+
+struct fy_node *fy_node_build_from_string(struct fy_document *fyd, const char *str, size_t len)
+{
+	struct fy_document_build_string_ctx ctx = {
+		.str = str,
+		.len = len,
+	};
+
+	return fy_node_build_internal(fyd, parser_setup_from_string, &ctx);
+}
+
+struct fy_node *fy_node_build_from_malloc_string(struct fy_document *fyd, char *str, size_t len)
+{
+	struct fy_document_build_malloc_string_ctx ctx = {
+		.str = str,
+		.len = len,
+	};
+
+	return fy_node_build_internal(fyd, parser_setup_from_malloc_string, &ctx);
+}
+
+struct fy_node *fy_node_build_from_file(struct fy_document *fyd, const char *file)
+{
+	struct fy_document_build_file_ctx ctx = {
+		.file = file,
+	};
+
+	return fy_node_build_internal(fyd, parser_setup_from_file, &ctx);
+}
+
+struct fy_node *fy_node_build_from_fp(struct fy_document *fyd, FILE *fp)
+{
+	struct fy_document_build_fp_ctx ctx = {
+		.name = NULL,
+		.fp = fp,
+	};
+
+	return fy_node_build_internal(fyd, parser_setup_from_fp, &ctx);
+}
+
+int fy_document_set_root(struct fy_document *fyd, struct fy_node *fyn)
+{
+	if (!fyd)
+		return -1;
+
+	if (fyn && fyn->attached)
+		return -1;
+
+	fy_node_detach_and_free(fyd->root);
+	fyd->root = NULL;
+
+	fyd->root = fyn;
+
+	if (fyn) {
+		fyn->parent = NULL;
+		fyn->attached = true;
+	}
+
+	return 0;
+}
+
+#define FYNCSIF_ALIAS		FY_BIT(0)
+#define FYNCSIF_SIMPLE		FY_BIT(1)
+#define FYNCSIF_COPY		FY_BIT(2)
+#define FYNCSIF_MALLOCED	FY_BIT(3)
+
+static struct fy_node *
+fy_node_create_scalar_internal(struct fy_document *fyd, const char *data, size_t size,
+			       unsigned int flags)
+{
+	const bool alias = !!(flags & FYNCSIF_ALIAS);
+	const bool simple = !!(flags & FYNCSIF_SIMPLE);
+	const bool copy = !!(flags & FYNCSIF_COPY);
+	const bool malloced = !!(flags & FYNCSIF_MALLOCED);
+	struct fy_node *fyn = NULL;
+	struct fy_input *fyi;
+	struct fy_atom handle;
+	enum fy_scalar_style style;
+	char *data_copy = NULL;
+
+	if (!fyd)
+		return NULL;
+
+	if (data && size == (size_t)-1)
+		size = strlen(data);
+
+	fyn = fy_node_alloc(fyd, FYNT_SCALAR);
+	fyd_error_check(fyd, fyn, err_out,
+			"fy_node_alloc() failed");
+
+	if (copy) {
+		data_copy = malloc(size);
+		fyd_error_check(fyd, data_copy, err_out,
+				"malloc() failed");
+		memcpy(data_copy, data, size);
+		fyi = fy_input_from_malloc_data(data_copy, size, &handle, simple);
+	} else if (malloced)
+		fyi = fy_input_from_malloc_data((void *)data, size, &handle, simple);
+	else
+		fyi = fy_input_from_data(data, size, &handle, simple);
+	fyd_error_check(fyd, fyi, err_out,
+			"fy_input_from_data() failed");
+	data_copy = NULL;
+
+	if (!alias) {
+
+		switch (handle.style & ~FYAS_MANUAL_MARK) {
+		case FYAS_PLAIN:
+			style = FYSS_PLAIN;
+			break;
+		case FYAS_SINGLE_QUOTED:
+			style = FYSS_SINGLE_QUOTED;
+			break;
+		case FYAS_DOUBLE_QUOTED:
+			style = FYSS_DOUBLE_QUOTED;
+			break;
+		case FYAS_LITERAL:
+			style = FYSS_LITERAL;
+			break;
+		case FYAS_FOLDED:
+			style = FYSS_FOLDED;
+			break;
+		default:
+			style = FYSS_DOUBLE_QUOTED;
+			break;
+		}
+
+		fyn->scalar = fy_token_create(FYTT_SCALAR, &handle, style);
+	} else
+		fyn->scalar = fy_token_create(FYTT_ALIAS, &handle, NULL);
+
+	fyd_error_check(fyd, fyn->scalar, err_out,
+			"fy_token_create() failed");
+
+	fyn->style = !alias ? (style == FYSS_PLAIN ? FYNS_PLAIN : FYNS_DOUBLE_QUOTED) : FYNS_ALIAS;
+
+	/* take away the input reference */
+	fy_input_unref(fyi);
+
+	return fyn;
+
+err_out:
+	if (data_copy)
+		free(data_copy);
+	fy_node_detach_and_free(fyn);
+	fyd->diag->on_error = false;
+	return NULL;
+}
+
+struct fy_node *fy_node_create_scalar(struct fy_document *fyd, const char *data, size_t size)
+{
+	return fy_node_create_scalar_internal(fyd, data, size, 0);
+}
+
+struct fy_node *fy_node_create_alias(struct fy_document *fyd, const char *data, size_t size)
+{
+	return fy_node_create_scalar_internal(fyd, data, size, FYNCSIF_ALIAS);
+}
+
+struct fy_node *fy_node_create_scalar_copy(struct fy_document *fyd, const char *data, size_t size)
+{
+	return fy_node_create_scalar_internal(fyd, data, size, FYNCSIF_COPY);
+}
+
+struct fy_node *fy_node_create_alias_copy(struct fy_document *fyd, const char *data, size_t size)
+{
+	return fy_node_create_scalar_internal(fyd, data, size, FYNCSIF_ALIAS | FYNCSIF_COPY);
+}
+
+struct fy_node *fy_node_create_vscalarf(struct fy_document *fyd, const char *fmt, va_list ap)
+{
+	if (!fyd || !fmt)
+		return NULL;
+
+	return fy_node_create_scalar_internal(fyd, fy_vsprintfa(fmt, ap), FY_NT, FYNCSIF_COPY);
+}
+
+struct fy_node *fy_node_create_scalarf(struct fy_document *fyd, const char *fmt, ...)
+{
+	va_list ap;
+	struct fy_node *fyn;
+
+	va_start(ap, fmt);
+	fyn = fy_node_create_vscalarf(fyd, fmt, ap);
+	va_end(ap);
+
+	return fyn;
+}
+
+int fy_node_set_tag(struct fy_node *fyn, const char *data, size_t len)
+{
+	struct fy_document *fyd;
+	struct fy_tag_scan_info info;
+	int handle_length, uri_length, prefix_length;
+	const char *handle_start;
+	int rc;
+	struct fy_atom handle;
+	struct fy_input *fyi = NULL;
+	struct fy_token *fyt = NULL, *fyt_td = NULL;
+
+	if (!fyn || !data || !len || !fyn->fyd)
+		return -1;
+
+	fyd = fyn->fyd;
+
+	if (len == (size_t)-1)
+		len = strlen(data);
+
+	memset(&info, 0, sizeof(info));
+
+	rc = fy_tag_scan(data, len, &info);
+	if (rc)
+		goto err_out;
+
+	handle_length = info.handle_length;
+	uri_length = info.uri_length;
+	prefix_length = info.prefix_length;
+
+	handle_start = data + prefix_length;
+
+	fyt_td = fy_document_state_lookup_tag_directive(fyd->fyds,
+			handle_start, handle_length);
+	if (!fyt_td)
+		goto err_out;
+
+	fyi = fy_input_from_data(data, len, &handle, true);
+	if (!fyi)
+		goto err_out;
+
+	handle.style = FYAS_URI;
+	handle.direct_output = false;
+	handle.storage_hint = 0;
+	handle.storage_hint_valid = false;
+
+	fyt = fy_token_create(FYTT_TAG, &handle, prefix_length,
+				handle_length, uri_length, fyt_td);
+	if (!fyt)
+		goto err_out;
+
+	fy_token_unref(fyn->tag);
+	fyn->tag = fyt;
+
+	/* take away the input reference */
+	fy_input_unref(fyi);
+
+	return 0;
+err_out:
+	fyd->diag->on_error = false;
+	return -1;
+}
+
+int fy_node_remove_tag(struct fy_node *fyn)
+{
+	if (!fyn || !fyn->tag)
+		return -1;
+
+	fy_token_unref(fyn->tag);
+	fyn->tag = NULL;
+
+	return 0;
+}
+
+struct fy_node *fy_node_create_sequence(struct fy_document *fyd)
+{
+	struct fy_node *fyn;
+
+	fyn = fy_node_alloc(fyd, FYNT_SEQUENCE);
+	if (!fyn)
+		return NULL;
+
+	return fyn;
+}
+
+struct fy_node *fy_node_create_mapping(struct fy_document *fyd)
+{
+	struct fy_node *fyn;
+
+	fyn = fy_node_alloc(fyd, FYNT_MAPPING);
+	if (!fyn)
+		return NULL;
+
+	return fyn;
+}
+
+static int fy_node_sequence_insert_prepare(struct fy_node *fyn_seq, struct fy_node *fyn)
+{
+	struct fy_document *fyd;
+
+	if (!fyn_seq || !fyn || fyn_seq->type != FYNT_SEQUENCE)
+		return -1;
+
+	/* can't insert a node that's attached already */
+	if (fyn->attached)
+		return -1;
+
+	/* a document must be associated with the sequence */
+	fyd = fyn_seq->fyd;
+	if (!fyd)
+		return -1;
+
+	/* the documents of the nodes must match */
+	if (fyn->fyd != fyd)
+		return -1;
+
+	fyn->parent = fyn_seq;
+
+	return 0;
+}
+
+int fy_node_sequence_append(struct fy_node *fyn_seq, struct fy_node *fyn)
+{
+	int ret;
+
+	ret = fy_node_sequence_insert_prepare(fyn_seq, fyn);
+	if (ret)
+		return ret;
+
+	fy_node_mark_synthetic(fyn_seq);
+	fy_node_list_add_tail(&fyn_seq->sequence, fyn);
+	fyn->attached = true;
+	return 0;
+}
+
+int fy_node_sequence_prepend(struct fy_node *fyn_seq, struct fy_node *fyn)
+{
+	int ret;
+
+	ret = fy_node_sequence_insert_prepare(fyn_seq, fyn);
+	if (ret)
+		return ret;
+
+	fy_node_mark_synthetic(fyn_seq);
+	fy_node_list_add(&fyn_seq->sequence, fyn);
+	fyn->attached = true;
+	return 0;
+}
+
+static bool fy_node_sequence_contains_node(struct fy_node *fyn_seq, struct fy_node *fyn)
+{
+	struct fy_node *fyni;
+
+	if (!fyn_seq || !fyn || fyn_seq->type != FYNT_SEQUENCE)
+		return false;
+
+	for (fyni = fy_node_list_head(&fyn_seq->sequence); fyni; fyni = fy_node_next(&fyn_seq->sequence, fyni))
+		if (fyni == fyn)
+			return true;
+
+	return false;
+}
+
+int fy_node_sequence_insert_before(struct fy_node *fyn_seq,
+				   struct fy_node *fyn_mark, struct fy_node *fyn)
+{
+	int ret;
+
+	if (!fy_node_sequence_contains_node(fyn_seq, fyn_mark))
+		return -1;
+
+	ret = fy_node_sequence_insert_prepare(fyn_seq, fyn);
+	if (ret)
+		return ret;
+
+	fy_node_mark_synthetic(fyn_seq);
+	fy_node_list_insert_before(&fyn_seq->sequence, fyn_mark, fyn);
+	fyn->attached = true;
+
+	return 0;
+}
+
+int fy_node_sequence_insert_after(struct fy_node *fyn_seq,
+				   struct fy_node *fyn_mark, struct fy_node *fyn)
+{
+	int ret;
+
+	if (!fy_node_sequence_contains_node(fyn_seq, fyn_mark))
+		return -1;
+
+	ret = fy_node_sequence_insert_prepare(fyn_seq, fyn);
+	if (ret)
+		return ret;
+
+	fy_node_mark_synthetic(fyn_seq);
+	fy_node_list_insert_after(&fyn_seq->sequence, fyn_mark, fyn);
+	fyn->attached = true;
+
+	return 0;
+}
+
+struct fy_node *fy_node_sequence_remove(struct fy_node *fyn_seq, struct fy_node *fyn)
+{
+	if (!fy_node_sequence_contains_node(fyn_seq, fyn))
+		return NULL;
+
+	fy_node_list_del(&fyn_seq->sequence, fyn);
+	fyn->parent = NULL;
+	fyn->attached = false;
+
+	fy_node_mark_synthetic(fyn_seq);
+
+	return fyn;
+}
+
+static struct fy_node_pair *
+fy_node_mapping_pair_insert_prepare(struct fy_node *fyn_map,
+				    struct fy_node *fyn_key, struct fy_node *fyn_value)
+{
+	struct fy_document *fyd;
+	struct fy_node_pair *fynp;
+
+	if (!fyn_map || fyn_map->type != FYNT_MAPPING)
+		return NULL;
+
+	/* a document must be associated with the mapping */
+	fyd = fyn_map->fyd;
+	if (!fyd)
+		return NULL;
+
+	/* if not NULL, the documents of the nodes must match */
+	if ((fyn_key && fyn_key->fyd != fyd) ||
+	    (fyn_value && fyn_value->fyd != fyd))
+		return NULL;
+
+	/* if not NULL neither the key nor the value must be attached */
+	if ((fyn_key && fyn_key->attached) ||
+	    (fyn_value && fyn_value->attached))
+		return NULL;
+
+	/* if we don't allow duplicate keys */
+	if (!(fyd->parse_cfg.flags & FYPCF_ALLOW_DUPLICATE_KEYS)) {
+
+		 if (fy_node_mapping_key_is_duplicate(fyn_map, fyn_key))
+			return NULL;
+	}
+
+	fynp = fy_node_pair_alloc(fyd);
+	if (!fynp)
+		return NULL;
+
+	if (fyn_key) {
+		fyn_key->parent = fyn_map;
+		fyn_key->key_root = true;
+	}
+	if (fyn_value)
+		fyn_value->parent = fyn_map;
+
+	fynp->key = fyn_key;
+	fynp->value = fyn_value;
+	fynp->parent = fyn_map;
+
+	return fynp;
+}
+
+int fy_node_mapping_append(struct fy_node *fyn_map,
+			   struct fy_node *fyn_key, struct fy_node *fyn_value)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_pair_insert_prepare(fyn_map, fyn_key, fyn_value);
+	if (!fynp)
+		return -1;
+
+	fy_node_pair_list_add_tail(&fyn_map->mapping, fynp);
+	if (fyn_map->xl)
+		fy_accel_insert(fyn_map->xl , fyn_key, fynp);
+
+	if (fyn_key)
+		fyn_key->attached = true;
+	if (fyn_value)
+		fyn_value->attached = true;
+
+	fy_node_mark_synthetic(fyn_map);
+
+	return 0;
+}
+
+int fy_node_mapping_prepend(struct fy_node *fyn_map,
+			    struct fy_node *fyn_key, struct fy_node *fyn_value)
+{
+	struct fy_node_pair *fynp;
+
+	fynp = fy_node_mapping_pair_insert_prepare(fyn_map, fyn_key, fyn_value);
+	if (!fynp)
+		return -1;
+
+	if (fyn_key)
+		fyn_key->attached = true;
+	if (fyn_value)
+		fyn_value->attached = true;
+	fy_node_pair_list_add(&fyn_map->mapping, fynp);
+	if (fyn_map->xl)
+		fy_accel_insert(fyn_map->xl, fyn_key, fynp);
+
+	fy_node_mark_synthetic(fyn_map);
+
+	return 0;
+}
+
+bool fy_node_mapping_contains_pair(struct fy_node *fyn_map, struct fy_node_pair *fynp)
+{
+	struct fy_node_pair *fynpi;
+
+	if (!fyn_map || !fynp || fyn_map->type != FYNT_MAPPING)
+		return false;
+
+	if (fyn_map->xl) {
+		fynpi = fy_node_accel_lookup_by_node(fyn_map, fynp->key);
+		if (fynpi == fynp)
+			return true;
+	} else {
+		for (fynpi = fy_node_pair_list_head(&fyn_map->mapping); fynpi; fynpi = fy_node_pair_next(&fyn_map->mapping, fynpi))
+			if (fynpi == fynp)
+				return true;
+	}
+
+	return false;
+}
+
+int fy_node_mapping_remove(struct fy_node *fyn_map, struct fy_node_pair *fynp)
+{
+	if (!fy_node_mapping_contains_pair(fyn_map, fynp))
+		return -1;
+
+	fy_node_pair_list_del(&fyn_map->mapping, fynp);
+	if (fyn_map->xl)
+		fy_accel_remove(fyn_map->xl, fynp->key);
+
+	if (fynp->key) {
+		fynp->key->parent = NULL;
+		fynp->key->attached = false;
+	}
+
+	if (fynp->value) {
+		fynp->value->parent = NULL;
+		fynp->value->attached = false;
+	}
+
+	fynp->parent = NULL;
+
+	return 0;
+}
+
+/* returns value */
+struct fy_node *fy_node_mapping_remove_by_key(struct fy_node *fyn_map, struct fy_node *fyn_key)
+{
+	struct fy_node_pair *fynp;
+	struct fy_node *fyn_value;
+
+	fynp = fy_node_mapping_lookup_pair(fyn_map, fyn_key);
+	if (!fynp)
+		return NULL;
+
+	fyn_value = fynp->value;
+	if (fyn_value) {
+		fyn_value->parent = NULL;
+		fyn_value->attached = false;
+	}
+
+	fynp->value = NULL;
+
+	fy_node_pair_list_del(&fyn_map->mapping, fynp);
+	if (fyn_map->xl)
+		fy_accel_remove(fyn_map->xl, fynp->key);
+
+	fy_node_pair_detach_and_free(fynp);
+
+	fy_node_mark_synthetic(fyn_map);
+
+	return fyn_value;
+}
+
+void *fy_node_mapping_sort_ctx_arg(struct fy_node_mapping_sort_ctx *ctx)
+{
+	return ctx->arg;
+}
+
+static int fy_node_mapping_sort_cmp(
+#ifdef __APPLE__
+void *arg, const void *a, const void *b
+#else
+const void *a, const void *b, void *arg
+#endif
+)
+{
+	struct fy_node_mapping_sort_ctx *ctx = arg;
+	struct fy_node_pair * const *fynppa = a, * const *fynppb = b;
+
+	assert(fynppa >= ctx->fynpp && fynppa < ctx->fynpp + ctx->count);
+	assert(fynppb >= ctx->fynpp && fynppb < ctx->fynpp + ctx->count);
+
+	return ctx->key_cmp(*fynppa, *fynppb, ctx->arg);
+}
+
+/* not! thread safe! */
+#if !defined(HAVE_QSORT_R) || !HAVE_QSORT_R || defined(__EMSCRIPTEN__)
+static struct fy_node_mapping_sort_ctx *fy_node_mapping_sort_ctx_no_qsort_r;
+
+static int fy_node_mapping_sort_cmp_no_qsort_r(const void *a, const void *b)
+{
+#ifdef __APPLE__
+	return fy_node_mapping_sort_cmp(
+			fy_node_mapping_sort_ctx_no_qsort_r,
+			a, b);
+#else
+	return fy_node_mapping_sort_cmp( a, b,
+			fy_node_mapping_sort_ctx_no_qsort_r);
+#endif
+}
+
+#endif
+
+static int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
+				      struct fy_node *fyn_b,
+				      void *arg)
+{
+	/* handles NULL cases */
+	if (fyn_a == fyn_b)
+		return 0;
+	if (!fyn_a)
+		return 1;
+	if (!fyn_b)
+		return -1;
+	return fy_token_cmp(fyn_a->scalar, fyn_b->scalar);
+}
+
+/* the default sort method */
+static int fy_node_mapping_sort_cmp_default(const struct fy_node_pair *fynp_a,
+					    const struct fy_node_pair *fynp_b,
+					    void *arg)
+{
+	int idx_a, idx_b;
+	bool alias_a, alias_b, scalar_a, scalar_b;
+	struct fy_node_cmp_arg *cmp_arg;
+	fy_node_scalar_compare_fn cmp_fn;
+	void *cmp_fn_arg;
+
+	cmp_arg = arg;
+	cmp_fn = cmp_arg ? cmp_arg->cmp_fn : fy_node_scalar_cmp_default;
+	cmp_fn_arg = cmp_arg ? cmp_arg->arg : NULL;
+
+	/* order is: maps first, followed by sequences, and last scalars sorted */
+	scalar_a = !fynp_a->key || fy_node_is_scalar(fynp_a->key);
+	scalar_b = !fynp_b->key || fy_node_is_scalar(fynp_b->key);
+
+	/* scalar? perform comparison */
+	if (scalar_a && scalar_b) {
+
+		/* if both are aliases, sort skipping the '*' */
+		alias_a = fy_node_is_alias(fynp_a->key);
+		alias_b = fy_node_is_alias(fynp_b->key);
+
+		/* aliases win */
+		if (alias_a && !alias_b)
+			return -1;
+
+		if (!alias_a && alias_b)
+			return 1;
+
+		return cmp_fn(fynp_a->key, fynp_b->key, cmp_fn_arg);
+	}
+
+	/* b is scalar, a is not */
+	if (!scalar_a && scalar_b)
+		return -1;
+
+	/* a is scalar, b is not */
+	if (scalar_a && !scalar_b)
+		return 1;
+
+	/* different types, mappings win */
+	if (fynp_a->key->type != fynp_b->key->type)
+		return fynp_a->key->type == FYNT_MAPPING ? -1 : 1;
+
+	/* ok, need to compare indices now */
+	idx_a = fy_node_mapping_get_pair_index(fynp_a->parent, fynp_a);
+	idx_b = fy_node_mapping_get_pair_index(fynp_b->parent, fynp_b);
+
+	return idx_a > idx_b ? 1 : (idx_a < idx_b ? -1 : 0);
+}
+
+void fy_node_mapping_fill_array(struct fy_node *fyn_map,
+		struct fy_node_pair **fynpp, int count)
+{
+	struct fy_node_pair *fynpi;
+	int i;
+
+	for (i = 0, fynpi = fy_node_pair_list_head(&fyn_map->mapping); i < count && fynpi;
+		fynpi = fy_node_pair_next(&fyn_map->mapping, fynpi), i++)
+		fynpp[i] = fynpi;
+
+	/* if there's enough space, put down a NULL at the end */
+	if (i < count)
+		fynpp[i++] = NULL;
+	assert(i == count);
+
+}
+
+void fy_node_mapping_perform_sort(struct fy_node *fyn_map,
+		fy_node_mapping_sort_fn key_cmp, void *arg,
+		struct fy_node_pair **fynpp, int count)
+{
+	struct fy_node_mapping_sort_ctx ctx;
+	struct fy_node_cmp_arg def_arg;
+
+	if (!key_cmp) {
+		def_arg.cmp_fn = fy_node_scalar_cmp_default;
+		def_arg.arg = arg;
+	} else {
+		def_arg.cmp_fn = NULL;
+		def_arg.arg = NULL;
+	}
+	ctx.key_cmp = key_cmp ? key_cmp : fy_node_mapping_sort_cmp_default;
+	ctx.arg = key_cmp ? arg : &def_arg;
+	ctx.fynpp = fynpp;
+	ctx.count = count;
+#if defined(HAVE_QSORT_R) && HAVE_QSORT_R && !defined(__EMSCRIPTEN__)
+#ifdef __APPLE__
+	qsort_r(fynpp, count, sizeof(*fynpp), &ctx, fy_node_mapping_sort_cmp);
+#else
+	qsort_r(fynpp, count, sizeof(*fynpp), fy_node_mapping_sort_cmp, &ctx);
+#endif
+#else
+	/* caution, not thread safe */
+	fy_node_mapping_sort_ctx_no_qsort_r = &ctx;
+	qsort(fynpp, count, sizeof(*fynpp), fy_node_mapping_sort_cmp_no_qsort_r);
+	fy_node_mapping_sort_ctx_no_qsort_r = NULL;
+#endif
+}
+
+struct fy_node_pair **fy_node_mapping_sort_array(struct fy_node *fyn_map,
+		fy_node_mapping_sort_fn key_cmp, void *arg, int *countp)
+{
+	int count;
+	struct fy_node_pair **fynpp;
+
+	count = fy_node_mapping_item_count(fyn_map);
+	if (count < 0)
+		return NULL;
+
+	fynpp = malloc((count + 1) * sizeof(*fynpp));
+	if (!fynpp)
+		return NULL;
+
+	memset(fynpp, 0, (count + 1) * sizeof(*fynpp));
+
+	fy_node_mapping_fill_array(fyn_map, fynpp, count);
+	fy_node_mapping_perform_sort(fyn_map, key_cmp, arg, fynpp, count);
+
+	if (countp)
+		*countp = count;
+
+	return fynpp;
+}
+
+void fy_node_mapping_release_array(struct fy_node *fyn_map, struct fy_node_pair **fynpp)
+{
+	if (!fyn_map || !fynpp)
+		return;
+
+	free(fynpp);
+}
+
+int fy_node_mapping_sort(struct fy_node *fyn_map,
+		fy_node_mapping_sort_fn key_cmp,
+		void *arg)
+{
+	int count, i;
+	struct fy_node_pair **fynpp, *fynpi;
+
+	fynpp = fy_node_mapping_sort_array(fyn_map, key_cmp, arg, &count);
+	if (!fynpp)
+		return -1;
+
+	fy_node_pair_list_init(&fyn_map->mapping);
+	for (i = 0; i < count; i++) {
+		fynpi = fynpp[i];
+		fy_node_pair_list_add_tail(&fyn_map->mapping, fynpi);
+	}
+
+	fy_node_mapping_release_array(fyn_map, fynpp);
+
+	return 0;
+}
+
+static int fy_node_sequence_sort_cmp(
+#ifdef __APPLE__
+void *arg, const void *a, const void *b
+#else
+const void *a, const void *b, void *arg
+#endif
+)
+{
+	struct fy_node_sequence_sort_ctx *ctx = arg;
+	struct fy_node * const *fynpa = a, * const *fynpb = b;
+
+	assert(fynpa >= ctx->fynp && fynpa < ctx->fynp + ctx->count);
+	assert(fynpb >= ctx->fynp && fynpb < ctx->fynp + ctx->count);
+
+	return ctx->cmp(*fynpa, *fynpb, ctx->arg);
+}
+
+/* not! thread safe! */
+#if !defined(HAVE_QSORT_R) || !HAVE_QSORT_R || defined(__EMSCRIPTEN__)
+static struct fy_node_sequence_sort_ctx *fy_node_sequence_sort_ctx_no_qsort_r;
+
+static int fy_node_sequence_sort_cmp_no_qsort_r(const void *a, const void *b)
+{
+#ifdef __APPLE__
+	return fy_node_sequence_sort_cmp(
+			fy_node_sequence_sort_ctx_no_qsort_r,
+			a, b);
+#else
+	return fy_node_sequence_sort_cmp(a, b,
+			fy_node_sequence_sort_ctx_no_qsort_r);
+#endif
+}
+
+#endif
+
+int fy_node_sequence_sort(struct fy_node *fyn_seq,
+		fy_node_sequence_sort_fn cmp, void *arg)
+{
+	struct fy_node_sequence_sort_ctx ctx;
+	struct fy_node **fynp, *fyni;
+	int count, i;
+
+	if (!fyn_seq || fyn_seq->type != FYNT_SEQUENCE || !cmp)
+		return -1;
+
+	count = fy_node_sequence_item_count(fyn_seq);
+	if (count <= 1)
+		return 0;
+
+	fynp = malloc(count * sizeof(*fynp));
+	if (!fynp)
+		return -1;
+
+	for (i = 0, fyni = fy_node_list_head(&fyn_seq->sequence); i < count && fyni;
+		fyni = fy_node_next(&fyn_seq->sequence, fyni), i++)
+		fynp[i] = fyni;
+
+	ctx.cmp = cmp;
+	ctx.arg = arg;
+	ctx.fynp = fynp;
+	ctx.count = count;
+
+#if defined(HAVE_QSORT_R) && HAVE_QSORT_R && !defined(__EMSCRIPTEN__)
+#ifdef __APPLE__
+	qsort_r(fynp, count, sizeof(*fynp), &ctx, fy_node_sequence_sort_cmp);
+#else
+	qsort_r(fynp, count, sizeof(*fynp), fy_node_sequence_sort_cmp, &ctx);
+#endif
+#else
+	/* caution, not thread safe */
+	fy_node_sequence_sort_ctx_no_qsort_r = &ctx;
+	qsort(fynp, count, sizeof(*fynp), fy_node_sequence_sort_cmp_no_qsort_r);
+	fy_node_sequence_sort_ctx_no_qsort_r = NULL;
+#endif
+
+	fy_node_list_init(&fyn_seq->sequence);
+	for (i = 0; i < count; i++)
+		fy_node_list_add_tail(&fyn_seq->sequence, fynp[i]);
+
+	free(fynp);
+
+	return 0;
+}
+
+int fy_node_sort(struct fy_node *fyn, fy_node_mapping_sort_fn key_cmp, void *arg)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi;
+	int ret;
+
+	if (!fyn)
+		return 0;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			fy_node_sort(fyni, key_cmp, arg);
+		}
+		break;
+
+	case FYNT_MAPPING:
+		ret = fy_node_mapping_sort(fyn, key_cmp, arg);
+		if (ret)
+			return ret;
+
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			/* the parent of the key is always NULL */
+			ret = fy_node_sort(fynp->key, key_cmp, arg);
+			if (ret)
+				return ret;
+
+			ret = fy_node_sort(fynp->value, key_cmp, arg);
+			if (ret)
+				return ret;
+
+			fynp->parent = fyn;
+		}
+		break;
+	}
+
+	return 0;
+}
+
+struct fy_node *fy_node_vbuildf(struct fy_document *fyd, const char *fmt, va_list ap)
+{
+	struct fy_document_vbuildf_ctx vctx;
+	struct fy_node *fyn;
+
+	vctx.fmt = fmt;
+	va_copy(vctx.ap, ap);
+	fyn = fy_node_build_internal(fyd, parser_setup_from_fmt_ap, &vctx);
+	va_end(ap);
+
+	return fyn;
+}
+
+struct fy_node *fy_node_buildf(struct fy_document *fyd, const char *fmt, ...)
+{
+	struct fy_node *fyn;
+	va_list ap;
+
+	va_start(ap, fmt);
+	fyn = fy_node_vbuildf(fyd, fmt, ap);
+	va_end(ap);
+
+	return fyn;
+}
+
+struct fy_document *fy_document_vbuildf(const struct fy_parse_cfg *cfg, const char *fmt, va_list ap)
+{
+	struct fy_document *fyd;
+	struct fy_document_vbuildf_ctx vctx;
+
+	vctx.fmt = fmt;
+	va_copy(vctx.ap, ap);
+	fyd = fy_document_build_internal(cfg, parser_setup_from_fmt_ap, &vctx);
+	va_end(ap);
+
+	return fyd;
+}
+
+struct fy_document *fy_document_buildf(const struct fy_parse_cfg *cfg, const char *fmt, ...)
+{
+	struct fy_document *fyd;
+	va_list ap;
+
+	va_start(ap, fmt);
+	fyd = fy_document_vbuildf(cfg, fmt, ap);
+	va_end(ap);
+
+	return fyd;
+}
+
+struct flow_reader_container {
+	struct fy_reader reader;
+	const struct fy_parse_cfg *cfg;
+};
+
+static struct fy_diag *flow_reader_get_diag(struct fy_reader *fyr)
+{
+	struct flow_reader_container *frc = container_of(fyr, struct flow_reader_container, reader);
+	return frc->cfg ? frc->cfg->diag : NULL;
+}
+
+static const struct fy_reader_ops reader_ops = {
+	.get_diag = flow_reader_get_diag,
+};
+
+struct fy_document *
+fy_flow_document_build_from_string(const struct fy_parse_cfg *cfg,
+				   const char *str, size_t len, size_t *consumed)
+{
+	struct flow_reader_container frc;
+	struct fy_reader *fyr = NULL;
+	struct fy_parser fyp_data, *fyp = &fyp_data;
+	struct fy_parse_cfg cfg_data;
+	struct fy_input *fyi;
+	struct fy_document *fyd;
+	struct fy_mark mark;
+	int rc;
+
+	if (!str)
+		return NULL;
+
+	if (consumed)
+		*consumed = 0;
+
+	if (!cfg) {
+		memset(&cfg_data, 0, sizeof(cfg_data));
+		cfg_data.flags = FYPCF_DEFAULT_PARSE;
+		cfg = &cfg_data;
+	}
+
+	memset(&frc, 0, sizeof(frc));
+	fyr = &frc.reader;
+	frc.cfg = cfg;
+
+	fy_reader_setup(fyr, &reader_ops);
+
+	rc = fy_parse_setup(fyp, cfg);
+	if (rc)
+		goto err_no_parse;
+
+	fyi = fy_input_from_data(str, len, NULL, false);
+	if (!fyi)
+		goto err_no_input;
+
+	rc = fy_reader_input_open(fyr, fyi, NULL);
+	if (rc)
+		goto err_no_input_open;
+
+	fy_parser_set_reader(fyp, fyr);
+	fy_parser_set_flow_only_mode(fyp, true);
+
+	fyd = fy_parse_load_document(fyp);
+
+	fy_parse_cleanup(fyp);
+
+	if (fyd && consumed) {
+		fy_reader_get_mark(fyr, &mark);
+		*consumed = mark.input_pos;
+	}
+
+	fy_reader_cleanup(fyr);
+	fy_input_unref(fyi);
+
+	return fyd;
+
+err_no_input_open:
+	fy_input_unref(fyi);
+err_no_input:
+	fy_parse_cleanup(fyp);
+err_no_parse:
+	fy_reader_cleanup(fyr);
+	return NULL;
+}
+
+struct fy_document *
+fy_block_document_build_from_string(const struct fy_parse_cfg *cfg,
+				   const char *str, size_t len, size_t *consumed)
+{
+	struct flow_reader_container frc;
+	struct fy_reader *fyr = NULL;
+	struct fy_parser fyp_data, *fyp = &fyp_data;
+	struct fy_parse_cfg cfg_data;
+	struct fy_input *fyi;
+	struct fy_document *fyd;
+	struct fy_mark mark;
+	int rc;
+
+	if (!str)
+		return NULL;
+
+	if (consumed)
+		*consumed = 0;
+
+	if (!cfg) {
+		memset(&cfg_data, 0, sizeof(cfg_data));
+		cfg_data.flags = FYPCF_DEFAULT_PARSE;
+		cfg = &cfg_data;
+	}
+
+	memset(&frc, 0, sizeof(frc));
+	fyr = &frc.reader;
+	frc.cfg = cfg;
+
+	fy_reader_setup(fyr, &reader_ops);
+
+	rc = fy_parse_setup(fyp, cfg);
+	if (rc)
+		goto err_no_parse;
+
+	fyi = fy_input_from_data(str, len, NULL, false);
+	if (!fyi)
+		goto err_no_input;
+
+	rc = fy_reader_input_open(fyr, fyi, NULL);
+	if (rc)
+		goto err_no_input_open;
+
+	fy_parser_set_reader(fyp, fyr);
+	fy_parser_set_block_only_mode(fyp, true);
+
+	fyd = fy_parse_load_document(fyp);
+
+	fy_parse_cleanup(fyp);
+
+	if (fyd && consumed) {
+		fy_reader_get_mark(fyr, &mark);
+		*consumed = mark.input_pos;
+	}
+
+	fy_reader_cleanup(fyr);
+	fy_input_unref(fyi);
+
+	return fyd;
+
+err_no_input_open:
+	fy_input_unref(fyi);
+err_no_input:
+	fy_parse_cleanup(fyp);
+err_no_parse:
+	fy_reader_cleanup(fyr);
+	return NULL;
+}
+
+int fy_node_vscanf(struct fy_node *fyn, const char *fmt, va_list ap)
+{
+	size_t len;
+	char *fmt_cpy, *s, *e, *t, *te, *key, *fmtspec;
+	const char *value;
+	char *value0;
+	size_t value_len, value0_len;
+	int count, ret;
+	struct fy_node *fynv;
+	va_list apt;
+
+	if (!fyn || !fmt)
+		goto err_out;
+
+	len = strlen(fmt);
+	fmt_cpy = alloca(len + 1);
+	memcpy(fmt_cpy, fmt, len + 1);
+	s = fmt_cpy;
+	e = s + len;
+
+	/* the format is of the form 'access key' %fmt[...] */
+	/* so we search for a (non escaped '%) */
+	value0 = NULL;
+	value0_len = 0;
+	count = 0;
+	while (s < e) {
+		/* a '%' format must exist */
+		t = strchr(s, '%');
+		if (!t)
+			goto err_out;
+
+		/* skip escaped % */
+		if (t + 1 < e && t[1] == '%') {
+			s = t + 2;
+			continue;
+		}
+
+		/* trim spaces from key */
+		while (isspace((unsigned char)*s))
+			s++;
+		te = t;
+		while (te > s && isspace((unsigned char)te[-1]))
+			*--te = '\0';
+
+		key = s;
+
+		/* we have to scan until the next space that's not in char set */
+		fmtspec = t;
+		while (t < e) {
+			if (isspace((unsigned char)*t))
+				break;
+			/* character set (may include space) */
+			if (*t == '[') {
+				t++;
+				/* skip caret */
+				if (t < e && *t == '^')
+					t++;
+				/* if first character in the set is ']' accept it */
+				if (t < e && *t == ']')
+					t++;
+				/* now skip until end of character set */
+				while (t < e && *t != ']')
+					t++;
+				continue;
+			}
+			t++;
+		}
+		if (t < e)
+			*t++ = '\0';
+
+		/* find by (relative) path - note that the size has changed */
+		fynv = fy_node_by_path(fyn, key, te - key, FYNWF_DONT_FOLLOW);
+		if (!fynv || fynv->type != FYNT_SCALAR)
+			break;
+
+		/* there must be a text */
+		value = fy_token_get_text(fynv->scalar, &value_len);
+		if (!value)
+			break;
+
+		/* allocate buffer it's smaller than the one we have already */
+		if (!value0 || value0_len < value_len) {
+			value0 = alloca(value_len + 1);
+			value0_len = value_len;
+		}
+
+		memcpy(value0, value, value_len);
+		value0[value_len] = '\0';
+
+		va_copy(apt, ap);
+		/* scanf, all arguments are pointers */
+		(void)va_arg(ap, void *);	/* advance argument pointer */
+
+		/* pass it to the system's scanf method */
+		ret = vsscanf(value0, fmtspec, apt);
+
+		/* since it's a single specifier, it must be one on success */
+		if (ret != 1)
+			break;
+
+		s = t;
+		count++;
+	}
+
+	return count;
+
+err_out:
+	errno = -EINVAL;
+	return -1;
+}
+
+int fy_node_scanf(struct fy_node *fyn, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = fy_node_vscanf(fyn, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+int fy_document_vscanf(struct fy_document *fyd, const char *fmt, va_list ap)
+{
+	if (!fyd)
+		return -1;
+	return fy_node_vscanf(fyd->root, fmt, ap);
+}
+
+int fy_document_scanf(struct fy_document *fyd, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = fy_document_vscanf(fyd, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+bool fy_document_has_directives(const struct fy_document *fyd)
+{
+	struct fy_document_state *fyds;
+
+	if (!fyd)
+		return false;
+
+	fyds = fyd->fyds;
+	if (!fyds)
+		return false;
+
+	return fyds->fyt_vd || !fy_token_list_empty(&fyds->fyt_td);
+}
+
+bool fy_document_has_explicit_document_start(const struct fy_document *fyd)
+{
+	return fyd ? !fyd->fyds->start_implicit : false;
+}
+
+bool fy_document_has_explicit_document_end(const struct fy_document *fyd)
+{
+	return fyd ? !fyd->fyds->end_implicit : false;
+}
+
+void *fy_node_get_meta(struct fy_node *fyn)
+{
+	return fyn && fyn->has_meta ? fyn->meta : NULL;
+}
+
+int fy_node_set_meta(struct fy_node *fyn, void *meta)
+{
+	struct fy_document *fyd;
+
+	if (!fyn || !fyn->fyd)
+		return -1;
+
+	fyd = fyn->fyd;
+	if (fyn->has_meta && fyd->meta_clear_fn)
+		fyd->meta_clear_fn(fyn, fyn->meta, fyd->meta_user);
+	fyn->meta = meta;
+	fyn->has_meta = true;
+
+	return 0;
+}
+
+void fy_node_clear_meta(struct fy_node *fyn)
+{
+	struct fy_document *fyd;
+
+	if (!fyn || !fyn->has_meta || !fyn->fyd)
+		return;
+
+	fyd = fyn->fyd;
+	if (fyd->meta_clear_fn)
+		fyd->meta_clear_fn(fyn, fyn->meta, fyd->meta_user);
+	fyn->meta = NULL;
+	fyn->has_meta = false;
+}
+
+static void fy_node_clear_meta_internal(struct fy_node *fyn)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi;
+
+	if (!fyn)
+		return;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			fy_node_clear_meta_internal(fyni);
+		}
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			fy_node_clear_meta_internal(fynp->key);
+			fy_node_clear_meta_internal(fynp->value);
+		}
+		break;
+	}
+
+	fy_node_clear_meta(fyn);
+}
+
+int fy_document_register_meta(struct fy_document *fyd,
+			      fy_node_meta_clear_fn clear_fn,
+			      void *user)
+{
+	if (!fyd || !clear_fn || fyd->meta_clear_fn)
+		return -1;
+
+	fyd->meta_clear_fn = clear_fn;
+	fyd->meta_user = user;
+
+	return 0;
+}
+
+void fy_document_unregister_meta(struct fy_document *fyd)
+{
+	if (!fyd)
+		return;
+
+	fy_node_clear_meta_internal(fy_document_root(fyd));
+
+	fyd->meta_clear_fn = NULL;
+	fyd->meta_user = NULL;
+}
+
+bool fy_node_set_marker(struct fy_node *fyn, unsigned int marker)
+{
+	unsigned int prev_marks;
+
+	if (!fyn || marker > FYNWF_MAX_USER_MARKER)
+		return false;
+	prev_marks = fyn->marks;
+	fyn->marks |= FY_BIT(marker);
+	return !!(prev_marks & FY_BIT(marker));
+}
+
+bool fy_node_clear_marker(struct fy_node *fyn, unsigned int marker)
+{
+	unsigned int prev_marks;
+
+	if (!fyn || marker > FYNWF_MAX_USER_MARKER)
+		return false;
+	prev_marks = fyn->marks;
+	fyn->marks &= ~FY_BIT(marker);
+	return !!(prev_marks & FY_BIT(marker));
+}
+
+bool fy_node_is_marker_set(struct fy_node *fyn, unsigned int marker)
+{
+	if (!fyn || marker > FYNWF_MAX_USER_MARKER)
+		return false;
+	return !!(fyn->marks & FY_BIT(marker));
+}
+
+FILE *fy_document_get_error_fp(struct fy_document *fyd)
+{
+	/* just this for now */
+	return stderr;
+}
+
+enum fy_parse_cfg_flags fy_document_get_cfg_flags(const struct fy_document *fyd)
+{
+	if (!fyd)
+		return fy_parser_get_cfg_flags(NULL);
+
+	return fyd->parse_cfg.flags;
+}
+
+bool fy_document_can_be_accelerated(struct fy_document *fyd)
+{
+	if (!fyd)
+		return false;
+
+	return !(fyd->parse_cfg.flags & FYPCF_DISABLE_ACCELERATORS);
+}
+
+bool fy_document_is_accelerated(struct fy_document *fyd)
+{
+	if (!fyd)
+		return false;
+
+	return fyd->axl && fyd->naxl;
+}
+
+static int hd_anchor_hash(struct fy_accel *xl, const void *key, void *userdata, void *hash)
+{
+	struct fy_token *fyt = (void *)key;
+	unsigned int *hashp = hash;
+	const char *text;
+	size_t len;
+
+	text = fy_token_get_text(fyt, &len);
+	if (!text)
+		return -1;
+
+	*hashp = XXH32(text, len, 2654435761U);
+	return 0;
+}
+
+static bool hd_anchor_eq(struct fy_accel *xl, const void *hash, const void *key1, const void *key2, void *userdata)
+{
+	struct fy_token *fyt1 = (void *)key1, *fyt2 = (void *)key2;
+	const char *text1, *text2;
+	size_t len1, len2;
+
+	text1 = fy_token_get_text(fyt1, &len1);
+	if (!text1)
+		return false;
+	text2 = fy_token_get_text(fyt2, &len2);
+	if (!text2)
+		return false;
+
+	return len1 == len2 && !memcmp(text1, text2, len1);
+}
+
+static const struct fy_hash_desc hd_anchor = {
+	.size = sizeof(unsigned int),
+	.max_bucket_grow_limit = 6,	/* TODO allow tuning */
+	.hash = hd_anchor_hash,
+	.eq = hd_anchor_eq,
+};
+
+static int hd_nanchor_hash(struct fy_accel *xl, const void *key, void *userdata, void *hash)
+{
+	struct fy_node *fyn = (void *)key;
+	unsigned int *hashp = hash;
+	uintptr_t ptr = (uintptr_t)fyn;
+
+	*hashp = XXH32(&ptr, sizeof(ptr), 2654435761U);
+
+	return 0;
+}
+
+static bool hd_nanchor_eq(struct fy_accel *xl, const void *hash, const void *key1, const void *key2, void *userdata)
+{
+	struct fy_node *fyn1 = (void *)key1, *fyn2 = (void *)key2;
+
+	return fyn1 == fyn2;
+}
+
+static const struct fy_hash_desc hd_nanchor = {
+	.size = sizeof(unsigned int),
+	.max_bucket_grow_limit = 6,	/* TODO allow tuning */
+	.hash = hd_nanchor_hash,
+	.eq = hd_nanchor_eq,
+};
+
+
+static int hd_mapping_hash(struct fy_accel *xl, const void *key, void *userdata, void *hash)
+{
+	return fy_node_hash_uint((struct fy_node *)key, hash);
+}
+
+static bool hd_mapping_eq(struct fy_accel *xl, const void *hash, const void *key1, const void *key2, void *userdata)
+{
+	return fy_node_compare((struct fy_node *)key1, (struct fy_node *)key2);
+}
+
+static const struct fy_hash_desc hd_mapping = {
+	.size = sizeof(unsigned int),
+	.max_bucket_grow_limit = 6,	/* TODO allow tuning */
+	.hash = hd_mapping_hash,
+	.eq = hd_mapping_eq,
+};
+
+typedef void (*fy_hash_update_fn)(void *state, const void *ptr, size_t size);
+
+static int
+fy_node_hash_internal(struct fy_node *fyn, fy_hash_update_fn update_fn, void *state)
+{
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp;
+	struct fy_node_pair **fynpp;
+	struct fy_token_iter iter;
+	int i, count, rc;
+	const struct fy_iter_chunk *ic;
+
+	if (!fyn) {
+		/* NULL */
+		update_fn(state, "s", 1);	/* as zero length scalar */
+		return 0;
+	}
+
+	switch (fyn->type) {
+	case FYNT_SEQUENCE:
+		/* SEQUENCE */
+		update_fn(state, "S", 1);
+
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+		     fyni = fy_node_next(&fyn->sequence, fyni)) {
+
+			rc = fy_node_hash_internal(fyni, update_fn, state);
+			if (rc)
+				return rc;
+		}
+
+		break;
+
+	case FYNT_MAPPING:
+		count = fy_node_mapping_item_count(fyn);
+
+		fynpp = alloca(sizeof(*fynpp) * (count + 1));
+
+		fy_node_mapping_fill_array(fyn, fynpp, count);
+		fy_node_mapping_perform_sort(fyn, NULL, NULL, fynpp, count);
+
+		/* MAPPING */
+		update_fn(state, "M", 1);
+
+		for (i = 0; i < count; i++) {
+			fynp = fynpp[i];
+
+			/* MAPPING KEY */
+			update_fn(state, "K", 1);
+			rc = fy_node_hash_internal(fynp->key, update_fn, state);
+			if (rc)
+				return rc;
+
+			/* MAPPING VALUE */
+			update_fn(state, "V", 1);
+			rc = fy_node_hash_internal(fynp->value, update_fn, state);
+			if (rc)
+				return rc;
+		}
+
+		break;
+
+	case FYNT_SCALAR:
+		update_fn(state, !fy_node_is_alias(fyn) ? "s" : "A", 1);
+
+		fy_token_iter_start(fyn->scalar, &iter);
+		ic = NULL;
+		while ((ic = fy_token_iter_chunk_next(&iter, ic, &rc)) != NULL)
+			update_fn(state, ic->str, ic->len);
+		fy_token_iter_finish(&iter);
+
+		break;
+	}
+
+	return 0;
+}
+
+static void update_xx32(void *state, const void *ptr, size_t size)
+{
+	XXH32_update(state, ptr, size);
+}
+
+int fy_node_hash_uint(struct fy_node *fyn, unsigned int *hashp)
+{
+	XXH32_state_t state;
+	int rc;
+
+	XXH32_reset(&state, 2654435761U);
+
+	rc = fy_node_hash_internal(fyn, update_xx32, &state);
+	if (rc)
+		return rc;
+
+	*hashp = XXH32_digest(&state);
+	return 0;
+}
+
+struct fy_document_state *fy_document_get_document_state(struct fy_document *fyd)
+{
+	return fyd ? fyd->fyds : NULL;
+}
+
+int fy_document_set_document_state(struct fy_document *fyd, struct fy_document_state *fyds)
+{
+	/* document must exist and not have any contents */
+	if (!fyd || fyd->root)
+		return -1;
+
+	if (!fyds)
+		fyds = fy_document_state_default(NULL, NULL);
+	else
+		fyds = fy_document_state_ref(fyds);
+
+	if (!fyds)
+		return -1;
+
+	/* drop the previous document state */
+	fy_document_state_unref(fyd->fyds);
+	/* and use the new document state from now on */
+	fyd->fyds = fyds;
+
+	return 0;
+}
+
+struct fy_ptr_node *fy_ptr_node_create(struct fy_node *fyn)
+{
+	struct fy_ptr_node *fypn;
+
+	if (!fyn)
+		return NULL;
+
+	fypn = malloc(sizeof(*fypn));
+	if (!fypn)
+		return NULL;
+	memset(&fypn->node, 0, sizeof(fypn->node));
+	fypn->fyn = fyn;
+	return fypn;
+}
+
+void fy_ptr_node_destroy(struct fy_ptr_node *fypn)
+{
+	free(fypn);
+}
+
+void fy_ptr_node_list_free_all(struct fy_ptr_node_list *fypnl)
+{
+	struct fy_ptr_node *fypn;
+
+	while ((fypn = fy_ptr_node_list_pop(fypnl)) != NULL)
+		fy_ptr_node_destroy(fypn);
+}
+
+bool fy_ptr_node_list_contains(struct fy_ptr_node_list *fypnl, struct fy_node *fyn)
+{
+	struct fy_ptr_node *fypn;
+
+	if (!fypnl || !fyn)
+		return false;
+	for (fypn = fy_ptr_node_list_head(fypnl); fypn; fypn = fy_ptr_node_next(fypnl, fypn)) {
+		if (fypn->fyn == fyn)
+			return true;
+	}
+	return false;
+}
+
+struct fy_document *
+fy_document_create_from_event(struct fy_parser *fyp, struct fy_event *fye)
+{
+	struct fy_document *fyd;
+	int rc;
+
+	if (!fyp || !fye || fye->type != FYET_DOCUMENT_START)
+		return NULL;
+
+	/* TODO update document end */
+	fyd = fy_document_create(&fyp->cfg);
+	fyp_error_check(fyp, fyd, err_out,
+		"fy_document_create() failed");
+
+	rc = fy_document_set_document_state(fyd, fye->document_start.document_state);
+	fyp_error_check(fyp, !rc, err_out,
+		"fy_document_set_document_state() failed");
+
+	return fyd;
+
+err_out:
+	fy_document_destroy(fyd);
+	return NULL;
+}
+
+int
+fy_document_update_from_event(struct fy_document *fyd, struct fy_parser *fyp, struct fy_event *fye)
+{
+	if (!fyd || !fyp || !fye || fye->type != FYET_DOCUMENT_END)
+		return -1;
+
+	/* nothing besides checks */
+	return 0;
+}
+
+struct fy_node *
+fy_node_create_from_event(struct fy_document *fyd, struct fy_parser *fyp, struct fy_event *fye)
+{
+	struct fy_node *fyn = NULL;
+	struct fy_token *value = NULL, *anchor = NULL;
+	int rc;
+
+	if (!fyd || !fye)
+		return NULL;
+
+	switch (fye->type) {
+	default:
+		break;
+
+	case FYET_SCALAR:
+		fyn = fy_node_alloc(fyd, FYNT_SCALAR);
+		fyp_error_check(fyp, fyn, err_out,
+			"fy_node_alloc() scalar failed");
+
+		value = fye->scalar.value;
+
+		if (value)	/* NULL scalar */
+			fyn->style = fy_node_style_from_scalar_style(value->scalar.style);
+		else
+			fyn->style = FYNS_PLAIN;
+
+		/* NULLs are OK */
+		fyn->tag = fy_token_ref(fye->scalar.tag);
+		fyn->scalar = fy_token_ref(value);
+		anchor = fye->scalar.anchor;
+		break;
+
+	case FYET_ALIAS:
+		fyn = fy_node_alloc(fyd, FYNT_SCALAR);
+		fyp_error_check(fyp, fyn, err_out,
+			"fy_node_alloc() alias failed");
+
+		value = fye->alias.anchor;
+		fyn->style = FYNS_ALIAS;
+		fyn->scalar = fy_token_ref(value);
+		anchor = NULL;
+		break;
+
+	case FYET_MAPPING_START:
+		fyn = fy_node_create_mapping(fyd);
+		fyp_error_check(fyp, fyn, err_out,
+			"fy_node_create_mapping() failed");
+
+		value = fye->mapping_start.mapping_start;
+		fyn->style = value->type == FYTT_FLOW_MAPPING_START ? FYNS_FLOW : FYNS_BLOCK;
+
+		fyn->tag = fy_token_ref(fye->mapping_start.tag);
+		fyn->mapping_start = fy_token_ref(value);
+		fyn->mapping_end = NULL;
+		anchor = fye->mapping_start.anchor;
+		break;
+
+	case FYET_SEQUENCE_START:
+		fyn = fy_node_create_sequence(fyd);
+		fyp_error_check(fyp, fyn, err_out,
+			"fy_node_create_sequence() failed");
+
+		value = fye->sequence_start.sequence_start;
+
+		fyn->style = value->type == FYTT_FLOW_SEQUENCE_START ? FYNS_FLOW : FYNS_BLOCK;
+
+		fyn->tag = fy_token_ref(fye->sequence_start.tag);
+		fyn->sequence_start = fy_token_ref(value);
+		fyn->sequence_end = NULL;
+		anchor = fye->sequence_start.anchor;
+
+		break;
+
+	}
+
+	if (fyn && anchor) {
+		rc = fy_document_register_anchor(fyd, fyn, fy_token_ref(anchor));
+		fyp_error_check(fyp, !rc, err_out,
+			"fy_document_register_anchor() failed");
+	}
+
+	return fyn;
+
+err_out:
+	/* NULL OK */
+	fy_node_free(fyn);
+	return NULL;
+}
+
+int
+fy_node_update_from_event(struct fy_node *fyn, struct fy_parser *fyp, struct fy_event *fye)
+{
+	if (!fyn || !fyp || !fye)
+		return -1;
+
+	switch (fye->type) {
+
+	case FYET_MAPPING_END:
+		if (!fy_node_is_mapping(fyn))
+			return -1;
+		fy_token_unref(fyn->mapping_end);
+		fyn->mapping_end = fy_token_ref(fye->mapping_end.mapping_end);
+
+		break;
+
+	case FYET_SEQUENCE_END:
+		if (!fy_node_is_sequence(fyn))
+			return -1;
+		fy_token_unref(fyn->sequence_end);
+		fyn->sequence_end = fy_token_ref(fye->sequence_end.sequence_end);
+
+		break;
+
+	default:
+		return -1;
+	}
+
+	return 0;
+}
+
+struct fy_node_pair *
+fy_node_pair_create_with_key(struct fy_document *fyd, struct fy_node *fyn_parent, struct fy_node *fyn)
+{
+	struct fy_node_pair *fynp;
+	bool is_duplicate;
+
+	if (!fyd || !fyn_parent || !fy_node_is_mapping(fyn_parent))
+		return NULL;
+
+	/* if we don't allow duplicate keys */
+	if (!(fyd->parse_cfg.flags & FYPCF_ALLOW_DUPLICATE_KEYS)) {
+
+		/* make sure we don't add an already existing key */
+		is_duplicate = fy_node_mapping_key_is_duplicate(fyn_parent, fyn);
+		if (is_duplicate) {
+			FYD_NODE_ERROR(fyd, fyn, FYEM_DOC,
+					"duplicate mapping key");
+			return NULL;
+		}
+	}
+
+	fynp = fy_node_pair_alloc(fyd);
+	fyd_error_check(fyd, fynp, err_out,
+			"fy_node_pair_alloc() failed");
+
+	fynp->parent = fyn_parent;
+
+	fynp->key = fyn;
+	if (fynp->key)
+		fynp->key->attached = true;
+
+	return fynp;
+
+err_out:
+	fy_node_pair_free(fynp);
+	return NULL;
+
+}
+
+int
+fy_node_pair_update_with_value(struct fy_node_pair *fynp, struct fy_node *fyn)
+{
+	struct fy_node *fyn_parent;
+	int rc;
+
+	/* node pair must exist and value must be NULL */
+	if (!fynp || fynp->value || !fynp->parent || !fy_node_is_mapping(fynp->parent) || !fyn->fyd)
+		return -1;
+
+	fynp->value = fyn;
+	if (fynp->value)
+		fynp->value->attached = true;
+
+	fyn_parent = fynp->parent;
+
+	fy_node_pair_list_add_tail(&fyn_parent->mapping, fynp);
+	if (fyn_parent->xl) {
+		rc = fy_accel_insert(fyn_parent->xl, fynp->key, fynp);
+		fyd_error_check(fyn->fyd, !rc, err_out,
+			"fy_accel_insert() failed");
+	}
+
+	return 0;
+
+err_out:
+	fy_node_pair_list_del(&fyn_parent->mapping, fynp);
+	if (fyn)
+		fyn->attached = false;
+	fynp->value = NULL;
+	return -1;
+}
+
+int
+fy_node_sequence_add_item(struct fy_node *fyn_parent, struct fy_node *fyn)
+{
+	/* node pair must exist and value must be NULL */
+	if (!fyn_parent || !fyn || !fy_node_is_sequence(fyn_parent) || !fyn->fyd)
+		return -1;
+
+	fyn->parent = fyn_parent;
+	fy_node_list_add_tail(&fyn_parent->sequence, fyn);
+	fyn->attached = true;
+	return 0;
+}
+
+int fy_document_iterator_setup(struct fy_document_iterator *fydi, const struct fy_document_iterator_cfg *cfg)
+{
+	memset(fydi, 0, sizeof(*fydi));
+
+	if (cfg)
+		fydi->cfg = *cfg;
+
+	fydi->state = FYDIS_WAITING_STREAM_START;
+	fydi->fyd = NULL;
+	fydi->iterate_root = NULL;
+
+	/* suppress recycling if we must */
+	fydi->suppress_recycling_force = getenv("FY_VALGRIND") && !getenv("FY_VALGRIND_RECYCLING");
+	fydi->suppress_recycling = fydi->suppress_recycling_force;
+
+	fy_eventp_list_init(&fydi->recycled_eventp);
+	fy_token_list_init(&fydi->recycled_token);
+
+	if (!fydi->suppress_recycling) {
+		fydi->recycled_eventp_list = &fydi->recycled_eventp;
+		fydi->recycled_token_list = &fydi->recycled_token;
+	} else {
+		fydi->recycled_eventp_list = NULL;
+		fydi->recycled_token_list = NULL;
+	}
+
+	/* start with the stack pointing to the in place data */
+	fydi->stack_top = (unsigned int)-1;
+	fydi->stack_alloc = sizeof(fydi->in_place) / sizeof(fydi->in_place[0]);
+	fydi->stack = fydi->in_place;
+
+	/* set generator state accordingly */
+	fydi->generator_state = 0;
+
+	/* without configuration, is the default */
+	if (!cfg)
+		return 0;
+
+	/* set the generator flags accordingly */
+	switch (fydi->cfg.flags & FYDICF_WANT_MASK) {
+	case FYDICF_WANT_STREAM_DOCUMENT_BODY_EVENTS:
+		fydi->generator_state |= FYDIGF_WANTS_STREAM | FYDIGF_WANTS_DOC | FYDIGF_ENDS_AFTER_DOC;
+		break;
+	case FYDICF_WANT_DOCUMENT_BODY_EVENTS:
+		fydi->generator_state |= FYDIGF_WANTS_DOC | FYDIGF_ENDS_AFTER_DOC;
+		fydi->state = FYDIS_WAITING_DOCUMENT_START;
+		break;
+	case FYDICF_WANT_BODY_EVENTS:
+		fydi->generator_state |= FYDIGF_ENDS_AFTER_BODY;
+		fydi->state = FYDIS_WAITING_BODY_START_OR_DOCUMENT_END;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+void fy_document_iterator_cleanup(struct fy_document_iterator *fydi)
+{
+	struct fy_token *fyt;
+	struct fy_eventp *fyep;
+
+	/* free the stack if it's not the inplace one */
+	if (fydi->stack != fydi->in_place)
+		free(fydi->stack);
+	fydi->stack_top = (unsigned int)-1;
+	fydi->stack_alloc = sizeof(fydi->in_place) / sizeof(fydi->in_place[0]);
+	fydi->stack = fydi->in_place;
+
+	while ((fyt = fy_token_list_pop(&fydi->recycled_token)) != NULL)
+		fy_token_free(fyt);
+
+	while ((fyep = fy_eventp_list_pop(&fydi->recycled_eventp)) != NULL)
+		fy_eventp_free(fyep);
+
+	fydi->state = FYDIS_WAITING_STREAM_START;
+	fydi->fyd = NULL;
+	fydi->iterate_root = NULL;
+}
+
+struct fy_document_iterator *
+fy_document_iterator_create_cfg(const struct fy_document_iterator_cfg *cfg)
+{
+	struct fy_document_iterator *fydi = NULL;
+	int rc;
+
+	fydi = malloc(sizeof(*fydi));
+	if (!fydi)
+		goto err_out;
+
+	rc = fy_document_iterator_setup(fydi, cfg);
+	if (rc)
+		goto err_out;
+
+	return fydi;
+
+err_out:
+	fy_document_iterator_destroy(fydi);
+	return NULL;
+}
+
+struct fy_document_iterator *fy_document_iterator_create(void)
+{
+	return fy_document_iterator_create_cfg(NULL);
+}
+
+struct fy_document_iterator *
+fy_document_iterator_create_on_document(struct fy_document *fyd)
+{
+	struct fy_document_iterator_cfg cfg;
+
+	if (!fyd)
+		return NULL;
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.flags = FYDICF_WANT_STREAM_DOCUMENT_BODY_EVENTS;
+	cfg.fyd = fyd;
+	cfg.iterate_root = fyd->root;
+
+	return fy_document_iterator_create_cfg(&cfg);
+}
+
+struct fy_document_iterator *
+fy_document_iterator_create_on_node(struct fy_node *fyn)
+{
+	struct fy_document_iterator_cfg cfg;
+
+	if (!fyn)
+		return NULL;
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.flags = FYDICF_WANT_STREAM_DOCUMENT_BODY_EVENTS;
+	cfg.fyd = fy_node_document(fyn);
+	cfg.iterate_root = fyn;
+
+	return fy_document_iterator_create_cfg(&cfg);
+}
+
+void fy_document_iterator_destroy(struct fy_document_iterator *fydi)
+{
+	if (!fydi)
+		return;
+	fy_document_iterator_cleanup(fydi);
+	free(fydi);
+}
+
+static struct fy_event *
+fydi_event_create(struct fy_document_iterator *fydi, struct fy_node *fyn, bool start)
+{
+	struct fy_eventp *fyep;
+	struct fy_event *fye;
+	struct fy_anchor *fya;
+	struct fy_token *anchor = NULL;
+
+	fyep = fy_document_iterator_eventp_alloc(fydi);
+	if (!fyep) {
+		fydi->state = FYDIS_ERROR;
+		return NULL;
+	}
+	fye = &fyep->e;
+
+	if (start) {
+		fya = fy_node_get_anchor(fyn);
+		anchor = fya ? fya->anchor : NULL;
+	}
+
+	switch (fyn->type) {
+
+	case FYNT_SCALAR:
+		if (fyn->style != FYNS_ALIAS) {
+			fye->type = FYET_SCALAR;
+			fye->scalar.anchor = fy_token_ref(anchor);
+			fye->scalar.tag = fy_token_ref(fyn->tag);
+			fye->scalar.value = fy_token_ref(fyn->scalar);
+		} else {
+			fye->type = FYET_ALIAS;
+			fye->alias.anchor = fy_token_ref(fyn->scalar);
+		}
+		break;
+
+	case FYNT_SEQUENCE:
+		if (start) {
+			fye->type = FYET_SEQUENCE_START;
+			fye->sequence_start.anchor = fy_token_ref(anchor);
+			fye->sequence_start.tag = fy_token_ref(fyn->tag);
+			fye->sequence_start.sequence_start = fy_token_ref(fyn->sequence_start);
+		} else {
+			fye->type = FYET_SEQUENCE_END;
+			fye->sequence_end.sequence_end = fy_token_ref(fyn->sequence_end);
+		}
+		break;
+
+	case FYNT_MAPPING:
+		if (start) {
+			fye->type = FYET_MAPPING_START;
+			fye->mapping_start.anchor = fy_token_ref(anchor);
+			fye->mapping_start.tag = fy_token_ref(fyn->tag);
+			fye->mapping_start.mapping_start = fy_token_ref(fyn->mapping_start);
+		} else {
+			fye->type = FYET_MAPPING_END;
+			fye->mapping_end.mapping_end = fy_token_ref(fyn->mapping_end);
+		}
+		break;
+	}
+
+	return fye;
+}
+
+struct fy_event *
+fy_document_iterator_stream_start(struct fy_document_iterator *fydi)
+{
+	struct fy_event *fye;
+
+	if (!fydi || fydi->state == FYDIS_ERROR)
+		return NULL;
+
+	/* both none and stream start are the same for this */
+	if (fydi->state != FYDIS_WAITING_STREAM_START &&
+	    fydi->state != FYDIS_WAITING_STREAM_END_OR_DOCUMENT_START)
+		goto err_out;
+
+	fye = fy_document_iterator_event_create(fydi, FYET_STREAM_START);
+	if (!fye)
+		goto err_out;
+
+	fydi->state = FYDIS_WAITING_DOCUMENT_START;
+	return fye;
+
+err_out:
+	fydi->state = FYDIS_ERROR;
+	return NULL;
+}
+
+struct fy_event *
+fy_document_iterator_stream_end(struct fy_document_iterator *fydi)
+{
+	struct fy_event *fye;
+
+	if (!fydi || fydi->state == FYDIS_ERROR)
+		return NULL;
+
+	if (fydi->state != FYDIS_WAITING_STREAM_END_OR_DOCUMENT_START &&
+	    fydi->state != FYDIS_WAITING_DOCUMENT_START)
+		goto err_out;
+
+	fye = fy_document_iterator_event_create(fydi, FYET_STREAM_END);
+	if (!fye)
+		goto err_out;
+
+	fydi->state = FYDIS_WAITING_STREAM_START;
+	return fye;
+
+err_out:
+	fydi->state = FYDIS_ERROR;
+	return NULL;
+}
+
+struct fy_event *
+fy_document_iterator_document_start_internal(struct fy_document_iterator *fydi, struct fy_document *fyd,
+					     struct fy_node *iterate_root)
+{
+	struct fy_event *fye = NULL;
+	struct fy_eventp *fyep;
+
+	if (!fydi || fydi->state == FYDIS_ERROR)
+		return NULL;
+
+	if (!fyd)
+		goto err_out;
+
+	/* we can transition to document start only from document start or stream end */
+	if (fydi->state != FYDIS_WAITING_DOCUMENT_START &&
+	    fydi->state != FYDIS_WAITING_STREAM_END_OR_DOCUMENT_START)
+		goto err_out;
+
+	fyep = fy_document_iterator_eventp_alloc(fydi);
+	if (!fyep)
+		goto err_out;
+	fye = &fyep->e;
+
+	fydi->fyd = fyd;
+
+	/* the iteration root is the document root if not given */
+	fydi->iterate_root = iterate_root ? iterate_root : fyd->root;
+
+	/* suppress recycling if we must */
+	fydi->suppress_recycling = (fyd->parse_cfg.flags & FYPCF_DISABLE_RECYCLING) ||
+				   fydi->suppress_recycling_force;
+
+	if (!fydi->suppress_recycling) {
+		fydi->recycled_eventp_list = &fydi->recycled_eventp;
+		fydi->recycled_token_list = &fydi->recycled_token;
+	} else {
+		fydi->recycled_eventp_list = NULL;
+		fydi->recycled_token_list = NULL;
+	}
+
+	fye->type = FYET_DOCUMENT_START;
+	fye->document_start.document_start = NULL;
+	fye->document_start.document_state = fy_document_state_ref(fyd->fyds);
+	fye->document_start.implicit = fyd->fyds->start_implicit;
+
+	/* and go into body */
+	fydi->state = FYDIS_WAITING_BODY_START_OR_DOCUMENT_END;
+
+	return fye;
+
+err_out:
+	fy_document_iterator_event_free(fydi, fye);
+	fydi->state = FYDIS_ERROR;
+	return NULL;
+}
+
+struct fy_event *
+fy_document_iterator_document_start(struct fy_document_iterator *fydi, struct fy_document *fyd)
+{
+	return fy_document_iterator_document_start_internal(fydi, fyd, NULL);
+}
+
+struct fy_event *
+fy_document_iterator_document_end(struct fy_document_iterator *fydi)
+{
+	struct fy_event *fye;
+
+	if (!fydi || fydi->state == FYDIS_ERROR)
+		return NULL;
+
+	if (!fydi->fyd || !fydi->fyd->fyds ||
+	    fydi->state != FYDIS_WAITING_DOCUMENT_END)
+		goto err_out;
+
+	fye = fy_document_iterator_event_create(fydi, FYET_DOCUMENT_END, (int)fydi->fyd->fyds->end_implicit);
+	if (!fye)
+		goto err_out;
+
+	fydi->fyd = NULL;
+	fydi->iterate_root = NULL;
+
+	fydi->state = FYDIS_WAITING_STREAM_END_OR_DOCUMENT_START;
+	return fye;
+
+err_out:
+	fydi->state = FYDIS_ERROR;
+	return NULL;
+}
+
+static bool
+fy_document_iterator_ensure_space(struct fy_document_iterator *fydi, unsigned int space)
+{
+	struct fy_document_iterator_body_state *new_stack;
+	size_t new_size, copy_size;
+	unsigned int new_stack_alloc;
+
+	/* empty stack should always have enough space */
+	if (fydi->stack_top == (unsigned int)-1) {
+		assert(fydi->stack_alloc >= space);
+		return true;
+	}
+
+	if (fydi->stack_top + space < fydi->stack_alloc)
+		return true;
+
+	/* make sure we have enough space */
+	new_stack_alloc = fydi->stack_alloc * 2;
+	while (fydi->stack_top + space >= new_stack_alloc)
+		new_stack_alloc *= 2;
+
+	new_size = new_stack_alloc * sizeof(*new_stack);
+
+	if (fydi->stack == fydi->in_place) {
+		new_stack = malloc(new_size);
+		if (!new_stack)
+			return false;
+		copy_size = (fydi->stack_top + 1) * sizeof(*new_stack);
+		memcpy(new_stack, fydi->stack, copy_size);
+	} else {
+		new_stack = realloc(fydi->stack, new_size);
+		if (!new_stack)
+			return false;
+	}
+	fydi->stack = new_stack;
+	fydi->stack_alloc = new_stack_alloc;
+	return true;
+}
+
+static bool
+fydi_push_collection(struct fy_document_iterator *fydi, struct fy_node *fyn)
+{
+	struct fy_document_iterator_body_state *s;
+
+	/* make sure there's enough space */
+	if (!fy_document_iterator_ensure_space(fydi, 1))
+		return false;
+
+	/* get the next */
+	fydi->stack_top++;
+	s = &fydi->stack[fydi->stack_top];
+	s->fyn = fyn;
+
+	switch (fyn->type) {
+	case FYNT_SEQUENCE:
+		s->fyni = fy_node_list_head(&fyn->sequence);
+		break;
+
+	case FYNT_MAPPING:
+		s->fynp = fy_node_pair_list_head(&fyn->mapping);
+		s->processed_key = false;
+		break;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	return true;
+}
+
+static inline void
+fydi_pop_collection(struct fy_document_iterator *fydi)
+{
+	assert(fydi->stack_top != (unsigned int)-1);
+	fydi->stack_top--;
+}
+
+static inline struct fy_document_iterator_body_state *
+fydi_last_collection(struct fy_document_iterator *fydi)
+{
+	if (fydi->stack_top == (unsigned int)-1)
+		return NULL;
+	return &fydi->stack[fydi->stack_top];
+}
+
+bool
+fy_document_iterator_body_next_internal(struct fy_document_iterator *fydi,
+					struct fy_document_iterator_body_result *res)
+{
+	struct fy_document_iterator_body_state *s;
+	struct fy_node *fyn, *fyn_col;
+	bool end;
+
+	if (!fydi || !res || fydi->state == FYDIS_ERROR)
+		return false;
+
+	if (fydi->state != FYDIS_WAITING_BODY_START_OR_DOCUMENT_END &&
+	    fydi->state != FYDIS_BODY)
+		goto err_out;
+
+	end = false;
+	s = fydi_last_collection(fydi);
+	if (!s) {
+
+		fyn = fydi->iterate_root;
+		/* empty root, or last */
+		if (!fyn || fydi->state == FYDIS_BODY) {
+			fydi->state = FYDIS_WAITING_DOCUMENT_END;
+			return false;
+		}
+
+		/* ok, in body proper */
+		fydi->state = FYDIS_BODY;
+
+	} else {
+
+		fyn_col = s->fyn;
+		assert(fyn_col);
+
+		fyn = NULL;
+		if (fyn_col->type == FYNT_SEQUENCE) {
+			fyn = s->fyni;
+			if (fyn)
+				s->fyni = fy_node_next(&fyn_col->sequence, s->fyni);
+		} else {
+			assert(fyn_col->type == FYNT_MAPPING);
+			if (s->fynp) {
+				if (!s->processed_key) {
+					fyn = s->fynp->key;
+					s->processed_key = true;
+				} else {
+					fyn = s->fynp->value;
+					s->processed_key = false;
+
+					/* next in mapping after value */
+					s->fynp = fy_node_pair_next(&fyn_col->mapping, s->fynp);
+				}
+			}
+		}
+
+		/* if no next node in the collection, it's the end of the collection */
+		if (!fyn) {
+			fyn = fyn_col;
+			end = true;
+		}
+	}
+
+	assert(fyn);
+
+	/* only for collections */
+	if (fyn->type != FYNT_SCALAR) {
+		if (!end) {
+			/* push the new sequence */
+			if (!fydi_push_collection(fydi, fyn))
+				goto err_out;
+		} else
+			fydi_pop_collection(fydi);
+	}
+
+	res->fyn = fyn;
+	res->end = end;
+	return true;
+
+err_out:
+	fydi->state = FYDIS_ERROR;
+	return false;
+}
+
+struct fy_event *fy_document_iterator_body_next(struct fy_document_iterator *fydi)
+{
+	struct fy_document_iterator_body_result res;
+
+	if (!fydi)
+		return NULL;
+
+	if (!fy_document_iterator_body_next_internal(fydi, &res))
+		return NULL;
+
+	return fydi_event_create(fydi, res.fyn, !res.end);
+}
+
+void
+fy_document_iterator_node_start(struct fy_document_iterator *fydi, struct fy_node *fyn)
+{
+	/* do nothing on error */
+	if (!fydi || fydi->state == FYDIS_ERROR)
+		return;
+
+	/* and go into body */
+	fydi->state = FYDIS_WAITING_BODY_START_OR_DOCUMENT_END;
+	fydi->iterate_root = fyn;
+	fydi->fyd = NULL;
+}
+
+struct fy_node *fy_document_iterator_node_next(struct fy_document_iterator *fydi)
+{
+	struct fy_document_iterator_body_result res;
+
+	if (!fydi)
+		return NULL;
+
+	/* do not return ending nodes, are not interested in them */
+	do {
+		if (!fy_document_iterator_body_next_internal(fydi, &res))
+			return NULL;
+
+	} while (res.end);
+
+	return res.fyn;
+}
+
+bool fy_document_iterator_get_error(struct fy_document_iterator *fydi)
+{
+	if (!fydi)
+		return true;
+
+	if (fydi->state != FYDIS_ERROR)
+		return false;
+
+	fy_document_iterator_cleanup(fydi);
+
+	return true;
+}
+
+struct fy_event *
+fy_document_iterator_generate_next(struct fy_document_iterator *fydi)
+{
+	struct fy_event *fye = NULL;
+
+	if (!fydi || fydi->state == FYDIS_ERROR)
+		return NULL;
+
+	if (fydi->generator_state & FYDIGF_GENERATED_NULL)
+		return NULL;
+
+	/* wants stream events and not generated yet */
+	if ((fydi->generator_state & (FYDIGF_WANTS_STREAM | FYDIGF_GENERATED_SS)) == FYDIGF_WANTS_STREAM) {
+		fye = fy_document_iterator_stream_start(fydi);
+		if (!fye)
+			return NULL;
+		fydi->generator_state |= FYDIGF_GENERATED_SS;
+		return fye;
+	}
+
+	/* wants document events and not generated yet */
+	if ((fydi->generator_state & (FYDIGF_WANTS_DOC | FYDIGF_GENERATED_DS)) == FYDIGF_WANTS_DOC) {
+		if (!fydi->cfg.fyd) {
+			fydi->state = FYDIS_ERROR;
+			return NULL;
+		}
+		fye = fy_document_iterator_document_start_internal(fydi, fydi->cfg.fyd, fydi->cfg.iterate_root);
+		if (!fye)
+			return NULL;
+		fydi->generator_state |= FYDIGF_GENERATED_DS;
+		return fye;
+	}
+
+	/* generate body events... */
+	if (!(fydi->generator_state & FYDIGF_GENERATED_BODY)) {
+		if (!fydi->iterate_root)
+			fydi->iterate_root = fydi->cfg.iterate_root ? fydi->cfg.iterate_root : fy_document_root(fydi->fyd);
+		fye = fy_document_iterator_body_next(fydi);
+		if (fye)
+			return fye;
+
+		fydi->generator_state |= FYDIGF_GENERATED_BODY;
+	}
+
+	/* wants document events and not generated yet */
+	if ((fydi->generator_state & (FYDIGF_WANTS_DOC | FYDIGF_GENERATED_DE)) == FYDIGF_WANTS_DOC) {
+		fye = fy_document_iterator_document_end(fydi);
+		if (!fye)
+			return NULL;
+		fydi->generator_state |= FYDIGF_GENERATED_DE;
+		return fye;
+	}
+
+	/* wants stream events and not generated yet */
+	if ((fydi->generator_state & (FYDIGF_WANTS_STREAM | FYDIGF_GENERATED_SE)) == FYDIGF_WANTS_STREAM) {
+		fye = fy_document_iterator_stream_end(fydi);
+		if (!fye)
+			return NULL;
+		fydi->generator_state |= FYDIGF_GENERATED_SE;
+		return fye;
+	}
+
+	fydi->generator_state |= FYDIGF_GENERATED_NULL;
+	return NULL;
+}
+
+const char *
+fy_node_get_comment(struct fy_node *fyn, enum fy_comment_placement placement)
+{
+	struct fy_token *fyt;
+
+	if (!fyn)
+		return NULL;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fyt = fyn->scalar;
+		break;
+	case FYNT_SEQUENCE:
+		fyt = fyn->sequence_start;
+		break;
+	case FYNT_MAPPING:
+		fyt = fyn->mapping_start;
+		break;
+	default:
+		fyt = NULL;
+		break;
+	}
+
+	if (!fyt)
+		return NULL;
+
+	return fy_token_get_comment(fyt, placement);
+}
+
+const char *
+fy_node_get_comments(struct fy_node *fyn)
+{
+	struct fy_token *fyt;
+
+	if (!fyn)
+		return NULL;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fyt = fyn->scalar;
+		break;
+	case FYNT_SEQUENCE:
+		fyt = fyn->sequence_start;
+		break;
+	case FYNT_MAPPING:
+		fyt = fyn->mapping_start;
+		break;
+	default:
+		fyt = NULL;
+		break;
+	}
+
+	if (!fyt)
+		return NULL;
+
+	return fy_token_get_comments(fyt);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-doc.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-doc.h
@@ -1,0 +1,397 @@
+/*
+ * fy-doc.h - YAML document internal header file
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_DOC_H
+#define FY_DOC_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-ctype.h"
+#include "fy-utf8.h"
+#include "fy-list.h"
+#include "fy-typelist.h"
+#include "fy-types.h"
+#include "fy-diag.h"
+#include "fy-dump.h"
+#include "fy-docstate.h"
+#include "fy-accel.h"
+#include "fy-walk.h"
+#include "fy-path.h"
+
+struct fy_eventp;
+
+/* TODO vary according to platfom */
+static inline int fy_depth_limit(void)
+{
+	return FYPCF_GUARANTEED_MINIMUM_DEPTH_LIMIT;
+}
+
+FY_TYPE_FWD_DECL_LIST(document);
+
+struct fy_node;
+
+struct fy_node_pair {
+	struct list_head node;
+	struct fy_node *key;
+	struct fy_node *value;
+	struct fy_document *fyd;
+	struct fy_node *parent;
+};
+FY_TYPE_FWD_DECL_LIST(node_pair);
+FY_TYPE_DECL_LIST(node_pair);
+
+FY_TYPE_FWD_DECL_LIST(node);
+struct fy_node {
+	struct list_head node;
+	struct fy_token *tag;
+	enum fy_node_style style;
+	struct fy_node *parent;
+	struct fy_document *fyd;
+	unsigned int marks;
+	unsigned int type : 2;	/* enum fy_node_type: 2 bits are enough for 3 types */
+	bool has_meta : 1;
+	bool attached : 1;		/* when it's attached somewhere */
+	bool synthetic : 1;		/* node has been modified programmaticaly */
+	bool key_root : 1;		/* node is the root of key fy_node_get_parent() will return NULL */
+	void *meta;
+	struct fy_accel *xl;		/* mapping access accelerator */
+	struct fy_path_expr_node_data *pxnd;
+	union {
+		struct fy_token *scalar;
+		struct fy_node_list sequence;
+		struct fy_node_pair_list mapping;
+	};
+	union {
+		struct fy_token *sequence_start;
+		struct fy_token *mapping_start;
+	};
+	union {
+		struct fy_token *sequence_end;
+		struct fy_token *mapping_end;
+	};
+};
+FY_TYPE_DECL_LIST(node);
+
+struct fy_node *fy_node_alloc(struct fy_document *fyd, enum fy_node_type type);
+struct fy_node_pair *fy_node_pair_alloc(struct fy_document *fyd);
+int fy_node_pair_free(struct fy_node_pair *fynp);
+
+void fy_node_detach_and_free(struct fy_node *fyn);
+void fy_node_pair_detach_and_free(struct fy_node_pair *fynp);
+
+struct fy_anchor {
+	struct list_head node;
+	struct fy_node *fyn;
+	struct fy_token *anchor;
+	bool multiple : 1;
+};
+FY_TYPE_FWD_DECL_LIST(anchor);
+FY_TYPE_DECL_LIST(anchor);
+
+struct fy_document {
+	struct list_head node;
+	struct fy_anchor_list anchors;
+	struct fy_accel *axl;		/* name -> anchor access accelerator */
+	struct fy_accel *naxl;		/* node -> anchor access accelerator */
+	struct fy_document_state *fyds;
+	struct fy_diag *diag;
+	struct fy_parse_cfg parse_cfg;
+	struct fy_node *root;
+	bool parse_error : 1;
+
+	struct fy_document *parent;
+	struct fy_document_list children;
+
+	fy_node_meta_clear_fn meta_clear_fn;
+	void *meta_user;
+
+	struct fy_path_expr_document_data *pxdd;
+};
+/* only the list declaration/methods */
+FY_TYPE_DECL_LIST(document);
+
+struct fy_document *fy_parse_document_create(struct fy_parser *fyp, struct fy_eventp *fyep);
+void fy_document_purge_anchors(struct fy_document *fyd);
+
+struct fy_node_mapping_sort_ctx {
+	fy_node_mapping_sort_fn key_cmp;
+	void *arg;
+	struct fy_node_pair **fynpp;
+	int count;
+};
+
+void fy_node_mapping_perform_sort(struct fy_node *fyn_map,
+		fy_node_mapping_sort_fn key_cmp, void *arg,
+		struct fy_node_pair **fynpp, int count);
+
+void fy_node_mapping_fill_array(struct fy_node *fyn_map,
+		struct fy_node_pair **fynpp, int count);
+
+struct fy_node_pair **fy_node_mapping_sort_array(struct fy_node *fyn_map,
+		fy_node_mapping_sort_fn key_cmp,
+		void *arg, int *countp);
+
+void fy_node_mapping_release_array(struct fy_node *fyn_map, struct fy_node_pair **fynpp);
+
+struct fy_node_sequence_sort_ctx {
+	fy_node_sequence_sort_fn cmp;
+	void *arg;
+	struct fy_node **fynp;
+	int count;
+};
+
+struct fy_node_walk_ctx {
+	unsigned int max_depth;
+	unsigned int next_slot;
+	unsigned int mark;
+	struct fy_node *marked[0];
+};
+
+bool fy_node_is_empty(struct fy_node *fyn);
+
+bool fy_check_ref_loop(struct fy_document *fyd, struct fy_node *fyn,
+		       enum fy_node_walk_flags flags,
+		       struct fy_node_walk_ctx *ctx,
+		       unsigned int depth);
+
+#define FYNWF_VISIT_MARKER	(FYNWF_MAX_USER_MARKER + 1)
+#define FYNWF_REF_MARKER	(FYNWF_MAX_USER_MARKER + 2)
+#define FYNWF_INSET_MARKER	(FYNWF_MAX_USER_MARKER + 3)
+
+#define FYNWF_SYSTEM_MARKS	(FY_BIT(FYNWF_VISIT_MARKER) | \
+				 FY_BIT(FYNWF_REF_MARKER) | \
+				 FY_BIT(FYNWF_INSET_MARKER) )
+
+void fy_node_clear_system_marks(struct fy_node *fyn);
+
+bool fy_node_uses_single_input_only(struct fy_node *fyn, struct fy_input *fyi);
+struct fy_input *fy_node_get_first_input(struct fy_node *fyn);
+bool fy_node_is_synthetic(struct fy_node *fyn);
+void fy_node_mark_synthetic(struct fy_node *fyn);
+struct fy_input *fy_node_get_input(struct fy_node *fyn);
+int fy_document_register_anchor(struct fy_document *fyd,
+				struct fy_node *fyn, struct fy_token *anchor);
+bool fy_node_mapping_key_is_duplicate(struct fy_node *fyn, struct fy_node *fyn_key);
+
+struct fy_token *fy_node_non_synthesized_token(struct fy_node *fyn);
+struct fy_token *fy_node_token(struct fy_node *fyn);
+
+FILE *fy_document_get_error_fp(struct fy_document *fyd);
+enum fy_parse_cfg_flags fy_document_get_cfg_flags(const struct fy_document *fyd);
+bool fy_document_is_accelerated(struct fy_document *fyd);
+bool fy_document_can_be_accelerated(struct fy_document *fyd);
+
+/* TODO move to main include */
+struct fy_node *fy_node_collection_iterate(struct fy_node *fyn, void **prevp);
+
+/* indirect node */
+FY_TYPE_FWD_DECL_LIST(ptr_node);
+struct fy_ptr_node {
+	struct list_head node;
+	struct fy_node *fyn;
+};
+FY_TYPE_DECL_LIST(ptr_node);
+
+struct fy_ptr_node *fy_ptr_node_create(struct fy_node *fyn);
+void fy_ptr_node_destroy(struct fy_ptr_node *fypn);
+void fy_ptr_node_list_free_all(struct fy_ptr_node_list *fypnl);
+bool fy_ptr_node_list_contains(struct fy_ptr_node_list *fypnl, struct fy_node *fyn);
+int fy_node_linearize_recursive(struct fy_ptr_node_list *fypnl, struct fy_node *fyn);
+int fy_node_linearize(struct fy_ptr_node_list *fypnl, struct fy_node *fyn);
+void fy_node_iterator_check(struct fy_node *fyn);
+
+
+enum fy_document_iterator_state {
+	FYDIS_WAITING_STREAM_START,
+	FYDIS_WAITING_DOCUMENT_START,
+	FYDIS_WAITING_BODY_START_OR_DOCUMENT_END,
+	FYDIS_BODY,
+	FYDIS_WAITING_DOCUMENT_END,
+	FYDIS_WAITING_STREAM_END_OR_DOCUMENT_START,
+	FYDIS_ENDED,
+	FYDIS_ERROR,
+};
+
+struct fy_document_iterator_body_state {
+	struct fy_node *fyn;	/* the collection node */
+	bool processed_key : 1;	/* for mapping only */
+	union {
+		struct fy_node *fyni;		/* for sequence */
+		struct fy_node_pair *fynp;	/* for mapping */
+	};
+};
+
+struct fy_document_iterator {
+	struct fy_document_iterator_cfg cfg;
+	enum fy_document_iterator_state state;
+	struct fy_document *fyd;
+	struct fy_node *iterate_root;
+	bool suppress_recycling_force : 1;
+	bool suppress_recycling : 1;
+
+	struct fy_eventp_list recycled_eventp;
+	struct fy_token_list recycled_token;
+
+	struct fy_eventp_list *recycled_eventp_list;	/* NULL when suppressing */
+	struct fy_token_list *recycled_token_list;	/* NULL when suppressing */
+
+	unsigned int stack_top;
+	unsigned int stack_alloc;
+	struct fy_document_iterator_body_state *stack;
+	struct fy_document_iterator_body_state in_place[FYPCF_GUARANTEED_MINIMUM_DEPTH_LIMIT];
+
+#define FYDIGF_GENERATED_SS	FY_BIT(0)
+#define FYDIGF_GENERATED_DS	FY_BIT(1)
+#define FYDIGF_GENERATED_DE	FY_BIT(2)
+#define FYDIGF_GENERATED_SE	FY_BIT(3)
+#define FYDIGF_GENERATED_BODY	FY_BIT(4)
+#define FYDIGF_GENERATED_NULL	FY_BIT(5)
+#define FYDIGF_ENDS_AFTER_BODY	FY_BIT(6)
+#define FYDIGF_ENDS_AFTER_DOC	FY_BIT(7)
+#define FYDIGF_WANTS_STREAM	FY_BIT(8)
+#define FYDIGF_WANTS_DOC	FY_BIT(9)
+	unsigned int generator_state;
+};
+
+int fy_document_iterator_setup(struct fy_document_iterator *fydi, const struct fy_document_iterator_cfg *cfg);
+void fy_document_iterator_cleanup(struct fy_document_iterator *fydi);
+struct fy_document_iterator *fy_document_iterator_create(void);
+void fy_document_iterator_destroy(struct fy_document_iterator *fydi);
+
+struct fy_event *
+fy_document_iterator_document_start_internal(struct fy_document_iterator *fydi, struct fy_document *fyd,
+					     struct fy_node *iterate_root);
+
+struct fy_document_iterator_body_result {
+	struct fy_node *fyn;
+	bool end;
+};
+
+bool
+fy_document_iterator_body_next_internal(struct fy_document_iterator *fydi,
+					struct fy_document_iterator_body_result *res);
+
+/* diagnostics */
+
+static inline bool
+fyd_debug_log_level_is_enabled(struct fy_document *fyd, enum fy_error_module module)
+{
+	return fyd && fy_diag_log_level_is_enabled(fyd->diag, FYET_DEBUG, module);
+}
+
+int fy_document_vdiag(struct fy_document *fyd, unsigned int flags,
+		      const char *file, int line, const char *func,
+		      const char *fmt, va_list ap);
+
+int fy_document_diag(struct fy_document *fyd, unsigned int flags,
+		     const char *file, int line, const char *func,
+		     const char *fmt, ...)
+	FY_FORMAT(printf, 6, 7);
+
+void fy_document_diag_vreport(struct fy_document *fyd,
+			      const struct fy_diag_report_ctx *fydrc,
+			      const char *fmt, va_list ap);
+void fy_document_diag_report(struct fy_document *fyd,
+			     const struct fy_diag_report_ctx *fydrc,
+			     const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+#ifdef FY_DEVMODE
+
+#define fyd_debug(_fyd, _fmt, ...) \
+	do { \
+		struct fy_document *__fyd = (_fyd); \
+		if (fyd_debug_log_level_is_enabled(__fyd, FYEM_DOC)) \
+			fy_document_diag(__fyd, FYET_DEBUG, \
+					__FILE__, __LINE__, __func__, \
+					(_fmt) , ## __VA_ARGS__); \
+	} while(0)
+#else
+
+#define fyd_debug(_fyd, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fyd_info(_fyd, _fmt, ...) \
+	fy_document_diag((_fyd), FYET_INFO, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyd_notice(_fyd, _fmt, ...) \
+	fy_document_diag((_fyd), FYET_NOTICE, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyd_warning(_fyd, _fmt, ...) \
+	fy_document_diag((_fyd), FYET_WARNING, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyd_error(_fyd, _fmt, ...) \
+	fy_document_diag((_fyd), FYET_ERROR, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+
+#define fyd_doc_debug(_fyd, _fmt, ...) \
+	fyd_debug((_fyd), (_fmt) , ## __VA_ARGS__)
+
+#define fyd_error_check(_fyd, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			fyd_error((_fyd), _fmt, ## __VA_ARGS__); \
+			goto _label ; \
+		} \
+	} while(0)
+
+#define _FYD_TOKEN_DIAG(_fyd, _fyt, _type, _module, _fmt, ...) \
+	do { \
+		struct fy_diag_report_ctx _drc; \
+		memset(&_drc, 0, sizeof(_drc)); \
+		_drc.type = (_type); \
+		_drc.module = (_module); \
+		_drc.fyt = (_fyt); \
+		fy_document_diag_report((_fyd), &_drc, (_fmt) , ## __VA_ARGS__); \
+	} while(0)
+
+#define FYD_TOKEN_DIAG(_fyd, _fyt, _type, _module, _fmt, ...) \
+	_FYD_TOKEN_DIAG(_fyd, fy_token_ref(_fyt), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYD_NODE_DIAG(_fyd, _fyn, _type, _module, _fmt, ...) \
+	_FYD_TOKEN_DIAG(_fyd, fy_node_token(_fyn), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYD_TOKEN_ERROR(_fyd, _fyt, _module, _fmt, ...) \
+	FYD_TOKEN_DIAG(_fyd, _fyt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYD_NODE_ERROR(_fyd, _fyn, _module, _fmt, ...) \
+	FYD_NODE_DIAG(_fyd, _fyn, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYD_TOKEN_ERROR_CHECK(_fyd, _fyt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYD_TOKEN_ERROR(_fyd, _fyt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYD_NODE_ERROR_CHECK(_fyd, _fyn, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYD_NODE_ERROR(_fyd, _fyn, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYD_TOKEN_WARNING(_fyd, _fyt, _module, _fmt, ...) \
+	FYD_TOKEN_DIAG(_fyd, _fyt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYD_NODE_WARNING(_fyd, _fyn, _type, _module, _fmt, ...) \
+	FYD_NODE_DIAG(_fyd, _fyn, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-docbuilder-diag.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-docbuilder-diag.c
@@ -1,0 +1,89 @@
+/*
+ * fy-docbuilder-diag.c - document builder diagnostics
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-diag.h"
+#include "fy-docbuilder.h"
+
+int fy_document_builder_vdiag(struct fy_document_builder *fydb, unsigned int flags,
+		      const char *file, int line, const char *func,
+		      const char *fmt, va_list ap)
+{
+	struct fy_diag_ctx fydc;
+	int rc;
+
+	if (!fydb || !fmt || !fydb->cfg.diag)
+		return -1;
+
+	/* perform the enable tests early to avoid the overhead */
+	if ((int)((flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT) < (int)fydb->cfg.diag->cfg.level)
+		return 0;
+
+	/* fill in fy_diag_ctx */
+	memset(&fydc, 0, sizeof(fydc));
+
+	fydc.level = (flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT;
+	fydc.module = (flags & FYDF_MODULE_MASK) >> FYDF_MODULE_SHIFT;
+	fydc.source_file = file;
+	fydc.source_line = line;
+	fydc.source_func = func;
+	fydc.line = -1;
+	fydc.column = -1;
+
+	rc = fy_vdiag(fydb->cfg.diag, &fydc, fmt, ap);
+
+	return rc;
+}
+
+int fy_document_builder_diag(struct fy_document_builder *fydb, unsigned int flags,
+		     const char *file, int line, const char *func,
+		     const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_document_builder_vdiag(fydb, flags, file, line, func, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+void fy_document_builder_diag_vreport(struct fy_document_builder *fydb,
+			      const struct fy_diag_report_ctx *fydrc,
+			      const char *fmt, va_list ap)
+{
+	if (!fydb || !fydb->cfg.diag || !fydrc || !fmt)
+		return;
+
+	fy_diag_vreport(fydb->cfg.diag, fydrc, fmt, ap);
+}
+
+void fy_document_builder_diag_report(struct fy_document_builder *fydb,
+			     const struct fy_diag_report_ctx *fydrc,
+			     const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_document_builder_diag_vreport(fydb, fydrc, fmt, ap);
+	va_end(ap);
+}
+

--- a/numcosmo/external/libfyaml/src/lib/fy-docbuilder.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-docbuilder.c
@@ -1,0 +1,600 @@
+/*
+ * fy-docbuilder.c - YAML document builder methods
+ *
+ * Copyright (c) 2022 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include <libfyaml.h>
+
+#include "fy-utils.h"
+
+#include "fy-docbuilder.h"
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+
+const char *fy_document_builder_state_txt[] = {
+	[FYDBS_NODE]	= "node",
+	[FYDBS_MAP_KEY]	= "map-key",
+	[FYDBS_MAP_VAL]	= "map-val",
+	[FYDBS_SEQ]	= "seq",
+};
+
+void
+fy_document_builder_reset(struct fy_document_builder *fydb)
+{
+	struct fy_document_builder_ctx *c;
+	unsigned int i;
+
+	if (!fydb)
+		return;
+
+	for (i = 0, c = fydb->stack; i < fydb->next; i++, c++) {
+		fy_node_free(c->fyn);
+		c->fyn = NULL;
+		fy_node_pair_free(c->fynp);
+		c->fynp = NULL;
+	}
+	fydb->next = 0;
+
+	if (fydb->fyd) {
+		fy_document_destroy(fydb->fyd);
+		fydb->fyd = NULL;
+	}
+	fydb->in_stream = false;
+	fydb->doc_done = false;
+}
+
+static const struct fy_document_builder_cfg docbuilder_default_cfg = {
+	.parse_cfg = {
+		.flags = FYPCF_DEFAULT_DOC,
+	}
+};
+
+struct fy_document_builder *
+fy_document_builder_create(const struct fy_document_builder_cfg *cfg)
+{
+	struct fy_document_builder *fydb = NULL;
+
+	if (!cfg)
+		cfg = &docbuilder_default_cfg;
+
+	fydb = malloc(sizeof(*fydb));
+	if (!fydb)
+		goto err_out;
+
+	memset(fydb, 0, sizeof(*fydb));
+	fydb->cfg = *cfg;
+	fydb->next = 0;
+	fydb->in_stream = false;
+	fydb->doc_done = false;
+	fydb->alloc = fy_depth_limit();	/* always start with this */
+	fydb->max_depth = (cfg->parse_cfg.flags & FYPCF_DISABLE_DEPTH_LIMIT) ? 0 : fy_depth_limit();
+
+	fydb->stack = malloc(fydb->alloc * sizeof(*fydb->stack));
+	if (!fydb->stack)
+		goto err_out;
+
+	return fydb;
+
+err_out:
+	if (fydb) {
+		if (fydb->stack)
+			free(fydb->stack);
+		free(fydb);
+	}
+
+	return NULL;
+}
+
+struct fy_document_builder *
+fy_document_builder_create_on_parser(struct fy_parser *fyp)
+{
+	struct fy_document_builder *fydb = NULL;
+	struct fy_document_state *fyds;
+	struct fy_document_builder_cfg cfg;
+	int rc;
+
+	if (!fyp)
+		return NULL;
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.parse_cfg = fyp->cfg;
+	cfg.diag = fy_diag_ref(fyp->diag);
+
+	fydb = fy_document_builder_create(&cfg);
+	if (!fydb) {
+		fy_diag_unref(cfg.diag);
+		return NULL;
+	}
+
+	fyds = fy_parser_get_document_state(fyp);
+	if (fyds) {
+		rc = fy_document_builder_set_in_document(fydb, fyds, true);
+		if (rc) {
+			fy_document_builder_destroy(fydb);
+			return NULL;
+		}
+	}
+
+	return fydb;
+}
+
+void
+fy_document_builder_destroy(struct fy_document_builder *fydb)
+{
+	if (!fydb)
+		return;
+
+	fy_document_builder_reset(fydb);
+
+	fy_diag_unref(fydb->cfg.diag);
+	if (fydb->stack)
+		free(fydb->stack);
+	free(fydb);
+}
+
+struct fy_document *
+fy_document_builder_get_document(struct fy_document_builder *fydb)
+{
+	return fydb ? fydb->fyd : NULL;
+}
+
+bool
+fy_document_builder_is_in_stream(struct fy_document_builder *fydb)
+{
+	return fydb && fydb->in_stream;
+}
+
+bool
+fy_document_builder_is_in_document(struct fy_document_builder *fydb)
+{
+	return fydb && fydb->fyd != NULL && !fydb->doc_done;
+}
+
+bool
+fy_document_builder_is_document_complete(struct fy_document_builder *fydb)
+{
+	return fydb && fydb->fyd != NULL && fydb->doc_done;
+}
+
+struct fy_document *
+fy_document_builder_take_document(struct fy_document_builder *fydb)
+{
+	struct fy_document *fyd;
+
+	if (!fy_document_builder_is_document_complete(fydb))
+		return NULL;
+	fyd = fydb->fyd;
+	fydb->fyd = NULL;
+	fydb->doc_done = false;
+	return fyd;
+}
+
+struct fy_document *
+fy_document_builder_peek_document(struct fy_document_builder *fydb)
+{
+	struct fy_document *fyd;
+	struct fy_document_builder_ctx *c;
+
+	if (!fydb)
+		return NULL;
+
+	/* just peek; may be incomplete */
+	fyd = fydb->fyd;
+
+	assert(fydb->next > 0);
+	c = &fydb->stack[0];
+
+	/* wire the root */
+	if (!fyd->root)
+		fyd->root = c->fyn;
+
+	return fyd;
+}
+
+
+void
+fy_document_builder_set_in_stream(struct fy_document_builder *fydb)
+{
+	if (!fydb)
+		return;
+	/* reset */
+	fy_document_builder_reset(fydb);
+
+	fydb->in_stream = true;
+}
+
+int
+fy_document_builder_set_in_document(struct fy_document_builder *fydb, struct fy_document_state *fyds, bool single)
+{
+	struct fy_document_builder_ctx *c;
+	int rc;
+
+	if (!fydb)
+		return -1;
+
+	/* reset */
+	fy_document_builder_reset(fydb);
+
+	fydb->in_stream = true;
+
+	fydb->fyd = fy_document_create(&fydb->cfg.parse_cfg);
+	if (!fydb->fyd)
+		return -1;
+
+	if (fyds) {
+		rc = fy_document_set_document_state(fydb->fyd, fyds);
+		if (rc)
+			return rc;
+	}
+
+	fydb->doc_done = false;
+	fydb->single_mode = single;
+
+	/* be paranoid */
+	assert(fydb->next < fydb->alloc);
+
+	c = &fydb->stack[++fydb->next - 1];
+	memset(c, 0, sizeof(*c));
+	c->s = FYDBS_NODE;
+
+	return 0;
+}
+
+int
+fy_document_builder_process_event(struct fy_document_builder *fydb, struct fy_event *fye)
+{
+	enum fy_event_type etype;
+	struct fy_document *fyd;
+	struct fy_document_builder_ctx *c, *cp;
+	struct fy_node *fyn, *fyn_parent;
+	struct fy_node_pair *fynp;
+	struct fy_document_builder_ctx *newc;
+	struct fy_token *fyt;
+	int rc;
+
+	etype = fye ? fye->type : FYET_NONE;
+	fyt = fye ? fy_event_get_token(fye) : NULL;
+
+	/* not in document */
+	if (!fydb->next) {
+		switch (etype) {
+		case FYET_STREAM_START:
+			FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC,
+					!fydb->in_stream, err_out,
+					"STREAM_START while in stream error");
+			fydb->in_stream = true;
+			break;
+
+		case FYET_STREAM_END:
+			FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC,
+					fydb->in_stream, err_out,
+					"STREAM_END while not in stream error");
+			fydb->in_stream = false;
+			return 1;
+
+		case FYET_DOCUMENT_START:
+			FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC,
+					fydb->in_stream, err_out,
+					"DOCUMENT_START while not in stream error");
+
+			/* no-one cares, destroy the document */
+			if (!fydb->fyd)
+				fy_document_destroy(fydb->fyd);
+
+			fydb->fyd = fy_document_create(&fydb->cfg.parse_cfg);
+			fydb_error_check(fydb, fydb->fyd, err_out,
+					"fy_document_create() failed");
+
+			rc = fy_document_set_document_state(fydb->fyd, fye->document_start.document_state);
+			fydb_error_check(fydb, !rc, err_out,
+					"fy_document_set_document_state() failed");
+
+			fydb->doc_done = false;
+			goto push;
+
+		case FYET_DOCUMENT_END:
+			FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC,
+					fydb->in_stream, err_out,
+					"DOCUMENT_END while not in stream error");
+
+			FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC,
+					fydb->fyd, err_out,
+					"DOCUMENT_END without a document");
+
+			fydb->doc_done = true;
+			break;
+
+		default:
+			/* unexpected event */
+			FYDB_TOKEN_ERROR(fydb, fyt, FYEM_DOC,
+					"Unexpected event %s in non-build mode\n",
+						fy_event_type_txt[etype]);
+			goto err_out;
+		}
+
+		return 0;
+	}
+
+	fyd = fydb->fyd;
+
+	c = &fydb->stack[fydb->next - 1];
+	fyn = NULL;
+
+	/* verify that we have a document */
+	assert(fydb->fyd);
+	/* the top state must always be NODE for processing the event */
+	assert(c->s == FYDBS_NODE);
+
+	switch (etype) {
+	case FYET_SCALAR:
+	case FYET_ALIAS:
+		fyn = fy_node_alloc(fyd, FYNT_SCALAR);
+		fydb_error_check(fydb, fyn, err_out,
+				"fy_node_alloc() SCALAR failed");
+
+		if (etype == FYET_SCALAR) {
+			if (fye->scalar.value)
+				fyn->style = fy_node_style_from_scalar_style(fye->scalar.value->scalar.style);
+			else
+				fyn->style = FYNS_PLAIN;
+			fyn->tag = fy_token_ref(fye->scalar.tag);
+			if (fye->scalar.anchor) {
+				rc = fy_document_register_anchor(fyd, fyn, fy_token_ref(fye->scalar.anchor));
+				fydb_error_check(fydb, !rc, err_out,
+						"fy_document_register_anchor() failed");
+			}
+			fyn->scalar = fy_token_ref(fye->scalar.value);
+		} else {
+			fyn->style = FYNS_ALIAS;
+			fyn->scalar = fy_token_ref(fye->alias.anchor);
+		}
+		goto complete;
+
+	case FYET_MAPPING_START:
+		c->s = FYDBS_MAP_KEY;
+
+		fyn = fy_node_alloc(fyd, FYNT_MAPPING);
+		fydb_error_check(fydb, fyn, err_out,
+				"fy_node_alloc() MAPPING failed");
+
+		c->fyn = fyn;
+		if (fye->mapping_start.mapping_start)
+			fyn->style = fye->mapping_start.mapping_start->type == FYTT_FLOW_MAPPING_START ? FYNS_FLOW : FYNS_BLOCK;
+		else
+			fyn->style = FYNS_ANY;
+		fyn->tag = fy_token_ref(fye->mapping_start.tag);
+		if (fye->mapping_start.anchor) {
+			rc = fy_document_register_anchor(fyd, fyn, fy_token_ref(fye->mapping_start.anchor));
+			fydb_error_check(fydb, !rc, err_out,
+					"fy_document_register_anchor() failed");
+		}
+		fyn->mapping_start = fy_token_ref(fye->mapping_start.mapping_start);
+		break;
+
+	case FYET_MAPPING_END:
+
+		FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC, fydb->next > 1, err_out,
+				"Unexpected MAPPING_END (unexpected end of mapping)");
+
+		cp = &fydb->stack[fydb->next - 2];
+
+		FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC, cp->s == FYDBS_MAP_KEY, err_out,
+				"Unexpected MAPPING_END (not in mapping)");
+
+		fyn = cp->fyn;
+		fyn->mapping_end = fy_token_ref(fye->mapping_end.mapping_end);
+		fydb->next--;
+		goto complete;
+
+	case FYET_SEQUENCE_START:
+		c->s = FYDBS_SEQ;
+		fyn = fy_node_alloc(fyd, FYNT_SEQUENCE);
+		fydb_error_check(fydb, fyn, err_out,
+				"fy_node_alloc() SEQUENCE failed");
+
+		c->fyn = fyn;
+		if (fye->sequence_start.sequence_start)
+			fyn->style = fye->sequence_start.sequence_start->type == FYTT_FLOW_SEQUENCE_START ? FYNS_FLOW : FYNS_BLOCK;
+		else
+			fyn->style = FYNS_ANY;
+		fyn->tag = fy_token_ref(fye->sequence_start.tag);
+		if (fye->sequence_start.anchor) {
+			rc = fy_document_register_anchor(fyd, fyn, fy_token_ref(fye->sequence_start.anchor));
+			fydb_error_check(fydb, !rc, err_out,
+					"fy_document_register_anchor() failed");
+		}
+		fyn->sequence_start = fy_token_ref(fye->sequence_start.sequence_start);
+		break;
+
+	case FYET_SEQUENCE_END:
+
+		FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC, fydb->next > 1, err_out,
+				"Unexpected SEQUENCE_END (unexpected end of sequence)");
+
+		cp = &fydb->stack[fydb->next - 2];
+
+		FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC, cp->s == FYDBS_SEQ, err_out,
+				"Unexpected MAPPING_SEQUENCE (not in sequence)");
+
+		fyn = cp->fyn;
+		fyn->sequence_end = fy_token_ref(fye->sequence_end.sequence_end);
+		fydb->next--;
+		goto complete;
+
+	default:
+		/* unexpected event */
+		FYDB_TOKEN_ERROR(fydb, fyt, FYEM_DOC,
+				"Unexpected event %s in build mode\n",
+					fy_event_type_txt[etype]);
+		goto err_out;
+	}
+
+push:
+	FYDB_TOKEN_ERROR_CHECK(fydb, fyt, FYEM_DOC,
+			!fydb->max_depth || fydb->next < fydb->max_depth, err_out,
+			"Max depth (%d) exceeded\n", fydb->next);
+
+	/* grow the stack? */
+	if (fydb->next >= fydb->alloc) {
+		newc = realloc(fydb->stack, fydb->alloc * 2 * sizeof(*fydb->stack));
+		fydb_error_check(fydb, newc, err_out,
+				"Unable to grow the context stack");
+		fydb->alloc *= 2;
+		fydb->stack = newc;
+	}
+	assert(fydb->next < fydb->alloc);
+
+	c = &fydb->stack[++fydb->next - 1];
+	memset(c, 0, sizeof(*c));
+	c->s = FYDBS_NODE;
+	return 0;
+
+err_out:
+	return -1;
+
+complete:
+	assert(fydb->next > 0);
+	c = &fydb->stack[fydb->next - 1];
+	c->fyn = fyn;
+	assert(fydb->next > 0);
+	fydb->next--;
+
+	/* root */
+	if (fydb->next == 0) {
+		fyd->root = fyn;
+		/* if we're in single mode, don't wait for doc end */
+		if (fydb->single_mode)
+			fydb->doc_done = true;
+		return 1;
+	}
+
+	c = &fydb->stack[fydb->next - 1];
+
+	fyn_parent = c->fyn;
+
+	switch (c->s) {
+
+	case FYDBS_MAP_KEY:
+		fynp = fy_node_pair_alloc(fyd);
+		assert(fynp);
+		fynp->key = fyn;
+		c->fynp = fynp;
+
+		/* if we don't allow duplicate keys */
+		if (!(fyd->parse_cfg.flags & FYPCF_ALLOW_DUPLICATE_KEYS)) {
+
+			/* make sure we don't add an already existing key */
+			if (fy_node_mapping_key_is_duplicate(fyn_parent, fyn)) {
+				FYDB_NODE_ERROR(fydb, fyn, FYEM_DOC, "duplicate key");
+				goto err_out;
+			}
+		}
+
+		c->s = FYDBS_MAP_VAL;
+		goto push;
+
+	case FYDBS_MAP_VAL:
+		fynp = c->fynp;
+		assert(fynp);
+		fynp->value = fyn;
+
+		/* set the parent of the node pair and value */
+		fynp->parent = fyn_parent;
+		if (fynp->key) {
+			fynp->key->parent = fyn_parent;
+			fynp->key->key_root = true;
+		}
+		if (fynp->value)
+			fynp->value->parent = fyn_parent;
+
+		fy_node_pair_list_add_tail(&c->fyn->mapping, fynp);
+		if (fyn->xl) {
+			rc = fy_accel_insert(fyn->xl, fynp->key, fynp);
+			assert(!rc);
+		}
+		if (fynp->key)
+			fynp->key->attached = true;
+		if (fynp->value)
+			fynp->value->attached = true;
+
+		c->fynp = NULL;
+		c->s = FYDBS_MAP_KEY;
+		goto push;
+
+	case FYDBS_SEQ:
+		/* append sequence */
+		fyn->parent = fyn_parent;
+		fy_node_list_add_tail(&c->fyn->sequence, fyn);
+		fyn->attached = true;
+		goto push;
+
+	case FYDBS_NODE:
+		/* complete is a scalar */
+		fyn->parent = fyn_parent;
+		return 0;
+	}
+
+	return 0;
+}
+
+struct fy_document *
+fy_document_builder_load_document(struct fy_document_builder *fydb,
+				  struct fy_parser *fyp)
+{
+	struct fy_eventp *fyep = NULL;
+	int rc;
+
+	if (fyp->state == FYPS_END)
+		return NULL;
+
+	while (!fy_document_builder_is_document_complete(fydb) &&
+		(fyep = fy_parse_private(fyp)) != NULL) {
+		rc = fy_document_builder_process_event(fydb, &fyep->e);
+		fy_parse_eventp_recycle(fyp, fyep);
+		if (rc < 0) {
+			fyp->stream_error = true;
+			return NULL;
+		}
+	}
+
+	/* get ownership of the document */
+	return fy_document_builder_take_document(fydb);
+}
+
+struct fy_document *
+fy_document_builder_event_document(struct fy_document_builder *fydb, struct fy_eventp_list *evpl)
+{
+	struct fy_eventp *fyep = NULL;
+	int rc;
+
+	if (!fydb || !evpl)
+		return NULL;
+
+	for (fyep = fy_eventp_list_head(evpl); fyep; fyep = fy_eventp_next(evpl, fyep)) {
+
+		if (fy_document_builder_is_document_complete(fydb))
+			break;
+
+		rc = fy_document_builder_process_event(fydb, &fyep->e);
+		if (rc < 0)
+			return NULL;
+
+	}
+
+	/* get ownership of the document */
+	return fy_document_builder_take_document(fydb);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-docbuilder.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-docbuilder.h
@@ -1,0 +1,161 @@
+/*
+ * fy-docbuilder.h - YAML document builder internal header file
+ *
+ * Copyright (c) 2022 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_DOCBUILDER_H
+#define FY_DOCBUILDER_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-doc.h"
+
+#include "fy-diag.h"
+
+enum fy_document_builder_state {
+	FYDBS_NODE,
+	FYDBS_MAP_KEY,
+	FYDBS_MAP_VAL,
+	FYDBS_SEQ,
+};
+
+struct fy_document_builder_ctx {
+	enum fy_document_builder_state s;
+	struct fy_node *fyn;
+	struct fy_node_pair *fynp;	/* for mapping */
+};
+
+struct fy_document_builder {
+	struct fy_document_builder_cfg cfg;
+	struct fy_document *fyd;
+	bool single_mode;
+	bool in_stream;
+	bool doc_done;
+	unsigned int next;
+	unsigned int alloc;
+	unsigned int max_depth;
+	struct fy_document_builder_ctx *stack;
+};
+
+/* internal only */
+struct fy_document *
+fy_document_builder_event_document(struct fy_document_builder *fydb, struct fy_eventp_list *evpl);
+
+/* diagnostics */
+
+static inline bool
+fydb_debug_log_level_is_enabled(struct fy_document_builder *fydb, enum fy_error_module module)
+{
+	return fydb && fy_diag_log_level_is_enabled(fydb->cfg.diag, FYET_DEBUG, module);
+}
+
+int fy_document_builder_vdiag(struct fy_document_builder *fydb, unsigned int flags,
+			      const char *file, int line, const char *func,
+			      const char *fmt, va_list ap);
+
+int fy_document_builder_diag(struct fy_document_builder *fydb, unsigned int flags,
+			     const char *file, int line, const char *func,
+			     const char *fmt, ...)
+	FY_FORMAT(printf, 6, 7);
+
+void fy_document_builder_diag_vreport(struct fy_document_builder *fydb,
+				      const struct fy_diag_report_ctx *fydrc,
+				      const char *fmt, va_list ap);
+void fy_document_builder_diag_report(struct fy_document_builder *fydb,
+				     const struct fy_diag_report_ctx *fydrc,
+				     const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+#ifdef FY_DEVMODE
+
+#define fydb_debug(_fydb, _module, _fmt, ...) \
+	do { \
+		struct fy_document_builder *__fydb = (_fydb); \
+		enum fy_error_module __module = (_module); \
+		\
+		if (fydb_debug_log_level_is_enabled(__fydb, __module)) \
+			fy_document_builder_diag(__fydb, FYET_DEBUG | FYDF_MODULE(_module), \
+					__FILE__, __LINE__, __func__, \
+					(_fmt) , ## __VA_ARGS__); \
+	} while(0)
+#else
+
+#define fydb_debug(_fydb, _module, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fydb_info(_fydb, _fmt, ...) \
+	fy_document_builder_diag((_fydb), FYET_INFO, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fydb_notice(_fydb, _fmt, ...) \
+	fy_document_builder_diag((_fydb), FYET_NOTICE, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fydb_warning(_fydb, _fmt, ...) \
+	fy_document_builder_diag((_fydb), FYET_WARNING, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fydb_error(_fydb, _fmt, ...) \
+	fy_document_builder_diag((_fydb), FYET_ERROR, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+
+#define fydb_error_check(_fydb, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			fydb_error((_fydb), _fmt, ## __VA_ARGS__); \
+			goto _label ; \
+		} \
+	} while(0)
+
+#define _FYDB_TOKEN_DIAG(_fydb, _fyt, _type, _module, _fmt, ...) \
+	do { \
+		struct fy_diag_report_ctx _drc; \
+		memset(&_drc, 0, sizeof(_drc)); \
+		_drc.type = (_type); \
+		_drc.module = (_module); \
+		_drc.fyt = (_fyt); \
+		fy_document_builder_diag_report((_fydb), &_drc, (_fmt) , ## __VA_ARGS__); \
+	} while(0)
+
+#define FYDB_TOKEN_DIAG(_fydb, _fyt, _type, _module, _fmt, ...) \
+	_FYDB_TOKEN_DIAG(_fydb, fy_token_ref(_fyt), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYDB_NODE_DIAG(_fydb, _fyn, _type, _module, _fmt, ...) \
+	_FYDB_TOKEN_DIAG(_fydb, fy_node_token(_fyn), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYDB_TOKEN_ERROR(_fydb, _fyt, _module, _fmt, ...) \
+	FYDB_TOKEN_DIAG(_fydb, _fyt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYDB_NODE_ERROR(_fydb, _fyn, _module, _fmt, ...) \
+	FYDB_NODE_DIAG(_fydb, _fyn, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYDB_TOKEN_ERROR_CHECK(_fydb, _fyt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYDB_TOKEN_ERROR(_fydb, _fyt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYDB_NODE_ERROR_CHECK(_fydb, _fyn, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYDB_NODE_ERROR(_fydb, _fyn, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYDB_TOKEN_WARNING(_fydb, _fyt, _module, _fmt, ...) \
+	FYDB_TOKEN_DIAG(_fydb, _fyt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-docstate.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-docstate.c
@@ -1,0 +1,504 @@
+/*
+ * fy-docstate.c - YAML document state methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+
+#include "fy-docstate.h"
+
+struct fy_document_state *fy_document_state_alloc(void)
+{
+	struct fy_document_state *fyds;
+
+	fyds = malloc(sizeof(*fyds));
+	if (!fyds)
+		return NULL;
+	memset(fyds, 0, sizeof(*fyds));
+
+	fyds->fyt_ds = NULL;
+	fyds->fyt_vd = NULL;
+	fy_token_list_init(&fyds->fyt_td);
+
+	fyds->refs = 1;
+
+	return fyds;
+}
+
+void fy_document_state_free(struct fy_document_state *fyds)
+{
+	if (!fyds)
+		return;
+
+	assert(fyds->refs == 1);
+
+	fy_token_unref(fyds->fyt_ds);
+	fy_token_unref(fyds->fyt_vd);
+	fy_token_list_unref_all(&fyds->fyt_td);
+
+	free(fyds);
+}
+
+struct fy_document_state *fy_document_state_ref(struct fy_document_state *fyds)
+{
+	if (!fyds)
+		return NULL;
+
+	assert(fyds->refs + 1 > 0);
+
+	fyds->refs++;
+
+	return fyds;
+}
+
+void fy_document_state_unref(struct fy_document_state *fyds)
+{
+	if (!fyds)
+		return;
+
+	assert(fyds->refs > 0);
+
+	if (fyds->refs == 1)
+		fy_document_state_free(fyds);
+	else
+		fyds->refs--;
+}
+
+int fy_document_state_append_tag(struct fy_document_state *fyds,
+				 const char *handle, const char *prefix,
+				 bool is_default)
+{
+	struct fy_token *fyt = NULL;
+	struct fy_input *fyi = NULL;
+	char *data;
+	size_t size, handle_size, prefix_size;
+	struct fy_atom atom;
+
+	size = strlen(handle) + 1 + strlen(prefix);
+	data = malloc(size + 1);
+	if (!data)
+		goto err_out;
+
+	snprintf(data, size + 1, "%s %s", handle, prefix);
+
+	fyi = fy_input_from_malloc_data(data, size, &atom, true);
+	if (!fyi)
+		goto err_out;
+	data = NULL;	/* ownership now at input */
+
+	handle_size = strlen(handle);
+	prefix_size = strlen(prefix);
+
+	fyt = fy_token_create(FYTT_TAG_DIRECTIVE, &atom,
+			     handle_size, prefix_size,
+			     is_default);
+	if (!fyt)
+		goto err_out;
+
+	fy_token_list_add_tail(&fyds->fyt_td, fyt);
+
+	if (!fy_tag_is_default_internal(handle, handle_size, prefix, prefix_size))
+		fyds->tags_explicit = true;
+
+	/* take away the input reference */
+	fy_input_unref(fyi);
+
+	return 0;
+
+err_out:
+	fy_token_unref(fyt);
+	fy_input_unref(fyi);
+	if (data)
+		free(data);
+	return -1;
+}
+
+struct fy_document_state *fy_document_state_default(
+		const struct fy_version *default_version,
+		const struct fy_tag * const *default_tags)
+{
+	struct fy_document_state *fyds = NULL;
+	const struct fy_tag *fytag;
+	int i, rc;
+
+	if (!default_version)
+		default_version = &fy_default_version;
+
+	if (!default_tags)
+		default_tags = fy_default_tags;
+
+	fyds = fy_document_state_alloc();
+	if (!fyds)
+		goto err_out;
+
+	fyds->version = *default_version;
+
+	fyds->version_explicit = false;
+	fyds->tags_explicit = false;
+	fyds->start_implicit = true;
+	fyds->end_implicit = true;
+	fyds->json_mode = false;
+
+	memset(&fyds->start_mark, 0, sizeof(fyds->start_mark));
+	memset(&fyds->end_mark, 0, sizeof(fyds->end_mark));
+
+	fyds->fyt_ds = NULL;
+	fyds->fyt_vd = NULL;
+	fy_token_list_init(&fyds->fyt_td);
+
+	for (i = 0; (fytag = default_tags[i]) != NULL; i++) {
+
+		rc = fy_document_state_append_tag(fyds, fytag->handle, fytag->prefix, true);
+		if (rc)
+			goto err_out;
+	}
+
+	return fyds;
+err_out:
+	fy_document_state_unref(fyds);
+	return NULL;
+}
+
+struct fy_document_state *fy_document_state_copy(struct fy_document_state *fyds)
+{
+	struct fy_document_state *fyds_new = NULL;
+	struct fy_token *fyt_td, *fyt;
+
+	fyds_new = fy_document_state_alloc();
+	if (!fyds_new)
+		goto err_out;
+
+	fyds_new->version = fyds->version;
+	fyds_new->version_explicit = fyds->version_explicit;
+	fyds_new->tags_explicit = fyds->tags_explicit;
+	fyds_new->start_implicit = fyds->start_implicit;
+	fyds_new->end_implicit = fyds->end_implicit;
+	fyds_new->json_mode = fyds->json_mode;
+
+	fyds_new->start_mark = fyds->start_mark;
+	fyds_new->end_mark = fyds->end_mark;
+
+	if (fyds->fyt_ds) {
+		fyt = fy_token_alloc();
+		if (!fyt)
+			goto err_out;
+
+		fyt->type = FYTT_DOCUMENT_START;
+		fyt->handle = fyds->fyt_ds->handle;
+
+		/* take reference */
+		fy_input_ref(fyt->handle.fyi);
+
+		fyds_new->fyt_ds = fyt;
+	}
+
+	if (fyds->fyt_vd) {
+		fyt = fy_token_alloc();
+		if (!fyt)
+			goto err_out;
+
+		fyt->type = FYTT_VERSION_DIRECTIVE;
+		fyt->handle = fyds->fyt_vd->handle;
+		fyt->version_directive.vers = fyds->fyt_vd->version_directive.vers;
+
+		/* take reference */
+		fy_input_ref(fyt->handle.fyi);
+
+		fyds_new->fyt_vd = fyt;
+	}
+
+	for (fyt = fy_token_list_first(&fyds->fyt_td); fyt; fyt = fy_token_next(&fyds->fyt_td, fyt)) {
+		fyt_td = fy_token_alloc();
+		if (!fyt_td)
+			goto err_out;
+
+		fyt_td->type = FYTT_TAG_DIRECTIVE;
+		fyt_td->tag_directive.tag_length = fyt->tag_directive.tag_length;
+		fyt_td->tag_directive.uri_length = fyt->tag_directive.uri_length;
+		fyt_td->tag_directive.is_default = fyt->tag_directive.is_default;
+		fyt_td->handle = fyt->handle;
+		fyt_td->tag_directive.prefix0 = NULL;
+		fyt_td->tag_directive.handle0 = NULL;
+
+		/* take reference */
+		fy_input_ref(fyt_td->handle.fyi);
+
+		/* append to the new document state */
+		fy_token_list_add_tail(&fyds_new->fyt_td, fyt_td);
+	}
+
+	return fyds_new;
+
+err_out:
+	fy_document_state_unref(fyds_new);
+	return NULL;
+}
+
+struct fy_token *fy_document_state_lookup_tag_directive(struct fy_document_state *fyds,
+		const char *handle, size_t handle_size)
+{
+	const char *td_handle;
+	size_t td_handle_size;
+	struct fy_token *fyt;
+
+	if (!fyds)
+		return NULL;
+
+	for (fyt = fy_token_list_first(&fyds->fyt_td); fyt; fyt = fy_token_next(&fyds->fyt_td, fyt)) {
+
+		td_handle = fy_tag_directive_token_handle(fyt, &td_handle_size);
+		assert(td_handle);
+
+		if (handle_size == td_handle_size && !memcmp(handle, td_handle, handle_size))
+			return fyt;
+
+	}
+
+	return NULL;
+}
+
+int fy_document_state_merge(struct fy_document_state *fyds,
+			    struct fy_document_state *fydsc)
+{
+	const char *td_prefix, *tdc_handle, *tdc_prefix;
+	size_t td_prefix_size, tdc_handle_size, tdc_prefix_size;
+	struct fy_token *fyt, *fytc_td, *fyt_td;
+
+	if (!fyds || !fydsc)
+		return -1;
+
+	/* check if there's a duplicate handle (which differs */
+	for (fytc_td = fy_token_list_first(&fydsc->fyt_td); fytc_td;
+			fytc_td = fy_token_next(&fydsc->fyt_td, fytc_td)) {
+
+		tdc_handle = fy_tag_directive_token_handle(fytc_td, &tdc_handle_size);
+		if (!tdc_handle)
+			goto err_out;
+		tdc_prefix = fy_tag_directive_token_prefix(fytc_td, &tdc_prefix_size);
+		if (!tdc_prefix)
+			goto err_out;
+
+		fyt_td = fy_document_state_lookup_tag_directive(fyds, tdc_handle, tdc_handle_size);
+		if (fyt_td) {
+			/* exists, must check whether the prefixes match */
+			td_prefix = fy_tag_directive_token_prefix(fyt_td, &td_prefix_size);
+			assert(td_prefix);
+
+			/* match? do nothing */
+			if (tdc_prefix_size == td_prefix_size &&
+			    !memcmp(tdc_prefix, td_prefix, td_prefix_size))
+				continue;
+
+			if (!fy_token_tag_directive_is_overridable(fyt_td))
+				goto err_out;
+
+			/* override tag directive */
+			fy_token_list_del(&fyds->fyt_td, fyt_td);
+			fy_token_unref(fyt_td);
+		}
+
+		fyt = fy_token_create(FYTT_TAG_DIRECTIVE,
+				&fytc_td->handle,
+				fytc_td->tag_directive.tag_length,
+				fytc_td->tag_directive.uri_length,
+				fytc_td->tag_directive.is_default);
+		if (!fyt)
+			goto err_out;
+
+		fy_token_list_add_tail(&fyds->fyt_td, fyt);
+	}
+
+	/* merge other document state */
+	fyds->version_explicit |= fydsc->version_explicit;
+	fyds->tags_explicit |= fydsc->tags_explicit;
+	/* NOTE: json mode is not carried over */
+
+	if (fyds->version.major < fydsc->version.major ||
+	    (fyds->version.major == fydsc->version.major &&
+		fyds->version.minor < fydsc->version.minor))
+		fyds->version = fydsc->version;
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+const struct fy_version *
+fy_document_state_version(struct fy_document_state *fyds)
+{
+	/* return the default if not set */
+	return fyds ? &fyds->version : &fy_default_version;
+}
+
+const struct fy_mark *fy_document_state_start_mark(struct fy_document_state *fyds)
+{
+	return fyds ? &fyds->start_mark : NULL;
+}
+
+const struct fy_mark *fy_document_state_end_mark(struct fy_document_state *fyds)
+{
+	return fyds ? &fyds->end_mark : NULL;
+}
+
+bool fy_document_state_version_explicit(struct fy_document_state *fyds)
+{
+	return fyds ? fyds->version_explicit : false;
+}
+
+bool fy_document_state_tags_explicit(struct fy_document_state *fyds)
+{
+	return fyds ? fyds->tags_explicit : false;
+}
+
+bool fy_document_state_start_implicit(struct fy_document_state *fyds)
+{
+	return fyds ? fyds->start_implicit : true;
+}
+
+bool fy_document_state_end_implicit(struct fy_document_state *fyds)
+{
+	return fyds ? fyds->end_implicit : true;
+}
+
+bool fy_document_state_json_mode(struct fy_document_state *fyds)
+{
+	return fyds ? fyds->json_mode : true;
+}
+
+const struct fy_tag *
+fy_document_state_tag_directive_iterate(struct fy_document_state *fyds, void **iterp)
+{
+	struct fy_token *fyt;
+	const struct fy_tag *tag;
+
+	if (!fyds || !iterp)
+		return NULL;
+
+	fyt = *iterp;
+	fyt = !fyt ? fy_token_list_head(&fyds->fyt_td) : fy_token_next(&fyds->fyt_td, fyt);
+	if (!fyt)
+		return NULL;
+
+	/* sanity check */
+	assert(fyt->type == FYTT_TAG_DIRECTIVE);
+
+	/* always refresh, should be relatively infrequent */
+	fyt->tag_directive.tag.handle = fy_tag_directive_token_handle0(fyt);
+	fyt->tag_directive.tag.prefix = fy_tag_directive_token_prefix0(fyt);
+
+	tag = &fyt->tag_directive.tag;
+
+	*iterp = fyt;
+
+	return tag;
+}
+
+struct fy_tag **
+fy_document_state_tag_directives(struct fy_document_state *fyds)
+{
+	struct fy_tag *tags, **tagsp;
+	const struct fy_tag *fytag;
+	size_t size, len;
+	void *iter;
+	char *s;
+	int i;
+
+	if (!fyds)
+		return NULL;
+
+	/* first find the extents of the area we're going to need */
+	i = 0;
+	size = 0;
+	iter = NULL;
+	while ((fytag = fy_document_state_tag_directive_iterate(fyds, &iter)) != NULL) {
+		size += strlen(fytag->handle) + 1 + strlen(fytag->prefix) + 1;
+		i++;
+	}
+	size += sizeof(struct fy_tag) * i;
+	size += sizeof(struct fy_tag *) * (i + 1);
+
+	tagsp = malloc(size);
+	if (!tagsp)
+		return NULL;
+	memset(tagsp, 0, size);
+	tags = (void *)(tagsp + i + 1);
+	s = (void *)(tags + i);
+
+	i = 0;
+	iter = NULL;
+	while ((fytag = fy_document_state_tag_directive_iterate(fyds, &iter)) != NULL) {
+		tags[i].handle = s;
+		len = strlen(fytag->handle);
+		memcpy(s, fytag->handle, len + 1);
+		s += len + 1;
+
+		tags[i].prefix = s;
+		len = strlen(fytag->prefix);
+		memcpy(s, fytag->prefix, len + 1);
+		s += len + 1;
+
+		tagsp[i] = &tags[i];
+
+		i++;
+	}
+	tagsp[i] = NULL;	/* NULL terminated */
+
+	return tagsp;
+}
+
+int fy_document_state_shorten_tag(struct fy_document_state *fyds,
+		const char *full_tag, size_t full_tag_size,
+		const char **handlep, size_t *handle_sizep,
+		const char **suffixp, size_t *suffix_sizep)
+{
+	const char *td_handle, *td_prefix;
+	size_t td_handle_size, td_prefix_size;
+	struct fy_token *fyt;
+
+	if (!fyds || !full_tag || !handlep || !handle_sizep || !suffixp || !suffix_sizep)
+		return -1;
+
+	if (full_tag_size == FY_NT)
+		full_tag_size = strlen(full_tag);
+
+	for (fyt = fy_token_list_first(&fyds->fyt_td); fyt; fyt = fy_token_next(&fyds->fyt_td, fyt)) {
+
+		td_prefix = fy_tag_directive_token_prefix(fyt, &td_prefix_size);
+		if (!td_prefix)
+			continue;
+
+		if (td_prefix_size < full_tag_size && !memcmp(td_prefix, full_tag, td_prefix_size)) {
+
+			td_handle = fy_tag_directive_token_handle(fyt, &td_handle_size);
+			if (!td_handle)
+				continue;
+
+			*handlep = td_handle;
+			*handle_sizep = td_handle_size;
+			*suffixp = full_tag + td_prefix_size;
+			*suffix_sizep = full_tag_size - td_prefix_size;
+
+			return 0;
+		}
+
+	}
+
+	return -1;
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-docstate.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-docstate.h
@@ -1,0 +1,70 @@
+/*
+ * fy-docstate.h - YAML document state header.
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_DOCSTATE_H
+#define FY_DOCSTATE_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-ctype.h"
+#include "fy-list.h"
+#include "fy-typelist.h"
+#include "fy-token.h"
+
+struct fy_document;
+
+struct fy_document_state {
+	int refs;
+	struct fy_version version;
+	bool version_explicit : 1;
+	bool tags_explicit : 1;
+	bool start_implicit : 1;
+	bool end_implicit : 1;
+	bool started_explicit : 1;
+	bool json_mode : 1;
+	struct fy_mark start_mark;
+	struct fy_mark end_mark;
+	struct fy_token *fyt_ds;		/* the document start token (if any) */
+	struct fy_token *fyt_vd;		/* version directive */
+	struct fy_token_list fyt_td;		/* tag directives */
+};
+
+struct fy_document_state *fy_document_state_alloc(void);
+void fy_document_state_free(struct fy_document_state *fyds);
+struct fy_document_state *fy_document_state_ref(struct fy_document_state *fyds);
+void fy_document_state_unref(struct fy_document_state *fyds);
+
+int fy_document_state_append_tag(struct fy_document_state *fyds,
+				 const char *handle, const char *prefix,
+				 bool is_default);
+
+struct fy_document_state *fy_document_state_default(
+		const struct fy_version *default_version,
+		const struct fy_tag * const *default_tags);
+
+struct fy_document_state *fy_document_state_copy(struct fy_document_state *fyds);
+int fy_document_state_merge(struct fy_document_state *fyds,
+			    struct fy_document_state *fydsc);
+
+struct fy_token *fy_document_state_lookup_tag_directive(struct fy_document_state *fyds,
+		const char *handle, size_t handle_size);
+
+int fy_document_state_shorten_tag(struct fy_document_state *fyds,
+		const char *full_tag, size_t full_tag_size,
+		const char **handlep, size_t *handle_sizep,
+		const char **suffixp, size_t *suffix_sizep);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-dump.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-dump.c
@@ -1,0 +1,309 @@
+/*
+ * fy-dump.c - various debugging methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <limits.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-ctype.h"
+#include "fy-utf8.h"
+
+const char *fy_token_type_txt[FYTT_COUNT] = {
+	[FYTT_NONE]			= "<NONE>",
+	[FYTT_STREAM_START]		= "STRM+",
+	[FYTT_STREAM_END]		= "STRM-",
+	[FYTT_VERSION_DIRECTIVE]	= "VRSD",
+	[FYTT_TAG_DIRECTIVE]		= "TAGD",
+	[FYTT_DOCUMENT_START]		= "DOC+",
+	[FYTT_DOCUMENT_END]		= "DOC-",
+	[FYTT_BLOCK_SEQUENCE_START]	= "BSEQ+",
+	[FYTT_BLOCK_MAPPING_START]	= "BMAP+",
+	[FYTT_BLOCK_END]		= "BEND",
+	[FYTT_FLOW_SEQUENCE_START]	= "FSEQ+",
+	[FYTT_FLOW_SEQUENCE_END]	= "FSEQ-",
+	[FYTT_FLOW_MAPPING_START]	= "FMAP+",
+	[FYTT_FLOW_MAPPING_END]		= "FMAP-",
+	[FYTT_BLOCK_ENTRY]		= "BENTR",
+	[FYTT_FLOW_ENTRY]		= "FENTR",
+	[FYTT_KEY]			= "KEY",
+	[FYTT_SCALAR]			= "SCLR",
+	[FYTT_VALUE]			= "VAL",
+	[FYTT_ALIAS]			= "ALIAS",
+	[FYTT_ANCHOR]			= "ANCHR",
+	[FYTT_TAG]			= "TAG",
+	[FYTT_INPUT_MARKER]		= "INPUT_MARKER",
+
+	[FYTT_PE_SLASH]			= "PE_SLASH",
+	[FYTT_PE_ROOT]			= "PE_ROOT",
+	[FYTT_PE_THIS]			= "PE_THIS",
+	[FYTT_PE_PARENT]		= "PE_PARENT",
+	[FYTT_PE_MAP_KEY]		= "PE_MAP_KEY",
+	[FYTT_PE_SEQ_INDEX]		= "PE_SEQ_INDEX",
+	[FYTT_PE_SEQ_SLICE]		= "PE_SEQ_SLICE",
+	[FYTT_PE_SCALAR_FILTER]		= "PE_SCALAR_FILTER",
+	[FYTT_PE_COLLECTION_FILTER]	= "PE_COLLECTION_FILTER",
+	[FYTT_PE_SEQ_FILTER]		= "PE_SEQ_FILTER",
+	[FYTT_PE_MAP_FILTER]		= "PE_MAP_FILTER",
+	[FYTT_PE_UNIQUE_FILTER]		= "PE_UNIQUE_FILTER",
+	[FYTT_PE_EVERY_CHILD]		= "PE_EVERY_CHILD",
+	[FYTT_PE_EVERY_CHILD_R]		= "PE_EVERY_CHILD_R",
+	[FYTT_PE_ALIAS]			= "PE_ALIAS",
+	[FYTT_PE_SIBLING]		= "PE_SIBLING",
+	[FYTT_PE_COMMA]			= "PE_COMMA",
+	[FYTT_PE_BARBAR]		= "PE_BARBAR",
+	[FYTT_PE_AMPAMP]		= "PE_AMPAMP",
+	[FYTT_PE_LPAREN]		= "PE_LPAREN",
+	[FYTT_PE_RPAREN]		= "PE_RPAREN",
+
+	[FYTT_PE_EQEQ]			= "PE_EQEQ",
+	[FYTT_PE_NOTEQ]			= "PE_NOTEQ",
+	[FYTT_PE_LT]			= "PE_LT",
+	[FYTT_PE_GT]			= "PE_GT",
+	[FYTT_PE_LTE]			= "PE_LTE",
+	[FYTT_PE_GTE]			= "PE_GTE",
+
+	[FYTT_SE_PLUS]			= "SE_PLUS",
+	[FYTT_SE_MINUS]			= "SE_MINUS",
+	[FYTT_SE_MULT]			= "SE_MULT",
+	[FYTT_SE_DIV]			= "SE_DIV",
+
+	[FYTT_PE_METHOD]		= "PE_METHOD",
+	[FYTT_SE_METHOD]		= "SE_METHOD",
+
+	[FYTT_PE_BANG]			= "PE_BANG",
+	[FYTT_PE_AT]			= "PE_AT",
+};
+
+char *fy_token_dump_format(struct fy_token *fyt, char *buf, size_t bufsz)
+{
+	const char *typetxt, *text;
+	size_t size;
+	enum fy_token_type type;
+	const char *pfx, *sfx;
+
+	if (fyt && (unsigned int)fyt->type < sizeof(fy_token_type_txt)/
+					     sizeof(fy_token_type_txt[0])) {
+		typetxt = fy_token_type_txt[fyt->type];
+		type = fyt->type;
+	} else {
+		typetxt = "<NULL>";
+		type = FYTT_NONE;
+	}
+
+	size = 0;
+	switch (type) {
+	case FYTT_SCALAR:
+	case FYTT_ALIAS:
+	case FYTT_ANCHOR:
+		text = fy_token_get_text(fyt, &size);
+		break;
+	default:
+		text = NULL;
+		break;
+	}
+
+	if (!text) {
+		snprintf(buf, bufsz, "%s", typetxt);
+		return buf;
+	}
+
+	pfx = typetxt;
+	sfx = "";
+	switch (type) {
+	case FYTT_SCALAR:
+
+		pfx = "\"";
+
+		/* not too large */
+		if (size > 20)
+			size = 20;
+		text = fy_utf8_format_text_a(text, size, fyue_doublequote);
+		size = strlen(text);
+		if (size > 10) {
+			sfx = "...\"";
+			size = 7;
+		} else {
+			sfx = "\"";
+		}
+		break;
+	case FYTT_ALIAS:
+	case FYTT_ANCHOR:
+		sfx = type == FYTT_ALIAS ? "*" : "&";
+		if (size > 10) {
+			sfx = "...";
+			size = 7;
+		} else
+			sfx = "";
+		break;
+
+	default:
+		break;
+	}
+
+	snprintf(buf, bufsz, "%s%.*s%s", pfx, (int)size, text, sfx);
+
+	return buf;
+}
+
+char *fy_token_list_dump_format(struct fy_token_list *fytl,
+		struct fy_token *fyt_highlight, char *buf, size_t bufsz)
+{
+	char *s, *e;
+	struct fy_token *fyt;
+
+	s = buf;
+	e = buf + bufsz - 1;
+	for (fyt = fy_token_list_first(fytl); fyt; fyt = fy_token_next(fytl, fyt)) {
+
+		if (s >= (e - 1))
+			break;
+
+		s += snprintf(s, e - s, "%s%s",
+				fyt != fy_token_list_first(fytl) ? "," : "",
+				fyt_highlight == fyt ? "*" : "");
+
+		fy_token_dump_format(fyt, s, e - s);
+
+		s += strlen(s);
+	}
+	*s = '\0';
+
+	return buf;
+}
+
+char *fy_simple_key_dump_format(struct fy_parser *fyp, struct fy_simple_key *fysk, char *buf, size_t bufsz)
+{
+	char tbuf[80];
+
+	if (!fysk) {
+		if (bufsz > 0)
+			*buf = '\0';
+		return buf;
+	}
+
+	fy_token_dump_format(fysk->token, tbuf, sizeof(tbuf));
+
+	snprintf(buf, bufsz, "%s/%c%c/%d/<%d-%d,%d-%d>", tbuf,
+			fysk->required ? 'R' : '-',
+			fysk->implicit_complex ? 'C' : '-',
+			fysk->flow_level,
+			fysk->mark.line, fysk->mark.column,
+			fysk->end_mark.line, fysk->end_mark.column);
+	return buf;
+}
+
+char *fy_simple_key_list_dump_format(struct fy_parser *fyp, struct fy_simple_key_list *fyskl,
+		struct fy_simple_key *fysk_highlight, char *buf, size_t bufsz)
+{
+	char *s, *e;
+	struct fy_simple_key *fysk;
+
+	s = buf;
+	e = buf + bufsz - 1;
+	for (fysk = fy_simple_key_list_first(fyskl); fysk; fysk = fy_simple_key_next(fyskl, fysk)) {
+
+		if (s >= (e - 1))
+			break;
+
+		s += snprintf(s, e - s, "%s%s",
+				fysk != fy_simple_key_list_first(fyskl) ? "," : "",
+				fysk_highlight == fysk ? "*" : "");
+
+		fy_simple_key_dump_format(fyp, fysk, s, e - s);
+
+		s += strlen(s);
+	}
+	*s = '\0';
+
+	return buf;
+}
+
+#ifdef FY_DEVMODE
+
+void fyp_debug_dump_token_list(struct fy_parser *fyp, struct fy_token_list *fytl,
+		struct fy_token *fyt_highlight, const char *banner)
+{
+	char buf[4096];
+
+	if (!fyp || !fyp->diag || FYET_DEBUG < fyp->diag->cfg.level)
+		return;
+
+	fyp_scan_debug(fyp, "%s%s\n", banner,
+			fy_token_list_dump_format(fytl, fyt_highlight, buf, sizeof(buf)));
+}
+
+void fyp_debug_dump_token(struct fy_parser *fyp, struct fy_token *fyt, const char *banner)
+{
+	char buf[80];
+
+	if (!fyp || !fyp->diag || FYET_DEBUG < fyp->diag->cfg.level)
+		return;
+
+	fyp_scan_debug(fyp, "%s%s\n", banner,
+			fy_token_dump_format(fyt, buf, sizeof(buf)));
+}
+
+void fyp_debug_dump_simple_key_list(struct fy_parser *fyp, struct fy_simple_key_list *fyskl,
+		struct fy_simple_key *fysk_highlight, const char *banner)
+{
+	char buf[4096];
+
+	if (!fyp || !fyp->diag || FYET_DEBUG < fyp->diag->cfg.level)
+		return;
+
+	fyp_scan_debug(fyp, "%s%s\n", banner,
+			fy_simple_key_list_dump_format(fyp, fyskl, fysk_highlight, buf, sizeof(buf)));
+}
+
+void fyp_debug_dump_simple_key(struct fy_parser *fyp, struct fy_simple_key *fysk, const char *banner)
+{
+	char buf[80];
+
+	if (!fyp || !fyp->diag || FYET_DEBUG < fyp->diag->cfg.level)
+		return;
+
+	fyp_scan_debug(fyp, "%s%s\n", banner,
+			fy_simple_key_dump_format(fyp, fysk, buf, sizeof(buf)));
+}
+
+void fyp_debug_dump_input(struct fy_parser *fyp, const struct fy_input_cfg *fyic,
+		const char *banner)
+{
+	switch (fyic->type) {
+	case fyit_file:
+		fyp_scan_debug(fyp, "%s: filename=\"%s\"\n", banner,
+				fyic->file.filename);
+		break;
+	case fyit_stream:
+		fyp_scan_debug(fyp, "%s: stream=\"%s\" fileno=%d\n", banner,
+				fyic->stream.name, fileno(fyic->stream.fp));
+		break;
+	case fyit_memory:
+		fyp_scan_debug(fyp, "%s: start=%p size=%zu\n", banner,
+				fyic->memory.data, fyic->memory.size);
+		break;
+	case fyit_alloc:
+		fyp_scan_debug(fyp, "%s: start=%p size=%zu\n", banner,
+				fyic->alloc.data, fyic->alloc.size);
+		break;
+	default:
+		break;
+	}
+}
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-dump.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-dump.h
@@ -1,0 +1,92 @@
+/*
+ * fy-dump.h - dumps for various internal structures
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_DUMP_H
+#define FY_DUMP_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+#include "fy-diag.h"
+
+struct fy_parser;
+struct fy_token;
+struct fy_token_list;
+struct fy_simple_key;
+struct fy_simple_key_list;
+struct fy_input_cfg;
+
+extern const char *fy_token_type_txt[];
+
+char *fy_token_dump_format(struct fy_token *fyt, char *buf, size_t bufsz);
+char *fy_token_list_dump_format(struct fy_token_list *fytl,
+		struct fy_token *fyt_highlight, char *buf, size_t bufsz);
+
+char *fy_simple_key_dump_format(struct fy_parser *fyp, struct fy_simple_key *fysk, char *buf, size_t bufsz);
+char *fy_simple_key_list_dump_format(struct fy_parser *fyp, struct fy_simple_key_list *fyskl,
+		struct fy_simple_key *fysk_highlight, char *buf, size_t bufsz);
+
+#ifdef FY_DEVMODE
+
+void fyp_debug_dump_token_list(struct fy_parser *fyp, struct fy_token_list *fytl,
+			       struct fy_token *fyt_highlight, const char *banner);
+void fyp_debug_dump_token(struct fy_parser *fyp, struct fy_token *fyt, const char *banner);
+
+void fyp_debug_dump_simple_key_list(struct fy_parser *fyp, struct fy_simple_key_list *fyskl,
+				    struct fy_simple_key *fysk_highlight, const char *banner);
+void fyp_debug_dump_simple_key(struct fy_parser *fyp, struct fy_simple_key *fysk, const char *banner);
+
+void fyp_debug_dump_input(struct fy_parser *fyp, const struct fy_input_cfg *fyic,
+			  const char *banner);
+
+#else
+
+static inline void
+fyp_debug_dump_token_list(struct fy_parser *fyp, struct fy_token_list *fytl,
+			  struct fy_token *fyt_highlight, const char *banner)
+{
+	/* nothing */
+}
+
+static inline void
+fyp_debug_dump_token(struct fy_parser *fyp, struct fy_token *fyt, const char *banner)
+{
+	/* nothing */
+}
+
+static inline void
+fyp_debug_dump_simple_key_list(struct fy_parser *fyp, struct fy_simple_key_list *fyskl,
+			       struct fy_simple_key *fysk_highlight, const char *banner)
+{
+	/* nothing */
+}
+
+static inline void
+fyp_debug_dump_simple_key(struct fy_parser *fyp, struct fy_simple_key *fysk, const char *banner)
+{
+	/* nothing */
+}
+
+static inline void
+fy_debug_dump_input(struct fy_parser *fyp, const struct fy_input_cfg *fyic,
+		    const char *banner)
+{
+	/* nothing */
+}
+
+#endif
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-emit-accum.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-emit-accum.h
@@ -1,0 +1,383 @@
+/*
+ * fy-emit-accum.h - internal YAML emitter accumulator header
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_EMIT_ACCUM_H
+#define FY_EMIT_ACCUM_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <libfyaml.h>
+
+#include "fy-utf8.h"
+#include "fy-event.h"
+
+struct fy_emit_accum {
+	char *accum;
+	size_t alloc;
+	size_t next;
+	char *inplace;
+	size_t inplacesz;
+	int col, row;
+	int ts;
+	enum fy_lb_mode lb_mode;
+};
+
+static inline void
+fy_emit_accum_init(struct fy_emit_accum *ea,
+		   void *inplace, size_t inplacesz,
+		   int ts, enum fy_lb_mode lb_mode)
+{
+	memset(ea, 0, sizeof(*ea));
+
+	ea->inplace = inplace;
+	ea->inplacesz = inplacesz;
+	ea->accum = ea->inplace;
+	ea->alloc = ea->inplacesz;
+	ea->ts = ts ? ts : 8;
+	ea->lb_mode = lb_mode;
+}
+
+static inline void
+fy_emit_accum_reset(struct fy_emit_accum *ea)
+{
+	ea->next = 0;
+	ea->col = 0;
+	ea->row = 0;
+}
+
+static inline void
+fy_emit_accum_cleanup(struct fy_emit_accum *ea)
+{
+	if (ea->accum && ea->accum != ea->inplace)
+		free(ea->accum);
+	ea->accum = ea->inplace;
+	ea->alloc = ea->inplacesz;
+	fy_emit_accum_reset(ea);
+}
+
+static inline void
+fy_emit_accum_start(struct fy_emit_accum *ea, int col, enum fy_lb_mode lb_mode)
+{
+	fy_emit_accum_reset(ea);
+	ea->col = col;
+	ea->lb_mode = lb_mode;
+}
+
+static inline void
+fy_emit_accum_finish(struct fy_emit_accum *ea)
+{
+	fy_emit_accum_reset(ea);
+}
+
+static inline int
+fy_emit_accum_grow(struct fy_emit_accum *ea, size_t need)
+{
+	size_t atleast, asz;
+	char *new_accum;
+
+	atleast = ea->alloc + need;
+	asz = ea->alloc;
+	/* minimum buffer is 32 */
+	if (asz < 32)
+		asz = 32;
+	do {
+		asz *= 2;
+	} while (asz < atleast);
+	assert(asz > ea->inplacesz);
+	new_accum = realloc(ea->accum == ea->inplace ? NULL : ea->accum, asz);
+	if (!new_accum)	/* out of memory */
+		return -1;
+	if (ea->accum && ea->accum == ea->inplace)
+		memcpy(new_accum, ea->accum, ea->next);
+	ea->alloc = asz;
+	ea->accum = new_accum;
+
+	return 0;
+}
+
+static inline int
+fy_emit_accum_utf8_put_raw(struct fy_emit_accum *ea, int c)
+{
+	size_t w, avail;
+	int ret;
+
+	/* grow if needed */
+	w = fy_utf8_width(c);
+	if (w > (avail = (ea->alloc - ea->next))) {
+		ret = fy_emit_accum_grow(ea, w - avail);
+		if (ret != 0)
+			return ret;
+	}
+	(void)fy_utf8_put_unchecked(ea->accum + ea->next, c);
+	ea->next += w;
+
+	return 0;
+}
+
+static inline int
+fy_emit_accum_put_raw(struct fy_emit_accum *ea, int c)
+{
+	int ret;
+
+	/* only lower ascii please */
+	if (c >= 0x80)
+		return -1;
+
+	/* grow if needed */
+	if (ea->next >= ea->alloc) {
+		ret = fy_emit_accum_grow(ea, 1);
+		if (ret != 0)
+			return ret;
+	}
+	*(ea->accum + ea->next) = (char)c;
+	ea->next++;
+
+	return 0;
+}
+
+static inline int
+fy_emit_accum_utf8_put(struct fy_emit_accum *ea, int c)
+{
+	int ret;
+
+	if (!fy_utf8_is_valid(c))
+		return -1;
+
+	if (fy_is_lb_m(c, ea->lb_mode)) {
+		ret = fy_emit_accum_put_raw(ea, '\n');
+		if (ret)
+			return ret;
+		ea->col = 0;
+		ea->row++;
+	} else if (fy_is_tab(c)) {
+		ret = fy_emit_accum_put_raw(ea, '\t');
+		if (ret)
+			return ret;
+		ea->col += (ea->ts - (ea->col % ea->ts));
+	} else {
+		if (c < 0x80) {
+			ret = fy_emit_accum_put_raw(ea, c);
+			if (ret)
+				return ret;
+		} else {
+			ret = fy_emit_accum_utf8_put_raw(ea, c);
+		}
+		ea->col++;
+	}
+
+	return 0;
+}
+
+static inline int
+fy_emit_accum_utf8_write_raw(struct fy_emit_accum *ea, const void *data, size_t len)
+{
+	size_t avail;
+	int ret;
+
+	/* grow if needed */
+	if (len > (avail = (ea->alloc - ea->next))) {
+		ret = fy_emit_accum_grow(ea, len - avail);
+		if (ret != 0)
+			return ret;
+	}
+	memcpy(ea->accum + ea->next, data, len);
+	ea->next += len;
+
+	return 0;
+}
+
+static inline int
+fy_emit_accum_utf8_write(struct fy_emit_accum *ea, const void *data, size_t len)
+{
+	const char *s, *e;
+	int c, w, ret;
+
+	for (s = data, e = s + len; (c = fy_utf8_get(s, (e - s), &w)) >= 0; s += w) {
+		ret = fy_emit_accum_utf8_put(ea, c);
+		if (ret)
+			break;
+	}
+	return c == FYUG_EOF ? 0 : -1;
+}
+
+static inline int
+fy_emit_accum_utf8_printf_raw(struct fy_emit_accum *ea, const char *fmt, ...)
+	FY_FORMAT(printf, 2, 3);
+
+static inline int
+fy_emit_accum_utf8_printf_raw(struct fy_emit_accum *ea, const char *fmt, ...)
+{
+	va_list ap;
+	size_t avail, len;
+	int ret;
+
+	/* get the size of the string */
+	va_start(ap, fmt);
+	len = vsnprintf(NULL, 0, fmt, ap);
+	va_end(ap);
+
+	/* grow if needed */
+	if ((len + 1) > (avail = (ea->alloc - ea->next))) {
+		ret = fy_emit_accum_grow(ea, (len + 1) - avail);
+		if (ret != 0)
+			return ret;
+	}
+
+	va_start(ap, fmt);
+	(void)vsnprintf(ea->accum + ea->next, len + 1, fmt, ap);
+	va_end(ap);
+
+	ea->next += len;
+
+	return 0;
+}
+
+static inline const char *
+fy_emit_accum_get(struct fy_emit_accum *ea, size_t *lenp)
+{
+	*lenp = ea->next;
+	if (!ea->next) {
+		return "";
+	}
+	return ea->accum;
+}
+
+static inline int
+fy_emit_accum_make_0_terminated(struct fy_emit_accum *ea)
+{
+	int ret;
+
+	/* the empty case is special cased */
+	if (!ea->next)
+		return 0;
+
+	/* grow if needed for the '\0' */
+	if (ea->next >= ea->alloc) {
+		ret = fy_emit_accum_grow(ea, 1);
+		if (ret != 0)
+			return ret;
+	}
+	assert(ea->next < ea->alloc);
+	*(ea->accum + ea->next) = '\0';
+	return 0;
+}
+
+static inline const char *
+fy_emit_accum_get0(struct fy_emit_accum *ea)
+{
+	int ret;
+
+	ret = fy_emit_accum_make_0_terminated(ea);
+	if (ret)
+		return NULL;
+	return ea->accum;
+}
+
+static inline char *
+fy_emit_accum_steal(struct fy_emit_accum *ea, size_t *lenp)
+{
+	int ret;
+	char *buf;
+
+	/* empty, return a malloc'ed buffer to "" */
+	if (!ea->next) {
+		buf = strdup("");
+		if (!buf) {
+			*lenp = 0;
+			return NULL;
+		}
+		*lenp = ea->next;
+	} else if (ea->inplace && ea->accum == ea->inplace) {
+		buf = malloc(ea->next + 1);
+		if (!buf) {
+			*lenp = 0;
+			return NULL;
+		}
+		memcpy(buf, ea->accum, ea->next);
+		buf[ea->next] = '\0';
+		*lenp = ea->next;
+	} else {
+		ret = fy_emit_accum_make_0_terminated(ea);
+		if (ret) {
+			*lenp = 0;
+			return NULL;
+		}
+		assert(ea->accum && ea->accum != ea->inplace);
+		buf = ea->accum;
+		*lenp = ea->next;
+		/* reset to inplace */
+		ea->accum = ea->inplace;
+		ea->alloc = ea->inplacesz;
+	}
+
+	fy_emit_accum_cleanup(ea);
+	return buf;
+}
+
+static inline char *
+fy_emit_accum_steal0(struct fy_emit_accum *ea)
+{
+	size_t len;
+
+	return fy_emit_accum_steal(ea, &len);
+}
+
+static inline bool
+fy_emit_accum_empty(struct fy_emit_accum *ea)
+{
+	return ea->next == 0;
+}
+
+static inline size_t
+fy_emit_accum_size(struct fy_emit_accum *ea)
+{
+	return ea->next;
+}
+
+static inline int
+fy_emit_accum_column(struct fy_emit_accum *ea)
+{
+	return ea->col;
+}
+
+static inline int
+fy_emit_accum_row(struct fy_emit_accum *ea)
+{
+	return ea->row;
+}
+
+struct fy_emit_accum_state {
+	int col;
+	int row;
+	size_t next;
+};
+
+static inline void
+fy_emit_accum_get_state(struct fy_emit_accum *ea, struct fy_emit_accum_state *s)
+{
+	s->col = ea->col;
+	s->row = ea->row;
+	s->next = ea->next;
+}
+
+static inline void
+fy_emit_accum_rewind_state(struct fy_emit_accum *ea, const struct fy_emit_accum_state *s)
+{
+	/* we can only go back */
+	assert(s->next <= ea->next);
+	ea->col = s->col;
+	ea->row = s->row;
+	ea->next = s->next;
+}
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-emit.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-emit.c
@@ -1,0 +1,4340 @@
+/*
+ * fy-emit.c - Internal YAML emitter methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-emit.h"
+
+static void fy_emitter_fill_default_colors(struct fy_emitter *fye);
+static FILE *fy_emitter_get_output_fp(struct fy_emitter *fye);
+static int fy_emitter_get_output_fd(struct fy_emitter *fye);
+static int fy_emitter_null_output(struct fy_emitter *fye, enum fy_emitter_write_type type, const char *str, int len, void *userdata);
+
+void fy_emit_save_ctx_cleanup(struct fy_emitter *emit, struct fy_emit_save_ctx *sc);
+
+static inline struct fy_token_list *token_recycle_list(struct fy_emitter *emit, struct fy_parser *fyp)
+{
+	if (fyp && fyp->recycled_token_list)
+		return fyp->recycled_token_list;
+	if (emit && emit->recycled_token_list)
+		return emit->recycled_token_list;
+	return NULL;
+}
+
+static inline void fy_emit_token_unref(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_token *fyt)
+{
+	fy_token_unref_rl(token_recycle_list(emit, fyp), fyt);
+}
+
+/* fwd decl */
+void fy_emit_write(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, size_t len);
+void fy_emit_printf(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+static inline bool fy_emit_is_json_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags;
+
+	if (emit->force_json)
+		return true;
+
+	flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+	return flags == FYECF_MODE_JSON || flags == FYECF_MODE_JSON_TP ||
+	       flags == FYECF_MODE_JSON_ONELINE || flags == FYECF_MODE_JSON_COMPACT;
+}
+
+static inline bool fy_emit_is_flow_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_FLOW || flags == FYECF_MODE_FLOW_ONELINE ||
+	       flags == FYECF_MODE_FLOW_COMPACT || fy_emit_is_json_mode(emit);
+}
+
+static inline bool fy_emit_is_block_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_BLOCK || flags == FYECF_MODE_DEJSON || flags == FYECF_MODE_PRETTY;
+}
+
+static inline bool fy_emit_is_oneline(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_FLOW_ONELINE || flags == FYECF_MODE_JSON_ONELINE;
+}
+
+static inline bool fy_emit_is_compact(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_FLOW_COMPACT || flags == FYECF_MODE_JSON_COMPACT;
+}
+
+static inline bool fy_emit_is_oneline_or_compact(const struct fy_emitter *emit)
+{
+	return fy_emit_is_oneline(emit) || fy_emit_is_compact(emit);
+}
+
+static inline bool fy_emit_sc_oneline(const struct fy_emitter *emit,
+				      const struct fy_emit_save_ctx *sc)
+{
+	return fy_emit_is_oneline_or_compact(emit) || sc->oneline_flow;
+}
+
+static inline bool fy_emit_preserve_flow_layout(const struct fy_emitter *emit)
+{
+	return !!(emit->xcfg.xflags & FYEXCF_PRESERVE_FLOW_LAYOUT);
+}
+
+static inline bool fy_emit_is_dejson_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_DEJSON;
+}
+
+static inline bool fy_emit_is_pretty_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_PRETTY;
+}
+
+static inline bool fy_emit_is_original_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_ORIGINAL;
+}
+
+static inline bool fy_emit_is_manual(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_MANUAL;
+}
+
+static inline int fy_emit_indent(struct fy_emitter *emit)
+{
+	int indent;
+
+	indent = (emit->xcfg.cfg.flags & FYECF_INDENT(FYECF_INDENT_MASK)) >> FYECF_INDENT_SHIFT;
+	return indent ? indent : 2;
+}
+
+static inline int fy_emit_width(struct fy_emitter *emit)
+{
+	int width;
+
+	if (fy_emit_is_oneline(emit))
+		return INT_MAX;
+
+	width = (emit->xcfg.cfg.flags & FYECF_WIDTH(FYECF_WIDTH_MASK)) >> FYECF_WIDTH_SHIFT;
+	if (width == 0)
+		return 80;
+	if (width == FYECF_WIDTH_MASK)
+		return INT_MAX;
+	return width;
+}
+
+static inline bool fy_emit_output_comments(struct fy_emitter *emit)
+{
+	return !!(emit->xcfg.cfg.flags & FYECF_OUTPUT_COMMENTS) &&
+		!fy_emit_is_oneline_or_compact(emit) &&
+		!fy_emit_is_json_mode(emit);
+}
+
+static int fy_emit_node_check_json(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	struct fy_document *fyd;
+	struct fy_node *fyni;
+	struct fy_node_pair *fynp, *fynpi;
+	int ret;
+
+	if (!fyn)
+		return 0;
+
+	fyd = fyn->fyd;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		FYD_TOKEN_ERROR_CHECK(fyd, fyn->scalar, FYEM_INTERNAL,
+				!fy_node_is_alias(fyn), err_out,
+				"aliases not allowed in JSON emit mode");
+		break;
+
+	case FYNT_SEQUENCE:
+		for (fyni = fy_node_list_head(&fyn->sequence); fyni;
+				fyni = fy_node_next(&fyn->sequence, fyni)) {
+			ret = fy_emit_node_check_json(emit, fyni);
+			if (ret)
+				return ret;
+		}
+		break;
+
+	case FYNT_MAPPING:
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp; fynp = fynpi) {
+
+			fynpi = fy_node_pair_next(&fyn->mapping, fynp);
+
+			ret = fy_emit_node_check_json(emit, fynp->key);
+			if (ret)
+				return ret;
+			ret = fy_emit_node_check_json(emit, fynp->value);
+			if (ret)
+				return ret;
+		}
+		break;
+	}
+	return 0;
+err_out:
+	return -1;
+}
+
+static int fy_emit_node_check(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	int ret;
+
+	if (!fyn)
+		return 0;
+
+	if (fy_emit_is_json_mode(emit) && !emit->source_json) {
+		ret = fy_emit_node_check_json(emit, fyn);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+void fy_emit_node_internal(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent, bool is_key);
+void fy_emit_scalar(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent, bool is_key);
+void fy_emit_sequence(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent);
+void fy_emit_mapping(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent);
+
+void fy_emit_write(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, size_t len);
+void fy_emit_puts(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str);
+void fy_emit_putc(struct fy_emitter *emit, enum fy_emitter_write_type type, int c);
+
+/* simple write, just ascii, advance column */
+void fy_emit_write_simple(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, size_t len)
+{
+	int outlen;
+
+	if (!len)
+		return;
+
+	outlen = emit->xcfg.cfg.output(emit, type, str, (int)len, emit->xcfg.cfg.userdata);
+	if (outlen != (int)len)
+		emit->output_error = true;
+
+	emit->column += (int)len;
+}
+
+/* simple puts as above */
+void fy_emit_puts_simple(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str)
+{
+	fy_emit_write_simple(emit, type, str, strlen(str));
+}
+
+void fy_emit_putc_simple(struct fy_emitter *emit, enum fy_emitter_write_type type, int c)
+{
+	char cc = (char)c;
+
+	fy_emit_write_simple(emit, type, &cc, 1);
+	if (cc == '\n') {
+		emit->column = 0;
+		emit->line++;
+	}
+}
+
+void fy_emit_write(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, size_t len)
+{
+	int c, w;
+	const char *m, *e;
+	int outlen;
+
+	if (!len || len > INT_MAX)
+		return;
+
+	outlen = emit->xcfg.cfg.output(emit, type, str, (int)len, emit->xcfg.cfg.userdata);
+	if (outlen != (int)len)
+		emit->output_error = true;
+
+	e = str + len;
+	while ((c = fy_utf8_get(str, (e - str), &w)) >= 0) {
+
+		/* special handling for MSDOS */
+		if (c == '\r' && (e - str) > 1 && str[1] == '\n') {
+			str += 2;
+			emit->column = 0;
+			emit->line++;
+			continue;
+		}
+
+		/* regular line break */
+		if (fy_is_lb_r_n(c)) {
+			emit->column = 0;
+			emit->line++;
+			str += w;
+			continue;
+		}
+
+		/* completely ignore ANSI color escape sequences */
+		if (c == '\x1b' && (e - str) > 2 && str[1] == '[' &&
+		    (m = memchr(str, 'm', e - str)) != NULL) {
+			str = m + 1;
+			continue;
+		}
+
+		emit->column++;
+		str += w;
+	}
+}
+
+void fy_emit_puts(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str)
+{
+	fy_emit_write(emit, type, str, strlen(str));
+}
+
+void fy_emit_putc(struct fy_emitter *emit, enum fy_emitter_write_type type, int c)
+{
+	char buf[FY_UTF8_FORMAT_BUFMIN];
+
+	fy_utf8_format(c, buf, fyue_none);
+	fy_emit_puts(emit, type, buf);
+}
+
+void fy_emit_vprintf(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *fmt, va_list ap)
+{
+	char *str;
+	int size;
+	va_list ap2;
+
+	va_copy(ap2, ap);
+
+	size = vsnprintf(NULL, 0, fmt, ap);
+	if (size < 0)
+		return;
+
+	str = alloca(size + 1);
+	size = vsnprintf(str, size + 1, fmt, ap2);
+	if (size < 0)
+		return;
+
+	fy_emit_write(emit, type, str, size);
+}
+
+void fy_emit_printf(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_emit_vprintf(emit, type, fmt, ap);
+	va_end(ap);
+}
+
+void fy_emit_write_ws(struct fy_emitter *emit)
+{
+	fy_emit_putc_simple(emit, fyewt_whitespace, ' ');
+	emit->flags |= FYEF_WHITESPACE;
+}
+
+void fy_emit_write_indent(struct fy_emitter *emit, int indent)
+{
+	int len;
+	char *ws;
+
+	indent = indent > 0 ? indent : 0;
+
+	if (!fy_emit_indentation(emit) || emit->column > indent ||
+	    (emit->column == indent && !fy_emit_whitespace(emit)))
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+
+	if (emit->column < indent) {
+		len = indent - emit->column;
+		ws = alloca(len + 1);
+		memset(ws, ' ', len);
+		ws[len] = '\0';
+		fy_emit_write_simple(emit, fyewt_indent, ws, len);
+	}
+
+	emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+}
+
+enum document_indicator {
+	di_question_mark,
+	di_colon,
+	di_dash,
+	di_left_bracket,
+	di_right_bracket,
+	di_left_brace,
+	di_right_brace,
+	di_comma,
+	di_bar,
+	di_greater,
+	di_single_quote_start,
+	di_single_quote_end,
+	di_double_quote_start,
+	di_double_quote_end,
+	di_ambersand,
+	di_star,
+};
+
+void fy_emit_write_indicator(struct fy_emitter *emit,
+		enum document_indicator indicator,
+		int flags, int indent,
+		enum fy_emitter_write_type wtype)
+{
+	/* extended indicators mode? */
+	if (wtype == fyewt_indicator &&
+	    (emit->xcfg.xflags & FYEXCF_EXTENDED_INDICATORS)) {
+		wtype = FYEWT_EXTENDED_INDICATORS_FIRST + (unsigned int)indicator;
+		assert(wtype >= FYEWT_EXTENDED_INDICATORS_FIRST &&
+				wtype <= FYEWT_EXTENDED_INDICATORS_LAST);
+	}
+
+	switch (indicator) {
+
+	case di_question_mark:
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, '?');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_OPEN_ENDED);
+		break;
+
+	case di_colon:
+		fy_emit_putc_simple(emit, wtype, ':');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_OPEN_ENDED);
+		break;
+
+	case di_dash:
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, '-');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_OPEN_ENDED);
+		break;
+
+	case di_left_bracket:
+	case di_left_brace:
+		emit->flow_level++;
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, indicator == di_left_bracket ? '[' : '{');
+		emit->flags |= FYEF_WHITESPACE;
+		emit->flags &= ~(FYEF_INDENTATION | FYEF_OPEN_ENDED);
+		break;
+
+	case di_right_bracket:
+	case di_right_brace:
+		emit->flow_level--;
+		fy_emit_putc_simple(emit, wtype, indicator == di_right_bracket ? ']' : '}');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION | FYEF_OPEN_ENDED);
+		break;
+
+	case di_comma:
+		fy_emit_putc_simple(emit, wtype, ',');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION | FYEF_OPEN_ENDED);
+		break;
+
+	case di_bar:
+	case di_greater:
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, indicator == di_bar ? '|' : '>');
+		emit->flags &= ~(FYEF_INDENTATION | FYEF_WHITESPACE | FYEF_OPEN_ENDED);
+		break;
+
+	case di_single_quote_start:
+	case di_double_quote_start:
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, indicator == di_single_quote_start ? '\'' : '"');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION | FYEF_OPEN_ENDED);
+		break;
+
+	case di_single_quote_end:
+	case di_double_quote_end:
+		fy_emit_putc_simple(emit, wtype, indicator == di_single_quote_end ? '\'' : '"');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION | FYEF_OPEN_ENDED);
+		break;
+
+	case di_ambersand:
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, '&');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION);
+		break;
+
+	case di_star:
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+		fy_emit_putc_simple(emit, wtype, '*');
+		emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION);
+		break;
+	}
+}
+
+int fy_emit_increase_indent(struct fy_emitter *emit, int flags, int indent)
+{
+	if (indent < 0)
+		return (flags & DDNF_FLOW) ? fy_emit_indent(emit) : 0;
+
+	if (!(flags & DDNF_INDENTLESS))
+		return indent + fy_emit_indent(emit);
+
+	return indent;
+}
+
+void fy_emit_write_comment(struct fy_emitter *emit, int flags, int indent, const char *str, size_t len, struct fy_atom *handle)
+{
+	const char *s, *e, *sr;
+	int c, w;
+	bool breaks;
+
+	if (!str || !len)
+		return;
+
+	if (len == (size_t)-1)
+		len = strlen(str);
+
+	if (!fy_emit_whitespace(emit))
+		fy_emit_write_ws(emit);
+	indent = emit->column;
+
+	s = str;
+	e = str + len;
+
+	sr = s;	/* start of normal output run */
+	breaks = false;
+	while (s < e && (c = fy_utf8_get(s, e - s, &w)) > 0) {
+
+		if (fy_is_lb_m(c, fy_atom_lb_mode(handle))) {
+
+			/* output run */
+			fy_emit_write(emit, fyewt_comment, sr, s - sr);
+			sr = s + w;
+			fy_emit_write_indent(emit, indent);
+			emit->flags |= FYEF_INDENTATION;
+			breaks = true;
+		} else {
+
+			if (breaks) {
+				fy_emit_write(emit, fyewt_comment, sr, s - sr);
+				sr = s;
+				fy_emit_write_indent(emit, indent);
+			}
+			emit->flags &= ~FYEF_INDENTATION;
+			breaks = false;
+		}
+
+		s += w;
+	}
+
+	/* dump what's remaining */
+	fy_emit_write(emit, fyewt_comment, sr, s - sr);
+
+	emit->flags |= (FYEF_WHITESPACE | FYEF_INDENTATION);
+}
+
+struct fy_atom *fy_emit_token_comment_handle(struct fy_emitter *emit, struct fy_token *fyt, enum fy_comment_placement placement)
+{
+	struct fy_atom *handle;
+
+	handle = fy_token_comment_handle(fyt, placement, false);
+	return handle && fy_atom_is_set(handle) ? handle : NULL;
+}
+
+void fy_emit_document_start_indicator(struct fy_emitter *emit)
+{
+	/* do not emit twice */
+	if (emit->flags & FYEF_HAD_DOCUMENT_START)
+		return;
+
+	/* do not try to emit if it's json mode */
+	if (fy_emit_is_json_mode(emit))
+		goto no_doc_emit;
+
+	/* output linebreak anyway */
+	if (emit->column)
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+
+	/* ok, emit document start indicator */
+	fy_emit_puts_simple(emit, fyewt_document_indicator, "---");
+	emit->flags &= ~FYEF_WHITESPACE;
+	emit->flags |= FYEF_HAD_DOCUMENT_START;
+	return;
+
+no_doc_emit:
+	emit->flags &= ~FYEF_HAD_DOCUMENT_START;
+}
+
+struct fy_token *fy_node_value_token(struct fy_node *fyn)
+{
+	struct fy_token *fyt;
+
+	if (!fyn)
+		return NULL;
+
+	switch (fyn->type) {
+	case FYNT_SCALAR:
+		fyt = fyn->scalar;
+		break;
+	case FYNT_SEQUENCE:
+		fyt = fyn->sequence_start;
+		break;
+	case FYNT_MAPPING:
+		fyt = fyn->mapping_start;
+		break;
+	default:
+		fyt = NULL;
+		break;
+	}
+
+	return fyt;
+}
+
+bool fy_emit_token_has_comment(struct fy_emitter *emit, struct fy_token *fyt, enum fy_comment_placement placement)
+{
+	if (!fy_emit_output_comments(emit))
+		return false;
+	return fy_emit_token_comment_handle(emit, fyt, placement) ? true : false;
+}
+
+bool fy_emit_node_has_comment(struct fy_emitter *emit, struct fy_node *fyn, enum fy_comment_placement placement)
+{
+	return fy_emit_token_has_comment(emit, fy_node_value_token(fyn), placement);
+}
+
+void fy_emit_token_comment(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent,
+			  enum fy_comment_placement placement)
+{
+	struct fy_atom *handle;
+	char *text;
+	const char *t;
+	size_t len;
+
+	handle = fy_emit_token_comment_handle(emit, fyt, placement);
+	if (!handle)
+		return;
+
+	len = fy_atom_format_text_length(handle);
+	if (len < 0)
+		return;
+
+	text = alloca(len + 1);
+
+	if (placement == fycp_top || placement == fycp_bottom) {
+		int comment_indent = indent > 0 ? indent : 0;
+		if (handle && indent >= 0) {
+			comment_indent = indent + handle->indent_delta;
+			if (comment_indent < 0)
+				comment_indent = 0;
+		}
+		fy_emit_write_indent(emit, comment_indent);
+		emit->flags |= FYEF_WHITESPACE;
+	}
+
+	t = fy_atom_format_text(handle, text, len + 1);
+
+	fy_emit_write_comment(emit, flags, indent, t, len, handle);
+
+	emit->flags &= ~FYEF_INDENTATION;
+
+	if (placement == fycp_top || placement == fycp_bottom) {
+		fy_emit_write_indent(emit, indent);
+		emit->flags |= FYEF_WHITESPACE;
+	}
+}
+
+void fy_emit_common_node_preamble(struct fy_emitter *emit,
+		struct fy_token *fyt_value,
+		struct fy_token *fyt_anchor,
+		struct fy_token *fyt_tag,
+		int flags, int indent)
+{
+	const char *anchor = NULL;
+	const char *tag = NULL;
+	const char *td_prefix __FY_DEBUG_UNUSED__;
+	const char *td_handle;
+	size_t td_prefix_size, td_handle_size;
+	size_t tag_len = 0, anchor_len = 0;
+	bool json_mode = false;
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+
+	(void)sc;
+
+	/* content for root always starts on a new line */
+	if (!fy_emit_is_oneline(emit) && (flags & DDNF_ROOT) && emit->column != 0 &&
+            !(emit->flags & FYEF_HAD_DOCUMENT_START)) {
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	json_mode = fy_emit_is_json_mode(emit);
+
+	if (!json_mode) {
+		if (!(emit->xcfg.cfg.flags & FYECF_STRIP_LABELS)) {
+			if (fyt_anchor)
+				anchor = fy_token_get_text(fyt_anchor, &anchor_len);
+		}
+
+		if (!(emit->xcfg.cfg.flags & FYECF_STRIP_TAGS)) {
+			if (fyt_tag)
+				tag = fy_token_get_text(fyt_tag, &tag_len);
+		}
+
+		if (anchor) {
+			fy_emit_write_indicator(emit, di_ambersand, flags, indent, fyewt_anchor);
+			fy_emit_write(emit, fyewt_anchor, anchor, anchor_len);
+		}
+
+		if (tag) {
+			if (!fy_emit_whitespace(emit))
+				fy_emit_write_ws(emit);
+
+			td_handle = fy_tag_token_get_directive_handle(fyt_tag, &td_handle_size);
+			assert(td_handle);
+			td_prefix = fy_tag_token_get_directive_prefix(fyt_tag, &td_prefix_size);
+			assert(td_prefix);
+
+			if (!td_handle_size)
+				fy_emit_printf(emit, fyewt_tag, "!<%.*s>", (int)tag_len, tag);
+			else
+				fy_emit_printf(emit, fyewt_tag, "%.*s%.*s",
+						(int)td_handle_size, td_handle,
+						(int)(tag_len - td_prefix_size), tag + td_prefix_size);
+
+			emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION);
+		}
+	}
+}
+
+void fy_emit_node_internal(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent, bool is_key)
+{
+	enum fy_node_type type;
+	struct fy_anchor *fya;
+	struct fy_token *fyt_anchor = NULL;
+	struct fy_token *fyt_value = NULL;
+
+	if (!(emit->xcfg.cfg.flags & FYECF_STRIP_LABELS)) {
+		fya = fy_document_lookup_anchor_by_node(emit->fyd, fyn);
+		if (fya)
+			fyt_anchor = fya->anchor;
+	}
+
+	type = fyn ? fyn->type : FYNT_SCALAR;
+
+	if (type == FYNT_SCALAR)
+		fyt_value = fyn ? fyn->scalar : NULL;
+	else if (type == FYNT_SEQUENCE)
+		fyt_value = fyn->sequence_start;
+	else if (type == FYNT_MAPPING)
+		fyt_value = fyn->mapping_start;
+
+	fy_emit_common_node_preamble(emit, fyt_value, fyt_anchor, fyn->tag, flags, indent);
+
+	if (type != FYNT_SCALAR && (flags & DDNF_ROOT) && emit->column != 0) {
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	switch (type) {
+	case FYNT_SCALAR:
+		/* if we're pretty and root at column 0 (meaning it's a single scalar document) output --- */
+		if ((flags & DDNF_ROOT) && fy_emit_is_pretty_mode(emit) && !emit->column &&
+				!fy_emit_is_flow_mode(emit) && !(flags & DDNF_FLOW))
+			fy_emit_document_start_indicator(emit);
+		fy_emit_scalar(emit, fyn, flags, indent, is_key);
+		break;
+	case FYNT_SEQUENCE:
+		FYD_TOKEN_ERROR_CHECK(fyn->fyd, fyn->sequence_start, FYEM_INTERNAL,
+				!is_key || !fy_emit_is_json_mode(emit), err_out,
+				"JSON does not allow sequences as keys");
+		fy_emit_sequence(emit, fyn, flags, indent);
+		break;
+	case FYNT_MAPPING:
+		FYD_TOKEN_ERROR_CHECK(fyn->fyd, fyn->mapping_start, FYEM_INTERNAL,
+				!is_key || !fy_emit_is_json_mode(emit), err_out,
+				"JSON does not allow mappings as keys");
+		fy_emit_mapping(emit, fyn, flags, indent);
+		break;
+	}
+err_out:
+	/* nothing */
+	return;
+}
+
+void fy_emit_token_write_plain(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent)
+{
+	bool allow_breaks, should_indent, spaces, breaks;
+	int c;
+	enum fy_emitter_write_type wtype;
+	const char *str = NULL;
+	size_t len = 0;
+	struct fy_atom *atom;
+	struct fy_atom_iter iter;
+
+	/* null and not json mode */
+	if (!fyt && !fy_emit_is_json_mode(emit))
+		goto out;
+
+	wtype = (flags & DDNF_SIMPLE_SCALAR_KEY) ? fyewt_plain_scalar_key : fyewt_plain_scalar;
+
+	atom = fy_token_atom(fyt);
+
+	/* null and json mode */
+	if (fy_emit_is_json_mode(emit) && fyt->scalar.is_null) {
+		fy_emit_puts_simple(emit, wtype, "null");
+		goto out;
+	}
+
+	allow_breaks = !(flags & DDNF_SIMPLE) && !fy_emit_is_json_mode(emit) && !fy_emit_is_oneline(emit);
+
+	/* very very simple case first (90% of cases) */
+	str = fy_token_get_direct_simple_output(fyt, &len);
+	if (str && (!allow_breaks || (fy_emit_accum_column(&emit->ea) + (int)len <= fy_emit_width(emit)))) {
+		fy_emit_write_simple(emit, wtype, str, len);
+		goto out;
+	}
+
+	/* simple case first (90% of cases) */
+	str = fy_token_get_direct_output(fyt, &len);
+	if (str && fy_token_atom_style(fyt) == FYAS_PLAIN) {
+		fy_emit_write(emit, wtype, str, len);
+		goto out;
+	}
+
+	if (!atom)
+		goto out;
+
+	spaces = false;
+	breaks = false;
+
+	fy_atom_iter_start(atom, &iter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+	while ((c = fy_atom_iter_utf8_get(&iter)) > 0) {
+
+		if (fy_is_ws(c)) {
+
+			should_indent = allow_breaks && !spaces &&
+					fy_emit_accum_column(&emit->ea) > fy_emit_width(emit);
+
+			if (should_indent && !fy_is_ws(fy_atom_iter_utf8_peek(&iter))) {
+				fy_emit_output_accum(emit, wtype, &emit->ea);
+				emit->flags &= ~FYEF_INDENTATION;
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			} else
+				fy_emit_accum_utf8_put(&emit->ea, c);
+
+			spaces = true;
+
+		} else if (fy_is_lb_m(c, fy_token_atom_lb_mode(fyt))) {
+
+			/* blergh */
+			if (!allow_breaks)
+				break;
+
+			/* output run */
+			if (!breaks) {
+				fy_emit_output_accum(emit, wtype, &emit->ea);
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			}
+
+			emit->flags &= ~FYEF_INDENTATION;
+			fy_emit_write_indent(emit, indent);
+			fy_emit_output_col_sync(emit, &emit->ea);
+
+			breaks = true;
+
+		} else {
+
+			if (breaks) {
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			}
+
+			fy_emit_accum_utf8_put(&emit->ea, c);
+
+			emit->flags &= ~FYEF_INDENTATION;
+
+			spaces = false;
+			breaks = false;
+		}
+	}
+	fy_emit_output_accum(emit, wtype, &emit->ea);
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_iter_finish(&iter);
+
+out:
+	emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION);
+}
+
+void fy_emit_token_write_alias(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent)
+{
+	const char *str = NULL;
+	size_t len = 0;
+	struct fy_atom_iter iter;
+	int c;
+
+	if (!fyt)
+		return;
+
+	fy_emit_write_indicator(emit, di_star, flags, indent, fyewt_alias);
+
+	/* try direct output first (99% of cases) */
+	str = fy_token_get_direct_output(fyt, &len);
+	if (str) {
+		fy_emit_write(emit, fyewt_alias, str, len);
+		return;
+	}
+
+	/* corner case, use iterator */
+	fy_atom_iter_start(fy_token_atom(fyt), &iter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+	while ((c = fy_atom_iter_utf8_get(&iter)) > 0)
+		fy_emit_accum_utf8_put(&emit->ea, c);
+	fy_emit_output_accum(emit, fyewt_alias, &emit->ea);
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_iter_finish(&iter);
+}
+
+void fy_emit_token_write_quoted(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent, char qc)
+{
+	const struct fy_token_analysis *ta;
+	bool allow_breaks, spaces, breaks;
+	int c, i, w, digit;
+	enum fy_emitter_write_type wtype;
+	const char *str = NULL;
+	size_t len = 0;
+	bool should_indent, done_esc;
+	struct fy_atom *atom;
+	struct fy_atom_iter iter;
+	enum fy_atom_style target_style;
+	uint32_t hi_surrogate, lo_surrogate;
+	uint8_t non_utf8[4];
+	size_t non_utf8_len, k;
+	int emit_width;
+
+	wtype = qc == '\'' ?
+		((flags & DDNF_SIMPLE_SCALAR_KEY) ?
+		 	fyewt_single_quoted_scalar_key : fyewt_single_quoted_scalar) :
+		((flags & DDNF_SIMPLE_SCALAR_KEY) ?
+		 	fyewt_double_quoted_scalar_key : fyewt_double_quoted_scalar);
+
+	fy_emit_write_indicator(emit,
+			qc == '\'' ? di_single_quote_start : di_double_quote_start,
+			flags, indent, wtype);
+
+	/* XXX check whether this is ever the case */
+	if (!fyt)
+		goto out;
+
+	/* note that if the original target style and the target differ
+	 * we can note use direct output
+	 */
+	target_style = qc == '"' ? FYAS_DOUBLE_QUOTED : FYAS_SINGLE_QUOTED;
+
+	allow_breaks = !(flags & DDNF_SIMPLE) && !fy_emit_is_json_mode(emit) && !fy_emit_is_oneline(emit);
+	emit_width = fy_emit_width(emit);
+
+	ta = fy_token_text_analyze(fyt);
+
+	/* simple case of direct output (large amount of cases) */
+	str = fy_token_get_direct_output(fyt, &len);
+	if (str && fy_token_atom_style(fyt) == target_style &&
+	   (ta->flags & FYTTAF_DIRECT_OUTPUT) && emit->column + ta->maxcol < emit_width) {
+		fy_emit_write(emit, wtype, str, len);
+		goto out;
+	}
+
+	/* no atom? i.e. empty */
+	atom = fy_token_atom(fyt);
+	if (!atom)
+		goto out;
+
+	spaces = false;
+	breaks = false;
+
+	fy_atom_iter_start(atom, &iter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+	for (;;) {
+		non_utf8_len = sizeof(non_utf8);
+		c = fy_atom_iter_utf8_quoted_get(&iter, &non_utf8_len, non_utf8);
+		if (c < 0)
+			break;
+
+		if (c == 0 && non_utf8_len > 0) {
+			for (k = 0; k < non_utf8_len; k++) {
+				c = (int)non_utf8[k] & 0xff;
+				fy_emit_accum_utf8_put(&emit->ea, '\\');
+				fy_emit_accum_utf8_put(&emit->ea, 'x');
+				digit = ((unsigned int)c >> 4) & 15;
+				fy_emit_accum_utf8_put(&emit->ea,
+						digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+				digit = (unsigned int)c & 15;
+				fy_emit_accum_utf8_put(&emit->ea,
+						digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+			}
+			continue;
+		}
+
+		if (fy_is_space(c) || (qc == '\'' && fy_is_ws(c))) {
+			should_indent = allow_breaks && !spaces &&
+					fy_emit_accum_column(&emit->ea) >= emit_width;
+
+			if (should_indent &&
+				((qc == '\'' && fy_is_ws(fy_atom_iter_utf8_peek(&iter))) ||
+				  qc == '"')) {
+				fy_emit_output_accum(emit, wtype, &emit->ea);
+
+				if (qc == '"' && fy_is_ws(fy_atom_iter_utf8_peek(&iter)))
+					fy_emit_putc_simple(emit, wtype, '\\');
+
+				emit->flags &= ~FYEF_INDENTATION;
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			} else
+				fy_emit_accum_utf8_put(&emit->ea, c);
+
+			spaces = true;
+			breaks = false;
+
+		} else if (qc == '\'' && fy_is_lb_m(c, fy_token_atom_lb_mode(fyt))) {
+
+			/* blergh */
+			if (!allow_breaks)
+				break;
+
+			/* output run */
+			if (!breaks) {
+				fy_emit_output_accum(emit, wtype, &emit->ea);
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			}
+
+			emit->flags &= ~FYEF_INDENTATION;
+			fy_emit_write_indent(emit, indent);
+			fy_emit_output_col_sync(emit, &emit->ea);
+
+			breaks = true;
+		} else {
+			/* output run */
+			if (breaks) {
+				fy_emit_output_accum(emit, wtype, &emit->ea);
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+
+			} else if (qc == '"' && allow_breaks && fy_emit_accum_column(&emit->ea) >= emit_width) {
+
+				fy_emit_output_accum(emit, wtype, &emit->ea);
+
+				fy_emit_putc_simple(emit, wtype, '\\');
+
+				emit->flags &= ~FYEF_INDENTATION;
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			}
+
+			/* escape */
+			if (qc == '\'' && c == '\'') {
+				fy_emit_accum_utf8_put(&emit->ea, '\'');
+				fy_emit_accum_utf8_put(&emit->ea, '\'');
+			} else if (qc == '"' &&
+				   ((!fy_is_printq(c) || c == '"' || c == '\\') ||
+				    (fy_emit_is_json_mode(emit) && !fy_is_json_unescaped(c)))) {
+
+				fy_emit_accum_utf8_put(&emit->ea, '\\');
+
+				/* common YAML and JSON escapes */
+				done_esc = false;
+				switch (c) {
+				case '\b':
+					fy_emit_accum_utf8_put(&emit->ea, 'b');
+					done_esc = true;
+					break;
+				case '\f':
+					fy_emit_accum_utf8_put(&emit->ea, 'f');
+					done_esc = true;
+					break;
+				case '\n':
+					fy_emit_accum_utf8_put(&emit->ea, 'n');
+					done_esc = true;
+					break;
+				case '\r':
+					fy_emit_accum_utf8_put(&emit->ea, 'r');
+					done_esc = true;
+					break;
+				case '\t':
+					fy_emit_accum_utf8_put(&emit->ea, 't');
+					done_esc = true;
+					break;
+				case '"':
+					fy_emit_accum_utf8_put(&emit->ea, '"');
+					done_esc = true;
+					break;
+				case '\\':
+					fy_emit_accum_utf8_put(&emit->ea, '\\');
+					done_esc = true;
+					break;
+				}
+
+				if (done_esc)
+					goto done;
+
+				if (!fy_emit_is_json_mode(emit)) {
+					switch (c) {
+					case '\0':
+						fy_emit_accum_utf8_put(&emit->ea, '0');
+						break;
+					case '\a':
+						fy_emit_accum_utf8_put(&emit->ea, 'a');
+						break;
+					case '\v':
+						fy_emit_accum_utf8_put(&emit->ea, 'v');
+						break;
+					case '\x1b':	// \e
+						fy_emit_accum_utf8_put(&emit->ea, 'e');
+						break;
+					case 0x85:
+						fy_emit_accum_utf8_put(&emit->ea, 'N');
+						break;
+					case 0xa0:
+						fy_emit_accum_utf8_put(&emit->ea, '_');
+						break;
+					case 0x2028:
+						fy_emit_accum_utf8_put(&emit->ea, 'L');
+						break;
+					case 0x2029:
+						fy_emit_accum_utf8_put(&emit->ea, 'P');
+						break;
+					default:
+						if ((unsigned int)c <= 0xff) {
+							fy_emit_accum_utf8_put(&emit->ea, 'x');
+							w = 2;
+						} else if ((unsigned int)c <= 0xffff) {
+							fy_emit_accum_utf8_put(&emit->ea, 'u');
+							w = 4;
+						} else if ((unsigned int)c <= 0xffffffff) {
+							fy_emit_accum_utf8_put(&emit->ea, 'U');
+							w = 8;
+						}
+
+						for (i = w - 1; i >= 0; i--) {
+							digit = ((unsigned int)c >> (i * 4)) & 15;
+							fy_emit_accum_utf8_put(&emit->ea,
+									digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+						}
+						break;
+					}
+
+				} else {
+					/* JSON escapes all others in \uXXXX and \uXXXX\uXXXX */
+					w = 4;
+					if ((unsigned int)c <= 0xffff) {
+						fy_emit_accum_utf8_put(&emit->ea, 'u');
+						for (i = w - 1; i >= 0; i--) {
+							digit = ((unsigned int)c >> (i * 4)) & 15;
+							fy_emit_accum_utf8_put(&emit->ea,
+									digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+						}
+					} else {
+						hi_surrogate = 0xd800 | ((((c >> 16) & 0x1f) - 1) << 6) | ((c >> 10) & 0x3f);
+						lo_surrogate = 0xdc00 | (c & 0x3ff);
+
+						fy_emit_accum_utf8_put(&emit->ea, 'u');
+						for (i = w - 1; i >= 0; i--) {
+							digit = ((unsigned int)hi_surrogate >> (i * 4)) & 15;
+							fy_emit_accum_utf8_put(&emit->ea,
+									digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+						}
+
+						fy_emit_accum_utf8_put(&emit->ea, '\\');
+						fy_emit_accum_utf8_put(&emit->ea, 'u');
+						for (i = w - 1; i >= 0; i--) {
+							digit = ((unsigned int)lo_surrogate >> (i * 4)) & 15;
+							fy_emit_accum_utf8_put(&emit->ea,
+									digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+						}
+					}
+				}
+			} else
+				fy_emit_accum_utf8_put(&emit->ea, c);
+done:
+			emit->flags &= ~FYEF_INDENTATION;
+			spaces = false;
+			breaks = false;
+		}
+	}
+	fy_emit_output_accum(emit, wtype, &emit->ea);
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_iter_finish(&iter);
+
+out:
+	fy_emit_write_indicator(emit,
+			qc == '\'' ? di_single_quote_end : di_double_quote_end,
+			flags, indent, wtype);
+}
+
+bool fy_emit_token_write_block_hints(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent, char *chompp)
+{
+	char chomp = '\0';
+	bool explicit_chomp = false;
+	struct fy_atom *atom;
+
+	atom = fy_token_atom(fyt);
+	if (!atom) {
+		emit->flags &= ~FYEF_OPEN_ENDED;
+		chomp = '-';
+		goto out;
+	}
+
+	if (atom->starts_with_ws || atom->starts_with_lb) {
+		fy_emit_putc_simple(emit, fyewt_indicator, '0' + fy_emit_indent(emit));
+		explicit_chomp = true;
+	}
+
+	if (fy_atom_style_is_block(atom->style) && atom->chomp_explicit) {
+		/* atom was parsed as a block scalar; trust the stored chomp */
+		switch ((enum fy_atom_chomp)atom->chomp) {
+		case FYAC_STRIP:
+			emit->flags &= ~FYEF_OPEN_ENDED;
+			chomp = '-';
+			break;
+		case FYAC_KEEP:
+			emit->flags |= FYEF_OPEN_ENDED;
+			chomp = '+';
+			break;
+		case FYAC_CLIP:
+		default:
+			emit->flags &= ~FYEF_OPEN_ENDED;
+			break;
+		}
+	} else {
+		/* atom was not a block scalar; derive chomp from content */
+		if (!atom->ends_with_lb) {
+			emit->flags &= ~FYEF_OPEN_ENDED;
+			chomp = '-';
+		} else if (atom->trailing_lb) {
+			emit->flags |= FYEF_OPEN_ENDED;
+			chomp = '+';
+		} else {
+			emit->flags &= ~FYEF_OPEN_ENDED;
+		}
+	}
+
+out:
+	if (chomp)
+		fy_emit_putc_simple(emit, fyewt_indicator, chomp);
+	*chompp = chomp;
+	return explicit_chomp;
+}
+
+void fy_emit_token_write_literal(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent)
+{
+	bool breaks;
+	int c;
+	char chomp;
+	struct fy_atom *atom;
+	struct fy_atom_iter iter;
+
+	fy_emit_write_indicator(emit, di_bar, flags, indent, fyewt_indicator);
+
+	fy_emit_token_write_block_hints(emit, fyt, flags, indent, &chomp);
+	if (flags & DDNF_ROOT)
+		indent += fy_emit_indent(emit);
+
+	fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+	emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+
+	atom = fy_token_atom(fyt);
+	if (!atom)
+		goto out;
+
+	breaks = true;
+
+	fy_atom_iter_start(atom, &iter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+	while ((c = fy_atom_iter_utf8_get(&iter)) > 0) {
+
+		if (breaks) {
+			fy_emit_write_indent(emit, indent);
+			fy_emit_output_col_sync(emit, &emit->ea);
+			breaks = false;
+		}
+
+		if (fy_is_lb_m(c, fy_token_atom_lb_mode(fyt))) {
+			fy_emit_output_accum(emit, fyewt_literal_scalar, &emit->ea);
+			emit->flags &= ~FYEF_INDENTATION;
+			breaks = true;
+		} else
+			fy_emit_accum_utf8_put(&emit->ea, c);
+	}
+	fy_emit_output_accum(emit, fyewt_literal_scalar, &emit->ea);
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_iter_finish(&iter);
+
+out:
+	emit->flags &= ~FYEF_INDENTATION;
+}
+
+static inline bool fy_emit_can_use_original_folded_breaks(struct fy_emitter *emit,
+                                                          struct fy_atom *atom)
+{
+	return fy_emit_is_original_mode(emit) && atom->fyi &&
+	       atom->chomp_explicit &&
+	       (atom->style & ~FYAS_MANUAL_MARK) == FYAS_FOLDED;
+}
+
+static void fy_emit_token_write_folded_original(struct fy_emitter *emit,
+                                                struct fy_token *fyt, struct fy_atom *atom, int indent)
+{
+	struct fy_atom_raw_line_iter rliter;
+	const struct fy_raw_line *rl;
+	int w;
+
+	fy_atom_raw_line_iter_start(atom, &rliter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+
+	const unsigned int orig_indent = atom->increment;
+
+	while ((rl = fy_atom_raw_line_iter_next(&rliter)) != NULL) {
+
+		if (rl->content_len == 0) {
+			/* blank line: emit newline only */
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+			continue;
+		}
+
+		/* content line: write indent, content, then newline */
+		fy_emit_write_indent(emit, indent);
+		fy_emit_output_col_sync(emit, &emit->ea);
+
+		const char *s = rl->content_start;
+		const char *e = s + rl->content_len;
+
+		/* skip the block scalar's base indentation */
+		{
+			unsigned int skip = orig_indent;
+			while (skip > 0 && s < e &&
+			       (!atom->tabsize ? (*s == ' ') : fy_utf8_is_ws((unsigned char)*s))) {
+				s++;
+				skip--;
+			}
+		}
+
+		while (s < e) {
+			const int c = fy_utf8_get(s, (size_t) (e - s), &w);
+			if (c <= 0)
+				break;
+			fy_emit_accum_utf8_put(&emit->ea, c);
+			s += w;
+		}
+		fy_emit_output_accum(emit, fyewt_folded_scalar, &emit->ea);
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_raw_line_iter_finish(&rliter);
+}
+
+void fy_emit_token_write_folded(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent)
+{
+	bool leading_spaces, breaks;
+	int c, nrbreaks, nrbreakslim;
+	char chomp;
+	struct fy_atom *atom;
+	struct fy_atom_iter iter;
+
+	fy_emit_write_indicator(emit, di_greater, flags, indent, fyewt_indicator);
+
+	fy_emit_token_write_block_hints(emit, fyt, flags, indent, &chomp);
+	if (flags & DDNF_ROOT)
+		indent += fy_emit_indent(emit);
+
+	fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+	emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+
+	atom = fy_token_atom(fyt);
+	if (!atom)
+		return;
+
+	/* in original mode with a parsed-as-folded atom, preserve original line breaks;
+	 * chomp_explicit distinguishes parsed block scalars from event-created atoms */
+	if (fy_emit_can_use_original_folded_breaks(emit, atom)) {
+		fy_emit_token_write_folded_original(emit, fyt, atom, indent);
+		return;
+	}
+
+	breaks = true;
+	leading_spaces = true;
+
+	fy_atom_iter_start(atom, &iter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+	while ((c = fy_atom_iter_utf8_get(&iter)) > 0) {
+
+		if (fy_is_lb_m(c, fy_token_atom_lb_mode(fyt))) {
+
+			/* output run */
+			if (!fy_emit_accum_empty(&emit->ea)) {
+				fy_emit_output_accum(emit, fyewt_literal_scalar, &emit->ea);
+				/* do not output a newline (indent) if at the end or
+				 * this is a leading spaces line */
+				if (!fy_is_z(fy_atom_iter_utf8_peek(&iter)) && !leading_spaces) {
+					fy_emit_write_indent(emit, indent);
+					fy_emit_output_col_sync(emit, &emit->ea);
+				}
+			}
+
+			/* count the number of consecutive breaks */
+			nrbreaks = 1;
+			while (fy_is_lb_m((c = fy_atom_iter_utf8_peek(&iter)), fy_token_atom_lb_mode(fyt))) {
+				nrbreaks++;
+				(void)fy_atom_iter_utf8_get(&iter);
+			}
+
+			/* NOTE: Because the number of indents is tricky
+			 * if it's a non blank, non end, it's the number of breaks
+			 * if it's a blank, it's the number of breaks minus 1
+			 * if it's the end, it's the number of breaks minus 2
+			 */
+			nrbreakslim = fy_is_z(c) ? 2 : fy_is_blank(c) ? 1 : 0;
+			while (nrbreaks-- > nrbreakslim) {
+				emit->flags &= ~FYEF_INDENTATION;
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			}
+
+			breaks = true;
+
+		} else {
+
+			/* if we had a break, output an indent */
+			if (breaks) {
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+
+				/* if this line starts with whitespace we need to know */
+				leading_spaces = fy_is_ws(c);
+			}
+
+			if (!breaks && fy_is_space(c) &&
+			    !fy_is_space(fy_atom_iter_utf8_peek(&iter)) &&
+			    fy_emit_accum_column(&emit->ea) > fy_emit_width(emit)) {
+				fy_emit_output_accum(emit, fyewt_folded_scalar, &emit->ea);
+				emit->flags &= ~FYEF_INDENTATION;
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+			} else
+				fy_emit_accum_utf8_put(&emit->ea, c);
+
+			breaks = false;
+		}
+	}
+	fy_emit_output_accum(emit, fyewt_folded_scalar, &emit->ea);
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_iter_finish(&iter);
+}
+
+static enum fy_node_style
+fy_emit_token_scalar_style(struct fy_emitter *emit, struct fy_token *fyt,
+			   int flags, int indent, enum fy_node_style style,
+			   struct fy_token *fyt_tag)
+{
+	const struct fy_token_analysis *ta = NULL;
+	bool json, flow, is_null_scalar, is_json_plain;
+	struct fy_atom *atom;
+	const char *tag;
+	size_t tag_len;
+
+	atom = fy_token_atom(fyt);
+
+	flow = fy_emit_is_flow_mode(emit) || (flags & DDNF_FLOW);
+
+	/* check if style is allowed (i.e. no block styles in flow context) */
+	if (flow && (style == FYNS_LITERAL || style == FYNS_FOLDED))
+		style = FYNS_ANY;
+
+	json = fy_emit_is_json_mode(emit);
+
+	is_null_scalar = !atom || (fyt->type == FYTT_SCALAR && fyt->scalar.is_null);
+
+	/* is this a plain json atom? */
+	is_json_plain = (json || emit->source_json || fy_emit_is_dejson_mode(emit)) &&
+			(is_null_scalar ||
+			!fy_atom_strcmp(atom, "false") ||
+			!fy_atom_strcmp(atom, "true") ||
+			!fy_atom_strcmp(atom, "null") ||
+			fy_atom_is_number(atom));
+
+	if (json) {
+		/* literal in JSON mode is output as quoted */
+		if (style == FYNS_LITERAL || style == FYNS_FOLDED)
+			return FYNS_DOUBLE_QUOTED;
+
+		if (is_json_plain) {
+			tag = fy_token_get_text(fyt_tag, &tag_len);
+
+			/* XXX hardcoded string tag resultion */
+			if (tag && tag_len &&
+			     ((tag_len == 1 && *tag == '!') ||
+			      (tag_len == 21 && !memcmp(tag, "tag:yaml.org,2002:str", 21))))
+				return FYNS_DOUBLE_QUOTED;
+		}
+
+		/* JSON NULL, but with plain style */
+		if ((style == FYNS_PLAIN || style == FYNS_ANY) &&
+		    (is_null_scalar || (is_json_plain && !atom->size0)))
+			return FYNS_PLAIN;
+
+		return FYNS_DOUBLE_QUOTED;
+	}
+
+	ta = fy_token_text_analyze(fyt);
+
+	/* if the style is block and we're a simple scalar key, this is not going to work */
+	if ((style == FYNS_LITERAL || style == FYNS_FOLDED) && (flags & DDNF_SIMPLE_SCALAR_KEY))
+		style = (ta->flags & FYTTAF_CAN_BE_PLAIN) ? FYNS_PLAIN : FYNS_DOUBLE_QUOTED;
+
+	if (flow && (style == FYNS_ANY || style == FYNS_LITERAL || style == FYNS_FOLDED)) {
+
+		/* if there's a linebreak, or ends in a colon, use double quoted style */
+		if (ta->flags & (FYTTAF_HAS_ANY_LB | FYTTAF_ENDS_WITH_COLON)) {
+			style = FYNS_DOUBLE_QUOTED;
+			goto out;
+		}
+
+		/* anything not empty is double quoted here */
+		style = (ta->flags & FYTTAF_EMPTY) ? FYNS_PLAIN :
+			((ta->flags & FYTTAF_CAN_BE_PLAIN) ? FYNS_PLAIN : FYNS_DOUBLE_QUOTED);
+	}
+
+	/* try to pretify */
+	if (!flow && fy_emit_is_pretty_mode(emit) &&
+		(style == FYNS_ANY || style == FYNS_DOUBLE_QUOTED || style == FYNS_SINGLE_QUOTED)) {
+
+		/* any original style can be a plain, but contains linebreaks, do a literal */
+		if ((ta->flags & (FYTTAF_CAN_BE_PLAIN | FYTTAF_HAS_LB)) == (FYTTAF_CAN_BE_PLAIN | FYTTAF_HAS_LB)) {
+			style = FYNS_LITERAL;
+			goto out;
+		}
+
+		/* any style, can be just a plain, just make it so */
+		if ((ta->flags & (FYTTAF_CAN_BE_PLAIN | FYTTAF_HAS_LB)) == FYTTAF_CAN_BE_PLAIN) {
+			style = FYNS_PLAIN;
+			goto out;
+		}
+	}
+
+	if (!flow && emit->source_json && fy_emit_is_dejson_mode(emit)) {
+		if (is_json_plain || (ta->flags & (FYTTAF_CAN_BE_PLAIN | FYTTAF_HAS_LB)) == FYTTAF_CAN_BE_PLAIN) {
+			style = FYNS_PLAIN;
+			goto out;
+		}
+	}
+
+out:
+	/* any zero (or non newline linebreak) -> double quoted */
+	if (ta->flags & (FYTTAF_HAS_ZERO | FYTTAF_HAS_NON_NL_LB))
+		style = FYNS_DOUBLE_QUOTED;
+
+	if (style == FYNS_ANY && (ta->flags & FYTTAF_CAN_BE_PLAIN)) {
+		if (!flow || (ta->flags & FYTTAF_CAN_BE_PLAIN_FLOW))
+			style = FYNS_PLAIN;
+	}
+
+	if (style == FYNS_PLAIN) {
+		if (flow && !(ta->flags & FYTTAF_CAN_BE_PLAIN_FLOW))
+			style = (ta->flags & FYTTAF_CAN_BE_SINGLE_QUOTED) ? FYNS_SINGLE_QUOTED : FYNS_DOUBLE_QUOTED;
+
+		/* plains in flow mode not being able to be plains
+		 * - plain in block mode that can't be plain in flow mode
+		 * - special handling for plains on start of line
+		 */
+		if ((flow && !(ta->flags & FYTTAF_CAN_BE_PLAIN_FLOW) && !(ta->flags & FYTTAF_CAN_BE_SIMPLE_KEY) && !is_null_scalar) ||
+		    ((ta->flags & FYTTAF_QUOTE_AT_0) && indent == 0))
+			style = FYNS_DOUBLE_QUOTED;
+
+		/* make it double quoted, but only if not already over the width (and contains a space/lb) */
+		if (style == FYNS_PLAIN && (ta->flags & (FYTTAF_HAS_LB | FYTTAF_HAS_WS)) &&
+			emit->column < fy_emit_width(emit) && (emit->column + ta->maxspan) > fy_emit_width(emit))
+			style = FYNS_DOUBLE_QUOTED;
+
+		if (style == FYNS_PLAIN && !(ta->flags & FYTTAF_CAN_BE_PLAIN)) {
+			style = FYNS_DOUBLE_QUOTED;
+		}
+	}
+
+	if (style == FYNS_ANY && (ta->flags & FYTTAF_CAN_BE_SINGLE_QUOTED))
+		style = FYNS_SINGLE_QUOTED;
+
+	if (style == FYNS_SINGLE_QUOTED && !(ta->flags & FYTTAF_CAN_BE_SINGLE_QUOTED))
+		style = FYNS_DOUBLE_QUOTED;
+
+	if (style == FYNS_ANY && (ta->flags & FYTTAF_CAN_BE_DOUBLE_QUOTED))
+		style = FYNS_DOUBLE_QUOTED;
+
+	/* should never happen, but still */
+	if (style == FYNS_ANY)
+		style = FYNS_DOUBLE_QUOTED;
+
+	return style;
+}
+
+void fy_emit_token_scalar(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent,
+			  enum fy_node_style style, struct fy_token *fyt_tag)
+{
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+
+	assert(style != FYNS_FLOW && style != FYNS_BLOCK);
+
+	if (sc->flags & DDNF_HANGING_INDENT)
+		fy_emit_write_indent(emit, sc->indent);
+
+	/* root scalar with a comment needs special handling */
+	if ((flags & DDNF_ROOT) && fy_emit_token_has_comment(emit, fyt, fycp_top))
+		fy_emit_token_comment(emit, fyt, flags, indent, fycp_top);
+
+	indent = fy_emit_increase_indent(emit, flags, indent);
+
+	if (!fy_emit_whitespace(emit))
+		fy_emit_write_ws(emit);
+
+	style = fy_emit_token_scalar_style(emit, fyt, flags, indent, style, fyt_tag);
+
+	switch (style) {
+	case FYNS_ALIAS:
+		fy_emit_token_write_alias(emit, fyt, flags, indent);
+		break;
+	case FYNS_PLAIN:
+		fy_emit_token_write_plain(emit, fyt, flags, indent);
+		break;
+	case FYNS_DOUBLE_QUOTED:
+		fy_emit_token_write_quoted(emit, fyt, flags, indent, '"');
+		break;
+	case FYNS_SINGLE_QUOTED:
+		fy_emit_token_write_quoted(emit, fyt, flags, indent, '\'');
+		break;
+	case FYNS_LITERAL:
+		fy_emit_token_write_literal(emit, fyt, flags, indent);
+		break;
+	case FYNS_FOLDED:
+		fy_emit_token_write_folded(emit, fyt, flags, indent);
+		break;
+	default:
+		break;
+	}
+
+	/* root scalar with a comment needs special handling */
+	if ((flags & DDNF_ROOT) && fy_emit_token_has_comment(emit, fyt, fycp_right)) {
+		fy_emit_token_comment(emit, fyt, flags, indent, fycp_right);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+}
+
+void fy_emit_scalar(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent, bool is_key)
+{
+	enum fy_node_style style;
+
+	/* default style */
+	style = fyn ? fyn->style : FYNS_ANY;
+
+	/* all JSON keys are double quoted */
+	if (fy_emit_is_json_mode(emit) && is_key)
+		style = FYNS_DOUBLE_QUOTED;
+
+	fy_emit_token_scalar(emit,
+			fyn ? fyn->scalar : NULL,
+			flags, indent,
+			style, fyn->tag);
+}
+
+static void fy_emit_sequence_prolog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+				    struct fy_token *fyt)
+{
+	bool json = fy_emit_is_json_mode(emit);
+	bool was_flow = sc->flow;
+
+	/* skip top comment if parent sequence_item_prolog already emitted it */
+	if (!(sc->flags & DDNF_SEQ) && fy_emit_token_has_comment(emit, fyt, fycp_top)) {
+		fy_emit_token_comment(emit, fyt, sc->flags, sc->indent, fycp_top);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	sc->old_indent = sc->indent;
+	if (!json) {
+		if (fy_emit_is_manual(emit))
+			sc->flow = (sc->xstyle == FYNS_BLOCK && was_flow) || sc->xstyle == FYNS_FLOW;
+		else if (fy_emit_is_block_mode(emit))
+			sc->flow = sc->empty;
+		else
+			sc->flow = fy_emit_is_flow_mode(emit) || emit->flow_level || sc->flow_token || sc->empty;
+	} else
+		sc->flow = true;
+
+	if (sc->flow) {
+		if (!emit->flow_level) {
+			sc->indent = fy_emit_increase_indent(emit, sc->flags, sc->indent);
+			sc->old_indent = sc->indent;
+		}
+
+		sc->flags = (sc->flags | DDNF_FLOW) | (sc->flags & ~DDNF_INDENTLESS);
+		fy_emit_write_indicator(emit, di_left_bracket, sc->flags, sc->indent, fyewt_indicator);
+
+		/* we need an indent afterward if not compact */
+		if (!fy_emit_sc_oneline(emit, sc))
+			sc->flags |= DDNF_HANGING_INDENT;
+	} else {
+		sc->flags = (sc->flags & ~DDNF_FLOW);
+	}
+
+	if (!fy_emit_sc_oneline(emit, sc)) {
+		if (was_flow || (sc->flags & (DDNF_ROOT | DDNF_SEQ))
+		    || ((sc->flags & DDNF_MAP)
+			&& (emit->xcfg.xflags & FYEXCF_INDENTED_SEQ_IN_MAP)))
+			sc->indent = fy_emit_increase_indent(emit, sc->flags, sc->indent);
+	}
+
+	sc->flags &= ~DDNF_ROOT;
+}
+
+static void fy_emit_sequence_epilog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc)
+{
+	if (sc->flow && (sc->flags & DDNF_HANGING_INDENT) && !fy_emit_sc_oneline(emit, sc) && !sc->empty)
+		fy_emit_write_indent(emit, sc->old_indent);
+
+	if (sc->flow || fy_emit_is_json_mode(emit)) {
+		fy_emit_write_indicator(emit, di_right_bracket, sc->flags, sc->old_indent, fyewt_indicator);
+	}
+}
+
+static void fy_emit_sequence_item_prolog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+					 struct fy_token *fyt_value)
+{
+	bool has_comment;
+
+	sc->flags |= DDNF_SEQ;
+
+	has_comment = fy_emit_token_has_comment(emit, fyt_value, fycp_top);
+
+	if (!fy_emit_sc_oneline(emit, sc) ||
+	    ((fy_emit_is_compact(emit) || sc->flow) && emit->column >= fy_emit_width(emit)))
+		fy_emit_write_indent(emit, sc->indent);
+
+	if (has_comment) {
+		fy_emit_token_comment(emit, fyt_value, sc->flags, sc->indent, fycp_top);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	if (!sc->flow && !fy_emit_is_json_mode(emit))
+		fy_emit_write_indicator(emit, di_dash, sc->flags, sc->indent, fyewt_indicator);
+}
+
+static void fy_emit_sequence_item_epilog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+					 bool last, struct fy_token *fyt_value)
+{
+	bool needs_hanging_indent;
+
+	if ((sc->flow || fy_emit_is_json_mode(emit)) && !last)
+		fy_emit_write_indicator(emit, di_comma, sc->flags, sc->indent, fyewt_indicator);
+
+	if (fy_emit_token_has_comment(emit, fyt_value, fycp_right)) {
+		fy_emit_token_comment(emit, fyt_value, sc->flags, sc->indent, fycp_right);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	needs_hanging_indent = sc->flow && !fy_emit_sc_oneline(emit, sc) && !sc->empty;
+
+	if (last && needs_hanging_indent && (sc->flags & DDNF_HANGING_INDENT))
+		fy_emit_write_indent(emit, sc->old_indent);
+	else if (needs_hanging_indent)
+		sc->flags |= DDNF_HANGING_INDENT;
+
+	sc->flags &= ~DDNF_SEQ;
+}
+
+void fy_emit_sequence(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent)
+{
+	struct fy_node *fyni, *fynin;
+	struct fy_token *fyt_value;
+	bool last;
+	struct fy_emit_save_ctx sct, *sc = &sct;
+
+	memset(sc, 0, sizeof(*sc));
+
+	sc->flags = flags;
+	sc->indent = indent;
+	sc->empty = fy_node_list_empty(&fyn->sequence);
+	sc->flow_token = fyn->style == FYNS_FLOW;
+	sc->oneline_flow = false;
+	if (sc->flow_token && fy_emit_preserve_flow_layout(emit)) {
+		const struct fy_mark *sm = fy_token_start_mark(fyn->sequence_start);
+		const struct fy_mark *em = fy_token_end_mark(fyn->sequence_end);
+		if (sm && em && sm->line == em->line)
+			sc->oneline_flow = true;
+	}
+	sc->flow = !!(flags & DDNF_FLOW);
+	sc->xstyle = fyn->style;
+	sc->old_indent = sc->indent;
+
+	fy_emit_sequence_prolog(emit, sc, fyn->sequence_start);
+
+	for (fyni = fy_node_list_head(&fyn->sequence); fyni; fyni = fynin) {
+
+		fynin = fy_node_next(&fyn->sequence, fyni);
+		last = !fynin;
+		fyt_value = fy_node_value_token(fyni);
+
+		fy_emit_sequence_item_prolog(emit, sc, fyt_value);
+
+		fy_emit_node_internal(emit, fyni, sc->flags & ~DDNF_ROOT, sc->indent, false);
+		fy_emit_sequence_item_epilog(emit, sc, last, fyt_value);
+	}
+
+	fy_emit_sequence_epilog(emit, sc);
+
+	/* emit right-comment attached to the closing bracket token */
+	if (fy_emit_token_has_comment(emit, fyn->sequence_end, fycp_right))
+		fy_emit_token_comment(emit, fyn->sequence_end, sc->flags, sc->indent, fycp_right);
+}
+
+static void fy_emit_mapping_prolog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+				   struct fy_token *fyt)
+{
+	bool json = fy_emit_is_json_mode(emit);
+	bool was_flow = sc->flow;
+
+	/* skip top comment if parent sequence_item_prolog already emitted it */
+	if (!(sc->flags & DDNF_SEQ) && fy_emit_token_has_comment(emit, fyt, fycp_top)) {
+		fy_emit_token_comment(emit, fyt, sc->flags, sc->indent, fycp_top);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	sc->old_indent = sc->indent;
+	if (!json) {
+		if (fy_emit_is_manual(emit))
+			sc->flow = (sc->xstyle == FYNS_BLOCK && was_flow) || sc->xstyle == FYNS_FLOW;
+		else if (fy_emit_is_block_mode(emit))
+			sc->flow = sc->empty;
+		else
+			sc->flow = fy_emit_is_flow_mode(emit) || emit->flow_level || sc->flow_token || sc->empty;
+	} else
+		sc->flow = true;
+
+	if (sc->flow) {
+		if (!emit->flow_level) {
+			sc->indent = fy_emit_increase_indent(emit, sc->flags, sc->indent);
+			sc->old_indent = sc->indent;
+		}
+
+		sc->flags = (sc->flags | DDNF_FLOW) | (sc->flags & ~DDNF_INDENTLESS);
+		fy_emit_write_indicator(emit, di_left_brace, sc->flags, sc->indent, fyewt_indicator);
+
+		/* we need an indent afterward if not compact */
+		if (!fy_emit_sc_oneline(emit, sc))
+			sc->flags |= DDNF_HANGING_INDENT;
+	} else {
+		sc->flags &= ~(DDNF_FLOW | DDNF_INDENTLESS);
+	}
+
+	if (!fy_emit_sc_oneline(emit, sc) && !sc->empty)
+		sc->indent = fy_emit_increase_indent(emit, sc->flags, sc->indent);
+
+	sc->flags &= ~DDNF_ROOT;
+}
+
+static void fy_emit_mapping_epilog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc)
+{
+	if (sc->flow || fy_emit_is_json_mode(emit)) {
+		if ((sc->flags & DDNF_HANGING_INDENT) && !fy_emit_sc_oneline(emit, sc) && !sc->empty)
+			fy_emit_write_indent(emit, sc->old_indent);
+		fy_emit_write_indicator(emit, di_right_brace, sc->flags, sc->old_indent, fyewt_indicator);
+	}
+}
+
+static void fy_emit_mapping_key_prolog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+				       struct fy_token *fyt_key, bool simple_key)
+{
+	const struct fy_token_analysis *ta;
+	bool do_indent, key_over, has_comment;
+
+	sc->flags = DDNF_MAP | (sc->flags & DDNF_FLOW);
+
+	if (!fy_emit_sc_oneline(emit, sc) ||
+	    ((fy_emit_is_compact(emit) || sc->flow) && emit->column >= fy_emit_width(emit)))
+		fy_emit_write_indent(emit, sc->indent);
+
+	/* emit top comment on key token (interstitial mapping comment) */
+	if (!sc->flow && fy_emit_token_has_comment(emit, fyt_key, fycp_top)) {
+		fy_emit_token_comment(emit, fyt_key, sc->flags, sc->indent, fycp_top);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	/* if we have a right comment then it's by a definition not a simple key */
+	has_comment = fy_emit_token_has_comment(emit, fyt_key, fycp_right);
+	if (simple_key /* && !has_comment */ ) {
+		sc->flags |= DDNF_SIMPLE;
+		if (fyt_key && fyt_key->type == FYTT_SCALAR)
+			sc->flags |= DDNF_SIMPLE_SCALAR_KEY;
+	} else {
+		/* do not emit the ? in flow modes at all */
+		if (fy_emit_is_flow_mode(emit))
+			sc->flags |= DDNF_SIMPLE;
+	}
+
+	do_indent = false;
+	if (!has_comment && !fy_emit_sc_oneline(emit, sc)) {
+		if (fyt_key && fyt_key->type != FYTT_SCALAR)
+			/* always indent on non scalar keys */
+			key_over = true;
+		else {
+			/* for scalar keys, check if key + 2 + quotes go over */
+			ta = fy_token_text_analyze(fyt_key);
+			key_over = (emit->column + ta->maxspan + 2 + (!simple_key ? 2 : 0)) >= fy_emit_width(emit);
+		}
+
+		do_indent = key_over;
+		if (!do_indent && !fy_emit_is_compact(emit))
+			do_indent = !sc->flow || (sc->flags & DDNF_HANGING_INDENT);
+	} else
+		do_indent = false;
+
+	if (do_indent)
+		fy_emit_write_indent(emit, sc->indent);
+
+	/* complex? */
+	if (!(sc->flags & DDNF_SIMPLE)) {
+		fy_emit_write_indicator(emit, di_question_mark, sc->flags, sc->indent, fyewt_indicator);
+	}
+}
+
+static void fy_emit_mapping_key_epilog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+				       struct fy_token *fyt_key)
+{
+	/* if the key is an alias, always output an extra whitespace */
+	if (fyt_key && fyt_key->type == FYTT_ALIAS)
+		fy_emit_write_ws(emit);
+
+	sc->flags &= ~DDNF_MAP;
+
+	if (!(sc->flags & DDNF_SIMPLE)) {
+
+		if (fy_emit_token_has_comment(emit, fyt_key, fycp_right)) {
+			fy_emit_token_comment(emit, fyt_key, sc->flags, sc->indent, fycp_right);
+			sc->flags |= DDNF_HANGING_INDENT;
+		}
+
+		if (!emit->flow_level && !fy_emit_is_oneline_or_compact(emit))
+			fy_emit_write_indent(emit, sc->indent);
+		if (!fy_emit_whitespace(emit))
+			fy_emit_write_ws(emit);
+	} else {
+	}
+
+	fy_emit_write_indicator(emit, di_colon, sc->flags, sc->indent, fyewt_indicator);
+
+	sc->flags &= ~DDNF_HANGING_INDENT;
+	if ((sc->flags & DDNF_SIMPLE) && fy_emit_token_has_comment(emit, fyt_key, fycp_right)) {
+		fy_emit_token_comment(emit, fyt_key, sc->flags, sc->indent, fycp_right);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	sc->flags = DDNF_MAP | (sc->flags & (DDNF_FLOW | DDNF_HANGING_INDENT));
+}
+
+static void fy_emit_mapping_value_prolog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+					 struct fy_token *fyt_value)
+{
+	const struct fy_token_analysis *ta;
+	bool value_over;
+
+	if (sc->flags & DDNF_HANGING_INDENT)
+		fy_emit_write_indent(emit, sc->indent);
+
+	/* don't do anything for those cases */
+	if (!sc->flow || fy_emit_sc_oneline(emit, sc) || !fyt_value || fyt_value->type != FYTT_SCALAR)
+		return;
+
+	ta = fy_token_text_analyze(fyt_value);
+	value_over = (emit->column + ta->maxspan) >= fy_emit_width(emit);
+
+	if (value_over) {
+		sc->indent = fy_emit_increase_indent(emit, sc->flags, sc->indent);
+		fy_emit_write_indent(emit, sc->indent);
+	}
+}
+
+static void fy_emit_mapping_value_epilog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
+					 bool last, struct fy_token *fyt_value)
+{
+	bool needs_hanging_indent;
+
+	if ((sc->flow || fy_emit_is_json_mode(emit)) && !last)
+		fy_emit_write_indicator(emit, di_comma, sc->flags, sc->indent, fyewt_indicator);
+
+	if (fy_emit_token_has_comment(emit, fyt_value, fycp_right)) {
+		fy_emit_token_comment(emit, fyt_value, sc->flags, sc->indent, fycp_right);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	needs_hanging_indent = sc->flow && !fy_emit_sc_oneline(emit, sc) && !sc->empty;
+
+	if (last && needs_hanging_indent && (sc->flags & DDNF_HANGING_INDENT))
+		fy_emit_write_indent(emit, sc->old_indent);
+	else if (needs_hanging_indent)
+		sc->flags |= DDNF_HANGING_INDENT;
+
+	sc->flags &= ~DDNF_MAP;
+}
+
+void fy_emit_mapping(struct fy_emitter *emit, struct fy_node *fyn, int flags, int indent)
+{
+	struct fy_node_pair *fynp, *fynpn, **fynpp = NULL;
+	struct fy_token *fyt_key, *fyt_value;
+	bool last, simple_key, used_malloc = false;
+	const struct fy_token_analysis *tak = NULL, *tav;
+	int i, count;
+	struct fy_emit_save_ctx sct, *sc = &sct;
+
+	memset(sc, 0, sizeof(*sc));
+
+	sc->flags = flags;
+	sc->indent = indent;
+	sc->empty = fy_node_pair_list_empty(&fyn->mapping);
+	sc->flow_token = fyn->style == FYNS_FLOW;
+	sc->oneline_flow = false;
+	if (sc->flow_token && fy_emit_preserve_flow_layout(emit)) {
+		const struct fy_mark *sm = fy_token_start_mark(fyn->mapping_start);
+		const struct fy_mark *em = fy_token_end_mark(fyn->mapping_end);
+		if (sm && em && sm->line == em->line)
+			sc->oneline_flow = true;
+	}
+	sc->flow = !!(flags & DDNF_FLOW);
+	sc->xstyle = fyn->style;
+	sc->old_indent = sc->indent;
+
+	fy_emit_mapping_prolog(emit, sc, fyn->mapping_start);
+
+	if (!(emit->xcfg.cfg.flags & (FYECF_SORT_KEYS | FYECF_STRIP_EMPTY_KV))) {
+		fynp = fy_node_pair_list_head(&fyn->mapping);
+		fynpp = NULL;
+	} else {
+		count = fy_node_mapping_item_count(fyn);
+
+		/* heuristic, avoid allocation for small maps */
+		if (count > 64) {
+			fynpp = malloc((count + 1) * sizeof(*fynpp));
+			fyd_error_check(fyn->fyd, fynpp, err_out,
+					"malloc() failed");
+			used_malloc = true;
+		} else
+			fynpp = alloca((count + 1) * sizeof(*fynpp));
+
+		/* fill (removing empty KVs) */
+		i = 0;
+		for (fynp = fy_node_pair_list_head(&fyn->mapping); fynp;
+				fynp = fy_node_pair_next(&fyn->mapping, fynp)) {
+
+			/* strip key/value pair from the output if it's empty */
+			if ((emit->xcfg.cfg.flags & FYECF_STRIP_EMPTY_KV) && fy_node_is_empty(fynp->value))
+				continue;
+
+			fynpp[i++] = fynp;
+		}
+		count = i;
+		fynpp[count] = NULL;
+
+		/* sort the keys */
+		if (emit->xcfg.cfg.flags & FYECF_SORT_KEYS)
+			fy_node_mapping_perform_sort(fyn, NULL, NULL, fynpp, count);
+
+		i = 0;
+		fynp = fynpp[i];
+	}
+
+	for (; fynp; fynp = fynpn) {
+
+		if (!fynpp)
+			fynpn = fy_node_pair_next(&fyn->mapping, fynp);
+		else
+			fynpn = fynpp[++i];
+
+		last = !fynpn;
+		fyt_key = fy_node_value_token(fynp->key);
+		fyt_value = fy_node_value_token(fynp->value);
+
+		FYD_NODE_ERROR_CHECK(fynp->fyd, fynp->key, FYEM_INTERNAL,
+				!fy_emit_is_json_mode(emit) ||
+					(fynp->key && fynp->key->type == FYNT_SCALAR),
+					err_out, "Non scalar keys are not allowed in JSON emit mode");
+
+		simple_key = false;
+		if (fynp->key) {
+			switch (fynp->key->type) {
+			case FYNT_SCALAR:
+				tak = fy_token_text_analyze(fynp->key->scalar);
+				simple_key = fy_emit_is_json_mode(emit) ||
+					     !!(tak->flags & FYTTAF_CAN_BE_SIMPLE_KEY);
+				break;
+			case FYNT_SEQUENCE:
+				simple_key = fy_node_list_empty(&fynp->key->sequence);
+				break;
+			case FYNT_MAPPING:
+				simple_key = fy_node_pair_list_empty(&fynp->key->mapping);
+				break;
+			}
+		}
+
+		/* special handling for compact mode simple key + scalar value*/
+		if (fy_emit_is_compact(emit) && simple_key &&
+		    fynp->value && fynp->value->type == FYNT_SCALAR && tak) {
+			tav = fy_token_text_analyze(fynp->value->scalar);
+
+			/* for plain key + value if we go over the width */
+			if ((tav->flags & FYTTAF_CAN_BE_PLAIN) &&
+			   (emit->column + tak->maxspan + 2 + tav->maxspan + 1) >= fy_emit_width(emit))
+				fy_emit_write_indent(emit, sc->indent);
+		}
+
+		fy_emit_mapping_key_prolog(emit, sc, fyt_key, simple_key);
+		if (fynp->key)
+			fy_emit_node_internal(emit, fynp->key, (sc->flags & ~DDNF_ROOT), sc->indent, true);
+		fy_emit_mapping_key_epilog(emit, sc, fyt_key);
+
+		fy_emit_mapping_value_prolog(emit, sc, fyt_value);
+		if (fynp->value)
+			fy_emit_node_internal(emit, fynp->value, (sc->flags & ~DDNF_ROOT), sc->indent, false);
+		fy_emit_mapping_value_epilog(emit, sc, last, fyt_value);
+	}
+
+	fy_emit_mapping_epilog(emit, sc);
+
+	/* emit right-comment attached to the closing brace token */
+	if (fy_emit_token_has_comment(emit, fyn->mapping_end, fycp_right))
+		fy_emit_token_comment(emit, fyn->mapping_end, sc->flags, sc->indent, fycp_right);
+
+err_out:
+	if (fynpp && used_malloc)
+		free(fynpp);
+	return;
+}
+
+int fy_emit_common_document_start(struct fy_emitter *emit,
+				  struct fy_document_state *fyds,
+				  bool root_tag_or_anchor)
+{
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+	struct fy_token *fyt_chk;
+	const char *td_handle, *td_prefix;
+	size_t td_handle_size, td_prefix_size;
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags;
+	enum fy_emitter_cfg_flags vd_flags = flags & FYECF_VERSION_DIR(FYECF_VERSION_DIR_MASK);
+	enum fy_emitter_cfg_flags td_flags = flags & FYECF_TAG_DIR(FYECF_TAG_DIR_MASK);
+	enum fy_emitter_cfg_flags dsm_flags = flags & FYECF_DOC_START_MARK(FYECF_DOC_START_MARK_MASK);
+	bool vd, td, dsm;
+	bool had_non_default_tag = false;
+	bool strip_doc = false;
+
+	if (!emit || !fyds || emit->fyds)
+		return -1;
+
+	strip_doc = !!(emit->xcfg.cfg.flags & FYECF_STRIP_DOC);
+
+	emit->fyds = fy_document_state_ref(fyds);
+
+	vd = ((vd_flags == FYECF_VERSION_DIR_AUTO && fyds->version_explicit) ||
+	       vd_flags == FYECF_VERSION_DIR_ON) &&
+	      !strip_doc;
+	td = ((td_flags == FYECF_TAG_DIR_AUTO && fyds->tags_explicit) ||
+	       td_flags == FYECF_TAG_DIR_ON) &&
+	      !strip_doc;
+
+	/* if either a version or directive tags exist, and no previous
+	 * explicit document end existed, output one now
+	 */
+	if (!fy_emit_is_json_mode(emit) && (vd || td) &&
+		(emit->flags & (FYEF_HAD_DOCUMENT_END | FYEF_HAD_DOCUMENT_OUTPUT)) ==
+			(FYEF_HAD_DOCUMENT_END | FYEF_HAD_DOCUMENT_OUTPUT)) {
+		if (emit->column)
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		if (!strip_doc) {
+			fy_emit_puts_simple(emit, fyewt_document_indicator, "...");
+			emit->flags &= ~FYEF_WHITESPACE;
+			emit->flags |= FYEF_HAD_DOCUMENT_END;
+		}
+	}
+
+	/* top comment */
+	if (fy_emit_token_has_comment(emit, fyds->fyt_ds, fycp_top)) {
+		if (emit->column)
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		fy_emit_token_comment(emit, fyds->fyt_ds, sc->flags, sc->indent, fycp_top);
+	}
+	/* right comment */
+	if (fy_emit_token_has_comment(emit, fyds->fyt_ds, fycp_right)) {
+		if (emit->column)
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		fy_emit_token_comment(emit, fyds->fyt_ds, sc->flags, sc->indent, fycp_right);
+		sc->flags |= DDNF_HANGING_INDENT;
+	}
+
+	if (!fy_emit_is_json_mode(emit) && vd) {
+		if (emit->column)
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		fy_emit_printf(emit, fyewt_version_directive, "%%YAML %d.%d",
+					fyds->version.major, fyds->version.minor);
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	if (!fy_emit_is_json_mode(emit) && td) {
+
+		for (fyt_chk = fy_token_list_first(&fyds->fyt_td); fyt_chk; fyt_chk = fy_token_next(&fyds->fyt_td, fyt_chk)) {
+
+			td_handle = fy_tag_directive_token_handle(fyt_chk, &td_handle_size);
+			td_prefix = fy_tag_directive_token_prefix(fyt_chk, &td_prefix_size);
+			assert(td_handle && td_prefix);
+
+			if (fy_tag_is_default_internal(td_handle, td_handle_size, td_prefix, td_prefix_size))
+				continue;
+
+			had_non_default_tag = true;
+
+			if (emit->column)
+				fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			fy_emit_printf(emit, fyewt_tag_directive, "%%TAG %.*s %.*s",
+					(int)td_handle_size, td_handle,
+					(int)td_prefix_size, td_prefix);
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+		}
+	}
+
+	/* always output document start indicator:
+	 * - was explicit
+	 * - document has tags
+	 * - document has an explicit version
+	 * - root exists & has a tag or an anchor
+	 */
+	dsm = (dsm_flags == FYECF_DOC_START_MARK_AUTO &&
+			(!fyds->start_implicit ||
+			(fyds->tags_explicit && had_non_default_tag) ||
+			fyds->version_explicit )) ||
+	       dsm_flags == FYECF_DOC_START_MARK_ON;
+
+	/* if there was previous output without document end */
+	if (!dsm && (emit->flags & FYEF_HAD_DOCUMENT_OUTPUT) &&
+	           !(emit->flags & FYEF_HAD_DOCUMENT_END))
+		dsm = true;
+
+	/* there was *any* document end output (and no document end) */
+	if (!dsm && (emit->flags & FYEF_HAD_DOCUMENT_END_OUTPUT) &&
+		    !(emit->flags & FYEF_HAD_DOCUMENT_END))
+		dsm = true;
+
+	/* output document start indicator if we should */
+	if (dsm && !fy_emit_is_json_mode(emit))
+		fy_emit_document_start_indicator(emit);
+
+	/* clear that in any case */
+	emit->flags &= ~FYEF_HAD_DOCUMENT_END;
+
+	return 0;
+}
+
+int fy_emit_document_start(struct fy_emitter *emit, struct fy_document *fyd,
+			   struct fy_node *fyn_root)
+{
+	struct fy_node *root;
+	bool root_tag_or_anchor;
+	int ret;
+
+	if (!emit || !fyd || !fyd->fyds)
+		return -1;
+
+	root = fyn_root ? fyn_root : fy_document_root(fyd);
+
+	root_tag_or_anchor = root && (root->tag || fy_document_lookup_anchor_by_node(fyd, root));
+
+	ret = fy_emit_common_document_start(emit, fyd->fyds, root_tag_or_anchor);
+	if (ret)
+		return ret;
+
+	emit->fyd = fyd;
+
+	return 0;
+}
+
+int fy_emit_common_document_end(struct fy_emitter *emit, bool override_state, bool implicit_override)
+{
+	const struct fy_document_state *fyds;
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags;
+	enum fy_emitter_cfg_flags dem_flags = flags & FYECF_DOC_END_MARK(FYECF_DOC_END_MARK_MASK);
+	bool implicit, dem;
+
+	if (!emit || !emit->fyds)
+		return -1;
+
+	fyds = emit->fyds;
+
+	implicit = fyds->end_implicit;
+	if (fyds->started_explicit)
+		implicit = false;
+	else if (override_state)
+		implicit = implicit_override;
+
+	dem = ((dem_flags == FYECF_DOC_END_MARK_AUTO && !implicit) ||
+		dem_flags == FYECF_DOC_END_MARK_ON) &&
+	       !(emit->xcfg.cfg.flags & FYECF_STRIP_DOC);
+
+	if (!(emit->xcfg.cfg.flags & FYECF_NO_ENDING_NEWLINE)) {
+		if (emit->column != 0) {
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+		}
+
+		if (!fy_emit_is_json_mode(emit) && dem) {
+			fy_emit_puts_simple(emit, fyewt_document_indicator, "...");
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+			emit->flags |= FYEF_HAD_DOCUMENT_END;
+		} else
+			emit->flags &= ~FYEF_HAD_DOCUMENT_END;
+	} else {
+		if (!fy_emit_is_json_mode(emit) && dem) {
+			if (emit->column != 0) {
+				fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+				emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+			}
+			fy_emit_puts_simple(emit, fyewt_document_indicator, "...");
+			emit->flags &= ~(FYEF_WHITESPACE | FYEF_INDENTATION);
+			emit->flags |= FYEF_HAD_DOCUMENT_END;
+		} else
+			emit->flags &= ~FYEF_HAD_DOCUMENT_END;
+	}
+
+	/* mark that we did output a document earlier */
+	emit->flags |= FYEF_HAD_DOCUMENT_OUTPUT;
+
+	/* stop our association with the document */
+	fy_document_state_unref(emit->fyds);
+	emit->fyds = NULL;
+
+	return 0;
+}
+
+int fy_emit_document_end(struct fy_emitter *emit)
+{
+	int ret;
+
+	ret = fy_emit_common_document_end(emit, false, false);
+	if (ret)
+		return ret;
+
+	emit->fyd = NULL;
+	return 0;
+}
+
+int fy_emit_common_explicit_document_end(struct fy_emitter *emit)
+{
+	if (!emit)
+		return -1;
+
+	if (emit->column != 0) {
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	if (!fy_emit_is_json_mode(emit)) {
+		fy_emit_puts_simple(emit, fyewt_document_indicator, "...");
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+		emit->flags |= FYEF_HAD_DOCUMENT_END;
+	} else
+		emit->flags &= ~FYEF_HAD_DOCUMENT_END;
+
+	/* mark that we did output a document earlier */
+	emit->flags |= FYEF_HAD_DOCUMENT_OUTPUT;
+
+	/* stop our association with the document */
+	fy_document_state_unref(emit->fyds);
+	emit->fyds = NULL;
+
+	return 0;
+}
+
+int fy_emit_explicit_document_end(struct fy_emitter *emit)
+{
+	int ret;
+
+	ret = fy_emit_common_explicit_document_end(emit);
+	if (ret)
+		return ret;
+
+	emit->fyd = NULL;
+	return 0;
+}
+
+void fy_emit_reset(struct fy_emitter *emit, bool reset_events)
+{
+	struct fy_eventp *fyep;
+
+	emit->line = 0;
+	emit->column = 0;
+	emit->flow_level = 0;
+	emit->output_error = 0;
+	/* clear/set flags for a fresh start */
+	emit->flags &= ~(FYEF_OPEN_ENDED | FYEF_HAD_DOCUMENT_START | FYEF_HAD_DOCUMENT_OUTPUT); 
+	emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+
+	emit->state = FYES_NONE;
+
+	/* reset the accumulator */
+	fy_emit_accum_reset(&emit->ea);
+
+	/* streaming mode indent */
+	emit->s_indent = -1;
+	/* streaming mode flags */
+	emit->s_flags = DDNF_ROOT;
+
+	fy_emit_save_ctx_cleanup(emit, &emit->s_sc);
+	while (emit->sc_stack_top > 0)
+		fy_emit_save_ctx_cleanup(emit, &emit->sc_stack[--emit->sc_stack_top]);
+
+	emit->state_stack_top = 0;
+
+	/* and release any queued events */
+	if (reset_events) {
+		while ((fyep = fy_eventp_list_pop(&emit->queued_events)) != NULL)
+			fy_eventp_release(fyep);
+	}
+}
+
+int fy_emit_setup(struct fy_emitter *emit, const struct fy_emitter_cfg *cfg)
+{
+	struct fy_diag *diag;
+
+	if (!cfg)
+		return -1;
+
+	memset(emit, 0, sizeof(*emit));
+	emit->output_fd = -1;
+
+	/* is it extended config or not? */
+	if (!(cfg->flags & FYECF_EXTENDED_CFG))
+		emit->xcfg.cfg = *cfg;
+	else
+		emit->xcfg = *container_of(cfg, struct fy_emitter_xcfg, cfg);
+
+	fy_emitter_fill_default_colors(emit);
+	emit->output_fp = fy_emitter_get_output_fp(emit);
+	if (!emit->output_fp)
+		emit->output_fd = fy_emitter_get_output_fd(emit);
+
+	if (!emit->xcfg.cfg.output) {
+		if (!emit->output_fp && emit->output_fd < 0) {
+			emit->xcfg.cfg.output = fy_emitter_null_output;
+		} else {
+			emit->xcfg.cfg.output = fy_emitter_default_output;
+			/* for the default, turn on extended indicators */
+			emit->xcfg.xflags |= FYEXCF_EXTENDED_INDICATORS;
+
+			switch (emit->xcfg.xflags & (FYEXCF_COLOR_MASK << FYEXCF_COLOR_SHIFT)) {
+			case FYEXCF_COLOR_AUTO:
+				emit->output_colorize = emit->output_fp ?
+						isatty(fileno(emit->output_fp)) :
+						isatty(emit->output_fd);
+				break;
+			case FYEXCF_COLOR_FORCE:
+				emit->output_colorize = true;
+				break;
+			default:
+				emit->output_colorize = false;
+				break;
+			}
+		}
+	}
+
+	diag = cfg->diag;
+
+	if (!diag) {
+		diag = fy_diag_create(NULL);
+		if (!diag)
+			return -1;
+	} else
+		fy_diag_ref(diag);
+
+	emit->diag = diag;
+
+	fy_emit_accum_init(&emit->ea, emit->ea_inplace_buf, sizeof(emit->ea_inplace_buf), 0, fylb_cr_nl);
+	fy_eventp_list_init(&emit->queued_events);
+
+	emit->state_stack = emit->state_stack_inplace;
+	emit->state_stack_alloc = sizeof(emit->state_stack_inplace)/sizeof(emit->state_stack_inplace[0]);
+
+	emit->sc_stack = emit->sc_stack_inplace;
+	emit->sc_stack_alloc = sizeof(emit->sc_stack_inplace)/sizeof(emit->sc_stack_inplace[0]);
+
+	fy_eventp_list_init(&emit->recycled_eventp);
+	fy_token_list_init(&emit->recycled_token);
+
+	/* suppress recycling if we must */
+	emit->suppress_recycling_force = getenv("FY_VALGRIND") && !getenv("FY_VALGRIND_RECYCLING");
+	emit->suppress_recycling = emit->suppress_recycling_force;
+
+	if (!emit->suppress_recycling) {
+		emit->recycled_eventp_list = &emit->recycled_eventp;
+		emit->recycled_token_list = &emit->recycled_token;
+	} else {
+		emit->recycled_eventp_list = NULL;
+		emit->recycled_token_list = NULL;
+	}
+
+	fy_emit_reset(emit, false);
+
+	return 0;
+}
+
+void fy_emit_save_ctx_cleanup(struct fy_emitter *emit, struct fy_emit_save_ctx *sc)
+{
+	fy_token_unref_rl(emit->recycled_token_list, sc->fyt_last_key);
+	sc->fyt_last_key = NULL;
+	fy_token_unref_rl(emit->recycled_token_list, sc->fyt_last_value);
+	sc->fyt_last_value = NULL;
+	memset(sc, 0, sizeof(*sc));
+}
+
+void fy_emit_cleanup(struct fy_emitter *emit)
+{
+	struct fy_eventp *fyep;
+	struct fy_token *fyt;
+
+	/* call the finalizer if it exists */
+	if (emit->finalizer)
+		emit->finalizer(emit);
+
+	fy_emit_save_ctx_cleanup(emit, &emit->s_sc);
+	while (emit->sc_stack_top > 0)
+		fy_emit_save_ctx_cleanup(emit, &emit->sc_stack[--emit->sc_stack_top]);
+
+	while ((fyt = fy_token_list_pop(&emit->recycled_token)) != NULL)
+		fy_token_free(fyt);
+
+	while ((fyep = fy_eventp_list_pop(&emit->recycled_eventp)) != NULL)
+		fy_eventp_free(fyep);
+
+	fy_document_state_unref(emit->fyds);
+	emit->fyds = NULL;
+
+	fy_emit_accum_cleanup(&emit->ea);
+
+	while ((fyep = fy_eventp_list_pop(&emit->queued_events)) != NULL)
+		fy_eventp_release(fyep);
+
+	if (emit->state_stack && emit->state_stack != emit->state_stack_inplace)
+		free(emit->state_stack);
+
+	if (emit->sc_stack && emit->sc_stack != emit->sc_stack_inplace)
+		free(emit->sc_stack);
+
+	fy_diag_unref(emit->diag);
+
+	if (emit->owned_output_fp)
+		fclose(emit->owned_output_fp);
+}
+
+int fy_emit_node_no_check(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	if (fyn)
+		fy_emit_node_internal(emit, fyn, DDNF_ROOT, -1, false);
+	return 0;
+}
+
+int fy_emit_node(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	int ret;
+
+	ret = fy_emit_node_check(emit, fyn);
+	if (ret)
+		return ret;
+
+	return fy_emit_node_no_check(emit, fyn);
+}
+
+int fy_emit_root_node_no_check(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	if (!emit || !fyn)
+		return -1;
+
+	fy_emit_node_internal(emit, fyn, DDNF_ROOT, -1, false);
+
+	return 0;
+}
+
+int fy_emit_root_node(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	int ret;
+
+	if (!emit || !fyn)
+		return -1;
+
+	ret = fy_emit_node_check(emit, fyn);
+	if (ret)
+		return ret;
+
+	return fy_emit_root_node_no_check(emit, fyn);
+}
+
+void fy_emit_prepare_document_state(struct fy_emitter *emit, struct fy_document_state *fyds)
+{
+	if (!emit || !fyds)
+		return;
+
+	/* if the original document was JSON and the mode is ORIGINAL turn on JSON mode */
+	emit->source_json = fyds && fyds->json_mode;
+	emit->force_json = (emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK)) == FYECF_MODE_ORIGINAL &&
+			   emit->source_json;
+}
+
+int fy_emit_document_no_check(struct fy_emitter *emit, struct fy_document *fyd)
+{
+	int rc;
+
+	rc = fy_emit_document_start(emit, fyd, NULL);
+	if (rc)
+		return rc;
+
+	rc = fy_emit_root_node_no_check(emit, fyd->root);
+	if (rc)
+		return rc;
+
+	rc = fy_emit_document_end(emit);
+
+	fy_emit_reset(emit, false);
+
+	return rc;
+}
+
+int fy_emit_document(struct fy_emitter *emit, struct fy_document *fyd)
+{
+	int ret;
+
+	if (!emit)
+		return -1;
+
+	if (fyd) {
+		fy_emit_prepare_document_state(emit, fyd->fyds);
+
+		if (fyd->root) {
+			ret = fy_emit_node_check(emit, fyd->root);
+			if (ret)
+				return ret;
+		}
+	}
+
+	return fy_emit_document_no_check(emit, fyd);
+}
+
+struct fy_emitter *fy_emitter_create(const struct fy_emitter_cfg *cfg)
+{
+	struct fy_emitter *emit;
+	int rc;
+
+	if (!cfg)
+		return NULL;
+
+	emit = malloc(sizeof(*emit));
+	if (!emit)
+		return NULL;
+
+	rc = fy_emit_setup(emit, cfg);
+	if (rc) {
+		free(emit);
+		return NULL;
+	}
+
+	return emit;
+}
+
+void fy_emitter_destroy(struct fy_emitter *emit)
+{
+	if (!emit)
+		return;
+
+	fy_emit_cleanup(emit);
+
+	free(emit);
+}
+
+const struct fy_emitter_cfg *fy_emitter_get_cfg(struct fy_emitter *emit)
+{
+	if (!emit)
+		return NULL;
+
+	return &emit->xcfg.cfg;
+}
+
+struct fy_diag *fy_emitter_get_diag(struct fy_emitter *emit)
+{
+	if (!emit || !emit->diag)
+		return NULL;
+	return fy_diag_ref(emit->diag);
+}
+
+int fy_emitter_set_diag(struct fy_emitter *emit, struct fy_diag *diag)
+{
+	struct fy_diag_cfg dcfg;
+
+	if (!emit)
+		return -1;
+
+	/* default? */
+	if (!diag) {
+		fy_diag_cfg_default(&dcfg);
+		diag = fy_diag_create(&dcfg);
+		if (!diag)
+			return -1;
+	}
+
+	fy_diag_unref(emit->diag);
+	emit->diag = fy_diag_ref(diag);
+
+	return 0;
+}
+
+void fy_emitter_set_finalizer(struct fy_emitter *emit,
+		void (*finalizer)(struct fy_emitter *emit))
+{
+	if (!emit)
+		return;
+	emit->finalizer = finalizer;
+}
+
+struct fy_emit_buffer_state {
+	char **bufp;
+	size_t *sizep;
+	char *buf;
+	size_t size;
+	size_t pos;
+	size_t need;
+	bool allocate_buffer;
+	size_t maxsize;
+};
+
+static int do_buffer_output(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, int leni, void *userdata)
+{
+	struct fy_emit_buffer_state *state = emit->xcfg.cfg.userdata;
+	size_t left, pagesize, size, len;
+	char *bufnew;
+
+	if (leni < 0)
+		return -1;
+
+	/* convert to unsigned and use that */
+	len = (size_t)leni;
+
+	/* no funky business */
+	if ((ssize_t)len < 0)
+		return -1;
+
+	state->need += len;
+	left = state->size - state->pos;
+	if (left < len) {
+		if (!state->allocate_buffer)
+			return 0;
+
+		pagesize = sysconf(_SC_PAGESIZE);
+		size = state->need + pagesize - 1;
+		size = size - size % pagesize;
+
+		bufnew = realloc(state->buf, size);
+		if (!bufnew)
+			return -1;
+		state->buf = bufnew;
+		state->size = size;
+		left = state->size - state->pos;
+
+	}
+
+	if (len > left)
+		len = left;
+	if (state->buf)
+		memcpy(state->buf + state->pos, str, len);
+	state->pos += len;
+
+	return (int)len;
+}
+
+static void
+fy_emitter_str_finalizer(struct fy_emitter *emit)
+{
+	struct fy_emit_buffer_state *state;
+
+	if (!emit || !(state = emit->xcfg.cfg.userdata))
+		return;
+
+	/* if the buffer is allowed to allocate_buffer... */
+	if (state->allocate_buffer && state->buf)
+		free(state->buf);
+	free(state);
+
+	emit->xcfg.cfg.userdata = NULL;
+}
+
+static struct fy_emitter *
+fy_emitter_create_str_internal(enum fy_emitter_cfg_flags flags, char **bufp, size_t *sizep, bool allocate_buffer)
+{
+	struct fy_emitter *emit;
+	struct fy_emitter_cfg emit_cfg;
+	struct fy_emit_buffer_state *state;
+
+	if (flags & FYECF_EXTENDED_CFG)
+		return NULL;
+
+	state = malloc(sizeof(*state));
+	if (!state)
+		return NULL;
+
+	/* if any of these NULL, it's a allocation case */
+	if ((!bufp || !sizep) && !allocate_buffer)
+		return NULL;
+
+	if (bufp && sizep) {
+		state->bufp = bufp;
+		state->buf = *bufp;
+		state->sizep = sizep;
+		state->size = *sizep;
+		state->maxsize = state->size;
+	} else {
+		state->bufp = NULL;
+		state->buf = NULL;
+		state->sizep = NULL;
+		state->size = 0;
+		state->maxsize = 0;
+	}
+	state->pos = 0;
+	state->need = 0;
+	state->allocate_buffer = allocate_buffer;
+
+	memset(&emit_cfg, 0, sizeof(emit_cfg));
+	emit_cfg.output = do_buffer_output;
+	emit_cfg.userdata = state;
+	emit_cfg.flags = flags;
+
+	emit = fy_emitter_create(&emit_cfg);
+	if (!emit)
+		goto err_out;
+
+	/* set finalizer to cleanup */
+	fy_emitter_set_finalizer(emit, fy_emitter_str_finalizer);
+
+	return emit;
+
+err_out:
+	if (state)
+		free(state);
+	return NULL;
+}
+
+static int
+fy_emitter_collect_str_internal(struct fy_emitter *emit, char **bufp, size_t *sizep)
+{
+	struct fy_emit_buffer_state *state;
+	char *buf;
+	size_t size;
+	int rc;
+
+	state = emit->xcfg.cfg.userdata;
+	assert(state);
+
+	/* if NULL, then use the values stored on the state */
+	if (!bufp)
+		bufp = state->bufp;
+	if (!sizep)
+		sizep = state->sizep;
+
+	/* terminating zero */
+	rc = do_buffer_output(emit, fyewt_terminating_zero, "\0", 1, state);
+	if (rc != 1)
+		goto err_out;
+
+	/* if we are on a fixed buffer don't output */
+	if (state->maxsize > 0 && state->need > state->maxsize)
+		goto err_out;
+
+	state->size = state->need;
+
+	if (state->allocate_buffer) {
+		/* resize */
+		buf = realloc(state->buf, state->size);
+		/* very likely since we shrink the buffer, but make sure we don't error out */
+		if (buf)
+			state->buf = buf;
+	}
+
+	/* retreive the buffer and size */
+	size = state->size;
+	if (size > 0 && state->buf[size-1] == '\0')
+		size--;
+	*sizep = size;
+	*bufp = state->buf;
+
+	/* reset the buffer, ownership now to the caller */
+	state->buf = NULL;
+	state->size = 0;
+	state->pos = 0;
+	state->bufp = NULL;
+	state->sizep = NULL;
+
+	return 0;
+
+err_out:
+	*bufp = NULL;
+	*sizep = 0;
+	return -1;
+}
+
+static int fy_emit_str_internal(struct fy_document *fyd,
+				enum fy_emitter_cfg_flags flags,
+				struct fy_node *fyn, char **bufp, size_t *sizep,
+				bool allocate_buffer)
+{
+	struct fy_emitter *emit = NULL;
+	int rc = -1;
+
+	emit = fy_emitter_create_str_internal(flags, bufp, sizep, allocate_buffer);
+	if (!emit)
+		goto out_err;
+
+	if (fyd) {
+		fy_emit_prepare_document_state(emit, fyd->fyds);
+		rc = 0;
+		if (fyd->root)
+			rc = fy_emit_node_check(emit, fyd->root);
+		if (!rc)
+			rc = fy_emit_document_no_check(emit, fyd);
+	} else {
+		rc = fy_emit_node_check(emit, fyn);
+		if (!rc)
+			rc = fy_emit_node_no_check(emit, fyn);
+	}
+
+	if (rc)
+		goto out_err;
+
+	rc = fy_emitter_collect_str_internal(emit, NULL, NULL);
+	if (rc)
+		goto out_err;
+
+	/* OK, all done */
+
+out_err:
+	fy_emitter_destroy(emit);
+	return rc;
+}
+
+int fy_emit_document_to_buffer(struct fy_document *fyd, enum fy_emitter_cfg_flags flags, char *buf, size_t size)
+{
+	int rc;
+
+	if (!buf)
+		return -1;
+
+	rc = fy_emit_str_internal(fyd, flags, NULL, &buf, &size, false);
+	if (rc != 0)
+		return -1;
+	if ((int)size < 0)
+		return -1;
+	return (int)size;
+}
+
+char *fy_emit_document_to_string(struct fy_document *fyd, enum fy_emitter_cfg_flags flags)
+{
+	char *buf;
+	size_t size;
+	int rc;
+
+	buf = NULL;
+	size = 0;
+	rc = fy_emit_str_internal(fyd, flags, NULL, &buf, &size, true);
+	if (rc != 0)
+		return NULL;
+	return buf;
+}
+
+struct fy_emitter *
+fy_emit_to_buffer(enum fy_emitter_cfg_flags flags, char *buf, size_t size)
+{
+	if (!buf)
+		return NULL;
+
+	return fy_emitter_create_str_internal(flags, &buf, &size, false);
+}
+
+char *
+fy_emit_to_buffer_collect(struct fy_emitter *emit, size_t *sizep)
+{
+	int rc;
+	char *buf;
+
+	if (!emit || !sizep)
+		return NULL;
+
+	rc = fy_emitter_collect_str_internal(emit, &buf, sizep);
+	if (rc) {
+		*sizep = 0;
+		return NULL;
+	}
+	return buf;
+}
+
+struct fy_emitter *
+fy_emit_to_string(enum fy_emitter_cfg_flags flags)
+{
+	return fy_emitter_create_str_internal(flags, NULL, NULL, true);
+}
+
+char *
+fy_emit_to_string_collect(struct fy_emitter *emit, size_t *sizep)
+{
+	int rc;
+	char *buf;
+
+	if (!emit || !sizep)
+		return NULL;
+
+	rc = fy_emitter_collect_str_internal(emit, &buf, sizep);
+	if (rc) {
+		*sizep = 0;
+		return NULL;
+	}
+	return buf;
+}
+
+static int do_file_output(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, int leni, void *userdata)
+{
+	FILE *fp = userdata;
+	size_t len, wrn;
+
+	/* no funky stuff */
+	if (leni < 0)
+		return -1;
+
+	len = (size_t)leni;
+	wrn = fwrite(str, 1, len, fp);
+	return (int)wrn;
+}
+
+int fy_emit_document_to_fp(struct fy_document *fyd, enum fy_emitter_cfg_flags flags,
+			   FILE *fp)
+{
+	struct fy_emitter emit_state, *emit = &emit_state;
+	struct fy_emitter_cfg emit_cfg;
+	int rc;
+
+	/* we don't allow an extended configuration */
+	if (!fp || (flags & FYECF_EXTENDED_CFG))
+		return -1;
+
+	memset(&emit_cfg, 0, sizeof(emit_cfg));
+	emit_cfg.output = do_file_output;
+	emit_cfg.userdata = fp;
+	emit_cfg.flags = flags;
+	fy_emit_setup(emit, &emit_cfg);
+
+	fy_emit_prepare_document_state(emit, fyd->fyds);
+
+	rc = 0;
+	if (fyd->root)
+		rc = fy_emit_node_check(emit, fyd->root);
+
+	rc = fy_emit_document_no_check(emit, fyd);
+
+	fy_emit_cleanup(emit);
+
+	return rc ? rc : 0;
+}
+
+int fy_emit_document_to_file(struct fy_document *fyd,
+			     enum fy_emitter_cfg_flags flags,
+			     const char *filename)
+{
+	FILE *fp;
+	int rc;
+
+	fp = filename ? fopen(filename, "wa") : stdout;
+	if (!fp)
+		return -1;
+
+	rc = fy_emit_document_to_fp(fyd, flags, fp);
+
+	if (fp != stdout)
+		fclose(fp);
+
+	return rc ? rc : 0;
+}
+
+static int do_fd_output(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, int leni, void *userdata)
+{
+	size_t len;
+	int fd;
+	ssize_t wrn;
+	int total;
+
+	len = (size_t)leni;
+
+	/* no funky stuff */
+	if (len < 0)
+		return -1;
+
+	/* get the file descriptor */
+	fd = (int)(uintptr_t)userdata;
+	if (fd < 0)
+		return -1;
+
+	/* loop output to fd */
+	total = 0;
+	while (len > 0) {
+
+		do {
+			wrn = write(fd, str, len);
+		} while (wrn == -1 && errno == EAGAIN);
+
+		if (wrn == -1)
+			return -1;
+
+		if (wrn == 0)
+			return total;
+
+		len -= wrn;
+		str += wrn;
+		total += (int)wrn;
+	}
+
+	return total;
+}
+
+int fy_emit_document_to_fd(struct fy_document *fyd, enum fy_emitter_cfg_flags flags, int fd)
+{
+	struct fy_emitter emit_state, *emit = &emit_state;
+	struct fy_emitter_cfg emit_cfg;
+	int rc;
+
+	if (fd < 0 || (flags & FYECF_EXTENDED_CFG))
+		return -1;
+
+	memset(&emit_cfg, 0, sizeof(emit_cfg));
+	emit_cfg.output = do_fd_output;
+	emit_cfg.userdata = (void *)(uintptr_t)fd;
+	emit_cfg.flags = flags;
+	fy_emit_setup(emit, &emit_cfg);
+
+	fy_emit_prepare_document_state(emit, fyd->fyds);
+
+	rc = 0;
+	if (fyd->root)
+		rc = fy_emit_node_check(emit, fyd->root);
+
+	rc = fy_emit_document_no_check(emit, fyd);
+
+	fy_emit_cleanup(emit);
+
+	return rc ? rc : 0;
+}
+
+int fy_emit_node_to_buffer(struct fy_node *fyn, enum fy_emitter_cfg_flags flags, char *buf, size_t size)
+{
+	int rc;
+
+	rc = fy_emit_str_internal(NULL, flags, fyn, &buf, &size, false);
+	if (rc != 0)
+		return -1;
+	return (int)size;
+}
+
+char *fy_emit_node_to_string(struct fy_node *fyn, enum fy_emitter_cfg_flags flags)
+{
+	char *buf;
+	size_t size;
+	int rc;
+
+	buf = NULL;
+	size = 0;
+	rc = fy_emit_str_internal(NULL, flags, fyn, &buf, &size, true);
+	if (rc != 0)
+		return NULL;
+	return buf;
+}
+
+/* we can consume events only if the lookaheads
+ * are satisfied. The lookaheads depends on the
+ * styling mode. Some styling modes do not require
+ * a lookahead at all but we do it anyway.
+ */
+static bool fy_emit_ready(struct fy_emitter *emit)
+{
+	struct fy_eventp *fyep;
+	int need, count;
+
+	/* When the head event starts a flow collection in ORIGINAL mode,
+	 * buffer events on the same source line so that oneline_flow
+	 * detection can compare start/end line marks before the prolog
+	 * runs.  We only buffer events that share the start token's line;
+	 * as soon as an event is on a different line we know the collection
+	 * is multi-line and can proceed immediately.  This keeps the buffer
+	 * bounded to a single line's worth of events rather than the
+	 * entire collection.
+	 */
+	fyep = fy_eventp_list_head(&emit->queued_events);
+	if (fyep && fy_emit_preserve_flow_layout(emit)) {
+		struct fy_token *start_token = NULL;
+		const struct fy_mark *sm;
+
+		if (fyep->e.type == FYET_SEQUENCE_START)
+			start_token = fyep->e.sequence_start.sequence_start;
+		else if (fyep->e.type == FYET_MAPPING_START)
+			start_token = fyep->e.mapping_start.mapping_start;
+
+		/* Only buffer when we have a flow start token with valid
+		 * source marks (skip synthetic events with 0:0:0 marks) */
+		sm = start_token ? fy_token_start_mark(start_token) : NULL;
+
+		if (start_token &&
+		    (start_token->type == FYTT_FLOW_SEQUENCE_START ||
+		     start_token->type == FYTT_FLOW_MAPPING_START) &&
+		    sm && !(sm->line == 0 && sm->column == 0 && sm->input_pos == 0)) {
+			int depth = 0;
+
+			sm = fy_token_start_mark(start_token);
+
+			/* Skip buffering for synthetic events (no source info) */
+			if (!sm || (sm->line == 0 && sm->column == 0 && sm->input_pos == 0))
+				goto normal;
+
+			for (fyep = fy_eventp_list_head(&emit->queued_events); fyep;
+					fyep = fy_eventp_next(&emit->queued_events, fyep)) {
+
+				switch (fyep->e.type) {
+				case FYET_SEQUENCE_START:
+				case FYET_MAPPING_START:
+					depth++;
+					break;
+				case FYET_SEQUENCE_END:
+				case FYET_MAPPING_END:
+					if (--depth == 0)
+						return true;
+					break;
+				default:
+					break;
+				}
+
+				/* If any event is on a different line, the
+				 * collection is multi-line — stop buffering */
+				if (depth > 0) {
+					struct fy_token *et = fy_event_get_token(&fyep->e);
+					const struct fy_mark *em = et ? fy_token_start_mark(et) : NULL;
+
+					if (em && em->line != sm->line)
+						return true;
+				}
+			}
+			return false;
+		}
+	}
+normal:
+
+	count = 0;
+	need = -1;
+	for (fyep = fy_eventp_list_head(&emit->queued_events); fyep;
+			fyep = fy_eventp_next(&emit->queued_events, fyep)) {
+
+		count++;
+		switch (fyep->e.type) {
+		case FYET_DOCUMENT_START:
+			need++;
+			break;
+
+		case FYET_SEQUENCE_START:
+			if (need < 0)
+				need = 2;
+			break;
+
+		case FYET_MAPPING_START:
+			if (need < 0)
+				need = 2;
+			break;
+
+		default:
+			need = 0;
+			break;
+		}
+
+		if (count >= need)
+			return true;
+
+	}
+
+	return false;
+}
+
+extern const char *fy_event_type_txt[];
+
+const char *fy_emitter_state_txt[] = {
+	[FYES_NONE]			= "NONE",
+	[FYES_STREAM_START]		= "STREAM_START",
+	[FYES_FIRST_DOCUMENT_START]	= "FIRST_DOCUMENT_START",
+	[FYES_DOCUMENT_START]		= "DOCUMENT_START",
+	[FYES_DOCUMENT_CONTENT]		= "DOCUMENT_CONTENT",
+	[FYES_DOCUMENT_END]		= "DOCUMENT_END",
+	[FYES_SEQUENCE_FIRST_ITEM]	= "SEQUENCE_FIRST_ITEM",
+	[FYES_SEQUENCE_ITEM]		= "SEQUENCE_ITEM",
+	[FYES_MAPPING_FIRST_KEY]	= "MAPPING_FIRST_KEY",
+	[FYES_MAPPING_KEY]		= "MAPPING_KEY",
+	[FYES_MAPPING_SIMPLE_VALUE]	= "MAPPING_SIMPLE_VALUE",
+	[FYES_MAPPING_VALUE]		= "MAPPING_VALUE",
+	[FYES_END]			= "END",
+};
+
+struct fy_eventp *
+fy_emit_next_event(struct fy_emitter *emit)
+{
+	if (!fy_emit_ready(emit))
+		return NULL;
+
+	return fy_eventp_list_pop(&emit->queued_events);
+}
+
+struct fy_eventp *
+fy_emit_peek_next_event(struct fy_emitter *emit)
+{
+	return fy_eventp_list_head(&emit->queued_events);
+}
+
+bool fy_emit_streaming_sequence_empty(struct fy_emitter *emit)
+{
+	struct fy_eventp *fyepn;
+
+	fyepn = fy_emit_peek_next_event(emit);
+
+	/* should never happen, check on debugging mode */
+	assert(fyepn);
+	if (!fyepn)
+		return false;
+
+	return fyepn->e.type == FYET_SEQUENCE_END;
+}
+
+bool fy_emit_streaming_mapping_empty(struct fy_emitter *emit)
+{
+	struct fy_eventp *fyepn;
+
+	fyepn = fy_emit_peek_next_event(emit);
+
+	/* should never happen, check on debugging mode */
+	assert(fyepn);
+	if (!fyepn)
+		return false;
+
+	return fyepn->e.type == FYET_MAPPING_END;
+}
+
+/* Scan queued events to determine if a flow collection fits on one line.
+ * Called after the START event has been popped; the queue begins with the
+ * first child event.  We track nesting depth to find the matching END.
+ * Returns true when start and end tokens are on the same source line.
+ * Returns false for synthetic events (marks at 0:0:0) which have no
+ * meaningful source position.
+ */
+static bool fy_emit_streaming_flow_oneline(struct fy_emitter *emit,
+					   struct fy_token *start_token)
+{
+	struct fy_eventp *fyep;
+	const struct fy_mark *sm, *em;
+	struct fy_token *end_token;
+	int depth = 1;
+
+	sm = fy_token_start_mark(start_token);
+	if (!sm || (sm->line == 0 && sm->column == 0 && sm->input_pos == 0))
+		return false;
+
+	for (fyep = fy_eventp_list_head(&emit->queued_events); fyep;
+			fyep = fy_eventp_next(&emit->queued_events, fyep)) {
+
+		switch (fyep->e.type) {
+		case FYET_SEQUENCE_START:
+		case FYET_MAPPING_START:
+			depth++;
+			break;
+		case FYET_SEQUENCE_END:
+			if (--depth == 0) {
+				end_token = fyep->e.sequence_end.sequence_end;
+				em = fy_token_end_mark(end_token);
+				return em && sm->line == em->line;
+			}
+			break;
+		case FYET_MAPPING_END:
+			if (--depth == 0) {
+				end_token = fyep->e.mapping_end.mapping_end;
+				em = fy_token_end_mark(end_token);
+				return em && sm->line == em->line;
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	return false;
+}
+
+static void fy_emit_goto_state(struct fy_emitter *emit, enum fy_emitter_state state)
+{
+	if (emit->state == state)
+		return;
+
+	emit->state = state;
+}
+
+static int fy_emit_push_state(struct fy_emitter *emit, enum fy_emitter_state state)
+{
+	enum fy_emitter_state *states;
+
+	if (emit->state_stack_top >= emit->state_stack_alloc) {
+		states = realloc(emit->state_stack == emit->state_stack_inplace ? NULL : emit->state_stack,
+				sizeof(emit->state_stack[0]) * emit->state_stack_alloc * 2);
+		if (!states)
+			return -1;
+
+		if (emit->state_stack == emit->state_stack_inplace)
+			memcpy(states, emit->state_stack, sizeof(emit->state_stack[0]) * emit->state_stack_top);
+		emit->state_stack = states;
+		emit->state_stack_alloc *= 2;
+	}
+	emit->state_stack[emit->state_stack_top++] = state;
+
+	return 0;
+}
+
+enum fy_emitter_state fy_emit_pop_state(struct fy_emitter *emit)
+{
+	if (!emit->state_stack_top)
+		return FYES_NONE;
+
+	return emit->state_stack[--emit->state_stack_top];
+}
+
+int fy_emit_push_sc(struct fy_emitter *emit, struct fy_emit_save_ctx *sc)
+{
+	struct fy_emit_save_ctx *scs;
+
+	if (emit->sc_stack_top >= emit->sc_stack_alloc) {
+		scs = realloc(emit->sc_stack == emit->sc_stack_inplace ? NULL : emit->sc_stack,
+				sizeof(emit->sc_stack[0]) * emit->sc_stack_alloc * 2);
+		if (!scs)
+			return -1;
+
+		if (emit->sc_stack == emit->sc_stack_inplace)
+			memcpy(scs, emit->sc_stack, sizeof(emit->sc_stack[0]) * emit->sc_stack_top);
+		emit->sc_stack = scs;
+		emit->sc_stack_alloc *= 2;
+	}
+	emit->sc_stack[emit->sc_stack_top++] = *sc;
+
+	return 0;
+}
+
+int fy_emit_pop_sc(struct fy_emitter *emit, struct fy_emit_save_ctx *sc)
+{
+	if (!emit->sc_stack_top)
+		return -1;
+
+	*sc = emit->sc_stack[--emit->sc_stack_top];
+
+	return 0;
+}
+
+static int fy_emit_streaming_node(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep, int flags)
+{
+	struct fy_event *fye = &fyep->e;
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+	enum fy_node_style style, xstyle;
+	int ret, s_flags, s_indent;
+
+	/* force collections after --- to start at a new line */
+	if (!fy_emit_is_oneline(emit) &&
+			fye->type != FYET_ALIAS && fye->type != FYET_SCALAR &&
+			(emit->s_flags & DDNF_ROOT) && emit->column != 0) {
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	emit->s_flags = flags;
+
+	switch (fye->type) {
+	case FYET_ALIAS:
+		fy_emit_token_write_alias(emit, fye->alias.anchor, emit->s_flags, emit->s_indent);
+		fy_emit_goto_state(emit, fy_emit_pop_state(emit));
+		break;
+
+	case FYET_SCALAR:
+		/* if we're pretty and at column 0 (meaning it's a single scalar document) output --- */
+		if ((emit->s_flags & DDNF_ROOT) && fy_emit_is_pretty_mode(emit) && !emit->column &&
+				!fy_emit_is_flow_mode(emit) && !(emit->s_flags & DDNF_FLOW)) {
+			fy_emit_document_start_indicator(emit);
+			emit->fyds->started_explicit = true;
+		}
+		fy_emit_common_node_preamble(emit, fye->scalar.value, fye->scalar.anchor, fye->scalar.tag, emit->s_flags, emit->s_indent);
+		style = fye->scalar.value ?
+				fy_node_style_from_scalar_style(fye->scalar.value->scalar.style) :
+				FYNS_PLAIN;
+		fy_emit_token_scalar(emit, fye->scalar.value, emit->s_flags, emit->s_indent, style, fye->scalar.tag);
+		fy_emit_goto_state(emit, fy_emit_pop_state(emit));
+		break;
+
+	case FYET_SEQUENCE_START:
+
+		/* save this context */
+		ret = fy_emit_push_sc(emit, sc);
+		if (ret)
+			return ret;
+
+		s_flags = emit->s_flags;
+		s_indent = emit->s_indent;
+
+		if (fye->sequence_start.sequence_start)
+			xstyle = fye->sequence_start.sequence_start->type == FYTT_BLOCK_SEQUENCE_START ?
+				FYNS_BLOCK : FYNS_FLOW;
+		else
+			xstyle = FYNS_ANY;
+
+		fy_emit_common_node_preamble(emit, fye->sequence_start.sequence_start,
+					     fye->sequence_start.anchor, fye->sequence_start.tag,
+					     emit->s_flags, emit->s_indent);
+
+		/* create new context */
+		memset(sc, 0, sizeof(*sc));
+		sc->flags = emit->s_flags & (DDNF_ROOT | DDNF_SEQ | DDNF_MAP);
+		sc->indent = emit->s_indent;
+		sc->empty = fy_emit_streaming_sequence_empty(emit);
+		sc->flow_token = xstyle == FYNS_FLOW;
+		if (sc->flow_token && fy_emit_preserve_flow_layout(emit))
+			sc->oneline_flow = fy_emit_streaming_flow_oneline(emit,
+					fye->sequence_start.sequence_start);
+		sc->flow = !!(s_flags & DDNF_FLOW);
+		sc->xstyle = xstyle;
+		sc->old_indent = sc->indent;
+		sc->s_flags = s_flags;
+		sc->s_indent = s_indent;
+
+		fy_emit_sequence_prolog(emit, sc, fye->sequence_start.sequence_start);
+		sc->flags &= ~DDNF_MAP;
+		sc->flags |= DDNF_SEQ;
+
+		emit->s_flags = sc->flags;
+		emit->s_indent = sc->indent;
+
+		fy_emit_goto_state(emit, FYES_SEQUENCE_FIRST_ITEM);
+		break;
+
+	case FYET_MAPPING_START:
+		/* save this context */
+		ret = fy_emit_push_sc(emit, sc);
+		if (ret)
+			return ret;
+
+		s_flags = emit->s_flags;
+		s_indent = emit->s_indent;
+
+		if (fye->mapping_start.mapping_start)
+			xstyle = fye->mapping_start.mapping_start->type == FYTT_BLOCK_MAPPING_START ?
+				FYNS_BLOCK : FYNS_FLOW;
+		else
+			xstyle = FYNS_ANY;
+
+		fy_emit_common_node_preamble(emit, fye->mapping_start.mapping_start,
+					     fye->mapping_start.anchor, fye->mapping_start.tag,
+					     emit->s_flags, emit->s_indent);
+
+		/* create new context */
+		memset(sc, 0, sizeof(*sc));
+		sc->flags = emit->s_flags & (DDNF_ROOT | DDNF_SEQ | DDNF_MAP);
+		sc->indent = emit->s_indent;
+		sc->empty = fy_emit_streaming_mapping_empty(emit);
+		sc->flow_token = xstyle == FYNS_FLOW;
+		if (sc->flow_token && fy_emit_preserve_flow_layout(emit))
+			sc->oneline_flow = fy_emit_streaming_flow_oneline(emit,
+					fye->mapping_start.mapping_start);
+		sc->flow = !!(s_flags & DDNF_FLOW);
+		sc->xstyle = xstyle;
+		sc->old_indent = sc->indent;
+		sc->s_flags = s_flags;
+		sc->s_indent = s_indent;
+
+		fy_emit_mapping_prolog(emit, sc, fye->mapping_start.mapping_start);
+		sc->flags &= ~DDNF_SEQ;
+		sc->flags |= DDNF_MAP;
+
+		emit->s_flags = sc->flags;
+		emit->s_indent = sc->indent;
+
+		fy_emit_goto_state(emit, FYES_MAPPING_FIRST_KEY);
+		break;
+
+	default:
+		fy_error(emit->diag, "%s: expected ALIAS|SCALAR|SEQUENCE_START|MAPPING_START", __func__);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int fy_emit_handle_stream_start(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_event *fye = &fyep->e;
+
+	if (fye->type != FYET_STREAM_START) {
+		fy_error(emit->diag, "%s: expected FYET_STREAM_START", __func__);
+		return -1;
+	}
+
+	fy_document_state_unref(emit->fyds);
+	emit->fyds = NULL;
+
+	fy_emit_reset(emit, false);
+
+	fy_emit_goto_state(emit, FYES_FIRST_DOCUMENT_START);
+
+	return 0;
+}
+
+static int fy_emit_handle_document_start(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep, bool first)
+{
+	struct fy_event *fye = &fyep->e;
+	struct fy_document_state *fyds;
+
+	if (fye->type != FYET_DOCUMENT_START &&
+	    fye->type != FYET_STREAM_END) {
+		fy_error(emit->diag, "%s: expected FYET_DOCUMENT_START|FYET_STREAM_END", __func__);
+		return -1;
+	}
+
+	if (fye->type == FYET_STREAM_END) {
+		fy_emit_goto_state(emit, FYES_END);
+		return 0;
+	}
+
+	/* transfer ownership to the emitter */
+	fyds = fye->document_start.document_state;
+	// fye->document_start.document_state = NULL;
+
+	/* prepare (i.e. adapt to the document state) */
+	fy_emit_prepare_document_state(emit, fyds);
+
+	fy_emit_common_document_start(emit, fyds, false);
+
+	fy_emit_goto_state(emit, FYES_DOCUMENT_CONTENT);
+
+	return 0;
+}
+
+static int fy_emit_handle_document_end(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_event *fye = &fyep->e;
+	int ret;
+
+	if (fye->type != FYET_DOCUMENT_END) {
+		fy_error(emit->diag, "%s: expected FYET_DOCUMENT_END", __func__);
+		return -1;
+	}
+
+	ret = fy_emit_common_document_end(emit, true, fye->document_end.implicit);
+	if (ret)
+		return ret;
+
+	fy_emit_reset(emit, false);
+	fy_emit_goto_state(emit, FYES_DOCUMENT_START);
+	emit->flags |= FYEF_HAD_DOCUMENT_END_OUTPUT;
+	return 0;
+}
+
+static int fy_emit_handle_document_content(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_event *fye = &fyep->e;
+	int ret;
+
+	/* empty document? */
+	if (fye->type == FYET_DOCUMENT_END)
+		return fy_emit_handle_document_end(emit, fyp, fyep);
+
+	ret = fy_emit_push_state(emit, FYES_DOCUMENT_END);
+	if (ret)
+		return ret;
+
+	return fy_emit_streaming_node(emit, fyp, fyep, DDNF_ROOT);
+}
+
+static int fy_emit_handle_sequence_item(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep, bool first)
+{
+	struct fy_event *fye = &fyep->e;
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+	struct fy_token *fyt_item = NULL;
+	int ret;
+
+	switch (fye->type) {
+	case FYET_SEQUENCE_END:
+		fy_emit_sequence_item_epilog(emit, sc, true, sc->fyt_last_value);
+
+		fy_emit_token_unref(emit, fyp, sc->fyt_last_value);
+		sc->fyt_last_value = NULL;
+
+		/* emit epilog */
+		fy_emit_sequence_epilog(emit, sc);
+
+		/* restore indent and flags */
+		emit->s_indent = sc->s_indent;
+		emit->s_flags = sc->s_flags;
+
+		/* pop state */
+		ret = fy_emit_pop_sc(emit, sc);
+		assert(!ret);
+
+		/* pop state */
+		fy_emit_goto_state(emit, fy_emit_pop_state(emit));
+		return ret;
+
+	case FYET_ALIAS:
+		fyt_item = fye->alias.anchor;
+		break;
+	case FYET_SCALAR:
+		fyt_item = fye->scalar.value;
+		break;
+	case FYET_SEQUENCE_START:
+		fyt_item = fye->sequence_start.sequence_start;
+		break;
+	case FYET_MAPPING_START:
+		fyt_item = fye->mapping_start.mapping_start;
+		break;
+	default:
+		fy_error(emit->diag, "%s: expected SEQUENCE_END|ALIAS|SCALAR|SEQUENCE_START|MAPPING_START", __func__);
+		return -1;
+	}
+
+	if (!first)
+		fy_emit_sequence_item_epilog(emit, sc, false, sc->fyt_last_value);
+	fy_emit_token_unref(emit, fyp, sc->fyt_last_value);
+	sc->fyt_last_value = NULL;
+
+	ret = fy_emit_push_state(emit, FYES_SEQUENCE_ITEM);
+	if (ret)
+		return ret;
+
+	/* reset indent and flags for each item */
+	emit->s_indent = sc->indent;
+	emit->s_flags = sc->flags;
+
+	sc->fyt_last_value = fyt_item;
+
+	fy_emit_sequence_item_prolog(emit, sc, fyt_item);
+
+	ret = fy_emit_streaming_node(emit, fyp, fyep, sc->flags);
+
+	switch (fye->type) {
+	case FYET_ALIAS:
+		fye->alias.anchor = NULL;	/* take ownership */
+		break;
+	case FYET_SCALAR:
+		fye->scalar.value = NULL;	/* take ownership */
+		break;
+	case FYET_SEQUENCE_START:
+		fye->sequence_start.sequence_start = NULL;	/* take ownership */
+		break;
+	case FYET_MAPPING_START:
+		fye->mapping_start.mapping_start = NULL;	/* take ownership */
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+static int fy_emit_handle_mapping_key(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep, bool first)
+{
+	struct fy_event *fye = &fyep->e;
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+	struct fy_token *fyt_key = NULL;
+	const struct fy_token_analysis *ta;
+	int ret;
+	bool simple_key;
+
+	simple_key = false;
+
+	switch (fye->type) {
+	case FYET_MAPPING_END:
+		fy_emit_mapping_value_epilog(emit, sc, true, sc->fyt_last_value);
+
+		/* emit epilog */
+		fy_emit_mapping_epilog(emit, sc);
+
+		fy_emit_token_unref(emit, fyp, sc->fyt_last_key);
+		sc->fyt_last_key = NULL;
+		fy_emit_token_unref(emit, fyp, sc->fyt_last_value);
+		sc->fyt_last_value = NULL;
+
+		/* restore indent and flags */
+		emit->s_indent = sc->s_indent;
+		emit->s_flags = sc->s_flags;
+
+		/* pop state */
+		ret = fy_emit_pop_sc(emit, sc);
+		assert(!ret);
+
+		/* pop state */
+		fy_emit_goto_state(emit, fy_emit_pop_state(emit));
+		return ret;
+
+	case FYET_ALIAS:
+		fyt_key = fye->alias.anchor;
+		simple_key = true;
+		break;
+	case FYET_SCALAR:
+		fyt_key = fye->scalar.value;
+		ta = fy_token_text_analyze(fyt_key);
+		simple_key = !!(ta->flags & FYTTAF_CAN_BE_SIMPLE_KEY);
+		break;
+	case FYET_SEQUENCE_START:
+		fyt_key = fye->sequence_start.sequence_start;
+		simple_key = fy_emit_streaming_sequence_empty(emit);
+		break;
+	case FYET_MAPPING_START:
+		fyt_key = fye->mapping_start.mapping_start;
+		simple_key = fy_emit_streaming_mapping_empty(emit);
+		break;
+	default:
+		fy_error(emit->diag, "%s: expected MAPPING_END|ALIAS|SCALAR|SEQUENCE_START|MAPPING_START", __func__);
+		return -1;
+	}
+
+	ret = fy_emit_push_state(emit, FYES_MAPPING_VALUE);
+	if (ret)
+		return ret;
+
+	/* reset indent and flags for each key/value pair */
+	emit->s_indent = sc->indent;
+	emit->s_flags = sc->flags;
+
+	if (!first)
+		fy_emit_mapping_value_epilog(emit, sc, false, sc->fyt_last_value);
+
+	fy_emit_token_unref(emit, fyp, sc->fyt_last_key);
+	sc->fyt_last_key = NULL;
+	fy_emit_token_unref(emit, fyp, sc->fyt_last_value);
+	sc->fyt_last_value = NULL;
+
+	sc->fyt_last_key = fyt_key;
+
+	fy_emit_mapping_key_prolog(emit, sc, fyt_key, simple_key);
+
+	ret = fy_emit_streaming_node(emit, fyp, fyep, sc->flags);
+
+	switch (fye->type) {
+	case FYET_ALIAS:
+		fye->alias.anchor = NULL;	/* take ownership */
+		break;
+	case FYET_SCALAR:
+		fye->scalar.value = NULL;	/* take ownership */
+		break;
+	case FYET_SEQUENCE_START:
+		fye->sequence_start.sequence_start = NULL;	/* take ownership */
+		break;
+	case FYET_MAPPING_START:
+		fye->mapping_start.mapping_start = NULL;	/* take ownership */
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+static int fy_emit_handle_mapping_value(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_eventp *fyep, bool simple)
+{
+	struct fy_event *fye = &fyep->e;
+	struct fy_emit_save_ctx *sc = &emit->s_sc;
+	struct fy_token *fyt_value = NULL;
+	int ret;
+
+	switch (fye->type) {
+	case FYET_ALIAS:
+		fyt_value = fye->alias.anchor;
+		break;
+	case FYET_SCALAR:
+		fyt_value = fye->scalar.value;	/* take ownership */
+		break;
+	case FYET_SEQUENCE_START:
+		fyt_value = fye->sequence_start.sequence_start;
+		break;
+	case FYET_MAPPING_START:
+		fyt_value = fye->mapping_start.mapping_start;
+		break;
+	default:
+		fy_error(emit->diag, "%s: expected ALIAS|SCALAR|SEQUENCE_START|MAPPING_START", __func__);
+		return -1;
+	}
+
+	ret = fy_emit_push_state(emit, FYES_MAPPING_KEY);
+	if (ret)
+		return ret;
+
+	fy_emit_mapping_key_epilog(emit, sc, sc->fyt_last_key);
+
+	sc->fyt_last_value = fyt_value;
+
+	fy_emit_mapping_value_prolog(emit, sc, fyt_value);
+
+	ret = fy_emit_streaming_node(emit, fyp, fyep, sc->flags);
+
+	switch (fye->type) {
+	case FYET_ALIAS:
+		fye->alias.anchor = NULL;	/* take ownership */
+		break;
+	case FYET_SCALAR:
+		fye->scalar.value = NULL;	/* take ownership */
+		break;
+	case FYET_SEQUENCE_START:
+		fye->sequence_start.sequence_start = NULL;	/* take ownership */
+		break;
+	case FYET_MAPPING_START:
+		fye->mapping_start.mapping_start = NULL;	/* take ownership */
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
+int fy_emit_event_from_parser(struct fy_emitter *emit, struct fy_parser *fyp, struct fy_event *fye)
+{
+	struct fy_eventp *fyep;
+	int ret;
+
+	if (!emit || !fye)
+		return -1;
+
+	/* we're using the raw emitter interface, now mark first state */
+	if (emit->state == FYES_NONE)
+		emit->state = FYES_STREAM_START;
+
+	/* handle reset (parser error recovery) */
+	if (fye->type == FYET_STREAM_START && emit->state != FYES_STREAM_START) {
+		if (emit->column != 0)
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		fy_emit_puts_simple(emit, fyewt_document_indicator, "...");
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->state = FYES_STREAM_START;
+	}
+
+	fyep = container_of(fye, struct fy_eventp, e);
+
+	fy_eventp_list_add_tail(&emit->queued_events, fyep);
+
+	ret = 0;
+	while ((fyep = fy_emit_next_event(emit)) != NULL) {
+
+		switch (emit->state) {
+		case FYES_STREAM_START:
+			ret = fy_emit_handle_stream_start(emit, fyp, fyep);
+			break;
+
+		case FYES_FIRST_DOCUMENT_START:
+		case FYES_DOCUMENT_START:
+			ret = fy_emit_handle_document_start(emit, fyp, fyep,
+					emit->state == FYES_FIRST_DOCUMENT_START);
+			break;
+
+		case FYES_DOCUMENT_CONTENT:
+			ret = fy_emit_handle_document_content(emit, fyp, fyep);
+			break;
+
+		case FYES_DOCUMENT_END:
+			ret = fy_emit_handle_document_end(emit, fyp, fyep);
+			break;
+
+		case FYES_SEQUENCE_FIRST_ITEM:
+		case FYES_SEQUENCE_ITEM:
+			ret = fy_emit_handle_sequence_item(emit, fyp, fyep,
+					emit->state == FYES_SEQUENCE_FIRST_ITEM);
+			break;
+
+		case FYES_MAPPING_FIRST_KEY:
+		case FYES_MAPPING_KEY:
+			ret = fy_emit_handle_mapping_key(emit, fyp, fyep,
+					emit->state == FYES_MAPPING_FIRST_KEY);
+			break;
+
+		case FYES_MAPPING_SIMPLE_VALUE:
+		case FYES_MAPPING_VALUE:
+			ret = fy_emit_handle_mapping_value(emit, fyp, fyep,
+					emit->state == FYES_MAPPING_SIMPLE_VALUE);
+			break;
+
+		case FYES_END:
+			ret = -1;
+			break;
+
+		default:
+			assert(1);      /* Invalid state. */
+		}
+
+		/* always release the event */
+		if (!fyp)
+			fy_eventp_release(fyep);
+		else
+			fy_parse_eventp_recycle(fyp, fyep);
+
+		if (ret)
+			break;
+	}
+
+	return ret;
+}
+
+int fy_emit_event(struct fy_emitter *emit, struct fy_event *fye)
+{
+	return fy_emit_event_from_parser(emit, NULL, fye);
+}
+
+struct fy_document_state *
+fy_emitter_get_document_state(struct fy_emitter *emit)
+{
+	return emit ? emit->fyds : NULL;
+}
+
+/* ANSI colors and escapes */
+#define A_RESET			"\x1b[0m"
+#define A_BLACK			"\x1b[30m"
+#define A_RED			"\x1b[31m"
+#define A_GREEN			"\x1b[32m"
+#define A_YELLOW		"\x1b[33m"
+#define A_BLUE			"\x1b[34m"
+#define A_MAGENTA		"\x1b[35m"
+#define A_CYAN			"\x1b[36m"
+#define A_LIGHT_GRAY		"\x1b[37m"	/* dark white is gray */
+#define A_GRAY			"\x1b[1;30m"
+#define A_BRIGHT_RED		"\x1b[1;31m"
+#define A_BRIGHT_GREEN		"\x1b[1;32m"
+#define A_BRIGHT_YELLOW		"\x1b[1;33m"
+#define A_BRIGHT_BLUE		"\x1b[1;34m"
+#define A_BRIGHT_MAGENTA	"\x1b[1;35m"
+#define A_BRIGHT_CYAN		"\x1b[1;36m"
+#define A_WHITE			"\x1b[1;37m"
+
+static const char *default_colors[FYEWT_COUNT] = {
+	[fyewt_document_indicator] 		= A_CYAN,
+	[fyewt_tag_directive]			= A_YELLOW,
+	[fyewt_version_directive]		= A_YELLOW,
+	[fyewt_indent]				= A_GREEN,	// when visible only
+	[fyewt_indicator]			= A_YELLOW,	// in extended mode we produce more
+	[fyewt_whitespace]			= A_GREEN,	// when visible only
+	[fyewt_plain_scalar]			= A_WHITE,
+	[fyewt_single_quoted_scalar]		= A_YELLOW,
+	[fyewt_double_quoted_scalar]		= A_YELLOW,
+	[fyewt_literal_scalar]			= A_YELLOW,
+	[fyewt_folded_scalar]			= A_YELLOW,
+	[fyewt_anchor]				= A_BRIGHT_GREEN,
+	[fyewt_tag]				= A_BRIGHT_GREEN,
+	[fyewt_linebreak]			= A_GREEN,	// when visible only
+	[fyewt_alias]				= A_BRIGHT_GREEN,
+	[fyewt_terminating_zero]		= A_BRIGHT_RED,	// when visible only
+	[fyewt_plain_scalar_key]		= A_BRIGHT_CYAN,
+	[fyewt_single_quoted_scalar_key]	= A_BRIGHT_CYAN,
+	[fyewt_double_quoted_scalar_key]	= A_BRIGHT_CYAN,
+	[fyewt_comment]				= A_BRIGHT_BLUE,
+	// extended
+	[fyewt_indicator_question_mark]		= A_MAGENTA,
+	[fyewt_indicator_colon]			= A_MAGENTA,
+	[fyewt_indicator_dash]			= A_MAGENTA,
+	[fyewt_indicator_left_bracket]		= A_MAGENTA,
+	[fyewt_indicator_right_bracket]		= A_MAGENTA,
+	[fyewt_indicator_left_brace]		= A_MAGENTA,
+	[fyewt_indicator_right_brace]		= A_MAGENTA,
+	[fyewt_indicator_comma]			= A_MAGENTA,
+	[fyewt_indicator_bar]			= A_MAGENTA,
+	[fyewt_indicator_greater]		= A_MAGENTA,
+	[fyewt_indicator_single_quote_start]	= A_YELLOW,
+	[fyewt_indicator_single_quote_end]	= A_YELLOW,
+	[fyewt_indicator_double_quote_start]	= A_YELLOW,
+	[fyewt_indicator_double_quote_end]	= A_YELLOW,
+	[fyewt_indicator_ambersand]		= A_BRIGHT_GREEN,
+	[fyewt_indicator_star]			= A_MAGENTA,
+	[fyewt_indicator_chomp]			= A_MAGENTA,
+	[fyewt_indicator_explicit_indent]	= A_MAGENTA,
+};
+
+static void fy_emitter_fill_default_colors(struct fy_emitter *fye)
+{
+	unsigned int i;
+
+	for (i = 0; i < FYEWT_COUNT; i++) {
+		if (!fye->xcfg.colors[i])
+			fye->xcfg.colors[i] = default_colors[i];
+	}
+}
+
+static FILE *fy_emitter_get_output_fp(struct fy_emitter *fye)
+{
+	switch (fye->xcfg.xflags & (FYEXCF_OUTPUT_MASK << FYEXCF_OUTPUT_SHIFT)) {
+	case FYEXCF_OUTPUT_STDOUT:
+		return stdout;
+	case FYEXCF_OUTPUT_STDERR:
+		return stderr;
+	case FYEXCF_OUTPUT_FILE:
+		return fye->xcfg.output_fp;
+	case FYEXCF_OUTPUT_FILENAME:
+		if (!fye->owned_output_fp && fye->xcfg.output_filename)
+			fye->owned_output_fp = fopen(fye->xcfg.output_filename, "wb");
+		return fye->owned_output_fp;
+	default:
+		break;
+	}
+	return NULL;
+}
+
+static int fy_emitter_get_output_fd(struct fy_emitter *fye)
+{
+	switch (fye->xcfg.xflags & (FYEXCF_OUTPUT_MASK << FYEXCF_OUTPUT_SHIFT)) {
+	case FYEXCF_OUTPUT_STDOUT:
+		return STDOUT_FILENO;
+	case FYEXCF_OUTPUT_STDERR:
+		return STDERR_FILENO;
+	case FYEXCF_OUTPUT_FD:
+		return fye->xcfg.output_fd;
+	default:
+		break;
+	}
+	return -1;
+}
+
+
+static int fy_emitter_null_output(struct fy_emitter *fye, enum fy_emitter_write_type type, const char *str, int len, void *userdata)
+{
+	return len;
+}
+
+static inline ssize_t raw_default_output(FILE *fp, int fd, const char *data, size_t len)
+{
+	ssize_t wrn, twrn;
+
+	if (fp)
+		return fwrite(data, 1, len, fp);
+
+	wrn = 0;
+	if (fd >= 0) {
+		while (len > 0) {
+			do {
+				twrn = write(fd, data, len);
+			} while (twrn == -1 && errno == EAGAIN);
+			if (twrn <= 0)
+				return wrn;
+			data += twrn;
+			len -= (size_t)twrn;
+			wrn += twrn;
+		}
+	}
+	return wrn;
+}
+
+int fy_emitter_default_output(struct fy_emitter *fye, enum fy_emitter_write_type type, const char *str, int len, void *userdata)
+{
+	struct fy_emitter_default_output_data d_local, *d;
+	FILE *fp;
+	int fd;
+	int ret, w;
+	const char *color = NULL;
+	const char *s, *e;
+	const char *visible;
+
+	d = userdata;
+	if (!d) {
+		d = &d_local;
+		fp = fye->output_fp;
+		fd = fye->output_fd;
+		d->colorize = fye->output_colorize;
+		d->visible = !!(fye->xcfg.xflags & FYEXCF_VISIBLE_WS);
+	} else {
+		fp = d->fp;
+		fd = -1;
+	}
+
+	if (!fp && fd < 0)
+		return len;
+
+	s = str;
+	e = str + len;
+
+	if (d->colorize) {
+
+		color = fye->xcfg.colors[type];
+
+		/* visible whitespace */
+		switch (type) {
+		case fyewt_indent:
+		case fyewt_whitespace:
+		case fyewt_linebreak:
+		case fyewt_terminating_zero:
+
+			/* if not visible don't bother */
+			if (!d->visible) {
+				color = NULL;
+				break;
+			}
+
+			if (color)
+				raw_default_output(fp, fd, color, strlen(color));
+
+			switch (type) {
+			case fyewt_indent:
+				/* open box - U+2423 */
+				visible = "\xe2\x90\xa3";
+				break;
+			case fyewt_whitespace:
+				/* symbol for space - U+2420 */
+				/* symbol for interpunct - U+00B7 */
+				visible = "\xc2\xb7";
+				break;
+			case fyewt_linebreak:
+				/* down arrow - U+2193 */
+				visible = "\xe2\x86\x93" "\n";
+				break;
+			case fyewt_terminating_zero:
+				visible = "\\0";
+				break;
+			default:
+				visible = "";	/* should never happen */
+				break;
+
+			}
+
+			while (s < e && (w = fy_utf8_width_by_first_octet(((uint8_t)*s))) > 0) {
+				raw_default_output(fp, fd, visible, strlen(visible));
+				s += w;
+			}
+
+			if (color)
+				raw_default_output(fp, fd, A_RESET, strlen(A_RESET));
+			return len;
+
+		default:
+			break;
+		}
+	} else
+		color = NULL;
+
+	/* don't output the terminating zero */
+	if (type == fyewt_terminating_zero)
+		return len;
+
+	if (color)
+		raw_default_output(fp, fd, color, strlen(color));
+
+	ret = (int)raw_default_output(fp, fd, str, len);
+
+	if (color)
+		raw_default_output(fp, fd, A_RESET, strlen(A_RESET));
+
+	return ret;
+}
+
+int fy_document_default_emit_to_fp(struct fy_document *fyd, FILE *fp)
+{
+	struct fy_emitter emit_local, *emit = &emit_local;
+	struct fy_emitter_cfg ecfg_local, *ecfg = &ecfg_local;
+	struct fy_emitter_default_output_data d_local, *d = &d_local;
+	int rc;
+
+	memset(d, 0, sizeof(*d));
+	d->fp = fp;
+	d->colorize = isatty(fileno(fp));
+	d->visible = false;
+
+	memset(ecfg, 0, sizeof(*ecfg));
+	ecfg->diag = fyd->diag;
+	ecfg->userdata = d;
+
+	rc = fy_emit_setup(emit, ecfg);
+	if (rc)
+		goto err_setup;
+
+	fy_emit_prepare_document_state(emit, fyd->fyds);
+
+	rc = 0;
+	if (fyd->root)
+		rc = fy_emit_node_check(emit, fyd->root);
+
+	rc = fy_emit_document_no_check(emit, fyd);
+	if (rc)
+		goto err_emit;
+
+	fy_emit_cleanup(emit);
+
+	return 0;
+
+err_emit:
+	fy_emit_cleanup(emit);
+err_setup:
+	return -1;
+}
+
+int fy_emit_body_node(struct fy_emitter *emit, struct fy_node *fyn)
+{
+	struct fy_document_iterator *fydi = NULL;
+	struct fy_event *fye;
+	struct fy_document_iterator_cfg cfg;
+	int rc;
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.flags = FYDICF_WANT_BODY_EVENTS;
+	cfg.fyd = fyn->fyd;
+	cfg.iterate_root = fyn;
+
+	fydi = fy_document_iterator_create_cfg(&cfg);
+	if (!fydi)
+		goto err_out;
+
+	while ((fye = fy_document_iterator_generate_next(fydi)) != NULL) {
+		rc = fy_emit_event(emit, fye);
+		if (rc)
+			goto err_out;
+	}
+
+	fy_document_iterator_destroy(fydi);
+	return 0;
+
+err_out:
+	fy_document_iterator_destroy(fydi);
+	return -1;
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-emit.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-emit.h
@@ -1,0 +1,166 @@
+/*
+ * fy-emit.h - internal YAML emitter header
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_EMIT_H
+#define FY_EMIT_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <libfyaml.h>
+
+#include "fy-utf8.h"
+#include "fy-event.h"
+#include "fy-emit-accum.h"
+
+#define FYEF_WHITESPACE			0x0001
+#define FYEF_INDENTATION		0x0002
+#define FYEF_OPEN_ENDED			0x0004
+#define FYEF_HAD_DOCUMENT_START		0x0008
+#define FYEF_HAD_DOCUMENT_END		0x0010
+#define FYEF_HAD_DOCUMENT_OUTPUT	0x0020
+#define FYEF_HAD_DOCUMENT_END_OUTPUT	0x0040
+
+struct fy_document;
+struct fy_emitter;
+struct fy_document_state;
+
+enum fy_emitter_state {
+	FYES_NONE,		/* when not using the raw emitter interface */
+	FYES_STREAM_START,
+	FYES_FIRST_DOCUMENT_START,
+	FYES_DOCUMENT_START,
+	FYES_DOCUMENT_CONTENT,
+	FYES_DOCUMENT_END,
+	FYES_SEQUENCE_FIRST_ITEM,
+	FYES_SEQUENCE_ITEM,
+	FYES_MAPPING_FIRST_KEY,
+	FYES_MAPPING_KEY,
+	FYES_MAPPING_SIMPLE_VALUE,
+	FYES_MAPPING_VALUE,
+	FYES_END,
+};
+
+struct fy_emit_save_ctx {
+	bool flow_token : 1;
+	bool flow : 1;
+	bool empty : 1;
+	bool oneline_flow : 1;
+	enum fy_node_style xstyle;
+	int old_indent;
+	int flags;
+	int indent;
+	struct fy_token *fyt_last_key;
+	struct fy_token *fyt_last_value;
+	int s_flags;
+	int s_indent;
+};
+
+/* internal flags */
+#define DDNF_ROOT		0x0001
+#define DDNF_SEQ		0x0002
+#define DDNF_MAP		0x0004
+#define DDNF_SIMPLE		0x0008
+#define DDNF_FLOW		0x0010
+#define DDNF_INDENTLESS		0x0020
+#define DDNF_SIMPLE_SCALAR_KEY	0x0040
+#define DDNF_HANGING_INDENT	0x0080
+
+struct fy_emitter {
+	int line;
+	int column;
+	int flow_level;
+	unsigned int flags;
+	bool output_error : 1;
+	bool source_json : 1;		/* the source was json */
+	bool force_json : 1;		/* force JSON mode unconditionally */
+	bool suppress_recycling_force : 1;
+	bool suppress_recycling : 1;
+
+	/* current document */
+	struct fy_emitter_xcfg xcfg;
+	FILE *output_fp;
+	int output_fd;
+	bool output_colorize;
+	FILE *owned_output_fp;
+
+	struct fy_document *fyd;
+	struct fy_document_state *fyds;	/* fyd->fyds when fyd != NULL */
+	struct fy_emit_accum ea;
+	char ea_inplace_buf[256];	/* the in place accumulator buffer before allocating */
+	struct fy_diag *diag;
+
+	/* streaming event mode */
+	enum fy_emitter_state state;
+	enum fy_emitter_state *state_stack;
+	unsigned int state_stack_alloc;
+	unsigned int state_stack_top;
+	enum fy_emitter_state state_stack_inplace[64];
+	struct fy_eventp_list queued_events;
+	int s_indent;
+	int s_flags;
+	struct fy_emit_save_ctx s_sc;
+	struct fy_emit_save_ctx *sc_stack;
+	unsigned int sc_stack_alloc;
+	unsigned int sc_stack_top;
+	struct fy_emit_save_ctx sc_stack_inplace[16];
+
+	/* recycled */
+	struct fy_eventp_list recycled_eventp;
+	struct fy_token_list recycled_token;
+
+	struct fy_eventp_list *recycled_eventp_list;	/* NULL when suppressing */
+	struct fy_token_list *recycled_token_list;	/* NULL when suppressing */
+
+	/* for special needs */
+	void (*finalizer)(struct fy_emitter *emit);
+};
+
+int fy_emit_setup(struct fy_emitter *emit, const struct fy_emitter_cfg *cfg);
+void fy_emit_cleanup(struct fy_emitter *emit);
+
+void fy_emit_write(struct fy_emitter *emit, enum fy_emitter_write_type type, const char *str, size_t len);
+
+static inline bool fy_emit_whitespace(struct fy_emitter *emit)
+{
+	return !!(emit->flags & FYEF_WHITESPACE);
+}
+
+static inline bool fy_emit_indentation(struct fy_emitter *emit)
+{
+	return !!(emit->flags & FYEF_INDENTATION);
+}
+
+static inline bool fy_emit_open_ended(struct fy_emitter *emit)
+{
+	return !!(emit->flags & FYEF_OPEN_ENDED);
+}
+
+static inline void
+fy_emit_output_accum(struct fy_emitter *emit, enum fy_emitter_write_type type, struct fy_emit_accum *ea)
+{
+	const char *text;
+	size_t len;
+
+	text = fy_emit_accum_get(ea, &len);
+	if (text && len > 0)
+		fy_emit_write(emit, type, text, len);
+	fy_emit_accum_reset(ea);
+}
+
+static inline void
+fy_emit_output_col_sync(struct fy_emitter *emit, struct fy_emit_accum *ea)
+{
+	ea->col += emit->column;
+}
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-event.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-event.c
@@ -1,0 +1,1445 @@
+/*
+ * fy-event.c - YAML event methods
+ *
+ * Copyright (c) 2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-emit.h"
+#include "fy-doc.h"
+
+#include "fy-ctype.h"
+#include "fy-utf8.h"
+#include "fy-utils.h"
+
+#include "fy-event.h"
+
+struct fy_eventp *fy_eventp_alloc(void)
+{
+	struct fy_eventp *fyep;
+
+	fyep = malloc(sizeof(*fyep));
+	if (!fyep)
+		return NULL;
+
+	fyep->e.type = FYET_NONE;
+
+	return fyep;
+}
+
+void fy_eventp_clean_rl(struct fy_token_list *fytl, struct fy_eventp *fyep)
+{
+	struct fy_event *fye;
+
+	if (!fyep)
+		return;
+
+	fye = &fyep->e;
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+	case FYET_STREAM_START:
+		fy_token_unref_rl(fytl, fye->stream_start.stream_start);
+		break;
+	case FYET_STREAM_END:
+		fy_token_unref_rl(fytl, fye->stream_end.stream_end);
+		break;
+	case FYET_DOCUMENT_START:
+		fy_token_unref_rl(fytl, fye->document_start.document_start);
+		fy_document_state_unref(fye->document_start.document_state);
+		break;
+	case FYET_DOCUMENT_END:
+		fy_token_unref_rl(fytl, fye->document_end.document_end);
+		break;
+	case FYET_MAPPING_START:
+		fy_token_unref_rl(fytl, fye->mapping_start.anchor);
+		fy_token_unref_rl(fytl, fye->mapping_start.tag);
+		fy_token_unref_rl(fytl, fye->mapping_start.mapping_start);
+		break;
+	case FYET_MAPPING_END:
+		fy_token_unref_rl(fytl, fye->mapping_end.mapping_end);
+		break;
+	case FYET_SEQUENCE_START:
+		fy_token_unref_rl(fytl, fye->sequence_start.anchor);
+		fy_token_unref_rl(fytl, fye->sequence_start.tag);
+		fy_token_unref_rl(fytl, fye->sequence_start.sequence_start);
+		break;
+	case FYET_SEQUENCE_END:
+		fy_token_unref_rl(fytl, fye->sequence_end.sequence_end);
+		break;
+	case FYET_SCALAR:
+		fy_token_unref_rl(fytl, fye->scalar.anchor);
+		fy_token_unref_rl(fytl, fye->scalar.tag);
+		fy_token_unref_rl(fytl, fye->scalar.value);
+		break;
+	case FYET_ALIAS:
+		fy_token_unref_rl(fytl, fye->alias.anchor);
+		break;
+	}
+
+	fye->type = FYET_NONE;
+}
+
+void fy_parse_eventp_clean(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	if (!fyp || !fyep)
+		return;
+
+	fy_eventp_clean_rl(fyp->recycled_token_list, fyep);
+}
+
+void fy_emit_eventp_clean(struct fy_emitter *emit, struct fy_eventp *fyep)
+{
+	if (!emit || !fyep)
+		return;
+
+	fy_eventp_clean_rl(emit->recycled_token_list, fyep);
+}
+
+void fy_eventp_free(struct fy_eventp *fyep)
+{
+	if (!fyep)
+		return;
+
+	/* clean, safe to do */
+	fy_eventp_clean_rl(NULL, fyep);
+
+	free(fyep);
+}
+
+void fy_eventp_release(struct fy_eventp *fyep)
+{
+	fy_eventp_free(fyep);
+}
+
+struct fy_eventp *fy_parse_eventp_alloc(struct fy_parser *fyp)
+{
+	struct fy_eventp *fyep = NULL;
+
+	if (!fyp)
+		return NULL;
+
+	if (fyp->recycled_eventp_list)
+		fyep = fy_eventp_list_pop(fyp->recycled_eventp_list);
+	if (!fyep)
+		fyep = fy_eventp_alloc();
+	if (!fyep)
+		return NULL;
+
+	fyep->e.type = FYET_NONE;
+
+	return fyep;
+}
+
+void fy_parse_eventp_recycle(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	if (!fyp || !fyep)
+		return;
+
+	/* clean, safe to do */
+	fy_parse_eventp_clean(fyp, fyep);
+
+	/* and push to the parser recycle list */
+	if (fyp->recycled_eventp_list)
+		fy_eventp_list_push(fyp->recycled_eventp_list, fyep);
+	else
+		fy_eventp_free(fyep);
+}
+
+void fy_parser_event_free(struct fy_parser *fyp, struct fy_event *fye)
+{
+	struct fy_eventp *fyep;
+
+	if (!fyp || !fye)
+		return;
+
+	if (fy_reader_generates_events(fyp->reader)) {
+		fy_reader_event_free(fyp->reader, fye);
+		return;
+	}
+
+	fyep = container_of(fye, struct fy_eventp, e);
+
+	fy_parse_eventp_recycle(fyp, fyep);
+}
+
+void fy_emit_eventp_recycle(struct fy_emitter *emit, struct fy_eventp *fyep)
+{
+	if (!emit || !fyep)
+		return;
+
+	/* clean, safe to do */
+	fy_emit_eventp_clean(emit, fyep);
+
+	if (emit->recycled_eventp_list)
+		fy_eventp_list_push(emit->recycled_eventp_list, fyep);
+	else
+		fy_eventp_free(fyep);
+}
+
+void fy_emit_event_free(struct fy_emitter *emit, struct fy_event *fye)
+{
+	struct fy_eventp *fyep;
+
+	if (!emit || !fye)
+		return;
+
+	fyep = container_of(fye, struct fy_eventp, e);
+
+	fy_emit_eventp_recycle(emit, fyep);
+}
+
+struct fy_eventp *
+fy_eventp_vcreate_internal(struct fy_eventp_list *recycled_list, struct fy_diag *diag,
+			   struct fy_document_state *fyds, enum fy_event_type type, va_list ap)
+{
+	struct fy_eventp *fyep = NULL;
+	struct fy_event *fye = NULL;
+	struct fy_document_state *fyds_new = NULL;
+	const struct fy_version *vers;
+	const struct fy_tag *tag, * const *tagp;
+	struct fy_token *fyt;
+	enum fy_token_type ttype;
+	int rc, tag_count = 0;
+	enum fy_node_style style;
+	enum fy_scalar_style sstyle;
+	struct fy_token **fyt_anchorp = NULL, **fyt_tagp = NULL;
+	struct fy_input *fyi = NULL;
+	struct fy_atom handle;
+	const char *value;
+	size_t len;
+	char *data = NULL;
+	struct fy_tag_scan_info info;
+	struct fy_token *fyt_td;
+
+	/* try the recycled list first */
+	if (recycled_list)
+		fyep = fy_eventp_list_pop(recycled_list);
+	/* if not there yet, allocate a fresh one */
+	if (!fyep)
+		fyep = fy_eventp_alloc();
+	if (!fyep)
+		return NULL;
+
+	fye = &fyep->e;
+
+	fye->type = type;
+
+	switch (type) {
+	case FYET_NONE:
+		break;
+	case FYET_STREAM_START:
+		fye->stream_start.stream_start = NULL;
+		break;
+	case FYET_STREAM_END:
+		fye->stream_end.stream_end = NULL;
+		break;
+	case FYET_DOCUMENT_START:
+		fye->document_start.document_start = NULL;
+		fyds_new = fy_document_state_default(fy_document_state_version(fyds), NULL);	/* start with the default state */
+		if (!fyds_new) {
+			fy_error(diag, "fy_document_state_alloc() failed\n");
+			goto err_out;
+		}
+		fye->document_start.implicit = va_arg(ap, int);
+		vers = va_arg(ap, const struct fy_version *);
+		if (vers) {
+			fyds_new->version = *vers;
+			fyds_new->version_explicit = true;
+		}
+		fyds_new->start_implicit = fye->document_start.implicit;
+		fyds_new->end_implicit = false;	/* this is not used right now */
+		tag_count = 0;
+		tagp = va_arg(ap, const struct fy_tag * const *);
+		if (tagp) {
+			while ((tag = tagp[tag_count]) != NULL) {
+				tag_count++;
+				rc = fy_document_state_append_tag(fyds_new, tag->handle, tag->prefix, false);
+				if (rc) {
+					fy_error(diag, "fy_document_state_append_tag() failed on handle='%s' prefix='%s'\n",
+							tag->handle, tag->prefix);
+					goto err_out;
+				}
+			}
+		}
+		if (tag_count)
+			fyds_new->tags_explicit = true;
+		fye->document_start.document_state = fyds_new;
+		fyds_new = NULL;
+		break;
+	case FYET_DOCUMENT_END:
+		fye->document_end.document_end = NULL;
+		fye->document_end.implicit = va_arg(ap, int);
+		break;
+	case FYET_MAPPING_START:
+	case FYET_SEQUENCE_START:
+		style = va_arg(ap, enum fy_node_style);
+		ttype = FYTT_NONE;
+
+		if (style != FYNS_ANY && style != FYNS_FLOW && style != FYNS_BLOCK) {
+			fy_error(diag, "illegal style for %s_START\n",
+					type == FYET_MAPPING_START ? "MAPPING" : "SEQUENCE");
+			goto err_out;
+		}
+
+		if (style != FYNS_ANY) {
+			if (style == FYNS_FLOW)
+				ttype = type == FYET_MAPPING_START ?
+							FYTT_FLOW_MAPPING_START :
+							FYTT_FLOW_SEQUENCE_START;
+			else
+				ttype = type == FYET_MAPPING_START ?
+							FYTT_BLOCK_MAPPING_START :
+							FYTT_BLOCK_SEQUENCE_START;
+			fyt = fy_token_create(ttype, NULL);
+			if (!fyt) {
+				fy_error(diag, "fy_token_create() failed for %s_START\n",
+						type == FYET_MAPPING_START ? "MAPPING" : "SEQUENCE");
+				goto err_out;
+			}
+		} else
+			fyt = NULL;
+
+		if (type == FYET_MAPPING_START) {
+			fye->mapping_start.mapping_start = fyt;
+			fye->mapping_start.anchor = NULL;
+			fye->mapping_start.tag = NULL;
+			fyt_anchorp = &fye->mapping_start.anchor;
+			fyt_tagp = &fye->mapping_start.tag;
+		} else {
+			fye->sequence_start.sequence_start = fyt;
+			fye->sequence_start.anchor = NULL;
+			fye->sequence_start.tag = NULL;
+			fyt_anchorp = &fye->sequence_start.anchor;
+			fyt_tagp = &fye->sequence_start.tag;
+		}
+		fyt = NULL;
+		break;
+	case FYET_MAPPING_END:
+		fye->mapping_end.mapping_end = NULL;
+		break;
+	case FYET_SEQUENCE_END:
+		fye->sequence_end.sequence_end = NULL;
+		break;
+
+	case FYET_SCALAR:
+	case FYET_ALIAS:
+
+		if (type == FYET_SCALAR) {
+			fye->scalar.value = fye->scalar.anchor = fye->scalar.tag = NULL;
+			sstyle = va_arg(ap, enum fy_scalar_style);
+			value = va_arg(ap, const char *);
+			len = FY_VA_ARG_SIZE_T(ap);
+			// map -1 to FY_NT (like on windows)
+			if (sizeof(int) != sizeof(size_t) && (int)len == -1)
+				len = FY_NT;
+			if (!value && len) {
+				fy_error(diag, "NULL value with len > 0, illegal SCALAR\n");
+				goto err_out;
+			}
+			if (len == FY_NT)
+				len = strlen(value);
+		} else {
+			fye->alias.anchor = NULL;
+			sstyle = FYSS_PLAIN;
+			value = va_arg(ap, const char *);
+			if (!value) {
+				fy_error(diag, "NULL value, illegal ALIAS\n");
+				goto err_out;
+			}
+			len = strlen(value);
+		}
+
+		fyt = NULL;
+		fyi = NULL;
+
+		data = malloc(len + 1);
+		if (!data) {
+			fy_error(diag, "malloc() failed\n");
+			goto err_out;
+		}
+		memcpy(data, value, len);
+		/* always NULL terminate */
+		data[len] = '\0';
+		fyi = fy_input_from_malloc_data_styled(data, len, &handle, sstyle);
+		if (!fyi) {
+			fy_error(diag, "fy_input_from_malloc_data() failed\n");
+			goto err_out;
+		}
+		data = NULL;
+
+		if (type == FYET_SCALAR) {
+			fyt = fy_token_create(FYTT_SCALAR, &handle, sstyle);
+			if (!fyt) {
+				fy_error(diag, "fy_token_create() failed for %s\n",
+						"SCALAR");
+				goto err_out;
+			}
+
+			fye->scalar.value = fyt;
+			fyt = NULL;
+
+			fye->scalar.anchor = NULL;
+			fye->scalar.tag = NULL;
+			fyt_anchorp = &fye->scalar.anchor;
+			fyt_tagp = &fye->scalar.tag;
+		} else {
+			fyt = fy_token_create(FYTT_ALIAS, &handle, NULL);
+			if (!fyt) {
+				fy_error(diag, "fy_token_create() failed for %s\n",
+						"ALIAS");
+				goto err_out;
+			}
+
+			fye->alias.anchor = fyt;
+			fyt = NULL;
+		}
+		fy_input_unref(fyi);
+		fyi = NULL;
+		break;
+	}
+
+	if (fyt_anchorp && (value = va_arg(ap, const char *)) != NULL) {
+
+		len = strlen(value);
+		data = malloc(len + 1);
+		if (!data) {
+			fy_error(diag, "malloc() failed\n");
+			goto err_out;
+		}
+		memcpy(data, value, len);
+		/* always NULL terminate */
+		data[len] = '\0';
+
+		fyi = fy_input_from_malloc_data(data, len, &handle, false);
+		if (!fyi) {
+			fy_error(diag, "fy_input_from_malloc_data() failed\n");
+			goto err_out;
+		}
+		data = NULL;
+
+		/* make sure the input as valid as an anchor */
+		if (!handle.valid_anchor) {
+			fy_error(diag, "input was not valid as anchor\n");
+			goto err_out;
+		}
+
+		fyt = fy_token_create(FYTT_ANCHOR, &handle);
+		if (!fyt) {
+			fy_error(diag, "fy_token_create() failed\n");
+			goto err_out;
+		}
+		*fyt_anchorp = fyt;
+		fyt = NULL;
+		fy_input_unref(fyi);
+		fyi = NULL;
+	}
+
+	if (fyt_tagp && (value = va_arg(ap, const char *)) != NULL) {
+
+		len = strlen(value);
+		data = malloc(len + 1);
+		if (!data) {
+			fy_error(diag, "malloc() failed\n");
+			goto err_out;
+		}
+		memcpy(data, value, len);
+		/* always NULL terminate */
+		data[len] = '\0';
+
+		rc = fy_tag_scan(data, len, &info);
+		if (rc) {
+			fy_error(diag, "invalid tag %s (tag_scan)\n", value);
+			goto err_out;
+		}
+
+		fyt_td = fy_document_state_lookup_tag_directive(fyds, data + info.prefix_length, info.handle_length);
+		if (!fyt_td) {
+			fy_error(diag, "invalid tag %s (lookup tag directive)\n", value);
+			goto err_out;
+		}
+
+		fyi = fy_input_from_malloc_data(data, len, &handle, false);
+		if (!fyi)
+			goto err_out;
+		data = NULL;
+
+		handle.style = FYAS_URI;
+		handle.direct_output = false;
+		handle.storage_hint = 0;
+		handle.storage_hint_valid = false;
+
+		fyt = fy_token_create(FYTT_TAG, &handle, info.prefix_length,
+				info.handle_length, info.uri_length, fyt_td);
+		if (!fyt) {
+			fy_error(diag, "fy_token_create() failed\n");
+			goto err_out;
+		}
+		*fyt_tagp = fyt;
+		fyt = NULL;
+		fy_input_unref(fyi);
+		fyi = NULL;
+	}
+
+	return fyep;
+
+err_out:
+	fy_input_unref(fyi);
+	if (data)
+		free(data);
+	fy_document_state_unref(fyds_new);
+	/* don't bother with recycling on error */
+	fy_eventp_free(fyep);
+	return NULL;
+}
+
+struct fy_eventp *
+fy_eventp_create_internal(struct fy_eventp_list *recycled_list, struct fy_diag *diag,
+			  struct fy_document_state *fyds,
+			  enum fy_event_type type, ...)
+{
+	struct fy_eventp *fyep;
+	va_list ap;
+
+	va_start(ap, type);
+	fyep = fy_eventp_vcreate_internal(recycled_list, diag, fyds, type, ap);
+	va_end(ap);
+
+	return fyep;
+}
+
+struct fy_event *
+fy_emit_event_vcreate(struct fy_emitter *emit, enum fy_event_type type, va_list ap)
+{
+	struct fy_eventp *fyep;
+
+	if (!emit)
+		return NULL;
+
+	fyep = fy_eventp_vcreate_internal(emit->recycled_eventp_list, emit->diag, emit->fyds, type, ap);
+	if (!fyep)
+		return NULL;
+
+	return &fyep->e;
+}
+
+struct fy_event *
+fy_emit_event_create(struct fy_emitter *emit, enum fy_event_type type, ...)
+{
+	struct fy_event *fye;
+	va_list ap;
+
+	va_start(ap, type);
+	fye = fy_emit_event_vcreate(emit, type, ap);
+	va_end(ap);
+
+	return fye;
+}
+
+int
+fy_emit_vevent(struct fy_emitter *emit, enum fy_event_type type, va_list ap)
+{
+	struct fy_event *fye;
+
+	if (!emit)
+		return -1;
+
+	fye = fy_emit_event_vcreate(emit, type, ap);
+	if (!fye)
+		return -1;
+
+	return fy_emit_event(emit, fye);
+}
+
+int
+fy_emit_eventf(struct fy_emitter *emit, enum fy_event_type type, ...)
+{
+	int rc;
+	va_list ap;
+
+	va_start(ap, type);
+	rc = fy_emit_vevent(emit, type, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+int
+fy_emit_scalar_write(struct fy_emitter *fye, enum fy_scalar_style style,
+		     const char *anchor, const char *tag,
+		     const char *text, size_t len)
+{
+	return fy_emit_eventf(fye, FYET_SCALAR, style, text, len, anchor, tag);
+}
+
+int
+fy_emit_scalar_vprintf(struct fy_emitter *fye, enum fy_scalar_style style,
+		       const char *anchor, const char *tag,
+		       const char *fmt, va_list ap)
+{
+	char *buf;
+	size_t len;
+	int rc;
+
+	rc = vasprintf(&buf, fmt, ap);
+	if (rc < 0)
+		return -1;
+	len = (size_t)rc;
+
+	rc = fy_emit_scalar_write(fye, style, anchor, tag, buf, len);
+	free(buf);
+
+	return rc;
+}
+
+int
+fy_emit_scalar_printf(struct fy_emitter *fye, enum fy_scalar_style style,
+		      const char *anchor, const char *tag,
+		      const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_emit_scalar_vprintf(fye, style, anchor, tag, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+struct fy_event *
+fy_parse_event_vcreate(struct fy_parser *fyp, enum fy_event_type type, va_list ap)
+{
+	struct fy_eventp *fyep;
+
+	if (!fyp)
+		return NULL;
+
+	fyep = fy_eventp_vcreate_internal(fyp->recycled_eventp_list, fyp->diag, fyp->current_document_state, type, ap);
+	if (!fyep)
+		return NULL;
+
+	return &fyep->e;
+}
+
+struct fy_event *
+fy_parse_event_create(struct fy_parser *fyp, enum fy_event_type type, ...)
+{
+	struct fy_event *fye;
+	va_list ap;
+
+	va_start(ap, type);
+	fye = fy_parse_event_vcreate(fyp, type, ap);
+	va_end(ap);
+
+	return fye;
+}
+
+bool fy_event_is_implicit(struct fy_event *fye)
+{
+	/* NULL event is implicit */
+	if (!fye)
+		return true;
+
+	switch (fye->type) {
+
+	case FYET_DOCUMENT_START:
+		return fye->document_start.implicit;
+
+	case FYET_DOCUMENT_END:
+		return fye->document_end.implicit;
+
+	case FYET_MAPPING_START:
+	case FYET_MAPPING_END:
+	case FYET_SEQUENCE_START:
+	case FYET_SEQUENCE_END:
+		return fy_event_get_node_style(fye) == FYNS_BLOCK;
+
+	default:
+		break;
+	}
+
+	return false;
+}
+
+bool fy_document_event_is_implicit(const struct fy_event *fye)
+{
+	if (fye->type == FYET_DOCUMENT_START)
+		return fye->document_start.implicit;
+
+	if (fye->type == FYET_DOCUMENT_END)
+		return fye->document_end.implicit;
+
+	return false;
+}
+
+struct fy_token *fy_event_get_token(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+
+	case FYET_STREAM_START:
+		return fye->stream_start.stream_start;
+
+	case FYET_STREAM_END:
+		return fye->stream_end.stream_end;
+
+	case FYET_DOCUMENT_START:
+		return fye->document_start.document_start;
+
+	case FYET_DOCUMENT_END:
+		return fye->document_end.document_end;
+
+	case FYET_MAPPING_START:
+		return fye->mapping_start.mapping_start;
+
+	case FYET_MAPPING_END:
+		return fye->mapping_end.mapping_end;
+
+	case FYET_SEQUENCE_START:
+		return fye->sequence_start.sequence_start;
+
+	case FYET_SEQUENCE_END:
+		return fye->sequence_end.sequence_end;
+
+	case FYET_SCALAR:
+		return fye->scalar.value;
+
+	case FYET_ALIAS:
+		return fye->alias.anchor;
+
+	}
+
+	return NULL;
+}
+
+struct fy_token *fy_event_get_anchor_token(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_MAPPING_START:
+		return fye->mapping_start.anchor;
+	case FYET_SEQUENCE_START:
+		return fye->sequence_start.anchor;
+	case FYET_SCALAR:
+		return fye->scalar.anchor;
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+struct fy_token *fy_event_get_and_clear_anchor_token(struct fy_event *fye)
+{
+	struct fy_token *fyt = NULL;
+
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_MAPPING_START:
+		fyt = fye->mapping_start.anchor;
+		fye->mapping_start.anchor = NULL;
+		break;
+
+	case FYET_SEQUENCE_START:
+		fyt = fye->sequence_start.anchor;
+		fye->sequence_start.anchor = NULL;
+		break;
+
+	case FYET_SCALAR:
+		fyt = fye->scalar.anchor;
+		fye->scalar.anchor = NULL;
+		break;
+
+	default:
+		break;
+	}
+
+	return fyt;
+}
+
+struct fy_token *fy_event_get_tag_token(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_MAPPING_START:
+		return fye->mapping_start.tag;
+	case FYET_SEQUENCE_START:
+		return fye->sequence_start.tag;
+	case FYET_SCALAR:
+		return fye->scalar.tag;
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+const struct fy_mark *
+fy_event_start_mark(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+
+	case FYET_STREAM_START:
+		return fy_token_start_mark(fye->stream_start.stream_start);
+
+	case FYET_STREAM_END:
+		return fy_token_start_mark(fye->stream_end.stream_end);
+
+	case FYET_DOCUMENT_START:
+		return fy_token_start_mark(fye->document_start.document_start);
+
+	case FYET_DOCUMENT_END:
+		return fy_token_start_mark(fye->document_end.document_end);
+
+	case FYET_MAPPING_START:
+		return fy_token_start_mark(fye->mapping_start.mapping_start);
+
+	case FYET_MAPPING_END:
+		return fy_token_start_mark(fye->mapping_end.mapping_end);
+
+	case FYET_SEQUENCE_START:
+		return fy_token_start_mark(fye->sequence_start.sequence_start);
+
+	case FYET_SEQUENCE_END:
+		return fy_token_start_mark(fye->sequence_end.sequence_end);
+
+	case FYET_SCALAR:
+		return fy_token_start_mark(fye->scalar.value);
+
+	case FYET_ALIAS:
+		return fy_token_start_mark(fye->alias.anchor);
+
+	}
+
+	return NULL;
+}
+
+const struct fy_mark *
+fy_event_end_mark(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+
+	case FYET_STREAM_START:
+		return fy_token_end_mark(fye->stream_start.stream_start);
+
+	case FYET_STREAM_END:
+		return fy_token_end_mark(fye->stream_end.stream_end);
+
+	case FYET_DOCUMENT_START:
+		return fy_token_end_mark(fye->document_start.document_start);
+
+	case FYET_DOCUMENT_END:
+		return fy_token_end_mark(fye->document_end.document_end);
+
+	case FYET_MAPPING_START:
+		return fy_token_end_mark(fye->mapping_start.mapping_start);
+
+	case FYET_MAPPING_END:
+		return fy_token_end_mark(fye->mapping_end.mapping_end);
+
+	case FYET_SEQUENCE_START:
+		return fy_token_end_mark(fye->sequence_start.sequence_start);
+
+	case FYET_SEQUENCE_END:
+		return fy_token_end_mark(fye->sequence_end.sequence_end);
+
+	case FYET_SCALAR:
+		return fy_token_end_mark(fye->scalar.value);
+
+	case FYET_ALIAS:
+		return fy_token_end_mark(fye->alias.anchor);
+
+	}
+
+	return NULL;
+}
+
+const struct fy_mark *
+fy_event_style_start_mark(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+
+	case FYET_STREAM_START:
+		return fy_token_style_start_mark(fye->stream_start.stream_start);
+
+	case FYET_STREAM_END:
+		return fy_token_style_start_mark(fye->stream_end.stream_end);
+
+	case FYET_DOCUMENT_START:
+		return fy_token_style_start_mark(fye->document_start.document_start);
+
+	case FYET_DOCUMENT_END:
+		return fy_token_style_start_mark(fye->document_end.document_end);
+
+	case FYET_MAPPING_START:
+		if (fye->mapping_start.tag)
+			return fy_token_style_start_mark(fye->mapping_start.tag);
+		return fy_token_style_start_mark(fye->mapping_start.mapping_start);
+
+	case FYET_MAPPING_END:
+		return fy_token_style_start_mark(fye->mapping_end.mapping_end);
+
+	case FYET_SEQUENCE_START:
+		if (fye->sequence_start.tag)
+			return fy_token_style_start_mark(fye->sequence_start.tag);
+		return fy_token_style_start_mark(fye->sequence_start.sequence_start);
+
+	case FYET_SEQUENCE_END:
+		return fy_token_style_start_mark(fye->sequence_end.sequence_end);
+
+	case FYET_SCALAR:
+		if (fye->scalar.tag)
+			return fy_token_style_start_mark(fye->scalar.tag);
+		return fy_token_style_start_mark(fye->scalar.value);
+
+	case FYET_ALIAS:
+		return fy_token_style_start_mark(fye->alias.anchor);
+
+	}
+
+	return NULL;
+}
+
+const struct fy_mark *
+fy_event_style_end_mark(struct fy_event *fye)
+{
+	if (!fye)
+		return NULL;
+
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+
+	case FYET_STREAM_START:
+		return fy_token_style_end_mark(fye->stream_start.stream_start);
+
+	case FYET_STREAM_END:
+		return fy_token_style_end_mark(fye->stream_end.stream_end);
+
+	case FYET_DOCUMENT_START:
+		return fy_token_style_end_mark(fye->document_start.document_start);
+
+	case FYET_DOCUMENT_END:
+		return fy_token_style_end_mark(fye->document_end.document_end);
+
+	case FYET_MAPPING_START:
+		return fy_token_style_end_mark(fye->mapping_start.mapping_start);
+
+	case FYET_MAPPING_END:
+		return fy_token_style_end_mark(fye->mapping_end.mapping_end);
+
+	case FYET_SEQUENCE_START:
+		return fy_token_style_end_mark(fye->sequence_start.sequence_start);
+
+	case FYET_SEQUENCE_END:
+		return fy_token_style_end_mark(fye->sequence_end.sequence_end);
+
+	case FYET_SCALAR:
+		return fy_token_style_end_mark(fye->scalar.value);
+
+	case FYET_ALIAS:
+		return fy_token_style_end_mark(fye->alias.anchor);
+
+	}
+
+	return NULL;
+}
+
+
+enum fy_node_style
+fy_event_get_node_style(struct fy_event *fye)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_event_get_token(fye);
+	if (!fyt)
+		return FYNS_ANY;
+
+	switch (fye->type) {
+		/* unstyled events */
+	case FYET_NONE:
+	case FYET_STREAM_START:
+	case FYET_STREAM_END:
+	case FYET_DOCUMENT_START:
+	case FYET_DOCUMENT_END:
+		return FYNS_ANY;
+
+	case FYET_MAPPING_START:
+		return fyt && fyt->type == FYTT_FLOW_MAPPING_START ? FYNS_FLOW : FYNS_BLOCK;
+
+	case FYET_MAPPING_END:
+		return fyt && fyt->type == FYTT_FLOW_MAPPING_END ? FYNS_FLOW : FYNS_BLOCK;
+
+	case FYET_SEQUENCE_START:
+		return fyt && fyt->type == FYTT_FLOW_SEQUENCE_START ? FYNS_FLOW : FYNS_BLOCK;
+
+	case FYET_SEQUENCE_END:
+		return fyt && fyt->type == FYTT_FLOW_SEQUENCE_END ? FYNS_FLOW : FYNS_BLOCK;
+
+	case FYET_SCALAR:
+		return fyt ? fy_node_style_from_scalar_style(fyt->scalar.style) : FYNS_PLAIN;
+
+	case FYET_ALIAS:
+		return FYNS_ALIAS;
+
+	}
+
+	return FYNS_ANY;
+}
+
+struct fy_eventp *fy_parse_eventp_clone(struct fy_parser *fyp, struct fy_eventp *fyep_src, bool strip_anchors)
+{
+	struct fy_eventp *fyep = NULL;
+	struct fy_event *fye, *fye_src;
+
+	if (!fyp || !fyep_src)
+		return NULL;
+
+	if (fyp->recycled_eventp_list)
+		fyep = fy_eventp_list_pop(fyp->recycled_eventp_list);
+	if (!fyep)
+		fyep = fy_eventp_alloc();
+	if (!fyep)
+		return NULL;
+
+	fye_src = &fyep_src->e;
+	fye = &fyep->e;
+
+	fye->type = fye_src->type;
+	switch (fye->type) {
+	case FYET_NONE:
+		break;
+	case FYET_STREAM_START:
+		fye->stream_start.stream_start = fy_token_ref(fye_src->stream_start.stream_start);
+		break;
+	case FYET_STREAM_END:
+		fye->stream_end.stream_end = fy_token_ref(fye_src->stream_end.stream_end);
+		break;
+	case FYET_DOCUMENT_START:
+		fye->document_start.document_start = fy_token_ref(fye_src->document_start.document_start);
+		fye->document_start.document_state = fy_document_state_ref(fye_src->document_start.document_state);
+		break;
+	case FYET_DOCUMENT_END:
+		fye->document_end.document_end = fy_token_ref(fye_src->document_end.document_end);
+		break;
+	case FYET_MAPPING_START:
+		if (!strip_anchors)
+			fye->mapping_start.anchor = fy_token_ref(fye_src->mapping_start.anchor);
+		else
+			fye->mapping_start.anchor = NULL;
+		fye->mapping_start.tag = fy_token_ref(fye_src->mapping_start.tag);
+		fye->mapping_start.mapping_start = fy_token_ref(fye_src->mapping_start.mapping_start);
+		break;
+	case FYET_MAPPING_END:
+		fye->mapping_end.mapping_end = fy_token_ref(fye_src->mapping_end.mapping_end);
+		break;
+	case FYET_SEQUENCE_START:
+		if (!strip_anchors)
+			fye->sequence_start.anchor = fy_token_ref(fye_src->sequence_start.anchor);
+		else
+			fye->sequence_start.anchor = NULL;
+		fye->sequence_start.tag = fy_token_ref(fye_src->sequence_start.tag);
+		fye->sequence_start.sequence_start = fy_token_ref(fye_src->sequence_start.sequence_start);
+		break;
+	case FYET_SEQUENCE_END:
+		fye->sequence_end.sequence_end = fy_token_ref(fye_src->sequence_end.sequence_end);
+		break;
+	case FYET_SCALAR:
+		if (!strip_anchors)
+			fye->scalar.anchor = fy_token_ref(fye_src->scalar.anchor);
+		else
+			fye->scalar.anchor = NULL;
+		fye->scalar.tag = fy_token_ref(fye_src->scalar.tag);
+		fye->scalar.value = fy_token_ref(fye_src->scalar.value);
+		break;
+	case FYET_ALIAS:
+		fye->alias.anchor = fy_token_ref(fye_src->alias.anchor);
+		break;
+	}
+	return fyep;
+}
+
+const char *fy_event_get_anchor(struct fy_event *fye, size_t *anchor_lenp)
+{
+	struct fy_token *anchor;
+
+	anchor = fy_event_get_anchor_token(fye);
+	if (!anchor)
+		return NULL;
+
+	return fy_token_get_text(anchor, anchor_lenp);
+}
+
+const struct fy_version *
+fy_document_start_event_version(struct fy_event *fye)
+{
+	/* return the default if not set */
+	if (!fye || fye->type != FYET_DOCUMENT_START)
+		return &fy_default_version;
+	return fy_document_state_version(fye->document_start.document_state);
+}
+
+char *fy_event_to_string(struct fy_event *fye)
+{
+	struct fy_memstream *fyms = NULL;
+	FILE *fp = NULL;
+	char *mbuf = NULL;
+	const char *anchor = NULL;
+	const char *tag = NULL;
+	const char *text = NULL;
+	const char *alias = NULL;
+	size_t msize, anchor_len = 0, tag_len = 0, text_len = 0, alias_len = 0;
+	enum fy_scalar_style style;
+	const uint8_t *p;
+	int i, c, w;
+
+	if (!fye)
+		return NULL;
+
+	fyms = fy_memstream_open(&fp);
+	if (!fyms)
+		return NULL;
+
+	/* event type */
+	switch (fye->type) {
+	case FYET_NONE:
+		fprintf(fp, "???");
+		break;
+	case FYET_STREAM_START:
+		fprintf(fp, "+STR");
+		break;
+	case FYET_STREAM_END:
+		fprintf(fp, "-STR");
+		break;
+	case FYET_DOCUMENT_START:
+		fprintf(fp, "+DOC");
+		break;
+	case FYET_DOCUMENT_END:
+		fprintf(fp, "-DOC");
+		break;
+	case FYET_MAPPING_START:
+		fprintf(fp, "+MAP");
+		if (fye->mapping_start.anchor)
+			anchor = fy_token_get_text(fye->mapping_start.anchor, &anchor_len);
+		if (fye->mapping_start.tag)
+			tag = fy_token_get_text(fye->mapping_start.tag, &tag_len);
+		if (fy_event_get_node_style(fye) == FYNS_FLOW)
+			fprintf(fp, " {}");
+		break;
+	case FYET_MAPPING_END:
+		fprintf(fp, "-MAP");
+		break;
+	case FYET_SEQUENCE_START:
+		fprintf(fp, "+SEQ");
+		if (fye->sequence_start.anchor)
+			anchor = fy_token_get_text(fye->sequence_start.anchor, &anchor_len);
+		if (fye->sequence_start.tag)
+			tag = fy_token_get_text(fye->sequence_start.tag, &tag_len);
+		if (fy_event_get_node_style(fye) == FYNS_FLOW)
+			fprintf(fp, " []");
+		break;
+	case FYET_SEQUENCE_END:
+		fprintf(fp, "-SEQ");
+		break;
+	case FYET_SCALAR:
+		fprintf(fp, "=VAL");
+		if (fye->scalar.anchor)
+			anchor = fy_token_get_text(fye->scalar.anchor, &anchor_len);
+		if (fye->scalar.tag)
+			tag = fy_token_get_text(fye->scalar.tag, &tag_len);
+		break;
+	case FYET_ALIAS:
+		fprintf(fp, "=ALI");
+		break;
+	default:
+		break;
+	}
+
+	/* (position) anchor and tag */
+	if (anchor)
+		fprintf(fp, " &%.*s", (int)anchor_len, anchor);
+	if (tag)
+		fprintf(fp, " <%.*s>", (int)tag_len, tag);
+
+	/* style hint */
+	switch (fye->type) {
+	default:
+		break;
+	case FYET_DOCUMENT_START:
+		if (!fy_document_event_is_implicit(fye))
+			fprintf(fp, " ---");
+		break;
+	case FYET_DOCUMENT_END:
+		if (!fy_document_event_is_implicit(fye))
+			fprintf(fp, " ...");
+		break;
+	case FYET_MAPPING_START:
+		break;
+	case FYET_SEQUENCE_START:
+		break;
+	case FYET_SCALAR:
+		style = fy_token_scalar_style(fye->scalar.value);
+		switch (style) {
+		case FYSS_ANY:
+			fprintf(fp, " !");
+			break;
+		case FYSS_PLAIN:
+			fprintf(fp, " :");
+			break;
+		case FYSS_SINGLE_QUOTED:
+			fprintf(fp, " '");
+			break;
+		case FYSS_DOUBLE_QUOTED:
+			fprintf(fp, " \"");
+			break;
+		case FYSS_LITERAL:
+			fprintf(fp, " |");
+			break;
+		case FYSS_FOLDED:
+			fprintf(fp, " >");
+			break;
+		default:
+			break;
+		}
+		break;
+	case FYET_ALIAS:
+		break;
+	}
+
+	/* content */
+	switch (fye->type) {
+	default:
+		break;
+	case FYET_SCALAR:
+		text = fy_token_get_text(fye->scalar.value, &text_len);
+		for (p = (const uint8_t *)text; text_len > 0; p += w, text_len -= (size_t)w) {
+
+			/* get width from the first octet */
+			w = (p[0] & 0x80) == 0x00 ? 1 :
+			    (p[0] & 0xe0) == 0xc0 ? 2 :
+			    (p[0] & 0xf0) == 0xe0 ? 3 :
+			    (p[0] & 0xf8) == 0xf0 ? 4 : 0;
+
+			/* error, clip it */
+			if ((size_t)w > text_len)
+				break;
+
+			/* initial value */
+			c = p[0] & (0xff >> w);
+			for (i = 1; i < w; i++) {
+				if ((p[i] & 0xc0) != 0x80)
+					break;
+				c = (c << 6) | (p[i] & 0x3f);
+			}
+
+			/* check for validity */
+			if ((w == 4 && c < 0x10000) ||
+			    (w == 3 && c <   0x800) ||
+			    (w == 2 && c <    0x80) ||
+			    (c >= 0xd800 && c <= 0xdfff) || c >= 0x110000)
+				break;
+
+			switch (c) {
+			case '\\':
+				fprintf(fp, "\\\\");
+				break;
+			case '\0':
+				fprintf(fp, "\\0");
+				break;
+			case '\b':
+				fprintf(fp, "\\b");
+				break;
+			case '\f':
+				fprintf(fp, "\\f");
+				break;
+			case '\n':
+				fprintf(fp, "\\n");
+				break;
+			case '\r':
+				fprintf(fp, "\\r");
+				break;
+			case '\t':
+				fprintf(fp, "\\t");
+				break;
+			case '\a':
+				fprintf(fp, "\\a");
+				break;
+			case '\v':
+				fprintf(fp, "\\v");
+				break;
+			case '\x1b':
+				fprintf(fp, "\\e");
+				break;
+			case 0x85:
+				fprintf(fp, "\\N");
+				break;
+			case 0xa0:
+				fprintf(fp, "\\_");
+				break;
+			case 0x2028:
+				fprintf(fp, "\\L");
+				break;
+			case 0x2029:
+				fprintf(fp, "\\P");
+				break;
+			default:
+				if ((c >= 0x01 && c <= 0x1f) || c == 0x7f ||	/* C0 */
+				    (c >= 0x80 && c <= 0x9f))			/* C1 */
+					fprintf(fp, "\\x%02x", c);
+				else
+					fprintf(fp, "%.*s", w, p);
+				break;
+			}
+		}
+		break;
+	case FYET_ALIAS:
+		alias = fy_token_get_text(fye->alias.anchor, &alias_len);
+		fprintf(fp, " %s%.*s", "*", (int)alias_len, alias);
+		break;
+	}
+
+	mbuf = fy_memstream_close(fyms, &msize);
+	return mbuf;
+}
+
+struct fy_eventp *
+fy_document_iterator_eventp_alloc(struct fy_document_iterator *fydi)
+{
+	struct fy_eventp *fyep = NULL;
+
+	if (!fydi)
+		return NULL;
+
+	if (fydi->recycled_eventp_list)
+		fyep = fy_eventp_list_pop(fydi->recycled_eventp_list);
+	if (!fyep)
+		fyep = fy_eventp_alloc();
+	if (!fyep)
+		return NULL;
+
+	fyep->e.type = FYET_NONE;
+
+	return fyep;
+}
+
+void fy_document_iterator_eventp_clean(struct fy_document_iterator *fydi, struct fy_eventp *fyep)
+{
+	if (!fydi || !fyep)
+		return;
+
+	fy_eventp_clean_rl(fydi->recycled_token_list, fyep);
+}
+
+void fy_document_iterator_eventp_recycle(struct fy_document_iterator *fydi, struct fy_eventp *fyep)
+{
+	if (!fydi || !fyep)
+		return;
+
+	/* clean, safe to do */
+	fy_document_iterator_eventp_clean(fydi, fyep);
+
+	if (fydi->recycled_eventp_list)
+		fy_eventp_list_push(fydi->recycled_eventp_list, fyep);
+	else
+		fy_eventp_free(fyep);
+}
+
+struct fy_event *
+fy_document_iterator_event_vcreate(struct fy_document_iterator *fydi, enum fy_event_type type, va_list ap)
+{
+	struct fy_eventp *fyep;
+
+	if (!fydi)
+		return NULL;
+
+	fyep = fy_eventp_vcreate_internal(fydi->recycled_eventp_list,
+			fydi->fyd ? fydi->fyd->diag : NULL,
+			fydi->fyd ? fydi->fyd->fyds : NULL,
+			type, ap);
+	if (!fyep)
+		return NULL;
+
+	return &fyep->e;
+}
+
+struct fy_event *
+fy_document_iterator_event_create(struct fy_document_iterator *fydi, enum fy_event_type type, ...)
+{
+	struct fy_event *fye;
+	va_list ap;
+
+	va_start(ap, type);
+	fye = fy_document_iterator_event_vcreate(fydi, type, ap);
+	va_end(ap);
+
+	return fye;
+}
+
+void fy_document_iterator_event_free(struct fy_document_iterator *fydi, struct fy_event *fye)
+{
+	struct fy_eventp *fyep;
+
+	if (!fydi || !fye)
+		return;
+
+	fyep = container_of(fye, struct fy_eventp, e);
+
+	fy_document_iterator_eventp_recycle(fydi, fyep);
+}
+
+const char *
+fy_event_get_comments(struct fy_event *fye)
+{
+	struct fy_token *fyt;
+
+	if (!fye)
+		return NULL;
+
+	fyt = fy_event_get_token(fye);
+	if (!fyt)
+		return NULL;
+
+	return fy_token_get_comments(fyt);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-event.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-event.h
@@ -1,0 +1,65 @@
+/*
+ * fy-event.h - YAML parser private event definition
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_EVENT_H
+#define FY_EVENT_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+#include "fy-typelist.h"
+
+/* private event type */
+FY_TYPE_FWD_DECL_LIST(eventp);
+struct fy_eventp {
+	struct list_head node;
+	struct fy_event e;
+};
+FY_TYPE_DECL_LIST(eventp);
+
+struct fy_eventp *fy_eventp_alloc(void);
+void fy_eventp_free(struct fy_eventp *fyep);
+
+/* called from internal emitter */
+void fy_eventp_release(struct fy_eventp *fyep);
+
+struct fy_eventp *fy_parse_eventp_alloc(struct fy_parser *fyp);
+void fy_parse_eventp_recycle(struct fy_parser *fyp, struct fy_eventp *fyep);
+
+struct fy_eventp *fy_emit_eventp_alloc(struct fy_emitter *fye);
+void fy_emit_eventp_recycle(struct fy_emitter *emit, struct fy_eventp *fyep);
+
+struct fy_eventp *fy_parse_eventp_clone(struct fy_parser *fyp, struct fy_eventp *fyep_src, bool strip_anchors);
+struct fy_token *fy_event_get_and_clear_anchor_token(struct fy_event *fye);
+const char *fy_event_get_anchor(struct fy_event *fye, size_t *anchor_lenp);
+
+struct fy_eventp *
+fy_eventp_vcreate_internal(struct fy_eventp_list *recycled_list, struct fy_diag *diag,
+			   struct fy_document_state *fyds, enum fy_event_type type, va_list ap);
+
+struct fy_token_list;
+
+void fy_eventp_clean_rl(struct fy_token_list *fytl, struct fy_eventp *fyep);
+
+/* convert to event dump string, string is malloc'ed */
+char *fy_event_to_string(struct fy_event *fye);
+
+struct fy_document_iterator;
+
+struct fy_eventp *fy_document_iterator_eventp_alloc(struct fy_document_iterator *fydi);
+void fy_document_iterator_eventp_recycle(struct fy_document_iterator *fydi, struct fy_eventp *fyep);
+struct fy_event *fy_document_iterator_event_create(struct fy_document_iterator *document_iterator, enum fy_event_type type, ...);
+struct fy_event *fy_document_iterator_event_vcreate(struct fy_document_iterator *document_iterator, enum fy_event_type type, va_list ap);
+void fy_document_iterator_event_free(struct fy_document_iterator *document_iterator, struct fy_event *fye);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-input-diag.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-input-diag.c
@@ -1,0 +1,89 @@
+/*
+ * fy-input-diag.c - input and reader diagnostics
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-diag.h"
+#include "fy-input.h"
+
+int fy_reader_vdiag(struct fy_reader *fyr, unsigned int flags,
+		    const char *file, int line, const char *func,
+		    const char *fmt, va_list ap)
+{
+	struct fy_diag_ctx fydc;
+	int fydc_level, fyd_level;
+
+	if (!fyr || !fyr->diag || !fmt)
+		return -1;
+
+	/* perform the enable tests early to avoid the overhead */
+	fydc_level = (flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT;
+	fyd_level = fyr->diag->cfg.level;
+
+	if (fydc_level < fyd_level)
+		return 0;
+
+	/* fill in fy_diag_ctx */
+	memset(&fydc, 0, sizeof(fydc));
+
+	fydc.level = fydc_level;
+	fydc.module = FYEM_SCAN;	/* reader is always scanner */
+	fydc.source_file = file;
+	fydc.source_line = line;
+	fydc.source_func = func;
+	fydc.line = fyr->line;
+	fydc.column = fyr->column;
+
+	return fy_vdiag(fyr->diag, &fydc, fmt, ap);
+}
+
+int fy_reader_diag(struct fy_reader *fyr, unsigned int flags,
+		   const char *file, int line, const char *func,
+		   const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_reader_vdiag(fyr, flags, file, line, func, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+void fy_reader_diag_vreport(struct fy_reader *fyr,
+		            const struct fy_diag_report_ctx *fydrc,
+			    const char *fmt, va_list ap)
+{
+	if (!fyr || !fyr->diag || !fydrc || !fmt)
+		return;
+
+	fy_diag_vreport(fyr->diag, fydrc, fmt, ap);
+}
+
+void fy_reader_diag_report(struct fy_reader *fyr,
+			   const struct fy_diag_report_ctx *fydrc,
+			   const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_reader_diag_vreport(fyr, fydrc, fmt, ap);
+	va_end(ap);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-input.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-input.c
@@ -1,0 +1,1316 @@
+/*
+ * fy-input.c - YAML input methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <limits.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#endif
+
+#include <libfyaml.h>
+
+#include "fy-win32.h"
+#include "fy-parse.h"
+#include "fy-ctype.h"
+
+#include "fy-input.h"
+
+/* amount of multiplication of page size for CHOP size
+ * for a 4K page this is 64K blocks
+ */
+#ifndef FYI_CHOP_MULT
+#define FYI_CHOP_MULT	16
+#endif
+
+struct fy_input *fy_input_alloc(void)
+{
+	struct fy_input *fyi;
+
+	fyi = malloc(sizeof(*fyi));
+	if (!fyi)
+		return NULL;
+	memset(fyi, 0, sizeof(*fyi));
+
+	fyi->state = FYIS_NONE;
+	fyi->refs = 1;
+
+	return fyi;
+}
+
+void fy_input_free(struct fy_input *fyi)
+{
+	if (!fyi)
+		return;
+
+	assert(fyi->refs == 1);
+
+	switch (fyi->state) {
+	case FYIS_NONE:
+	case FYIS_QUEUED:
+	case FYIS_ERROR:
+		/* nothing to do */
+		break;
+	case FYIS_PARSE_IN_PROGRESS:
+	case FYIS_PARSED:
+		fy_input_close(fyi);
+		break;
+	}
+
+	/* always release the memory of the alloc memory */
+	switch (fyi->cfg.type) {
+	case fyit_alloc:
+		free(fyi->cfg.alloc.data);
+		break;
+
+	default:
+		break;
+	}
+	if (fyi->name)
+		free(fyi->name);
+
+	free(fyi);
+}
+
+const char *fy_input_get_filename(struct fy_input *fyi)
+{
+	if (!fyi)
+		return NULL;
+
+	return fyi->name;
+}
+
+static void
+fy_input_from_data_setup_styled(struct fy_input *fyi,
+		struct fy_atom *handle, enum fy_scalar_style sstyle)
+{
+	const char *data;
+	size_t size;
+	unsigned int aflags;
+
+	/* this is an internal method, you'd better to pass garbage */
+	data = fy_input_start(fyi);
+	size = fy_input_size(fyi);
+
+	fyi->buffer = NULL;
+	fyi->allocated = 0;
+	fyi->read = 0;
+	fyi->chunk = 0;
+	fyi->chop = 0;
+	fyi->fp = NULL;
+
+	if (!handle)
+		goto out;
+
+	memset(handle, 0, sizeof(*handle));
+
+	aflags = fy_analyze_scalar_content(data, size,
+			false, fylb_cr_nl, fyfws_space_tab);	/* hardcoded yaml mode */
+
+	if (sstyle == FYSS_ANY) {
+		sstyle = (aflags & (FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN |
+				    FYACF_LB | FYACF_ENDS_WITH_COLON |
+				    FYACF_STARTS_WITH_WS | FYACF_STARTS_WITH_LB |
+				    FYACF_ENDS_WITH_WS | FYACF_ENDS_WITH_LB | FYACF_CONSECUTIVE_LB))
+				== (FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN) ? FYSS_PLAIN : FYSS_DOUBLE_QUOTED;
+	}
+
+	handle->start_mark.input_pos = 0;
+	handle->start_mark.line = 0;
+	handle->start_mark.column = 0;
+	handle->end_mark.input_pos = size;
+	handle->end_mark.line = 0;
+	handle->end_mark.column = fy_utf8_count(data, size);
+
+	handle->storage_hint = 0;	/* just calculate */
+	handle->storage_hint_valid = false;
+	handle->direct_output = false;
+
+	switch (sstyle) {
+	case FYSS_PLAIN:
+		handle->style = FYAS_PLAIN | FYAS_MANUAL_MARK;
+		break;
+	case FYSS_SINGLE_QUOTED:
+		handle->style = FYAS_SINGLE_QUOTED | FYAS_MANUAL_MARK;
+		break;
+	case FYSS_DOUBLE_QUOTED:
+		handle->style = FYAS_DOUBLE_QUOTED | FYAS_MANUAL_MARK;
+		break;
+	case FYSS_LITERAL:
+		handle->style = FYAS_LITERAL | FYAS_MANUAL_MARK;
+		/* we need everything */
+		if (aflags & FYACF_ENDS_WITH_LB)
+			aflags |= FYACF_TRAILING_LB;
+		break;
+	case FYSS_FOLDED:
+		handle->style = FYAS_FOLDED | FYAS_MANUAL_MARK;
+		/* we need everything */
+		if (aflags & FYACF_ENDS_WITH_LB)
+			aflags |= FYACF_TRAILING_LB;
+		break;
+
+	case FYSS_ANY:
+	default:
+		handle->style = FYAS_DOUBLE_QUOTED_MANUAL | FYAS_MANUAL_MARK;
+		break;
+	}
+
+	handle->empty = !!(aflags & FYACF_EMPTY);
+	handle->has_lb = !!(aflags & FYACF_LB);
+	handle->has_ws = !!(aflags & FYACF_WS);
+	handle->starts_with_ws = !!(aflags & FYACF_STARTS_WITH_WS);
+	handle->starts_with_lb = !!(aflags & FYACF_STARTS_WITH_LB);
+	handle->ends_with_ws = !!(aflags & FYACF_ENDS_WITH_WS);
+	handle->ends_with_lb = !!(aflags & FYACF_ENDS_WITH_LB);
+	handle->trailing_lb = !!(aflags & FYACF_TRAILING_LB);
+	handle->size0 = !!(aflags & FYACF_SIZE0);
+	handle->valid_anchor = !!(aflags & FYACF_VALID_ANCHOR);
+
+	handle->chomp = FYAC_STRIP;
+	handle->increment = 0;
+	handle->fyi = fyi;
+	handle->fyi_generation = fyi->generation;
+	handle->tabsize = 0;
+	handle->json_mode = false;	/* XXX hardcoded */
+	handle->lb_mode = fylb_cr_nl;
+	handle->fws_mode = fyfws_space_tab;
+	handle->directive0_mode = false;
+out:
+	fyi->state = FYIS_PARSED;
+}
+
+
+static void fy_input_from_data_setup(struct fy_input *fyi,
+				     struct fy_atom *handle, bool simple)
+{
+	fy_input_from_data_setup_styled(fyi, handle,
+			simple ? FYSS_PLAIN : FYSS_ANY);
+}
+
+struct fy_input *fy_input_from_data(const char *data, size_t size,
+				    struct fy_atom *handle, bool simple)
+{
+	struct fy_input *fyi;
+
+	if (data && size == (size_t)-1)
+		size = strlen(data);
+
+	fyi = fy_input_alloc();
+	if (!fyi)
+		return NULL;
+
+	fyi->cfg.type = fyit_memory;
+	fyi->cfg.userdata = NULL;
+	fyi->cfg.memory.data = data;
+	fyi->cfg.memory.size = size;
+
+	fy_input_from_data_setup(fyi, handle, simple);
+
+	return fyi;
+}
+
+struct fy_input *fy_input_from_malloc_data(char *data, size_t size,
+					   struct fy_atom *handle, bool simple)
+{
+	struct fy_input *fyi;
+
+	if (data && size == (size_t)-1)
+		size = strlen(data);
+
+	fyi = fy_input_alloc();
+	if (!fyi)
+		return NULL;
+
+	fyi->cfg.type = fyit_alloc;
+	fyi->cfg.userdata = NULL;
+	fyi->cfg.alloc.data = data;
+	fyi->cfg.alloc.size = size;
+
+	fy_input_from_data_setup(fyi, handle, simple);
+
+	return fyi;
+}
+
+struct fy_input *fy_input_from_data_styled(const char *data, size_t size,
+				    struct fy_atom *handle, enum fy_scalar_style sstyle)
+{
+	struct fy_input *fyi;
+
+	if (data && size == (size_t)-1)
+		size = strlen(data);
+
+	fyi = fy_input_alloc();
+	if (!fyi)
+		return NULL;
+
+	fyi->cfg.type = fyit_memory;
+	fyi->cfg.userdata = NULL;
+	fyi->cfg.memory.data = data;
+	fyi->cfg.memory.size = size;
+
+	fy_input_from_data_setup_styled(fyi, handle, sstyle);
+
+	return fyi;
+}
+
+struct fy_input *fy_input_from_malloc_data_styled(char *data, size_t size,
+					   struct fy_atom *handle,  enum fy_scalar_style sstyle)
+{
+	struct fy_input *fyi;
+
+	if (data && size == (size_t)-1)
+		size = strlen(data);
+
+	fyi = fy_input_alloc();
+	if (!fyi)
+		return NULL;
+
+	fyi->cfg.type = fyit_alloc;
+	fyi->cfg.userdata = NULL;
+	fyi->cfg.alloc.data = data;
+	fyi->cfg.alloc.size = size;
+
+	fy_input_from_data_setup_styled(fyi, handle, sstyle);
+
+	return fyi;
+}
+
+void fy_input_close(struct fy_input *fyi)
+{
+	if (!fyi)
+		return;
+
+	switch (fyi->cfg.type) {
+
+	case fyit_file:
+	case fyit_fd:
+
+		if (fyi->addr) {
+			munmap(fyi->addr, fyi->length);
+			fyi->addr = NULL;
+		}
+
+		if (fyi->fd != -1) {
+			if (!fyi->cfg.no_close_fd)
+				close(fyi->fd);
+			fyi->fd = -1;
+		}
+
+		if (fyi->buffer) {
+			free(fyi->buffer);
+			fyi->buffer = NULL;
+		}
+		if (fyi->fp) {
+			if (!fyi->cfg.no_fclose_fp)
+				fclose(fyi->fp);
+			fyi->fp = NULL;
+		}
+		break;
+
+	case fyit_stream:
+	case fyit_callback:
+		if (fyi->buffer) {
+			free(fyi->buffer);
+			fyi->buffer = NULL;
+		}
+		break;
+
+	case fyit_memory:
+		/* nothing */
+		break;
+
+	case fyit_alloc:
+		/* nothing */
+		break;
+
+	case fyit_dociter:
+		/* nothing */
+		break;
+
+	default:
+		break;
+	}
+}
+
+ssize_t fy_input_estimate_queued_size(const struct fy_input *fyi)
+{
+	struct stat sb;
+	int fd, rc;
+
+	if (!fyi || fyi->state != FYIS_QUEUED)
+		return 0;
+
+	memset(&sb, 0, sizeof(sb));
+
+	switch (fyi->cfg.type) {
+	case fyit_file:
+		rc = stat(fyi->cfg.file.filename, &sb);
+		if (rc)
+			return -1;
+		break;
+
+	case fyit_stream:
+		fd = fileno(fyi->cfg.stream.fp);
+		if (fd < 0)
+			return -1;
+		rc = fstat(fd, &sb);
+		if (rc)
+			return -1;
+		break;
+
+	case fyit_memory:
+		return (ssize_t)fyi->cfg.memory.size;
+
+	case fyit_alloc:
+		return (ssize_t)fyi->cfg.alloc.size;
+
+	case fyit_fd:
+		rc = fstat(fyi->cfg.fd.fd, &sb);
+		if (rc)
+			return -1;
+		break;
+
+	case fyit_callback:
+	case fyit_dociter:
+	default:
+		return SSIZE_MAX;	/* cannot determine */
+	}
+
+	/* only do it for regular files */
+	if ((sb.st_mode & S_IFMT) != S_IFREG)
+		return SSIZE_MAX;
+
+	/* check for very impossible roll-over */
+	if ((size_t)sb.st_size > (size_t)SSIZE_MAX)
+		return SSIZE_MAX;
+
+	/* ok, we did find it */
+	return (ssize_t)sb.st_size;
+}
+
+struct fy_diag *fy_reader_get_diag(struct fy_reader *fyr)
+{
+	if (fyr && fyr->ops && fyr->ops->get_diag)
+		return fyr->ops->get_diag(fyr);
+
+	return NULL;
+}
+
+int fy_reader_file_open(struct fy_reader *fyr, const char *filename)
+{
+	int flags = O_RDONLY;
+
+	if (!fyr || !filename)
+		return -1;
+
+	if (fyr->ops && fyr->ops->file_open)
+		return fyr->ops->file_open(fyr, filename);
+
+	return open(filename, flags);
+}
+
+void fy_reader_reset(struct fy_reader *fyr)
+{
+	const struct fy_reader_ops *ops;
+	struct fy_diag *diag;
+
+	if (!fyr)
+		return;
+
+	ops = fyr->ops;
+	diag = fyr->diag;
+
+	fy_input_unref(fyr->current_input);
+
+	memset(fyr, 0, sizeof(*fyr));
+
+	/* by default we're always in yaml mode */
+	fyr->mode = fyrm_yaml;
+	fyr->ops = ops;
+	fyr->diag = diag;
+}
+
+void fy_reader_setup(struct fy_reader *fyr, const struct fy_reader_ops *ops)
+{
+	if (!fyr)
+		return;
+
+	fyr->ops = ops;
+	fyr->diag = fy_reader_get_diag(fyr);
+	fyr->current_input = NULL;
+	fy_reader_reset(fyr);
+}
+
+void fy_reader_cleanup(struct fy_reader *fyr)
+{
+	if (!fyr)
+		return;
+
+	fy_input_unref(fyr->current_input);
+	fyr->current_input = NULL;
+	fy_reader_reset(fyr);
+}
+
+void fy_reader_apply_mode(struct fy_reader *fyr)
+{
+	struct fy_input *fyi;
+
+	assert(fyr);
+
+	/* set input mode from the current reader settings */
+	switch (fyr->mode) {
+	case fyrm_yaml:
+		fyr->json_mode = false;
+		fyr->lb_mode = fylb_cr_nl;
+		fyr->fws_mode = fyfws_space_tab;
+		fyr->directive0_mode = false;
+		break;
+	case fyrm_json:
+		fyr->json_mode = true;
+		fyr->lb_mode = fylb_cr_nl;
+		fyr->fws_mode = fyfws_space;
+		fyr->directive0_mode = false;
+		break;
+	case fyrm_yaml_1_1:
+		fyr->json_mode = false;
+		fyr->lb_mode = fylb_cr_nl_N_L_P;
+		fyr->fws_mode = fyfws_space_tab;
+		fyr->directive0_mode = true;
+		break;
+	}
+	fyi = fyr->current_input;
+	if (fyi) {
+		fyi->json_mode = fyr->json_mode;
+		fyi->lb_mode = fyr->lb_mode;
+		fyi->fws_mode = fyr->fws_mode;
+		fyi->directive0_mode = fyr->directive0_mode;
+	}
+}
+
+int fy_reader_input_open(struct fy_reader *fyr, struct fy_input *fyi, const struct fy_reader_input_cfg *icfg)
+{
+	struct stat sb;
+	struct fy_document_iterator *fydi;
+	int rc;
+
+	if (!fyi)
+		return -1;
+
+	/* unref any previous input */
+	fy_input_unref(fyr->current_input);
+	fyr->current_input = fy_input_ref(fyi);
+
+	fy_reader_apply_mode(fyr);
+
+	if (!icfg)
+		memset(&fyr->current_input_cfg, 0, sizeof(fyr->current_input_cfg));
+	else
+		fyr->current_input_cfg = *icfg;
+
+	/* reset common data */
+	fyi->buffer = NULL;
+	fyi->allocated = 0;
+	fyi->read = 0;
+	fyi->chunk = 0;
+	fyi->chop = 0;
+	fyi->fp = NULL;
+
+	switch (fyi->cfg.type) {
+
+	case fyit_file:
+	case fyit_fd:
+
+		switch (fyi->cfg.type) {
+		case fyit_file:
+			fyi->fd = fy_reader_file_open(fyr, fyi->cfg.file.filename);
+			fyr_error_check(fyr, fyi->fd != -1, err_out,
+					"failed to open %s",  fyi->cfg.file.filename);
+			break;
+
+		case fyit_fd:
+			fyi->fd = fyi->cfg.fd.fd;
+			fyr_error_check(fyr, fyi->fd >= 0, err_out,
+					"bad file.fd %d",  fyi->cfg.fd.fd);
+			break;
+		default:
+			FY_IMPOSSIBLE_ABORT();
+		}
+
+		rc = fstat(fyi->fd, &sb);
+		fyr_error_check(fyr, rc != -1, err_out,
+				"failed to fstat %s", fyi->cfg.file.filename);
+
+		fyi->length = sb.st_size;
+
+		/* only map if not zero (and is not disabled) */
+		if (sb.st_size > 0 && !fyr->current_input_cfg.disable_mmap_opt) {
+			fyi->addr = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fyi->fd, 0);
+
+			/* convert from MAP_FAILED to NULL */
+			if (fyi->addr == MAP_FAILED) {
+				fyr_debug(fyr, "mmap failed for file %s",
+						fyi->cfg.file.filename);
+				fyi->addr = NULL;
+			}
+		}
+		/* if we've managed to mmap, we' good */
+		if (fyi->addr)
+			break;
+
+		/* if we're not ignoring stdio, open a FILE* using the fd */
+		if (sb.st_size > 0 && !fyi->cfg.ignore_stdio) {
+			fyi->fp = fdopen(fyi->fd, "rb");
+			fyr_error_check(fyr, rc != -1, err_out, "failed to fdopen %s", fyi->name);
+		} else
+			fyi->fp = NULL;
+
+		break;
+
+	case fyit_stream:
+		if (!fyi->cfg.ignore_stdio)
+			fyi->fp = fyi->cfg.stream.fp;
+		else
+			fyi->fd = fileno(fyi->cfg.stream.fp);
+		break;
+
+	case fyit_memory:
+		/* nothing to do for memory */
+		break;
+
+	case fyit_alloc:
+		/* nothing to do for memory */
+		break;
+
+	case fyit_callback:
+		break;
+
+	case fyit_dociter:
+		fydi = fyi->cfg.dociter.fydi;
+		fyr_error_check(fyr, fydi, err_out,
+				"missing document iterator");
+		break;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	switch (fyi->cfg.type) {
+
+		/* those two need no memory */
+	case fyit_memory:
+	case fyit_alloc:
+	case fyit_dociter:
+		break;
+
+		/* all the rest need it */
+	default:
+		/* if we're not in mmap mode */
+		if (fyi->addr && !fyr->current_input_cfg.disable_mmap_opt)
+			break;
+
+		fyi->chunk = fyi->cfg.chunk;
+		if (!fyi->chunk)
+			fyi->chunk = sysconf(_SC_PAGESIZE);
+		fyi->chop = fyi->chunk * FYI_CHOP_MULT;
+		fyi->buffer = malloc(fyi->chunk);
+		fyr_error_check(fyr, fyi->buffer, err_out,
+				"fy_alloc() failed");
+		fyi->allocated = fyi->chunk;
+		break;
+	}
+
+	fyr->this_input_start = 0;
+	fyr->line = 0;
+	fyr->column = 0;
+	fyr->current_ptr = NULL;
+	fyr->current_ptr_start = NULL;
+	fyr->current_ptr_end = NULL;
+
+	fyi->state = FYIS_PARSE_IN_PROGRESS;
+
+	return 0;
+
+err_out:
+	fy_input_close(fyi);
+	fyi->state = FYIS_ERROR;
+	return -1;
+}
+
+int fy_reader_input_done(struct fy_reader *fyr)
+{
+	struct fy_input *fyi;
+	void *buf;
+	size_t current_input_pos;
+
+	if (!fyr)
+		return -1;
+
+	fyi = fyr->current_input;
+	if (!fyi)
+		return 0;
+
+	current_input_pos = fy_reader_current_input_pos(fyr);
+
+	switch (fyi->cfg.type) {
+	case fyit_file:
+	case fyit_fd:
+		if (fyi->addr)
+			break;
+
+		/* fall-through */
+
+	case fyit_stream:
+	case fyit_callback:
+		/* chop extra buffer */
+		if (current_input_pos > 0) {
+			buf = realloc(fyi->buffer, current_input_pos);
+			fyr_error_check(fyr, buf || !current_input_pos, err_out,
+					"realloc() failed");
+		} else {
+			/* for empty stream, just free everything */
+			free(fyi->buffer);
+			buf = NULL;
+		}
+
+		/* increate input generation; required for direct input to work */
+		if (fyi->buffer != buf) {
+			fyi->buffer = buf;
+			fyi->generation++;
+		}
+
+		fyi->allocated = current_input_pos;
+
+		break;
+
+	default:
+		break;
+
+	}
+
+	fyi->state = FYIS_PARSED;
+	fy_input_unref(fyi);
+	fyr->current_input = NULL;
+
+	return 0;
+
+err_out:
+	fyi->state = FYIS_ERROR;
+	return -1;
+}
+
+int fy_reader_input_scan_token_mark_slow_path(struct fy_reader *fyr)
+{
+	struct fy_input *fyi, *fyi_new = NULL;
+	size_t current_input_pos;
+
+	assert(fyr);
+
+	if (!fy_reader_input_chop_active(fyr))
+		return 0;
+
+	fyi = fyr->current_input;
+	assert(fyi);
+
+	fyi_new = fy_input_alloc();
+	fyr_error_check(fyr, fyi_new, err_out,
+			"fy_input_alloc() failed\n");
+
+	/* copy the config over */
+	fyi_new->cfg = fyi->cfg;
+	fyi_new->name = strdup(fyi->name);
+	fyr_error_check(fyr, fyi_new->name, err_out,
+			"strdup() failed\n");
+
+	fyi_new->chunk = fyi->chunk;
+	fyi_new->chop = fyi->chop;
+	fyi_new->buffer = malloc(fyi->chunk);
+	fyr_error_check(fyr, fyi_new->buffer, err_out,
+			"fy_alloc() failed");
+	fyi_new->allocated = fyi->chunk;
+	fyi_new->fp = fyi->fp;
+
+	fyi->fp = NULL;	/* the file pointer now assigned to the new */
+
+	fyi_new->lb_mode = fyi->lb_mode;
+	fyi_new->fws_mode = fyi->fws_mode;
+	fyi_new->directive0_mode = fyi->directive0_mode;
+
+	fyi_new->state = FYIS_PARSE_IN_PROGRESS;
+
+	/* adjust and copy the left over reads */
+	current_input_pos = fy_reader_current_input_pos(fyr);
+	assert(fyi->read >= current_input_pos);
+	fyi_new->read = fyi->read - current_input_pos;
+	if (fyi_new->read > 0)
+		memcpy(fyi_new->buffer, (const char *)fyi->buffer + current_input_pos, fyi_new->read);
+
+	fyr->this_input_start += current_input_pos;
+
+	/* update the reader to point to the new input */
+	fyr->current_input = fyi_new;
+	fyr->current_ptr = fyi_new->buffer;
+	fyr->current_ptr_start = fyi_new->buffer;
+	fyr->current_ptr_end = (const char *)fyr->current_ptr_start + fyi_new->read;
+
+	fyr_debug(fyr, "chop at this_input_start=%zu chop=%zu\n", fyr->this_input_start, fyi->chop);
+
+	/* free the old input - while references to it exist it will hang around */
+	fyi->state = FYIS_PARSED;
+	fy_input_unref(fyi);
+	fyi = NULL;
+
+	return 0;
+err_out:
+	fy_input_unref(fyi_new);
+	return -1;
+}
+
+const void *fy_reader_ptr_slow_path(struct fy_reader *fyr, size_t *leftp)
+{
+	struct fy_input *fyi;
+	const void *p, *start;
+	size_t size, left, current_input_pos;
+
+	if (fyr->current_ptr) {
+		if (leftp)
+			*leftp = fy_reader_current_left(fyr);
+		return fyr->current_ptr;
+	}
+
+	fyi = fyr->current_input;
+	if (!fyi)
+		return NULL;
+
+	/* tokens cannot cross boundaries */
+	start = fy_input_start_size(fyi, &size);
+
+	current_input_pos = fy_reader_current_input_pos(fyr);
+	left = size - current_input_pos;
+	assert(left <= size);
+
+	p = (const char *)start + current_input_pos;
+
+	if (leftp)
+		*leftp = left;
+
+	if (!fyr->current_ptr_start) {
+		fyr->current_ptr_start = start;
+		fyr->current_ptr_end = (const char *)start + size;
+	}
+
+	fyr->current_ptr = p;
+
+	assert(current_input_pos <= size);
+
+	return p;
+}
+
+int fy_reader_peek_at_offset_width_slow_path(struct fy_reader *fyr, size_t offset, int *wp)
+{
+	const uint8_t *p;
+	size_t left;
+	int w;
+
+	assert(fyr);
+
+	/* ensure that the first octet at least is pulled in */
+	p = fy_reader_ensure_lookahead(fyr, offset + 1, &left);
+	if (!p)
+		return FYUG_EOF;
+
+	/* get width by first octet */
+	w = fy_utf8_width_by_first_octet(p[offset]);
+	if (!w)
+		return FYUG_INV;
+
+	/* make sure that there's enough to cover the utf8 width */
+	if (offset + w > left) {
+		p = fy_reader_ensure_lookahead(fyr, offset + w, &left);
+		if (!p)
+			return FYUG_PARTIAL;
+	}
+
+	return fy_utf8_get(p + offset, left - offset, wp);
+}
+
+int64_t fy_reader_peek_at_offset_width_slow_path_64(struct fy_reader *fyr, size_t offset)
+{
+	const uint8_t *p;
+	size_t left;
+	int w;
+
+	assert(fyr);
+
+	/* ensure that the first octet at least is pulled in */
+	p = fy_reader_ensure_lookahead(fyr, offset + 1, &left);
+	if (!p)
+		return FYUG_EOF;
+
+	/* get width by first octet */
+	w = fy_utf8_width_by_first_octet(p[offset]);
+	if (!w)
+		return FYUG_INV;
+
+	/* make sure that there's enough to cover the utf8 width */
+	if (offset + w > left) {
+		p = fy_reader_ensure_lookahead(fyr, offset + w, &left);
+		if (!p)
+			return FYUG_PARTIAL;
+	}
+
+	return fy_utf8_get_64(p + offset, left - offset);
+}
+
+const void *fy_reader_input_try_pull(struct fy_reader *fyr, struct fy_input *fyi,
+				     size_t pull, size_t *leftp)
+{
+	const void *p;
+	size_t left, pos, size, nread, nreadreq, missing;
+	ssize_t snread, current_input_pos;
+	size_t space __FY_DEBUG_UNUSED__;
+	void *buf;
+
+	if (!fyr || !fyi || fyi->state == FYIS_ERROR) {
+		if (leftp)
+			*leftp = 0;
+		return NULL;
+	}
+
+	p = NULL;
+	left = 0;
+
+	current_input_pos = fy_reader_current_input_pos(fyr);
+	pos = current_input_pos;
+
+	switch (fyi->cfg.type) {
+	case fyit_file:
+	case fyit_fd:
+
+		if (fyi->addr) {
+			assert(fyi->length >= (fyr->this_input_start + pos));
+
+			left = fyi->length - (fyr->this_input_start + pos);
+			if (!left) {
+				fyr_debug(fyr, "file input exhausted");
+				break;
+			}
+			p = (char *)fyi->addr + pos;
+			break;
+		}
+
+		/* fall-through */
+
+	case fyit_stream:
+	case fyit_callback:
+
+		assert(fyi->read >= pos);
+		assert(fyi->chunk > 0);
+
+		left = fyi->read - pos;
+		p = (char *)fyi->buffer + pos;
+
+		/* enough to satisfy directly */
+		if (left >= pull)
+			break;
+
+		/* no more */
+		if (fyi->eof) {
+			if (!left) {
+				fyr_debug(fyr, "input exhausted (EOF)");
+				p = NULL;
+			}
+			break;
+		}
+
+		space = fyi->allocated - pos;
+
+		/* if we're missing more than the buffer space */
+		missing = pull - left;
+
+		fyr_debug(fyr, "input: allocated=%zu read=%zu pos=%zu pull=%zu left=%zu space=%zu missing=%zu",
+				fyi->allocated, fyi->read, pos, pull, left, space, missing);
+
+		if (pos + pull > fyi->allocated) {
+
+			/* align size to chunk */
+			size = fyi->allocated + missing + fyi->chunk - 1;
+			size = size - size % fyi->chunk;
+
+			fyr_debug(fyr, "input buffer missing %zu bytes (pull=%zu)", missing, pull);
+
+			buf = realloc(fyi->buffer, size);
+			if (!buf) {
+				fyr_error(fyr, "realloc() failed");
+				goto err_out;
+			}
+
+			fyr_debug(fyr, "input read allocated=%zu new-size=%zu", fyi->allocated, size);
+
+			/* increase input generation; required for direct input to work */
+			if (fyi->buffer != buf) {
+				fyi->buffer = buf;
+				fyi->generation++;
+			}
+
+			fyi->allocated = size;
+			space = fyi->allocated - pos;
+			p = (char *)fyi->buffer + pos;
+		}
+
+		/* always try to read up to the allocated space */
+		do {
+			nreadreq = fyi->allocated - fyi->read;
+			assert(nreadreq > 0);
+
+			if (fyi->cfg.type == fyit_callback) {
+
+				fyr_debug(fyr, "performing callback request of %zu", nreadreq);
+
+				nread = fyi->cfg.callback.input(fyi->cfg.userdata, (char *)fyi->buffer + fyi->read, nreadreq);
+
+				fyr_debug(fyr, "callback returned %zu", nread);
+
+				if (nread <= 0) {
+					if (!nread) {
+						fyi->eof = true;
+						fyr_debug(fyr, "callback got EOF");
+					} else {
+						fyi->err = true;
+						fyr_debug(fyr, "callback got error");
+					}
+					break;
+				}
+
+			} else if (fyi->fp) {
+
+				fyr_debug(fyr, "performing fread request of %zu", nreadreq);
+
+				nread = fread((char *)fyi->buffer + fyi->read, 1, nreadreq, fyi->fp);
+
+				fyr_debug(fyr, "fread returned %zu", nread);
+
+				if (nread <= 0) {
+					fyi->err = ferror(fyi->fp);
+					if (fyi->err) {
+						fyi->eof = true;
+						fyr_debug(fyr, "fread got ERROR");
+						goto err_out;
+					}
+
+					fyi->eof = feof(fyi->fp);
+					if (fyi->eof)
+						fyr_debug(fyr, "fread got EOF");
+					nread = 0;
+					break;
+				}
+
+			} else if (fyi->fd >= 0) {
+
+				fyr_debug(fyr, "performing read request of %zu", nreadreq);
+
+				do {
+					snread = read(fyi->fd, (char *)fyi->buffer + fyi->read, nreadreq);
+				} while (snread == -1 && errno == EAGAIN);
+				fyr_debug(fyr, "read returned %zd", snread);
+
+				if (snread == -1) {
+					fyi->err = true;
+					fyi->eof = true;
+					fyr_error(fyr, "read() failed: %s", strerror(errno));
+					goto err_out;
+				}
+
+				if (!snread) {
+					fyi->eof = true;
+					nread = 0;
+					break;
+				}
+
+				nread = snread;
+			} else {
+				fyr_error(fyr, "No FILE* nor fd available?");
+				fyi->eof = true;
+				nread = 0;
+				goto err_out;
+			}
+
+			assert(nread > 0);
+
+			fyi->read += nread;
+			left = fyi->read - pos;
+
+		} while (left < pull);
+
+		/* no more, move it to parsed input chunk list */
+		if (!left) {
+			fyr_debug(fyr, "input exhausted");
+			p = NULL;
+		}
+		break;
+
+	case fyit_memory:
+		assert(fyi->cfg.memory.size >= pos);
+
+		left = fyi->cfg.memory.size - pos;
+		if (!left) {
+			fyr_debug(fyr, "memory input exhausted");
+			break;
+		}
+		p = (const char *)fyi->cfg.memory.data + pos;
+		break;
+
+	case fyit_alloc:
+		assert(fyi->cfg.alloc.size >= pos);
+
+		left = fyi->cfg.alloc.size - pos;
+		if (!left) {
+			fyr_debug(fyr, "alloc input exhausted");
+			break;
+		}
+		p = (const char *)fyi->cfg.alloc.data + pos;
+		break;
+
+	case fyit_dociter:
+		FY_IMPOSSIBLE_ABORT();
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	if (leftp)
+		*leftp = left;
+	return p;
+
+err_out:
+	if (leftp)
+		*leftp = 0;
+	return NULL;
+}
+
+void
+fy_reader_advance_slow_path(struct fy_reader *fyr, int c)
+{
+	bool is_line_break = false;
+
+	if (c < 0)
+		return;
+
+	fy_reader_advance_octets(fyr, fy_utf8_width(c));
+
+	/* first check for CR/LF */
+	if (c == '\r' && fy_reader_peek(fyr) == '\n') {
+		fy_reader_advance_octets(fyr, 1);
+		is_line_break = true;
+	} else if (fy_reader_is_lb(fyr, c))
+		is_line_break = true;
+
+	if (is_line_break) {
+		fyr->column = 0;
+		fyr->line++;
+	} else if (fyr->tabsize && fy_is_tab(c))
+		fyr->column += (fyr->tabsize - (fyr->column % fyr->tabsize));
+	else
+		fyr->column++;
+}
+
+struct fy_input *fy_input_create(const struct fy_input_cfg *fyic)
+{
+	struct fy_input *fyi = NULL;
+	int ret;
+
+	fyi = fy_input_alloc();
+	if (!fyi)
+		return NULL;
+	fyi->cfg = *fyic;
+
+	/* copy filename pointers and switch */
+	switch (fyic->type) {
+
+	case fyit_file:
+		fyi->name = strdup(fyic->file.filename);
+		break;
+
+	case fyit_fd:
+		ret = asprintf(&fyi->name, "<fd-%d>", fyic->fd.fd);
+		if (ret == -1)
+			fyi->name = NULL;
+		break;
+
+	case fyit_stream:
+		if (fyic->stream.name)
+			fyi->name = strdup(fyic->stream.name);
+		else if (fyic->stream.fp == stdin)
+			fyi->name = strdup("<stdin>");
+		else {
+			ret = asprintf(&fyi->name, "<stream-%d>",
+					fileno(fyic->stream.fp));
+			if (ret == -1)
+				fyi->name = NULL;
+		}
+		break;
+	case fyit_memory:
+		ret = asprintf(&fyi->name, "<memory-@%p-%p>",
+			fyic->memory.data, (const char *)fyic->memory.data + fyic->memory.size - 1);
+		if (ret == -1)
+			fyi->name = NULL;
+		break;
+	case fyit_alloc:
+		ret = asprintf(&fyi->name, "<alloc-@%p-%p>",
+			fyic->memory.data, (const char *)fyic->memory.data + fyic->memory.size - 1);
+		if (ret == -1)
+			fyi->name = NULL;
+		break;
+	case fyit_callback:
+		ret = asprintf(&fyi->name, "<callback>");
+		if (ret == -1)
+			fyi->name = NULL;
+		break;
+
+	case fyit_dociter:
+		ret = asprintf(&fyi->name, "<dociter-@%p>", fyi->cfg.dociter.fydi);
+		if (ret == -1)
+			fyi->name = NULL;
+		break;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+	if (!fyi->name)
+		goto err_out;
+
+	fyi->buffer = NULL;
+	fyi->allocated = 0;
+	fyi->read = 0;
+	fyi->chunk = 0;
+	fyi->chop = 0;
+	fyi->fp = NULL;
+	fyi->fd = -1;
+	fyi->addr = NULL;
+	fyi->length = -1;
+
+	/* default modes */
+	fyi->lb_mode = fylb_cr_nl;
+	fyi->fws_mode = fyfws_space_tab;
+	fyi->directive0_mode = false;
+
+	return fyi;
+
+err_out:
+	fy_input_unref(fyi);
+	return NULL;
+}
+
+/* ensure that there are at least size octets available */
+const void *fy_reader_ensure_lookahead_slow_path(struct fy_reader *fyr, size_t size, size_t *leftp)
+{
+	const void *p, *new_start, *old_start;
+	size_t left, new_size, old_size;
+
+	if (!leftp)
+		leftp = &left;
+
+	p = fy_reader_ptr(fyr, leftp);
+	if (!p || *leftp < size) {
+
+		if (!fyr->current_input) {
+			fyr_debug(fyr, "ensure lookahead size=%zd left=%zd no input left",
+					size, *leftp);
+			return NULL;
+		}
+		fyr_debug(fyr, "ensure lookahead size=%zd left=%zd (%s - %zu)",
+				size, *leftp,
+				fy_input_get_filename(fyr->current_input),
+				fy_reader_current_input_pos(fyr));
+
+		/* update with what is new */
+		old_start = fy_input_start_size(fyr->current_input, &old_size);
+
+		p = fy_reader_input_try_pull(fyr, fyr->current_input, size, leftp);
+		if (!p || *leftp < size)
+			return NULL;
+
+		/* update with what is new */
+		new_start = fy_input_start_size(fyr->current_input, &new_size);
+
+		/* oops, input characteristics changed */
+		if (old_start != new_start || old_size != new_size) {
+
+			/* buffer just grew in place */
+			if (old_start == new_start) {
+				fyr_debug(fyr, "buffer grew %zu -> %zu",
+						old_size, new_size);
+			} else {
+				fyr_debug(fyr, "buffer changed %p/%zu -> %p/%zu",
+						old_start, old_size, new_start, new_size);
+
+				fyr->current_ptr_start = new_start;
+			}
+
+			fyr->current_ptr_end = (const char *)fyr->current_ptr_start + new_size;
+		}
+
+		fyr->current_ptr = p;
+	}
+	return p;
+}
+
+struct fy_event *fy_reader_generate_next_event(struct fy_reader *fyr)
+{
+	struct fy_input *fyi;
+	struct fy_document_iterator *fydi;
+	struct fy_event *fye;
+
+	fyi = fy_reader_current_input(fyr);
+	if (!fyi || fyi->cfg.type != fyit_dociter)
+		return NULL;
+
+	fydi = fyi->cfg.dociter.fydi;
+
+	do {
+		fye = fy_document_iterator_generate_next(fydi);
+		if (!fye)
+			return NULL;
+
+		/* remove if we don't want the event */
+		if (((fye->type == FYET_STREAM_START || fye->type == FYET_STREAM_END) &&
+				!(fyi->cfg.dociter.flags & FYPEGF_GENERATE_STREAM_EVENTS)) ||
+		    ((fye->type == FYET_DOCUMENT_START || fye->type == FYET_DOCUMENT_END) &&
+				!(fyi->cfg.dociter.flags & FYPEGF_GENERATE_DOCUMENT_EVENTS))) {
+			fy_document_iterator_event_free(fydi, fye);
+			fye = NULL;
+		}
+	} while (!fye);
+
+	return fye;
+}
+
+void fy_reader_event_free(struct fy_reader *fyr, struct fy_event *fye)
+{
+	struct fy_input *fyi;
+
+	fyi = fy_reader_current_input(fyr);
+	assert(fyi);
+	assert(fy_reader_generates_events(fyr));
+
+	assert (fyi->cfg.type == fyit_dociter);
+
+	fy_document_iterator_event_free(fyi->cfg.dociter.fydi, fye);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-input.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-input.h
@@ -1,0 +1,1016 @@
+/*
+ * fy-input.h - YAML input methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_INPUT_H
+#define FY_INPUT_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
+#include <libfyaml.h>
+
+#include "fy-utils.h"
+#include "fy-typelist.h"
+#include "fy-ctype.h"
+
+#include "fy-atom.h"
+#include "fy-diag.h"
+
+struct fy_atom;
+struct fy_parser;
+
+enum fy_input_type {
+	fyit_file,
+	fyit_stream,
+	fyit_memory,
+	fyit_alloc,
+	fyit_callback,
+	fyit_fd,
+	fyit_dociter,
+};
+
+struct fy_input_cfg {
+	enum fy_input_type type;
+	void *userdata;
+	size_t chunk;
+	bool ignore_stdio : 1;
+	bool no_fclose_fp : 1;
+	bool no_close_fd : 1;
+	union {
+		struct {
+			const char *filename;
+		} file;
+		struct {
+			const char *name;
+			FILE *fp;
+		} stream;
+		struct {
+			const void *data;
+			size_t size;
+		} memory;
+		struct {
+			void *data;
+			size_t size;
+		} alloc;
+		struct {
+			/* negative return is error, 0 is EOF */
+			ssize_t (*input)(void *user, void *buf, size_t count);
+		} callback;
+		struct {
+			int fd;
+		} fd;
+		struct {
+			enum fy_parser_event_generator_flags flags;
+			struct fy_document_iterator *fydi;
+			struct fy_document *fyd;
+			bool owns_iterator;
+		} dociter;
+	};
+};
+
+enum fy_input_state {
+	FYIS_NONE,
+	FYIS_QUEUED,
+	FYIS_PARSE_IN_PROGRESS,
+	FYIS_PARSED,
+	FYIS_ERROR,
+};
+
+FY_TYPE_FWD_DECL_LIST(input);
+struct fy_input {
+	struct list_head node;
+	enum fy_input_state state;
+	struct fy_input_cfg cfg;
+	int refs;		/* number of referers */
+	char *name;
+	void *buffer;		/* when the file can't be mmaped */
+	uint64_t generation;
+	size_t allocated;
+	size_t read;
+	size_t chunk;
+	size_t chop;
+	FILE *fp;		/* FILE* for the input if it exists */
+	int fd;			/* fd for file and stream */
+	size_t length;		/* length of file */
+	void *addr;		/* mmaped for files, allocated for streams */
+	bool eof : 1;		/* got EOF */
+	bool err : 1;		/* got an error */
+
+	/* propagated */
+	bool json_mode;
+	enum fy_lb_mode lb_mode;
+	enum fy_flow_ws_mode fws_mode;
+	bool directive0_mode;
+};
+FY_TYPE_DECL_LIST(input);
+
+static inline const void *
+fy_input_start_size(const struct fy_input *fyi, size_t *sizep)
+{
+	const void *start;
+	size_t size;
+
+	/* tokens cannot cross boundaries */
+	switch (fyi->cfg.type) {
+	case fyit_file:
+	case fyit_fd:
+		if (fyi->addr) {
+			start = fyi->addr;
+			size = fyi->length;
+			break;
+		}
+
+		/* fall-through */
+
+	case fyit_stream:
+	case fyit_callback:
+		start = fyi->buffer;
+		size = fyi->read;
+		break;
+
+	case fyit_memory:
+		start = fyi->cfg.memory.data;
+		size = fyi->cfg.memory.size;
+		break;
+
+	case fyit_alloc:
+		start = fyi->cfg.alloc.data;
+		size = fyi->cfg.alloc.size;
+		break;
+
+	default:
+		start = NULL;
+		size = 0;
+		break;
+	}
+
+	/* if we've parsed need to clamp */
+	if (fyi->state == FYIS_PARSED || fyi->state == FYIS_ERROR) {
+		switch (fyi->cfg.type) {
+		case fyit_file:
+		case fyit_fd:
+		case fyit_stream:
+		case fyit_callback:
+			if (fyi->allocated < size)
+				size = fyi->allocated;
+			break;
+		default:
+			break;
+		}
+	}
+
+	*sizep = size;
+	return start;
+}
+
+static inline const void *fy_input_start(const struct fy_input *fyi)
+{
+	size_t size;
+	return fy_input_start_size(fyi, &size);
+}
+
+static inline size_t fy_input_size(const struct fy_input *fyi)
+{
+	size_t size;
+	(void)fy_input_start_size(fyi, &size);
+	return size;
+}
+
+struct fy_input *fy_input_alloc(void);
+void fy_input_free(struct fy_input *fyi);
+
+static inline enum fy_input_state fy_input_get_state(struct fy_input *fyi)
+{
+	return fyi->state;
+}
+
+struct fy_input *fy_input_create(const struct fy_input_cfg *fyic);
+
+const char *fy_input_get_filename(struct fy_input *fyi);
+
+struct fy_input *fy_input_from_data(const char *data, size_t size,
+				    struct fy_atom *handle, bool simple);
+struct fy_input *fy_input_from_malloc_data(char *data, size_t size,
+					   struct fy_atom *handle, bool simple);
+
+struct fy_input *fy_input_from_data_styled(const char *data, size_t size,
+				    struct fy_atom *handle, enum fy_scalar_style sstyle);
+struct fy_input *fy_input_from_malloc_data_styled(char *data, size_t size,
+					   struct fy_atom *handle, enum fy_scalar_style sstyle);
+
+void fy_input_close(struct fy_input *fyi);
+
+static inline struct fy_input *
+fy_input_ref(struct fy_input *fyi)
+{
+	if (!fyi)
+		return NULL;
+
+
+	assert(fyi->refs + 1 > 0);
+
+	fyi->refs++;
+
+	return fyi;
+}
+
+static inline void
+fy_input_unref(struct fy_input *fyi)
+{
+	if (!fyi)
+		return;
+
+	assert(fyi->refs > 0);
+
+	if (fyi->refs == 1)
+		fy_input_free(fyi);
+	else
+		fyi->refs--;
+}
+
+ssize_t fy_input_estimate_queued_size(const struct fy_input *fyi);
+
+struct fy_reader;
+
+enum fy_reader_mode {
+	fyrm_yaml,
+	fyrm_json,
+	fyrm_yaml_1_1,	/* yaml 1.1 mode */
+};
+
+struct fy_reader_ops {
+	struct fy_diag *(*get_diag)(struct fy_reader *fyr);
+	int (*file_open)(struct fy_reader *fyr, const char *filename);
+};
+
+struct fy_reader_input_cfg {
+	bool disable_mmap_opt;
+};
+
+struct fy_reader {
+	const struct fy_reader_ops *ops;
+	enum fy_reader_mode mode;
+
+	struct fy_reader_input_cfg current_input_cfg;
+	struct fy_input *current_input;
+
+	size_t this_input_start;	/* this input start */
+	const void *current_ptr;	/* current pointer into the buffer */
+	const void *current_ptr_start;	/* the start of this input */
+	const void *current_ptr_end;	/* the end of this input */
+
+	int line;			/* always on input */
+	int column;
+
+	int tabsize;			/* very experimental tab size for indent purposes */
+
+	struct fy_diag *diag;
+
+	/* decoded mode variables; update when changing modes */
+	bool json_mode;
+	enum fy_lb_mode lb_mode;
+	enum fy_flow_ws_mode fws_mode;
+	bool directive0_mode;
+};
+
+void fy_reader_reset(struct fy_reader *fyr);
+void fy_reader_setup(struct fy_reader *fyr, const struct fy_reader_ops *ops);
+void fy_reader_cleanup(struct fy_reader *fyr);
+
+int fy_reader_input_open(struct fy_reader *fyr, struct fy_input *fyi, const struct fy_reader_input_cfg *icfg);
+int fy_reader_input_done(struct fy_reader *fyr);
+int fy_reader_input_scan_token_mark_slow_path(struct fy_reader *fyr);
+
+static FY_ALWAYS_INLINE inline size_t
+fy_reader_current_input_pos(const struct fy_reader *fyr)
+{
+	return (size_t)((const char *)fyr->current_ptr - (const char *)fyr->current_ptr_start);
+}
+
+static FY_ALWAYS_INLINE inline size_t
+fy_reader_current_left(const struct fy_reader *fyr)
+{
+	return (size_t)((const char *)fyr->current_ptr_end - (const char *)fyr->current_ptr);
+}
+
+static inline bool
+fy_reader_input_chop_active(struct fy_reader *fyr)
+{
+	struct fy_input *fyi;
+
+	assert(fyr);
+
+	fyi = fyr->current_input;
+	assert(fyi);
+
+	if (!fyi->chop)
+		return false;
+
+	switch (fyi->cfg.type) {
+	case fyit_file:
+		return !fyi->addr && fyi->fp;	/* non-mmap mode */
+
+	case fyit_stream:
+	case fyit_callback:
+		return true;
+
+	default:
+		/* all the others do not support chop */
+		break;
+	}
+
+	return false;
+}
+
+static inline int
+fy_reader_input_scan_token_mark(struct fy_reader *fyr)
+{
+	/* don't chop until ready */
+	if (!fy_reader_input_chop_active(fyr) ||
+	    fyr->current_input->chop > fy_reader_current_input_pos(fyr))
+		return 0;
+
+	return fy_reader_input_scan_token_mark_slow_path(fyr);
+}
+
+const void *fy_reader_ptr_slow_path(struct fy_reader *fyr, size_t *leftp);
+const void *fy_reader_ensure_lookahead_slow_path(struct fy_reader *fyr, size_t size, size_t *leftp);
+
+void fy_reader_apply_mode(struct fy_reader *fyr);
+
+static FY_ALWAYS_INLINE inline enum fy_reader_mode
+fy_reader_get_mode(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->mode;
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_set_mode(struct fy_reader *fyr, enum fy_reader_mode mode)
+{
+	assert(fyr);
+	fyr->mode = mode;
+	fy_reader_apply_mode(fyr);
+}
+
+static FY_ALWAYS_INLINE inline enum fy_reader_mode
+fy_reader_calculate_mode(const struct fy_version *vers, bool json_mode)
+{
+	enum fy_reader_mode mode;
+
+	if (!json_mode)
+		mode = fy_version_compare(vers, fy_version_make(1, 1)) <= 0 ? fyrm_yaml_1_1 : fyrm_yaml;
+	else
+		mode = fyrm_json;
+
+	return mode;
+}
+
+static FY_ALWAYS_INLINE inline struct fy_input *
+fy_reader_current_input(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->current_input;
+}
+
+static FY_ALWAYS_INLINE inline uint64_t
+fy_reader_current_input_generation(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	assert(fyr->current_input);
+	return fyr->current_input->generation;
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_column(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->column;
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_tabsize(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->tabsize;
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_line(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->line;
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_generates_events(const struct fy_reader *fyr)
+{
+	struct fy_input *fyi;
+
+	fyi = fy_reader_current_input(fyr);
+	if (!fyi)
+		return false;
+
+	return fyi->cfg.type == fyit_dociter;
+}
+
+struct fy_event *fy_reader_generate_next_event(struct fy_reader *fyr);
+void fy_reader_event_free(struct fy_reader *fyr, struct fy_event *fye);
+
+/* force new line at the end of stream */
+static inline void fy_reader_stream_end(struct fy_reader *fyr)
+{
+	assert(fyr);
+
+	/* force new line */
+	if (fyr->column) {
+		fyr->column = 0;
+		fyr->line++;
+	}
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_get_mark(struct fy_reader *fyr, struct fy_mark *fym)
+{
+	assert(fyr);
+	fym->input_pos = fy_reader_current_input_pos(fyr);
+	fym->line = fyr->line;
+	fym->column = fyr->column;
+}
+
+static FY_ALWAYS_INLINE inline const void *
+fy_reader_ptr(struct fy_reader *fyr, size_t *leftp)
+{
+	if (fyr->current_ptr) {
+		if (leftp)
+			*leftp = fy_reader_current_left(fyr);
+		return fyr->current_ptr;
+	}
+
+	return fy_reader_ptr_slow_path(fyr, leftp);
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_json_mode(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->json_mode;
+}
+
+static FY_ALWAYS_INLINE inline enum fy_lb_mode
+fy_reader_lb_mode(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->lb_mode;
+}
+
+static FY_ALWAYS_INLINE inline enum fy_flow_ws_mode
+fy_reader_flow_ws_mode(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->fws_mode;
+}
+
+static FY_ALWAYS_INLINE inline enum fy_flow_ws_mode
+fy_reader_directive0_mode(const struct fy_reader *fyr)
+{
+	assert(fyr);
+	return fyr->directive0_mode;
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_lb(const struct fy_reader *fyr, int c)
+{
+	return fy_is_lb_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_lbz(const struct fy_reader *fyr, int c)
+{
+	return fy_is_lbz_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_blankz(const struct fy_reader *fyr, int c)
+{
+	return fy_is_blankz_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_generic_lb(const struct fy_reader *fyr, int c)
+{
+	return fy_is_generic_lb_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_generic_lbz(const struct fy_reader *fyr, int c)
+{
+	return fy_is_generic_lbz_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_generic_blankz(const struct fy_reader *fyr, int c)
+{
+	return fy_is_generic_blankz_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_flow_ws(const struct fy_reader *fyr, int c)
+{
+	return fy_is_flow_ws_m(c, fy_reader_flow_ws_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_flow_blank(const struct fy_reader *fyr, int c)
+{
+	return fy_reader_is_flow_ws(fyr, c);	/* same */
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_flow_blankz(const struct fy_reader *fyr, int c)
+{
+	return fy_is_flow_ws_m(c, fy_reader_flow_ws_mode(fyr)) ||
+	       fy_is_generic_lbz_m(c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline const void *
+fy_reader_ensure_lookahead(struct fy_reader *fyr, size_t size, size_t *leftp)
+{
+	size_t current_left = fy_reader_current_left(fyr);
+
+	if (current_left >= size) {
+		*leftp = current_left;
+		return fyr->current_ptr;
+	}
+	return fy_reader_ensure_lookahead_slow_path(fyr, size, leftp);
+}
+
+/* compare string at the current point (n max) */
+static inline int
+fy_reader_strncmp(struct fy_reader *fyr, const char *str, size_t n)
+{
+	const char *p;
+	size_t len;
+	int ret;
+
+	assert(fyr);
+	p = fy_reader_ensure_lookahead(fyr, n, &len);
+	if (!p)
+		return -1;
+
+	/* not enough? */
+	if (n > len)
+		return 1;
+
+	ret = strncmp(p, str, n);
+	return ret ? 1 : 0;
+}
+
+int fy_reader_peek_at_offset_width_slow_path(struct fy_reader *fyr, size_t offset, int *wp);
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_at_offset_width(struct fy_reader *fyr, size_t offset, int *wp)
+{
+	assert(fyr);
+
+	if ((ssize_t)(fy_reader_current_left(fyr) - offset) >= 4)
+		return fy_utf8_get((const char *)fyr->current_ptr + offset, 4, wp);
+
+	return fy_reader_peek_at_offset_width_slow_path(fyr, offset, wp);
+}
+
+int64_t fy_reader_peek_at_offset_width_slow_path_64(struct fy_reader *fyr, size_t offset);
+
+static FY_ALWAYS_INLINE inline int64_t
+fy_reader_peek_at_offset_width_64(struct fy_reader *fyr, size_t offset)
+{
+	assert(fyr);
+
+	if ((ssize_t)(fy_reader_current_left(fyr) - offset) >= 4)
+		return fy_utf8_get_64((const char *)fyr->current_ptr + offset, 4);
+
+	return fy_reader_peek_at_offset_width_slow_path_64(fyr, offset);
+}
+
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_at_offset(struct fy_reader *fyr, size_t offset)
+{
+	int w;
+
+	return fy_reader_peek_at_offset_width(fyr, offset, &w);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_at_width_internal(struct fy_reader *fyr, int pos, ssize_t *offsetp, int *wp)
+{
+	int i, c, w;
+	size_t offset;
+
+	offset = (size_t)*offsetp;
+	if ((ssize_t)offset < 0) {
+		for (i = 0, offset = 0; i < pos; i++, offset += w) {
+			c = fy_reader_peek_at_offset_width(fyr, offset, &w);
+			if (c < 0)
+				return c;
+		}
+	}
+	c = fy_reader_peek_at_offset_width(fyr, offset, wp);
+
+	*offsetp = offset + *wp;
+	return c;
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_at_internal(struct fy_reader *fyr, int pos, ssize_t *offsetp)
+{
+	int w;
+
+	return fy_reader_peek_at_width_internal(fyr, pos, offsetp, &w);
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_blank_at_offset(struct fy_reader *fyr, size_t offset)
+{
+	return fy_is_blank(fy_reader_peek_at_offset(fyr, offset));
+}
+
+static FY_ALWAYS_INLINE inline bool
+fy_reader_is_blankz_at_offset(struct fy_reader *fyr, size_t offset)
+{
+	return fy_reader_is_blankz(fyr, fy_reader_peek_at_offset(fyr, offset));
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_at_width(struct fy_reader *fyr, int pos, int *wp)
+{
+	int i, c, w;
+	size_t offset;
+
+	assert(fyr);
+	for (i = 0, offset = 0; i < pos; i++, offset += w) {
+		c = fy_reader_peek_at_offset_width(fyr, offset, &w);
+		if (c < 0)
+			return c;
+	}
+
+	return fy_reader_peek_at_offset_width(fyr, offset, wp);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_at(struct fy_reader *fyr, int pos)
+{
+	int i, c, w;
+	size_t offset;
+
+	assert(fyr);
+	for (i = 0, offset = 0; i < pos; i++, offset += w) {
+		c = fy_reader_peek_at_offset_width(fyr, offset, &w);
+		if (c < 0)
+			return c;
+	}
+
+	return fy_reader_peek_at_offset(fyr, offset);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek_width(struct fy_reader *fyr, int *wp)
+{
+	return fy_reader_peek_at_offset_width(fyr, 0, wp);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_peek(struct fy_reader *fyr)
+{
+	int w;
+	return fy_reader_peek_width(fyr, &w);
+}
+
+static FY_ALWAYS_INLINE inline const void *
+fy_reader_peek_block(struct fy_reader *fyr, size_t *lenp)
+{
+	const void *p;
+
+	/* try to pull at least one utf8 character usually */
+	p = fy_reader_ensure_lookahead(fyr, 4, lenp);
+
+	/* not a utf8 character available? try a single byte */
+	if (!p)
+		p = fy_reader_ensure_lookahead(fyr, 1, lenp);
+	if (!*lenp)
+		p = NULL;
+	return p;
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_advance_octets(struct fy_reader *fyr, size_t advance)
+{
+	fyr->current_ptr = (const char *)fyr->current_ptr + advance;
+}
+
+void fy_reader_advance_slow_path(struct fy_reader *fyr, int c);
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_advance_printable_ascii(struct fy_reader *fyr, int c)
+{
+	assert(fyr);
+	fy_reader_advance_octets(fyr, 1);
+	fyr->column++;
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_update_state_lb_mode(struct fy_reader *fyr, const int c, const enum fy_lb_mode lb_mode)
+{
+	if (fy_is_lb_m(c, lb_mode)) {
+		fyr->column = 0;
+		fyr->line++;
+	} else if (fy_is_tab(c) && fyr->tabsize)
+		fyr->column += (fyr->tabsize - (fyr->column % fyr->tabsize));
+	else
+		fyr->column++;
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_advance_lb_mode(struct fy_reader *fyr, const int c, const enum fy_lb_mode lb_mode)
+{
+	assert(fy_utf8_is_valid(c));
+	fy_reader_advance_octets(fyr, fy_utf8_width(c));
+	/* Handle CRLF as single line break */
+	if (c == '\r' && fy_reader_peek(fyr) == '\n') {
+		fy_reader_advance_octets(fyr, 1);
+		fyr->column = 0;
+		fyr->line++;
+	} else {
+		fy_reader_update_state_lb_mode(fyr, c, lb_mode);
+	}
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_advance(struct fy_reader *fyr, const int c)
+{
+	fy_reader_advance_lb_mode(fyr, c, fy_reader_lb_mode(fyr));
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_advance_ws(struct fy_reader *fyr, int c)
+{
+	/* skip this character */
+	fy_reader_advance_octets(fyr, fy_utf8_width(c));
+
+	if (fy_is_tab(c) && fyr->tabsize)
+		fyr->column += (fyr->tabsize - (fyr->column % fyr->tabsize));
+	else
+		fyr->column++;
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_reader_advance_space(struct fy_reader *fyr)
+{
+	fy_reader_advance_octets(fyr, 1);
+	fyr->column++;
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_get(struct fy_reader *fyr)
+{
+	int value;
+
+	value = fy_reader_peek(fyr);
+	if (value < 0)
+		return value;
+
+	fy_reader_advance(fyr, value);
+
+	return value;
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_advance_by(struct fy_reader *fyr, int count)
+{
+	int i, c;
+
+	for (i = 0; i < count; i++) {
+		c = fy_reader_get(fyr);
+		if (c < 0)
+			break;
+	}
+	return i ? i : -1;
+}
+
+/* compare string at the current point */
+static inline bool
+fy_reader_strcmp(struct fy_reader *fyr, const char *str)
+{
+	return fy_reader_strncmp(fyr, str, strlen(str));
+}
+
+/* atom */
+
+static inline void
+fy_reader_fill_atom_start(struct fy_reader *fyr, struct fy_atom *handle)
+{
+	/* start mark */
+	fy_reader_get_mark(fyr, &handle->start_mark);
+	handle->fyi = fy_reader_current_input(fyr);
+	handle->fyi_generation = fy_reader_current_input_generation(fyr);
+
+	handle->increment = 0;
+	handle->tozero = 0;
+
+	/* note that handle->data may be zero for empty input */
+}
+
+static inline void
+fy_reader_fill_atom_end_at(struct fy_reader *fyr, struct fy_atom *handle, struct fy_mark *end_mark)
+{
+	if (end_mark)
+		handle->end_mark = *end_mark;
+	else
+		fy_reader_get_mark(fyr, &handle->end_mark);
+
+	/* default is plain, modify at return */
+	handle->style = FYAS_PLAIN;
+	handle->chomp = FYAC_CLIP;
+	/* by default we don't do storage hints, it's the job of the caller */
+	handle->storage_hint = 0;
+	handle->storage_hint_valid = false;
+	handle->tabsize = fy_reader_tabsize(fyr);
+	handle->json_mode = fy_reader_json_mode(fyr);
+	handle->lb_mode = fy_reader_lb_mode(fyr);
+	handle->fws_mode = fy_reader_flow_ws_mode(fyr);
+	handle->directive0_mode = fy_reader_directive0_mode(fyr);
+}
+
+static inline void
+fy_reader_fill_atom_end(struct fy_reader *fyr, struct fy_atom *handle)
+{
+	fy_reader_fill_atom_end_at(fyr, handle, NULL);
+}
+
+/* diag */
+
+static inline bool
+fyr_debug_log_level_is_enabled(struct fy_reader *fyr)
+{
+	return fyr && fy_diag_log_level_is_enabled(fyr->diag, FYET_DEBUG, FYEM_SCAN);
+}
+
+int fy_reader_vdiag(struct fy_reader *fyr, unsigned int flags,
+		    const char *file, int line, const char *func,
+		    const char *fmt, va_list ap);
+
+int fy_reader_diag(struct fy_reader *fyr, unsigned int flags,
+		   const char *file, int line, const char *func,
+		   const char *fmt, ...)
+	FY_FORMAT(printf, 6, 7);
+
+void fy_reader_diag_vreport(struct fy_reader *fyr,
+			    const struct fy_diag_report_ctx *fydrc,
+			    const char *fmt, va_list ap);
+void fy_reader_diag_report(struct fy_reader *fyr,
+			   const struct fy_diag_report_ctx *fydrc,
+			   const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+#ifdef FY_DEVMODE
+
+#define fyr_debug(_fyr, _fmt, ...) \
+	do { \
+		struct fy_reader *__fyr = (_fyr); \
+		\
+		if (fyr_debug_log_level_is_enabled(__fyr)) \
+			fy_reader_diag(__fyr, FYET_DEBUG, \
+					__FILE__, __LINE__, __func__, \
+					(_fmt) , ## __VA_ARGS__); \
+	} while(0)
+#else
+
+#define fyr_debug(_fyr, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fyr_info(_fyr, _fmt, ...) \
+	fy_reader_diag((_fyr), FYET_INFO, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyr_notice(_fyr, _fmt, ...) \
+	fy_reader_diag((_fyr), FYET_NOTICE, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyr_warning(_fyr, _fmt, ...) \
+	fy_reader_diag((_fyr), FYET_WARNING, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyr_error(_fyr, _fmt, ...) \
+	fy_reader_diag((_fyr), FYET_ERROR, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+
+#define fyr_error_check(_fyr, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			fyr_error((_fyr), _fmt, ## __VA_ARGS__); \
+			goto _label ; \
+		} \
+	} while(0)
+
+#define _FYR_TOKEN_DIAG(_fyr, _fyt, _type, _module, _fmt, ...) \
+	do { \
+		struct fy_diag_report_ctx _drc; \
+		memset(&_drc, 0, sizeof(_drc)); \
+		_drc.type = (_type); \
+		_drc.module = (_module); \
+		_drc.fyt = (_fyt); \
+		fy_reader_diag_report((_fyr), &_drc, (_fmt) , ## __VA_ARGS__); \
+	} while(0)
+
+#define FYR_TOKEN_DIAG(_fyr, _fyt, _type, _module, _fmt, ...) \
+	_FYR_TOKEN_DIAG(_fyr, fy_token_ref(_fyt), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_PARSE_DIAG(_fyr, _adv, _cnt, _type, _module, _fmt, ...) \
+	_FYR_TOKEN_DIAG(_fyr, \
+		fy_token_create(FYTT_INPUT_MARKER, \
+			fy_reader_fill_atom_at((_fyr), (_adv), (_cnt), \
+			alloca(sizeof(struct fy_atom)))), \
+		_type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_MARK_DIAG(_fyr, _sm, _em, _type, _module, _fmt, ...) \
+	_FYR_TOKEN_DIAG(_fyr, \
+		fy_token_create(FYTT_INPUT_MARKER, \
+			fy_reader_fill_atom_mark(((_fyr)), (_sm), (_em), \
+				alloca(sizeof(struct fy_atom)))), \
+		_type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_NODE_DIAG(_fyr, _fyn, _type, _module, _fmt, ...) \
+	_FYR_TOKEN_DIAG(_fyr, fy_node_token(_fyn), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_TOKEN_ERROR(_fyr, _fyt, _module, _fmt, ...) \
+	FYR_TOKEN_DIAG(_fyr, _fyt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_PARSE_ERROR(_fyr, _adv, _cnt, _module, _fmt, ...) \
+	FYR_PARSE_DIAG(_fyr, _adv, _cnt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_MARK_ERROR(_fyr, _sm, _em, _module, _fmt, ...) \
+	FYR_MARK_DIAG(_fyr, _sm, _em, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_NODE_ERROR(_fyr, _fyn, _module, _fmt, ...) \
+	FYR_NODE_DIAG(_fyr, _fyn, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_TOKEN_ERROR_CHECK(_fyr, _fyt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYR_TOKEN_ERROR(_fyr, _fyt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYR_PARSE_ERROR_CHECK(_fyr, _adv, _cnt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYR_PARSE_ERROR(_fyr, _adv, _cnt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYR_MARK_ERROR_CHECK(_fyr, _sm, _em, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYR_MARK_ERROR(_fyr, _sm, _em, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYR_NODE_ERROR_CHECK(_fyr, _fyn, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYR_NODE_ERROR(_fyr, _fyn, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYR_TOKEN_WARNING(_fyr, _fyt, _module, _fmt, ...) \
+	FYR_TOKEN_DIAG(_fyr, _fyt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_PARSE_WARNING(_fyr, _adv, _cnt, _module, _fmt, ...) \
+	FYR_PARSE_DIAG(_fyr, _adv, _cnt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_MARK_WARNING(_fyr, _sm, _em, _module, _fmt, ...) \
+	FYR_MARK_DIAG(_fyr, _sm, _em, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYR_NODE_WARNING(_fyr, _fyn, _type, _module, _fmt, ...) \
+	FYR_NODE_DIAG(_fyr, _fyn, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+struct fy_input *fy_input_from_data(const char *data, size_t size,
+				    struct fy_atom *handle, bool simple);
+struct fy_input *fy_input_from_malloc_data(char *data, size_t size,
+					   struct fy_atom *handle, bool simple);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-parse-diag.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-parse-diag.c
@@ -1,0 +1,159 @@
+/*
+ * fy-parse-diag.c - parser diagnostics
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+#include <libfyaml.h>
+
+#include "fy-diag.h"
+#include "fy-parse.h"
+
+int fy_parser_vdiag(struct fy_parser *fyp, unsigned int flags,
+		    const char *file, int line, const char *func,
+		    const char *fmt, va_list ap)
+{
+	enum fy_error_type level;
+	enum fy_error_module module;
+	struct fy_diag_ctx fydc;
+	int rc;
+
+	if (!fyp || !fyp->diag || !fmt)
+		return -1;
+
+	level = (flags & FYDF_LEVEL_MASK) >> FYDF_LEVEL_SHIFT;
+	module = (flags & FYDF_MODULE_MASK) >> FYDF_MODULE_SHIFT;
+
+	if (!fy_diag_log_level_is_enabled(fyp->diag, level, module))
+		return 0;
+
+	/* fill in fy_diag_ctx */
+	memset(&fydc, 0, sizeof(fydc));
+
+	fydc.level = level;
+	fydc.module = module;
+	fydc.source_file = file;
+	fydc.source_line = line;
+	fydc.source_func = func;
+	fydc.line = fyp_line(fyp);
+	fydc.column = fyp_column(fyp);
+
+	rc = fy_vdiag(fyp->diag, &fydc, fmt, ap);
+
+	if (fyp && !fyp->stream_error && fyp->diag->on_error)
+		fyp->stream_error = true;
+
+	return rc;
+}
+
+int fy_parser_diag(struct fy_parser *fyp, unsigned int flags,
+	    const char *file, int line, const char *func,
+	    const char *fmt, ...)
+{
+	va_list ap;
+	int rc;
+
+	va_start(ap, fmt);
+	rc = fy_parser_vdiag(fyp, flags, file, line, func, fmt, ap);
+	va_end(ap);
+
+	return rc;
+}
+
+void fy_parser_diag_vreport(struct fy_parser *fyp,
+		            const struct fy_diag_report_ctx *fydrc,
+			    const char *fmt, va_list ap)
+{
+	struct fy_diag *diag;
+
+	if (!fyp || !fyp->diag || !fydrc || !fmt)
+		return;
+
+	diag = fyp->diag;
+
+	fy_diag_vreport(diag, fydrc, fmt, ap);
+
+	if (fyp && !fyp->stream_error && diag->on_error)
+		fyp->stream_error = true;
+}
+
+void fy_parser_diag_report(struct fy_parser *fyp,
+			   const struct fy_diag_report_ctx *fydrc,
+			   const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_parser_diag_vreport(fyp, fydrc, fmt, ap);
+	va_end(ap);
+}
+
+void fy_parser_vlog(struct fy_parser *fyp, enum fy_error_type type,
+		    const char *fmt, va_list ap)
+{
+	struct fy_diag_ctx ctx = {
+		.level = type,
+		.module = FYEM_UNKNOWN,
+		.source_func = "",
+		.source_file = "",
+		.source_line = 0,
+		.file = NULL,
+		.line = 0,
+		.column = 0,
+	};
+
+	if (!fyp || !fyp->diag)
+		return;
+
+	(void)fy_vdiag(fyp->diag, &ctx, fmt, ap);
+}
+
+void fy_parser_log(struct fy_parser *fyp, enum fy_error_type type,
+		   const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_parser_vlog(fyp, type, fmt, ap);
+	va_end(ap);
+}
+
+void fy_parser_vreport(struct fy_parser *fyp, enum fy_error_type type,
+		       struct fy_token *fyt, const char *fmt, va_list ap)
+{
+	struct fy_diag_report_ctx fydrc_local, *fydrc = &fydrc_local;
+
+	if (!fyp || !fyp->diag || !fyt)
+		return;
+
+	memset(fydrc, 0, sizeof(*fydrc));
+	fydrc->type = type;
+	fydrc->module = FYEM_UNKNOWN;
+	fydrc->fyt = fy_token_ref(fyt);
+
+	fy_parser_diag_vreport(fyp, fydrc, fmt, ap);
+}
+
+void fy_parser_report(struct fy_parser *fyp, enum fy_error_type type,
+		      struct fy_token *fyt, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_parser_vreport(fyp, type, fyt, fmt, ap);
+	va_end(ap);
+}
+

--- a/numcosmo/external/libfyaml/src/lib/fy-parse.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-parse.c
@@ -1,0 +1,9247 @@
+/*
+ * fy-parse.c - Internal parse interface
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <limits.h>
+#include <fcntl.h>
+
+#include <libfyaml.h>
+
+#include "fy-win32.h"
+#include "fy-parse.h"
+
+#include "fy-utils.h"
+
+/* only check atom sizes on debug */
+#ifndef NDEBUG
+#define ATOM_SIZE_CHECK
+#endif
+
+#ifdef ATOM_SIZE_CHECK
+#define FORCE_ATOM_SIZE_CHECK_DEFAULT	true
+#else
+#define FORCE_ATOM_SIZE_CHECK_DEFAULT	false
+#endif
+
+static struct fy_eventp *
+fy_parser_event_resolve_hook_merge_key(struct fy_parser *fyp, struct fy_eventp *fyep);
+
+const char *fy_library_version(void)
+{
+#ifndef VERSION
+#warning No version defined
+	return "UNKNOWN";
+#else
+	return VERSION;
+#endif
+}
+
+int fy_parse_input_append(struct fy_parser *fyp, const struct fy_input_cfg *fyic)
+{
+	struct fy_input *fyi = NULL;
+
+	fyi = fy_input_create(fyic);
+	fyp_error_check(fyp, fyi != NULL, err_out,
+			"fy_parse_input_create() failed!");
+
+	fyi->state = FYIS_QUEUED;
+	fy_input_list_add_tail(&fyp->queued_inputs, fyi);
+
+	return 0;
+
+err_out:
+	fy_input_unref(fyi);
+	return -1;
+}
+
+bool fy_parse_have_more_inputs(struct fy_parser *fyp)
+{
+	return !fy_input_list_empty(&fyp->queued_inputs);
+}
+
+int fy_parse_get_next_input(struct fy_parser *fyp)
+{
+	const char *s;
+	struct fy_reader_input_cfg icfg;
+	struct fy_input *fyi;
+	int rc;
+	bool json_mode;
+	enum fy_reader_mode rdmode;
+
+	assert(fyp);
+
+	if (fy_reader_current_input(fyp->reader)) {
+		fyp_scan_debug(fyp, "get next input: already exists");
+		return 1;
+	}
+
+	/* get next queued input */
+	fyi = fy_input_list_pop(&fyp->queued_inputs);
+
+	/* none left? we're done */
+	if (!fyi) {
+		fyp_scan_debug(fyp, "get next input: all inputs exhausted");
+		return 0;
+	}
+
+	json_mode = false;
+	if ((fyp->cfg.flags & (FYPCF_JSON_MASK << FYPCF_JSON_SHIFT)) == FYPCF_JSON_AUTO) {
+		/* detection only works for filenames (sucks) */
+		if (fyi->cfg.type == fyit_file) {
+			s = fyi->cfg.file.filename;
+			if (s)
+				s = strrchr(s, '.');
+			json_mode = s && !strcmp(s, ".json");
+		}
+	} else if ((fyp->cfg.flags & (FYPCF_JSON_MASK << FYPCF_JSON_SHIFT)) == FYPCF_JSON_FORCE)
+		json_mode = true;
+
+	/* set the initial reader mode according to json option and default version */
+	rdmode = fy_reader_calculate_mode(&fyp->stream_version, json_mode);
+	fy_reader_set_mode(fyp->reader, rdmode);
+
+	memset(&icfg, 0, sizeof(icfg));
+	icfg.disable_mmap_opt = !!(fyp->cfg.flags & FYPCF_DISABLE_MMAP_OPT);
+
+	rc = fy_reader_input_open(fyp->reader, fyi, &icfg);
+	fyp_error_check(fyp, !rc, err_out,
+			"failed to open input");
+
+	/* take off the reference; reader now owns */
+	fy_input_unref(fyi);
+
+	// inherit the JSON mode
+	if (fyp->current_document_state)
+		fyp->current_document_state->json_mode = fyp_json_mode(fyp);
+
+	fyp_scan_debug(fyp, "get next input: new input - %s mode", json_mode ? "JSON" : "YAML");
+
+	return 1;
+
+err_out:
+	fy_input_unref(fyi);
+	return -1;
+}
+
+ssize_t fy_parse_estimate_queued_input_size(struct fy_parser *fyp)
+{
+	struct fy_input *fyi;
+	ssize_t size, total;
+
+	if (!fyp)
+		return 0;
+
+	total = 0;
+	for (fyi = fy_input_list_head(&fyp->queued_inputs); fyi; fyi = fy_input_next(&fyp->queued_inputs, fyi)) {
+		if (fyi->state != FYIS_QUEUED)
+			continue;
+
+		size = fy_input_estimate_queued_size(fyi);
+		if (size < 0)
+			return -1;
+
+		/* something that's indetermined */
+		if (size == SSIZE_MAX)
+			return SSIZE_MAX;
+
+		total += size;
+
+		/* roll-over check */
+		if (total < 0)
+			return SSIZE_MAX;
+	}
+
+	return total;
+}
+
+static inline void
+fy_token_queue_epilogue(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	/* special handling for zero indented scalars */
+	fyp->token_activity_counter++;
+	if (fyt->type == FYTT_DOCUMENT_START)
+		fyp->document_first_content_token = true;
+	else if (fyp->document_first_content_token && fy_token_type_is_content(fyt->type))
+		fyp->document_first_content_token = false;
+}
+
+static inline struct fy_token *
+fy_token_queue_simple_internal(struct fy_parser *fyp, struct fy_token_list *fytl, enum fy_token_type type, int advance_octets)
+{
+	struct fy_reader *fyr = fyp->reader;
+	struct fy_token *fyt;
+
+	/* allocate and copy in place */
+	fyt = fy_token_alloc_rl(fyp->recycled_token_list);
+	if (!fyt)
+		return NULL;
+
+	fyt->type = type;
+
+	/* the advance is always octets */
+	fy_reader_fill_atom_start(fyr, &fyt->handle);
+	if (advance_octets > 0) {
+		fy_reader_advance_octets(fyr, advance_octets);
+		fyr->column += advance_octets;
+	}
+	fy_reader_fill_atom_end(fyr, &fyt->handle);
+
+	fy_input_ref(fyt->handle.fyi);
+
+	fy_token_list_add_tail(fytl, fyt);
+
+	return fyt;
+}
+
+static inline struct fy_token *
+fy_token_queue_simple(struct fy_parser *fyp, struct fy_token_list *fytl, enum fy_token_type type, int advance_octets)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_token_queue_simple_internal(fyp, fytl, type, advance_octets);
+	if (!fyt)
+		return NULL;
+
+	fy_token_queue_epilogue(fyp, fyt);
+	return fyt;
+}
+
+struct fy_token *
+fy_token_vqueue_internal(struct fy_parser *fyp, struct fy_token_list *fytl,
+			 enum fy_token_type type, va_list ap)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_token_vcreate_rl(fyp->recycled_token_list, type, ap);
+	if (!fyt)
+		return NULL;
+	fy_token_list_add_tail(fytl, fyt);
+
+	fy_token_queue_epilogue(fyp, fyt);
+	return fyt;
+}
+
+struct fy_token *fy_token_queue_internal(struct fy_parser *fyp, struct fy_token_list *fytl,
+					 enum fy_token_type type, ...)
+{
+	va_list ap;
+	struct fy_token *fyt;
+
+	va_start(ap, type);
+	fyt = fy_token_vqueue_internal(fyp, fytl, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+struct fy_token *fy_token_vqueue(struct fy_parser *fyp, enum fy_token_type type, va_list ap)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_token_vqueue_internal(fyp, &fyp->queued_tokens, type, ap);
+	if (fyt)
+		fyp->token_activity_counter++;
+	return fyt;
+}
+
+struct fy_token *fy_token_queue(struct fy_parser *fyp, enum fy_token_type type, ...)
+{
+	va_list ap;
+	struct fy_token *fyt;
+
+	va_start(ap, type);
+	fyt = fy_token_vqueue(fyp, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+const struct fy_version fy_default_version = {
+	.major = 1,
+	.minor = 2
+};
+
+int fy_version_compare(const struct fy_version *va, const struct fy_version *vb)
+{
+	unsigned int vanum, vbnum;
+
+	if (!va)
+		va = &fy_default_version;
+	if (!vb)
+		vb = &fy_default_version;
+
+#define FY_VERSION_UINT(_major, _minor) \
+	((((unsigned int)(_major) & 0xff) << 8) | ((unsigned int)((_minor) & 0xff)))
+
+	vanum = FY_VERSION_UINT(va->major, va->minor);
+	vbnum = FY_VERSION_UINT(vb->major, vb->minor);
+
+#undef FY_VERSION_UINT
+
+	return vanum == vbnum ?  0 :
+	       vanum <  vbnum ? -1 : 1;
+}
+
+const struct fy_version *
+fy_version_default(void)
+{
+	return &fy_default_version;
+}
+
+static const struct fy_version * const fy_map_option_to_version[] = {
+	[FYPCF_DEFAULT_VERSION_AUTO >> FYPCF_DEFAULT_VERSION_SHIFT] = &fy_default_version,
+	[FYPCF_DEFAULT_VERSION_1_1  >> FYPCF_DEFAULT_VERSION_SHIFT] = fy_version_make(1, 1),
+	[FYPCF_DEFAULT_VERSION_1_2  >> FYPCF_DEFAULT_VERSION_SHIFT] = fy_version_make(1, 2),
+	[FYPCF_DEFAULT_VERSION_1_3  >> FYPCF_DEFAULT_VERSION_SHIFT] = fy_version_make(1, 3),
+};
+
+bool fy_version_is_supported(const struct fy_version *vers)
+{
+	unsigned int i;
+	const struct fy_version *vers_chk;
+
+	if (!vers)
+		return true;	/* NULL means default, which is supported */
+
+	for (i = 0; i < sizeof(fy_map_option_to_version)/sizeof(fy_map_option_to_version[0]); i++) {
+
+		vers_chk = fy_map_option_to_version[i];
+		if (!vers_chk)
+			continue;
+
+		if (fy_version_compare(vers, vers_chk) == 0)
+			return true;
+	}
+
+	return false;
+}
+
+static const struct fy_version *
+fy_parse_cfg_to_version(enum fy_parse_cfg_flags flags)
+{
+	unsigned int idx;
+
+	idx = (flags >> FYPCF_DEFAULT_VERSION_SHIFT) & FYPCF_DEFAULT_VERSION_MASK;
+
+	if (idx >= sizeof(fy_map_option_to_version)/sizeof(fy_map_option_to_version[0]))
+		return NULL;
+
+	return fy_map_option_to_version[idx];
+}
+
+const struct fy_version *fy_version_supported_iterate(void **prevp)
+{
+	const struct fy_version * const *versp;
+	const struct fy_version *vers;
+	unsigned int idx;
+
+	if (!prevp)
+		return NULL;
+
+	versp = (const struct fy_version * const *)*prevp;
+	if (!versp) {
+		/* we skip over the first (which is the default) */
+		versp = fy_map_option_to_version;
+	}
+
+	versp++;
+
+	idx = (unsigned int)(versp - fy_map_option_to_version);
+	if (idx >= sizeof(fy_map_option_to_version)/sizeof(fy_map_option_to_version[0]))
+		return NULL;
+
+	vers = *versp;
+	*prevp = (void **)versp;
+
+	return vers;
+}
+
+const struct fy_tag * const fy_default_tags[] = {
+	&(struct fy_tag) { .handle = "!",  .prefix = "!", },
+	&(struct fy_tag) { .handle = "!!", .prefix = "tag:yaml.org,2002:", },
+	&(struct fy_tag) { .handle = "",   .prefix = "", },
+	NULL
+};
+
+bool fy_tag_handle_is_default(const char *handle, size_t handle_size)
+{
+	int i;
+	const struct fy_tag *fytag;
+
+	if (handle_size == (size_t)-1)
+		handle_size = strlen(handle);
+
+	for (i = 0; (fytag = fy_default_tags[i]) != NULL; i++) {
+
+		if (handle_size == strlen(fytag->handle) &&
+		    !memcmp(handle, fytag->handle, handle_size))
+			return true;
+
+	}
+	return false;
+}
+
+bool fy_tag_is_default_internal(const char *handle, size_t handle_size,
+				const char *prefix, size_t prefix_size)
+{
+	int i;
+	const struct fy_tag *fytag;
+
+	if (handle_size == (size_t)-1)
+		handle_size = strlen(handle);
+
+	if (prefix_size == (size_t)-1)
+		prefix_size = strlen(prefix);
+
+	for (i = 0; (fytag = fy_default_tags[i]) != NULL; i++) {
+
+		if (handle_size == strlen(fytag->handle) &&
+		    !memcmp(handle, fytag->handle, handle_size) &&
+		    prefix_size == strlen(fytag->prefix) &&
+		    !memcmp(prefix, fytag->prefix, prefix_size))
+			return true;
+
+	}
+	return false;
+}
+
+bool fy_document_state_tag_is_default(struct fy_document_state *fyds, const struct fy_tag *tag)
+{
+	struct fy_token *fyt_td;
+
+	/* default tag, but it might be overriden */
+	fyt_td = fy_document_state_lookup_tag_directive(fyds, tag->handle, strlen(tag->handle));
+	if (!fyt_td)
+		return false;	/* Huh? */
+
+	return fyt_td->tag_directive.is_default;
+}
+
+bool fy_token_tag_directive_is_overridable(struct fy_token *fyt_td)
+{
+	const struct fy_tag *fytag;
+	const char *handle, *prefix;
+	size_t handle_size, prefix_size;
+	int i;
+
+	if (!fyt_td)
+		return false;
+
+	handle = fy_tag_directive_token_handle(fyt_td, &handle_size);
+	prefix = fy_tag_directive_token_prefix(fyt_td, &prefix_size);
+	if (!handle || !prefix)
+		return false;
+
+	for (i = 0; (fytag = fy_default_tags[i]) != NULL; i++) {
+
+		if (handle_size == strlen(fytag->handle) &&
+		    !memcmp(handle, fytag->handle, handle_size) &&
+		    prefix_size == strlen(fytag->prefix) &&
+		    !memcmp(prefix, fytag->prefix, prefix_size))
+			return true;
+
+	}
+	return false;
+}
+
+int fy_reset_document_state(struct fy_parser *fyp)
+{
+	struct fy_document_state *fyds_new = NULL;
+	enum fy_reader_mode rdmode;
+
+	fyp_scan_debug(fyp, "resetting document state");
+
+	if (!fyp->default_document_state) {
+		fyds_new = fy_document_state_default(&fyp->stream_version, NULL);
+		fyp_error_check(fyp, fyds_new, err_out,
+				"fy_document_state_default() failed");
+	} else {
+		fyds_new = fy_document_state_copy(fyp->default_document_state);
+		fyp_error_check(fyp, fyds_new, err_out,
+				"fy_document_state_copy() failed");
+	}
+	// inherit the JSON mode
+	fyds_new->json_mode = fyp_json_mode(fyp);
+
+	if (fyp->current_document_state)
+		fy_document_state_unref(fyp->current_document_state);
+	fyp->current_document_state = fyds_new;
+
+	/* TODO check when cleaning flow lists */
+	fyp->flow_level = 0;
+	fyp->flow = FYFT_NONE;
+	fy_parse_flow_list_recycle_all(fyp, &fyp->flow_stack);
+
+	/* and reset all aliases (TODO look for cross document aliases) */
+	fy_parse_streaming_aliases_reset(fyp);
+
+	rdmode = fy_reader_calculate_mode(&fyds_new->version, fyds_new->json_mode);
+	fy_reader_set_mode(fyp->reader, rdmode);
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int fy_parser_set_default_document_state(struct fy_parser *fyp,
+					 struct fy_document_state *fyds)
+{
+	if (!fyp)
+		return -1;
+
+	/* only in a safe state */
+	if (fyp->state != FYPS_NONE && fyp->state != FYPS_END)
+		return -1;
+
+	if (fyp->default_document_state != fyds) {
+		if (fyp->default_document_state) {
+			fy_document_state_unref(fyp->default_document_state);
+			fyp->default_document_state = NULL;
+		}
+
+		if (fyds)
+			fyp->default_document_state = fy_document_state_ref(fyds);
+	}
+
+	fy_reset_document_state(fyp);
+
+	return 0;
+}
+
+void fy_parser_set_next_single_document(struct fy_parser *fyp)
+{
+	if (!fyp)
+		return;
+
+	fyp->next_single_document = true;
+}
+
+int fy_check_document_version(struct fy_parser *fyp)
+{
+	int major, minor;
+
+	major = fyp->current_document_state->version.major;
+	minor = fyp->current_document_state->version.minor;
+
+	/* we only support YAML version 1.x */
+	if (major == 1) {
+		/* 1.1 is supported without warnings */
+		if (minor == 1 || minor == 2)
+			goto ok;
+
+		if (minor == 3)
+			goto experimental;
+	}
+
+	return -1;
+
+experimental:
+	fyp_scan_debug(fyp, "Experimental support for version %d.%d",
+			major, minor);
+ok:
+	return 0;
+}
+
+int fy_parse_version_directive(struct fy_parser *fyp, struct fy_token *fyt, bool scan_mode)
+{
+	struct fy_document_state *fyds;
+	const char *vs;
+	size_t vs_len;
+	char *vs0;
+	char *s, *e;
+	long v;
+	int rc;
+
+	fyp_error_check(fyp, fyt && fyt->type == FYTT_VERSION_DIRECTIVE, err_out,
+			"illegal token (or missing) version directive token");
+
+	fyds = fyp->current_document_state;
+	fyp_error_check(fyp, fyds, err_out,
+			"no current document state error");
+
+	if (!scan_mode) {
+		FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				!fyds->fyt_vd, err_out,
+				"duplicate version directive");
+	} else {
+		/* in scan mode, we just override everything */
+		fy_token_unref_rl(fyp->recycled_token_list, fyds->fyt_vd);
+		fyds->fyt_vd = NULL;
+	}
+
+	/* version directive of the form: MAJ.MIN */
+	vs = fy_token_get_text(fyt, &vs_len);
+	fyp_error_check(fyp, vs, err_out,
+			"fy_token_get_text() failed");
+	vs0 = alloca(vs_len + 1);
+	memcpy(vs0, vs, vs_len);
+	vs0[vs_len] = '\0';
+
+	/* parse version numbers */
+	v = strtol(vs0, &e, 10);
+	fyp_error_check(fyp, e > vs0 && v >= 0 && v <= INT_MAX, err_out,
+			"illegal major version number (%s)", vs0);
+	fyp_error_check(fyp, *e == '.', err_out,
+			"illegal version separator");
+	fyds->version.major = (int)v;
+
+	s = e + 1;
+	v = strtol(s, &e, 10);
+	fyp_error_check(fyp, e > s && v >= 0 && v <= INT_MAX, err_out,
+			"illegal minor version number");
+	fyp_error_check(fyp, *e == '\0', err_out,
+			"garbage after version number");
+	fyds->version.minor = (int)v;
+
+	fyp_scan_debug(fyp, "document parsed YAML version: %d.%d",
+			fyds->version.major,
+			fyds->version.minor);
+
+	rc = fy_check_document_version(fyp);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"unsupport version number %d.%d",
+			fyds->version.major,
+			fyds->version.minor);
+
+	fyds->version_explicit = true;
+	fyds->fyt_vd = fyt;
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	fy_token_unref_rl(fyp->recycled_token_list, fyt);
+	return rc;
+}
+
+int fy_parse_tag_directive(struct fy_parser *fyp, struct fy_token *fyt, bool scan_mode)
+{
+	struct fy_document_state *fyds;
+	struct fy_token *fyt_td;
+	const char *handle, *prefix;
+	size_t handle_size, prefix_size;
+	bool can_override;
+
+	fyds = fyp->current_document_state;
+	fyp_error_check(fyp, fyds, err_out,
+			"no current document state error");
+
+	handle = fy_tag_directive_token_handle(fyt, &handle_size);
+	fyp_error_check(fyp, handle, err_out,
+			"bad tag directive token (handle)");
+
+	prefix = fy_tag_directive_token_prefix(fyt, &prefix_size);
+	fyp_error_check(fyp, prefix, err_out,
+			"bad tag directive token (prefix)");
+
+	fyt_td = fy_document_state_lookup_tag_directive(fyds, handle, handle_size);
+
+	can_override = fyt_td && (fy_token_tag_directive_is_overridable(fyt_td) || scan_mode);
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+			!fyt_td || can_override, err_out,
+			"duplicate tag directive");
+
+	if (fyt_td) {
+		/* fyp_notice(fyp, "overriding tag"); */
+		fy_token_list_del(&fyds->fyt_td, fyt_td);
+		fy_token_unref_rl(fyp->recycled_token_list, fyt_td);
+		/* when we override a default tag the tags are explicit */
+		fyds->tags_explicit = true;
+	}
+
+	fy_token_list_add_tail(&fyds->fyt_td, fyt);
+	fyt = NULL;
+
+	fyp_scan_debug(fyp, "document parsed tag directive with handle=%.*s",
+			(int)handle_size, handle);
+
+	if (!fy_tag_is_default_internal(handle, handle_size, prefix, prefix_size))
+		fyds->tags_explicit = true;
+
+	return 0;
+err_out:
+	fy_token_unref_rl(fyp->recycled_token_list, fyt);
+	return -1;
+}
+
+static const struct fy_parse_cfg default_parse_cfg = {
+	.flags = FYPCF_DEFAULT_PARSE,
+};
+
+static struct fy_diag *fy_parser_reader_get_diag(struct fy_reader *fyr)
+{
+	struct fy_parser *fyp = container_of(fyr, struct fy_parser, builtin_reader);
+	return fyp->diag;
+}
+
+static int fy_parser_reader_file_open(struct fy_reader *fyr, const char *name)
+{
+	struct fy_parser *fyp = container_of(fyr, struct fy_parser, builtin_reader);
+	char *sp, *s, *e, *t, *newp;
+	size_t len, maxlen;
+	int fd;
+
+	if (!fyp || !name || name[0] == '\0')
+		return -1;
+
+	/* for a full path, or no search path, open directly */
+	if (name[0] == '/' || !fyp->cfg.search_path || !fyp->cfg.search_path[0]) {
+		fd = open(name, O_RDONLY);
+		if (fd == -1)
+			fyp_scan_debug(fyp, "failed to open file %s\n", name);
+		else
+			fyp_scan_debug(fyp, "opened file %s\n", name);
+		return fd;
+	}
+
+	len = strlen(fyp->cfg.search_path);
+	sp = alloca(len + 1);
+	memcpy(sp, fyp->cfg.search_path, len + 1);
+
+	/* allocate the maximum possible so that we don't deal with reallocations */
+	maxlen = len + 1 + strlen(name);
+	newp = malloc(maxlen + 1);
+	if (!newp)
+		return -1;
+
+	s = sp;
+	e = sp + strlen(s);
+	while (s < e) {
+		/* skip completely empty */
+		if (*s == ':') {
+			s++;
+			continue;
+		}
+
+		t = strchr(s, ':');
+		if (t)
+			*t++ = '\0';
+		else
+			t = e;
+
+		len = strlen(s) + 1 + strlen(name) + 1;
+		snprintf(newp, maxlen, "%s/%s", s, name);
+
+		/* try opening */
+		fd = open(newp, O_RDONLY);
+		if (fd != -1) {
+			fyp_scan_debug(fyp, "opened file %s at %s", name, newp);
+			free(newp);
+			return fd;
+		}
+
+		s = t;
+	}
+
+	if (newp)
+		free(newp);
+	return -1;
+}
+
+static const struct fy_reader_ops fy_parser_reader_ops = {
+	.get_diag = fy_parser_reader_get_diag,
+	.file_open = fy_parser_reader_file_open,
+};
+
+int fy_parse_setup(struct fy_parser *fyp, const struct fy_parse_cfg *cfg)
+{
+	struct fy_diag *diag;
+	struct fy_diag_cfg dcfg;
+	const struct fy_version *vers;
+	int rc;
+
+	if (!fyp)
+		return -1;
+
+	memset(fyp, 0, sizeof(*fyp));
+
+	diag = cfg ? cfg->diag : NULL;
+	fyp->cfg = cfg ? *cfg : default_parse_cfg;
+
+	/* supported version? */
+	vers = fy_parse_cfg_to_version(fyp->cfg.flags);
+	if (!vers)
+		return -1;
+
+	if (!diag) {
+		fy_diag_cfg_default(&dcfg);
+		diag = fy_diag_create(&dcfg);
+		if (!diag)
+			return -1;
+	} else
+		fy_diag_ref(diag);
+
+	fyp->diag = diag;
+
+	fy_reader_setup(&fyp->builtin_reader, &fy_parser_reader_ops);
+	fyp->reader = &fyp->builtin_reader;
+
+	fyp->default_version = *vers;
+	fyp->stream_version = fyp->default_version;
+
+	fy_indent_list_init(&fyp->indent_stack);
+	fy_indent_list_init(&fyp->recycled_indent);
+	fyp->indent = -2;
+	fyp->indent_line = -1;
+	fyp->starting_indent = -1;
+	fyp->generated_block_map = false;
+	fyp->last_was_comma = false;
+
+	fy_simple_key_list_init(&fyp->simple_keys);
+	fy_simple_key_list_init(&fyp->recycled_simple_key);
+
+	fy_token_list_init(&fyp->queued_tokens);
+
+	fy_input_list_init(&fyp->queued_inputs);
+
+	fyp->state = FYPS_NONE;
+	fy_parse_state_log_list_init(&fyp->state_stack);
+	fy_parse_state_log_list_init(&fyp->recycled_parse_state_log);
+
+	fy_eventp_list_init(&fyp->recycled_eventp);
+	fy_token_list_init(&fyp->recycled_token);
+
+	fy_flow_list_init(&fyp->flow_stack);
+	fyp->flow = FYFT_NONE;
+	fy_flow_list_init(&fyp->recycled_flow);
+
+	fyp->pending_complex_key_column = -1;
+	fyp->last_block_mapping_key_line = -1;
+
+	fy_streaming_alias_list_init(&fyp->streaming_aliases);
+	fy_streaming_alias_list_init(&fyp->recycled_streaming_alias);
+	fy_eventp_list_init(&fyp->mks.args);
+
+	fy_atom_reset(&fyp->last_comment);
+	fy_atom_reset(&fyp->override_comment);
+
+	fyp->suppress_recycling = !!(fyp->cfg.flags & FYPCF_DISABLE_RECYCLING) ||
+		                  (getenv("FY_VALGRIND") &&
+				   !getenv("FY_VALGRIND_RECYCLING"));
+
+	if (fyp->suppress_recycling)
+		fyp_parse_debug(fyp, "Suppressing recycling");
+
+	if (!fyp->suppress_recycling) {
+		fyp->recycled_eventp_list = &fyp->recycled_eventp;
+		fyp->recycled_token_list = &fyp->recycled_token;
+	} else {
+		fyp->recycled_eventp_list = NULL;
+		fyp->recycled_token_list = NULL;
+	}
+
+	fyp->current_document_state = NULL;
+
+	rc = fy_reset_document_state(fyp);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_reset_document_state() failed");
+	return 0;
+
+err_out_rc:
+	return rc;
+}
+
+void fy_parse_cleanup(struct fy_parser *fyp)
+{
+	struct fy_input *fyi, *fyin;
+	struct fy_eventp *fyep;
+	struct fy_token *fyt;
+
+	fy_parse_eventp_recycle(fyp, fyp->fyep_peek);
+
+	fy_parse_streaming_aliases_reset(fyp);
+
+	fy_input_unref(fyp->last_comment.fyi);
+	fy_atom_reset(&fyp->last_comment);
+
+	fy_input_unref(fyp->override_comment.fyi);
+	fy_atom_reset(&fyp->override_comment);
+
+	fy_input_unref(fyp->last_event_handle.fyi);
+	fy_atom_reset(&fyp->last_event_handle);
+
+	fy_composer_destroy(fyp->fyc);
+	fy_document_builder_destroy(fyp->fydb);
+
+	fy_parse_indent_list_recycle_all(fyp, &fyp->indent_stack);
+	fy_parse_simple_key_list_recycle_all(fyp, &fyp->simple_keys);
+	fy_token_list_unref_all(&fyp->queued_tokens);
+
+	fy_parse_parse_state_log_list_recycle_all(fyp, &fyp->state_stack);
+	fy_parse_flow_list_recycle_all(fyp, &fyp->flow_stack);
+	fy_parse_streaming_alias_list_recycle_all(fyp, &fyp->streaming_aliases);
+
+	fy_token_unref_rl(fyp->recycled_token_list, fyp->stream_end_token);
+
+	fy_document_state_unref(fyp->current_document_state);
+	fy_document_state_unref(fyp->default_document_state);
+
+	for (fyi = fy_input_list_head(&fyp->queued_inputs); fyi; fyi = fyin) {
+		fyin = fy_input_next(&fyp->queued_inputs, fyi);
+		fy_input_unref(fyi);
+	}
+
+	/* clean the builtin reader */
+	fy_reader_cleanup(&fyp->builtin_reader);
+
+	/* and vacuum (free everything) */
+	fy_parse_indent_vacuum(fyp);
+	fy_parse_simple_key_vacuum(fyp);
+	fy_parse_parse_state_log_vacuum(fyp);
+	fy_parse_flow_vacuum(fyp);
+	fy_parse_streaming_alias_vacuum(fyp);
+
+	/* free the recycled events */
+	while ((fyep = fy_eventp_list_pop(&fyp->recycled_eventp)) != NULL) {
+		/* catch double recycles */
+		/* assert(fy_eventp_list_head(&fyp->recycled_eventp)!= fyep); */
+		fy_eventp_free(fyep);
+	}
+
+	/* and the recycled tokens */
+	while ((fyt = fy_token_list_pop(&fyp->recycled_token)) != NULL)
+		fy_token_free(fyt);
+
+	fy_diag_unref(fyp->diag);
+}
+
+static const char *state_txt[] __FY_DEBUG_UNUSED__ = {
+	[FYPS_NONE] = "NONE",
+	[FYPS_STREAM_START] = "STREAM_START",
+	[FYPS_IMPLICIT_DOCUMENT_START] = "IMPLICIT_DOCUMENT_START",
+	[FYPS_DOCUMENT_START] = "DOCUMENT_START",
+	[FYPS_DOCUMENT_CONTENT] = "DOCUMENT_CONTENT",
+	[FYPS_DOCUMENT_END] = "DOCUMENT_END",
+	[FYPS_BLOCK_NODE] = "BLOCK_NODE",
+	[FYPS_BLOCK_SEQUENCE_FIRST_ENTRY] = "BLOCK_SEQUENCE_FIRST_ENTRY",
+	[FYPS_BLOCK_SEQUENCE_ENTRY] = "BLOCK_SEQUENCE_ENTRY",
+	[FYPS_INDENTLESS_SEQUENCE_ENTRY] = "INDENTLESS_SEQUENCE_ENTRY",
+	[FYPS_BLOCK_MAPPING_FIRST_KEY] = "BLOCK_MAPPING_FIRST_KEY",
+	[FYPS_BLOCK_MAPPING_KEY] = "BLOCK_MAPPING_KEY",
+	[FYPS_BLOCK_MAPPING_VALUE] = "BLOCK_MAPPING_VALUE",
+	[FYPS_FLOW_SEQUENCE_FIRST_ENTRY] = "FLOW_SEQUENCE_FIRST_ENTRY",
+	[FYPS_FLOW_SEQUENCE_ENTRY] = "FLOW_SEQUENCE_ENTRY",
+	[FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_KEY] = "FLOW_SEQUENCE_ENTRY_MAPPING_KEY",
+	[FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE] = "FLOW_SEQUENCE_ENTRY_MAPPING_VALUE",
+	[FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_END] = "FLOW_SEQUENCE_ENTRY_MAPPING_END",
+	[FYPS_FLOW_MAPPING_FIRST_KEY] = "FLOW_MAPPING_FIRST_KEY",
+	[FYPS_FLOW_MAPPING_KEY] = "FLOW_MAPPING_KEY",
+	[FYPS_FLOW_MAPPING_VALUE] = "FLOW_MAPPING_VALUE",
+	[FYPS_FLOW_MAPPING_EMPTY_VALUE] = "FLOW_MAPPING_EMPTY_VALUE",
+	[FYPS_SINGLE_DOCUMENT_END] = "SINGLE_DOCUMENT_END",
+	[FYPS_END] = "END"
+};
+
+int fy_scan_comment(struct fy_parser *fyp, struct fy_atom *handle, bool single_line)
+{
+	int c, column, start_column, lines, scan_ahead;
+	bool has_ws;
+
+	c = fy_parse_peek(fyp);
+	if (c != '#')
+		return -1;
+
+	/* if it's no comment parsing is enabled just consume it */
+	if (!(fyp->cfg.flags & FYPCF_PARSE_COMMENTS) || !handle) {
+		fy_advance(fyp, c);
+		while (!(fyp_is_lbz(fyp, c = fy_parse_peek(fyp))))
+			fy_advance(fyp, c);
+		return 0;
+	}
+
+	if (handle->fyi)
+		fy_input_unref(handle->fyi);
+
+	memset(handle, 0, sizeof(*handle));
+
+	fy_fill_atom_start(fyp, handle);
+
+	lines = 0;
+	start_column = fyp_column(fyp);
+	column = fyp_column(fyp);
+	scan_ahead = 0;
+
+	has_ws = false;
+
+	/* continuation must be a # on the same column */
+	while (c == '#' && column == start_column) {
+
+		lines++;
+		if (c == '#') {
+			/* chomp until line break */
+			fy_advance(fyp, c);
+			while (!(fyp_is_lbz(fyp, c = fy_parse_peek(fyp)))) {
+				if (fy_is_ws(c))
+					has_ws = true;
+				fy_advance(fyp, c);
+			}
+
+			/* end of input break */
+			if (fy_is_z(c))
+				break;
+		}
+
+		if (fy_is_ws(c))
+			has_ws = true;
+
+		if (!fyp_is_lb(fyp, c))
+			break;
+
+		column = 0;
+
+		scan_ahead = 1;	/* skipping over lb */
+		while (fy_is_blank(c = fy_parse_peek_at(fyp, scan_ahead))) {
+			scan_ahead++;
+			column++;
+		}
+
+		if (fy_is_z(c) || single_line)
+			break;
+
+		if (c == '#' && column == start_column) {
+			fy_advance_by(fyp, scan_ahead);
+			c = fy_parse_peek(fyp);
+		}
+	}
+
+	fy_fill_atom_end(fyp, handle);
+	handle->style = FYAS_COMMENT;
+	handle->direct_output = false;
+	handle->storage_hint = 0;
+	handle->storage_hint_valid = false;
+	handle->empty = false;
+	handle->has_lb = true;
+	handle->has_ws = has_ws;
+	handle->starts_with_ws = false; /* no-one cares for those */
+	handle->starts_with_lb = false;
+	handle->ends_with_ws = false;
+	handle->ends_with_lb = false;
+	handle->trailing_lb = false;
+	handle->size0 = lines > 0;
+	handle->valid_anchor = false;
+
+	/* and take the ref */
+	fy_input_ref(handle->fyi);
+
+	return 0;
+}
+
+bool
+fy_comment_atoms_seperated_by_ws(struct fy_parser *fyp, struct fy_atom *a, struct fy_atom *b)
+{
+	struct fy_atom *tmpatom;
+	struct fy_atom inbetween;
+	struct fy_atom_iter iter;
+	int c;
+	bool ws_or_lb;
+
+	if (!a || !b)
+		return false;
+
+	/* must be on same input */
+	if (a->fyi != b->fyi)
+		return false;
+
+	/* must be comments */
+	if (a->style != FYAS_COMMENT || b->style != FYAS_COMMENT)
+		return false;
+
+	/* a must be before */
+	if (a->end_mark.input_pos > b->start_mark.input_pos) {
+		tmpatom = a;
+		a = b;
+		b = tmpatom;
+	}
+
+	memcpy(&inbetween, a, sizeof(inbetween));
+	inbetween.start_mark = a->end_mark;
+	inbetween.end_mark = b->start_mark;
+
+	fy_atom_iter_start(&inbetween, &iter);
+	ws_or_lb = true;
+	while (ws_or_lb && (c = fy_atom_iter_utf8_get(&iter)) >= 0)
+		ws_or_lb = fy_is_ws(c) || fy_is_lb_m(c, a->lb_mode);
+	fy_atom_iter_finish(&iter);
+	return ws_or_lb;
+}
+
+/* -1 error, 0, no comment attached, 1 comment attached */
+int fy_attach_comments_if_any(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	struct fy_atom *handle;
+	struct fy_mark fym;
+	int c, rc, count, ref_indent;
+
+	if (!fyp || !fyt)
+		return -1;
+
+	if (!(fyp->cfg.flags & FYPCF_PARSE_COMMENTS))
+		return 0;
+
+	count = 0;
+
+	/* special handling for document start */
+	if (fyt->type == FYTT_DOCUMENT_START && fy_atom_is_set(&fyp->override_comment)) {
+
+		handle = fy_token_comment_handle(fyt, fycp_top, true);
+		fyp_error_check(fyp, handle, err_out,
+				"fy_token_comment_handle() top failed\n");
+
+		fy_input_unref(handle->fyi);
+		fy_atom_reset(handle);
+
+		*handle = fyp->override_comment;
+		ref_indent = fyp->indent > 0 ? fyp->indent : 0;
+		fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
+		count++;
+
+		fy_atom_reset(&fyp->override_comment);
+	}
+
+	/* if a last comment exists and is valid */
+	if (fy_atom_is_set(&fyp->last_comment)) {
+
+		handle = fy_token_comment_handle(fyt, count == 0 ? fycp_top : fycp_right, true);
+		fyp_error_check(fyp, handle, err_out,
+				"fy_token_comment_handle() top failed\n");
+
+		fy_input_unref(handle->fyi);
+		fy_atom_reset(handle);
+
+		*handle = fyp->last_comment;
+		ref_indent = fyp->indent > 0 ? fyp->indent : 0;
+		fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
+		count++;
+
+		fy_atom_reset(&fyp->last_comment);
+	}
+
+	/* right hand comment */
+
+	/* skip white space */
+	while (fy_is_ws(c = fy_parse_peek(fyp)))
+		fy_advance(fyp, c);
+
+	if (c != '#')
+		return 0;
+
+	fy_get_mark(fyp, &fym);
+
+	/* only the one that in the same line */
+	if (fym.line != fyt->handle.end_mark.line)
+		return 0;
+
+	/* it's a right comment only if it's on the same line */
+	handle = fy_token_comment_handle(fyt, fycp_right, true);
+	fyp_error_check(fyp, handle, err_out,
+			"fy_token_comment_handle() right failed\n");
+
+	fy_input_unref(handle->fyi);
+	fy_atom_reset(handle);
+
+	rc = fy_scan_comment(fyp, handle, false);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_scan_comment() failed");
+
+	if (fy_atom_is_set(handle))
+		count++;
+	return count;
+
+err_out_rc:
+	return rc;
+err_out:
+	rc = -1;
+	goto err_out;
+}
+
+int fy_fetch_flow_collection_entry(struct fy_parser *fyp, int c);
+
+int fy_parse_handle_comma(struct fy_parser *fyp, int c)
+{
+	struct fy_mark m;
+	int rc;
+
+	fyp->indent_line = fyp_line(fyp);
+
+	fyp_error_check(fyp, c == ',', err_out,
+			"illegal comma");
+
+	fy_get_mark(fyp, &m);
+
+	fyp_scan_debug(fyp, "fy_fetch_flow_collection_entry(%c)", c);
+	rc = fy_fetch_flow_collection_entry(fyp, c);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_fetch_flow_collection_entry() failed");
+
+	fyp->last_was_comma = true;
+	fyp->last_comma_mark = m;
+
+	return 0;
+
+err_out_rc:
+	return rc;
+err_out:
+	rc = -1;
+	goto err_out_rc;
+}
+
+int fy_parse_handle_right_comment_after_comma(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	int c, rc, start_line;
+
+	/* not collecting comment or now in flow mode */
+	if (!(fyp->cfg.flags & FYPCF_PARSE_COMMENTS) || !fyp->flow_level)
+		return 0;
+
+	/* we can only attach right to these tokens */
+	if (fyt->type != FYTT_SCALAR &&
+	    fyt->type != FYTT_FLOW_SEQUENCE_END &&
+	    fyt->type != FYTT_FLOW_MAPPING_END)
+		return 0;
+
+	/* skip white space while we're on the same line */
+	start_line = fyp_line(fyp);
+	while (fy_is_ws(c = fy_parse_peek(fyp)))
+		fy_advance(fyp, c);
+
+	/* is it a comma at the same line? */
+	if (c != ',' || start_line != fyp_line(fyp))
+		return 0;
+
+	/* immediately parse the comma because grab the scalar to attach the comment */
+	rc = fy_parse_handle_comma(fyp, ',');
+	fyp_error_check(fyp, !rc, err_out_rc,
+		"fy_parse_handle_comma() failed");
+
+	return 0;
+err_out_rc:
+	return rc;
+}
+
+int fy_parse_handle_comments_after_token(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	int rc;
+
+	if (!(fyp->cfg.flags & FYPCF_PARSE_COMMENTS))
+		return 0;
+
+	rc = fy_attach_comments_if_any(fyp, fyt);
+	fyp_error_check(fyp, rc >= 0, err_out_rc,
+			"fy_attach_right_hand_comment() failed");
+
+	rc = fy_parse_handle_right_comment_after_comma(fyp, fyt);
+	fyp_error_check(fyp, rc >= 0, err_out_rc,
+			"fy_parse_handle_right_comment_after_comma() failed");
+
+	return 0;
+
+err_out_rc:
+	return rc;
+err_out:
+	rc = -1;
+	goto err_out;
+}
+
+int fy_scan_to_next_token(struct fy_parser *fyp)
+{
+	int c, c_after_ws, i, rc = 0;
+	bool tabs_allowed, sloppy_flow, no_indent;
+	ssize_t offset;
+	struct fy_atom this_comment;
+	struct fy_reader *fyr;
+
+	fyr = fyp->reader;
+
+	rc = fy_reader_input_scan_token_mark(fyr);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_reader_input_scan_token_mark() failed");
+
+	/* skip BOM at the start of the stream */
+	if (fy_reader_current_input_pos(fyr) == 0 && (c = fy_parse_peek(fyp)) == FY_UTF8_BOM) {
+
+		fy_advance(fyp, c);
+		/* reset column */
+		fyr->column = 0;
+	}
+
+	/* json does not have comments or tab handling... */
+	if (fyp_json_mode(fyp)) {
+		fy_reader_skip_ws_cr_nl(fyr);
+		goto done;
+	}
+
+	tabs_allowed = fyp->flow_level > 0 || !fyp->simple_key_allowed || fyp_tabsize(fyp) > 0;
+	sloppy_flow = fyp->flow_level > 0 && (fyp->cfg.flags & FYPCF_SLOPPY_FLOW_INDENTATION);
+
+	for (;;) {
+
+		/* skip white space, tabs are allowed in flow context */
+		/* tabs also allowed in block context but not at start of line or after -?: */
+
+		/* if we're not in sloppy flow indent mode, a tab may not be used as indentation */
+		if (!sloppy_flow) {
+			// fyp_notice(fyp, "not sloppy flow check c='%c' col=%d indent=%d\n", fy_parse_peek(fyp), fyp_column(fyp), fyp->indent);
+			c = -1;
+			while (fyp_column(fyp) <= fyp->indent && fy_is_ws(c = fy_parse_peek(fyp))) {
+				if (fy_is_tab(c))
+					break;
+				fy_advance(fyp, c);
+			}
+
+			/* it's an error, only if it is used for intentation */
+			/* comments and empty lines are OK */
+			if (fy_is_tab(c)) {
+
+				/* skip all space and tabs */
+				i = 0;
+				offset = -1;
+				while (fy_is_ws(c_after_ws = fy_parse_peek_at_internal(fyp, i, &offset)))
+					i++;
+
+				no_indent = c_after_ws == '#' || fyp_is_lb(fyp, c_after_ws);
+
+				FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+						no_indent, err_out,
+						"tab character may not be used as indentation");
+
+				/* advance by that amount */
+				fy_advance_by(fyp, i);
+			}
+		}
+
+		if (!tabs_allowed) {
+			/* skip space only */
+			fy_reader_skip_space(fyr);
+			c = fy_parse_peek(fyp);
+
+			/* it's a tab, here we go */
+			if (fy_is_tab(c)) {
+
+				/* we need to see if after ws follows a flow start marker */
+
+				/* skip all space and tabs */
+				i = 0;
+				offset = -1;
+				while (fy_is_ws(c_after_ws = fy_parse_peek_at_internal(fyp, i, &offset)))
+					i++;
+
+				/* flow start marker after spaces? allow tabs */
+				if (c_after_ws == '{' || c_after_ws == '[') {
+					fy_advance_by(fyp, i);
+					c = fy_parse_peek(fyp);
+				}
+			}
+		} else {
+			fy_reader_skip_ws(fyr);
+			c = fy_parse_peek(fyp);
+		}
+
+		/* comment? */
+		if (c == '#') {
+
+			if (!(fyp->cfg.flags & FYPCF_PARSE_COMMENTS)) {
+				rc = fy_scan_comment(fyp, NULL, false);
+				fyp_error_check(fyp, !rc, err_out_rc,
+						"fy_scan_comment() failed");
+			} else {
+
+				memset(&this_comment, 0, sizeof(this_comment));
+				fy_atom_reset(&this_comment);
+				rc = fy_scan_comment(fyp, &this_comment, false);
+				fyp_error_check(fyp, !rc, err_out_rc,
+						"fy_scan_comment() failed");
+
+				if (fy_atom_is_set(&fyp->last_comment)) {
+
+					/* merge consecutive override comments */
+					if (fy_atom_is_set(&fyp->override_comment) &&
+						fy_comment_atoms_seperated_by_ws(fyp, &fyp->override_comment, &fyp->last_comment)) {
+						fyp->override_comment.end_mark = fyp->last_comment.end_mark;
+						fy_input_unref(fyp->last_comment.fyi);
+					} else {
+						/* override comment keeps the last comment */
+						fy_input_unref(fyp->override_comment.fyi);
+						fy_atom_reset(&fyp->override_comment);
+						/* transfer the reference, do not take an additional one */
+						fyp->override_comment = fyp->last_comment;
+					}
+
+					fy_atom_reset(&fyp->last_comment);
+					fyp->last_comment = this_comment;
+				} else
+					fyp->last_comment = this_comment;
+			}
+
+			tabs_allowed = (fyp->flow_level || !fyp->simple_key_allowed) || fyp_tabsize(fyp);
+		}
+
+		c = fy_parse_peek(fyp);
+
+		/* not linebreak? we're done */
+		if (!fyp_is_lb(fyp, c))
+			goto done;
+
+		/* line break */
+		fy_advance(fyp, c);
+
+		/* may start simple key (in block ctx) */
+		if (!fyp->flow_level && !fyp->simple_key_allowed) {
+			fyp->simple_key_allowed = true;
+			fyp->tab_used_for_ws = false;
+			tabs_allowed = fyp->flow_level || !fyp->simple_key_allowed || fyp_tabsize(fyp);
+			fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+		}
+	}
+
+	fyp_scan_debug(fyp, "%s: no-next-token", __func__);
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+
+done:
+	rc = fy_reader_input_scan_token_mark(fyr);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_reader_input_scan_token_mark() failed");
+
+	fyp_scan_debug(fyp, "%s: next token starts with c='%s'", __func__,
+			fy_utf8_format_a(fy_parse_peek(fyp), fyue_singlequote));
+	return 0;
+}
+
+static void fy_purge_required_simple_key_report(struct fy_parser *fyp,
+		struct fy_token *fyt, enum fy_token_type next_type)
+{
+	bool is_anchor, is_tag;
+
+	is_anchor = fyt && fyt->type == FYTT_ANCHOR;
+	is_tag = fyt && fyt->type == FYTT_TAG;
+
+	if (is_anchor || is_tag) {
+		if ((fyp->state == FYPS_BLOCK_MAPPING_VALUE ||
+		     fyp->state == FYPS_BLOCK_MAPPING_FIRST_KEY) &&
+			next_type == FYTT_BLOCK_ENTRY) {
+
+			FYP_TOKEN_ERROR(fyp, fyt, FYEM_SCAN,
+					"invalid %s indent for sequence",
+					is_anchor ? "anchor" : "tag");
+			return;
+		}
+
+		if (fyp->state == FYPS_BLOCK_MAPPING_VALUE && next_type == FYTT_SCALAR) {
+			FYP_TOKEN_ERROR(fyp, fyt, FYEM_SCAN,
+					"invalid %s indent for mapping",
+					is_anchor ? "anchor" : "tag");
+			return;
+		}
+	}
+
+	if (fyt)
+		FYP_TOKEN_ERROR(fyp, fyt, FYEM_SCAN,
+			"could not find expected ':'");
+	else
+		FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN,
+			"could not find expected ':'");
+}
+
+static inline bool
+fy_any_simple_keys(struct fy_parser *fyp)
+{
+	return !fy_simple_key_list_empty(&fyp->simple_keys);
+}
+
+static int fy_purge_stale_simple_keys(struct fy_parser *fyp, bool *did_purgep,
+		enum fy_token_type next_type)
+{
+	struct fy_simple_key *fysk;
+	bool purge;
+	int line;
+
+	*did_purgep = false;
+	while ((fysk = fy_simple_key_list_head(&fyp->simple_keys)) != NULL) {
+
+#ifdef FY_DEVMODE
+		fyp_scan_debug(fyp, "purge-check: flow_level=%d fysk->flow_level=%d fysk->mark.line=%d line=%d",
+				fyp->flow_level, fysk->flow_level,
+				fysk->mark.line, fyp_line(fyp));
+
+		fyp_debug_dump_simple_key(fyp, fysk, "purge-check: ");
+#endif
+
+		line = fysk->mark.line;
+
+		/* in non-flow context we purge keys that are on different line */
+		/* in flow context we purge only those with higher flow level */
+		if (!fyp->flow_level) {
+			purge = fyp_line(fyp) > line;
+		} else {
+			purge = fyp->flow_level < fysk->flow_level;
+			/* also purge implicit complex keys on a different line */
+			if (!purge && fysk->implicit_complex) {
+				purge = fyp_line(fyp) > line;
+			}
+		}
+
+		if (!purge)
+			break;
+
+		if (fysk->required) {
+			fy_purge_required_simple_key_report(fyp, fysk->token, next_type);
+			goto err_out;
+		}
+
+#ifdef FY_DEVMODE
+		fyp_debug_dump_simple_key(fyp, fysk, "purging: ");
+#endif
+
+		fy_simple_key_list_del(&fyp->simple_keys, fysk);
+		fy_parse_simple_key_recycle(fyp, fysk);
+
+		*did_purgep = true;
+	}
+
+	if (*did_purgep && fy_simple_key_list_empty(&fyp->simple_keys))
+		fyp_scan_debug(fyp, "(purge) simple key list is now empty!");
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int fy_push_indent(struct fy_parser *fyp, int indent, bool generated_block_map, int indent_line)
+{
+	struct fy_indent *fyit;
+
+	fyit = fy_parse_indent_alloc(fyp);
+	fyp_error_check(fyp, fyit != NULL, err_out,
+		"fy_indent_alloc() failed");
+
+	fyit->indent = fyp->indent;
+	fyit->indent_line = fyp->indent_line;
+	fyit->generated_block_map = fyp->generated_block_map;
+
+	/* push */
+	fy_indent_list_push(&fyp->indent_stack, fyit);
+
+	/* update current state */
+	fyp->parent_indent = fyp->indent;
+	fyp->indent = indent;
+	fyp->indent_line = indent_line;
+	if (fyp->parse_block_only && fyp->starting_indent < 0)
+		fyp->starting_indent = indent;
+	fyp->generated_block_map = generated_block_map;
+
+	fyp_scan_debug(fyp, "push_indent %d -> %d - generated_block_map=%s\n",
+			fyp->parent_indent, fyp->indent,
+			fyp->generated_block_map ? "true" : "false");
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int fy_pop_indent(struct fy_parser *fyp)
+{
+	struct fy_indent *fyit;
+	int prev_indent __FY_DEBUG_UNUSED__;
+
+	fyit = fy_indent_list_pop(&fyp->indent_stack);
+	if (!fyit)
+		return -1;
+
+	prev_indent = fyp->indent;
+
+	/* pop the indent and update */
+	fyp->indent = fyit->indent;
+	fyp->generated_block_map = fyit->generated_block_map;
+	fyp->indent_line = fyit->indent_line;
+
+	/* pop and recycle */
+	fy_parse_indent_recycle(fyp, fyit);
+
+	/* update the parent indent */
+	fyit = fy_indent_list_head(&fyp->indent_stack);
+	fyp->parent_indent = fyit ? fyit->indent : -2;
+
+	fyp_scan_debug(fyp, "pop indent %d -> %d (parent %d) - generated_block_map=%s\n",
+			prev_indent, fyp->indent, fyp->parent_indent,
+			fyp->generated_block_map ? "true" : "false");
+
+	return 0;
+}
+
+int fy_parse_unroll_indent(struct fy_parser *fyp, int column)
+{
+	struct fy_token *fyt;
+	int rc;
+
+	/* do nothing in flow context */
+	if (fyp->flow_level)
+		return 0;
+
+	/* pop while indentation level greater than argument */
+	while (fyp->indent > column) {
+
+		fyp_scan_debug(fyp, "unrolling: %d/%d", fyp->indent, column);
+
+		/* create a block end token */
+		fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_BLOCK_END, 0);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue_simple() failed");
+
+		rc = fy_pop_indent(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_pop_indent() failed");
+
+		/* the ident line has now moved */
+		fyp->indent_line = fyp_line(fyp);
+	}
+	return 0;
+err_out:
+	return -1;
+}
+
+void fy_remove_all_simple_keys(struct fy_parser *fyp)
+{
+	struct fy_simple_key *fysk;
+
+	fyp_scan_debug(fyp, "SK: removing all");
+
+	while ((fysk = fy_simple_key_list_pop(&fyp->simple_keys)) != NULL)
+		fy_parse_simple_key_recycle(fyp, fysk);
+
+	fyp->simple_key_allowed = true;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+}
+
+struct fy_simple_key *fy_would_remove_required_simple_key(struct fy_parser *fyp)
+{
+	struct fy_simple_key *fysk;
+
+	/* no simple key? */
+	for (fysk = fy_simple_key_list_head(&fyp->simple_keys);
+			fysk && fysk->flow_level >= fyp->flow_level;
+			fysk = fy_simple_key_next(&fyp->simple_keys, fysk)) {
+		if (fysk->required)
+			return fysk;
+	}
+
+	return NULL;
+}
+
+int fy_remove_simple_key(struct fy_parser *fyp, enum fy_token_type next_type)
+{
+	struct fy_simple_key *fysk;
+
+	/* no simple key? */
+	while ((fysk = fy_simple_key_list_first(&fyp->simple_keys)) != NULL &&
+		fysk->flow_level >= fyp->flow_level) {
+
+#ifdef FY_DEVMODE
+		fyp_debug_dump_simple_key(fyp, fysk, "removing: ");
+#endif
+
+		/* remove it from the list */
+		fy_simple_key_list_del(&fyp->simple_keys, fysk);
+
+		if (fysk->required) {
+			fy_purge_required_simple_key_report(fyp, fysk->token, next_type);
+			goto err_out;
+		}
+
+		fy_parse_simple_key_recycle(fyp, fysk);
+	}
+
+	return 0;
+
+err_out:
+	fy_parse_simple_key_recycle(fyp, fysk);
+	return -1;
+}
+
+struct fy_simple_key *fy_simple_key_find(struct fy_parser *fyp, const struct fy_token *fyt)
+{
+	struct fy_simple_key *fysk;
+
+	if (!fyt)
+		return NULL;
+
+	/* no simple key? */
+	for (fysk = fy_simple_key_list_head(&fyp->simple_keys); fysk;
+			fysk = fy_simple_key_next(&fyp->simple_keys, fysk))
+		if (fysk->token == fyt)
+			return fysk;
+
+	return NULL;
+}
+
+int fy_save_simple_key(struct fy_parser *fyp, struct fy_mark *mark, struct fy_mark *end_mark,
+		struct fy_token *fyt, bool required, int flow_level,
+		enum fy_token_type next_type)
+{
+	struct fy_simple_key *fysk;
+	bool did_purge;
+	int rc;
+
+	fyp_error_check(fyp, fyt && mark && end_mark, err_out,
+			"illegal arguments to fy_save_simple_key");
+
+	if (fy_any_simple_keys(fyp)) {
+		rc = fy_purge_stale_simple_keys(fyp, &did_purge, next_type);
+		fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_purge_stale_simple_keys() failed");
+	}
+
+	/* if no simple key is allowed, don't save */
+	if (!fyp->simple_key_allowed) {
+		fyp_scan_debug(fyp, "not saving simple key; not allowed");
+		return 0;
+	}
+
+	/* remove pending complex key mark if in non flow context and a new line */
+	if (!fyp->flow_level && fyp->pending_complex_key_column >= 0 &&
+	    mark->line > fyp->pending_complex_key_mark.line &&
+	    mark->column <= fyp->pending_complex_key_mark.column ) {
+
+		fyp_scan_debug(fyp, "resetting pending_complex_key mark->line=%d line=%d\n",
+				mark->line, fyp->pending_complex_key_mark.line);
+
+		fyp->pending_complex_key_column = -1;
+		fyp_scan_debug(fyp, "pending_complex_key_column -> %d",
+				fyp->pending_complex_key_column);
+	}
+
+	fysk = fy_simple_key_list_head(&fyp->simple_keys);
+
+	/* create new simple key if it does not exist or if has flow level less */
+	if (!fysk || fysk->flow_level < fyp->flow_level) {
+
+		fysk = fy_parse_simple_key_alloc(fyp);
+		fyp_error_check(fyp, fysk != NULL, err_out,
+			"fy_simple_key_alloc()");
+
+		fyp_scan_debug(fyp, "new simple key");
+
+		fy_simple_key_list_push(&fyp->simple_keys, fysk);
+
+	} else {
+		fyp_error_check(fyp, !fysk->required, err_out,
+				"cannot save simple key, top is required");
+
+		if (fysk == fy_simple_key_list_tail(&fyp->simple_keys))
+			fyp_scan_debug(fyp, "(reuse) simple key list is now empty!");
+
+		fyp_scan_debug(fyp, "reusing simple key");
+
+	}
+
+	fysk->mark = *mark;
+	fysk->end_mark = *end_mark;
+
+	fysk->required = required;
+	fysk->token = fyt;
+	fysk->flow_level = flow_level;
+
+	/* if this is a an implicit flow collection key */
+	fysk->implicit_complex = fyp->pending_complex_key_column < 0 &&
+				 (fyt->type == FYTT_FLOW_MAPPING_START || fyt->type == FYTT_FLOW_SEQUENCE_START);
+
+
+#ifdef FY_DEVMODE
+	fyp_debug_dump_simple_key_list(fyp, &fyp->simple_keys, fysk, "fyp->simple_keys (saved): ");
+#endif
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+struct fy_simple_key_mark {
+	struct fy_mark mark;
+	bool required;
+	int flow_level;
+};
+
+void fy_get_simple_key_mark(struct fy_parser *fyp, struct fy_simple_key_mark *fyskm)
+{
+	fy_get_mark(fyp, &fyskm->mark);
+	fyskm->flow_level = fyp->flow_level;
+	fyskm->required = !fyp->flow_level && fyp->indent == fyp_column(fyp);
+}
+
+int fy_save_simple_key_mark(struct fy_parser *fyp,
+			struct fy_simple_key_mark *fyskm,
+			enum fy_token_type next_type,
+			struct fy_mark *end_markp)
+{
+	struct fy_mark end_mark;
+
+	if (!end_markp) {
+		fy_get_mark(fyp, &end_mark);
+		end_markp = &end_mark;
+	}
+
+	return fy_save_simple_key(fyp, &fyskm->mark, end_markp,
+			fy_token_list_last(&fyp->queued_tokens),
+			fyskm->required, fyskm->flow_level,
+			next_type);
+}
+
+int fy_parse_flow_push(struct fy_parser *fyp)
+{
+	struct fy_flow *fyf;
+
+	fyf = fy_parse_flow_alloc(fyp);
+	fyp_error_check(fyp, fyf != NULL, err_out,
+			"fy_flow_alloc() failed!");
+	fyf->flow = fyp->flow;
+
+	fyf->pending_complex_key_column = fyp->pending_complex_key_column;
+	fyf->pending_complex_key_mark = fyp->pending_complex_key_mark;
+
+	fyp_scan_debug(fyp, "flow_push: flow=%d pending_complex_key_column=%d",
+			(int)fyf->flow,
+			fyf->pending_complex_key_column);
+
+	fy_flow_list_push(&fyp->flow_stack, fyf);
+
+	if (fyp->pending_complex_key_column >= 0) {
+		fyp->pending_complex_key_column = -1;
+		fyp_scan_debug(fyp, "pending_complex_key_column -> %d",
+				fyp->pending_complex_key_column);
+	}
+
+	return 0;
+err_out:
+	return -1;
+}
+
+int fy_parse_flow_pop(struct fy_parser *fyp)
+{
+	struct fy_flow *fyf;
+
+	fyf = fy_flow_list_pop(&fyp->flow_stack);
+	fyp_error_check(fyp, fyf, err_out,
+			"no flow to pop");
+
+	fyp->flow = fyf->flow;
+	fyp->pending_complex_key_column = fyf->pending_complex_key_column;
+	fyp->pending_complex_key_mark = fyf->pending_complex_key_mark;
+
+	fy_parse_flow_recycle(fyp, fyf);
+
+	fyp_scan_debug(fyp, "flow_pop: flow=%d pending_complex_key_column=%d",
+			(int)fyp->flow,
+			fyp->pending_complex_key_column);
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+/* special case for allowing whitespace (including tabs) after -?: */
+static int fy_ws_indentation_check(struct fy_parser *fyp, bool *found_tabp, struct fy_mark *tab_mark)
+{
+	int c, adv, tab_adv;
+	bool indentation, found_tab;
+
+	found_tab = false;
+
+	/* not meaning in flow mode */
+	if (fyp->flow_level)
+		goto out;
+
+	/* scan forward, keeping track if we found a tab */
+	adv = 0;
+	tab_adv = -1;
+	if (tab_mark)
+		fy_get_mark(fyp, tab_mark);
+	while (fy_is_ws(c = fy_parse_peek_at(fyp, adv))) {
+		if (!found_tab && fy_is_tab(c)) {
+			found_tab = true;
+			tab_adv = adv;
+			/* XXX somewhat hacky, space is 1 char only so adjust */
+			if (tab_mark) {
+				tab_mark->input_pos += adv;
+				tab_mark->column += adv;
+			}
+		}
+		adv++;
+	}
+
+	if (found_tab) {
+		indentation = fy_utf8_strchr("?:|>", c) ||
+				(c == '-' && fyp_is_blankz(fyp, fy_parse_peek_at(fyp, adv + 1)));
+
+		/* any kind of block indentation is not allowed */
+		FYP_PARSE_ERROR_CHECK(fyp, tab_adv, 1, FYEM_SCAN,
+				!indentation, err_out,
+				"cannot use tab for indentation of block entry");
+		fy_advance_by(fyp, tab_adv + 1);
+	}
+
+	/* now chomp spaces only afterwards */
+	while (fy_is_space(c = fy_parse_peek(fyp)))
+		fy_advance(fyp, c);
+
+out:
+	if (found_tabp)
+		*found_tabp = found_tab;
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int fy_fetch_stream_start(struct fy_parser *fyp)
+{
+	struct fy_token *fyt;
+
+	/* simple key is allowed */
+	fyp->simple_key_allowed = true;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_STREAM_START, 0);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int fy_fetch_stream_end(struct fy_parser *fyp)
+{
+	struct fy_token *fyt;
+	int rc;
+
+	/* only reset the stream in regular mode */
+	if (!fyp->parse_flow_only && !fyp->parse_block_only)
+		fy_reader_stream_end(fyp->reader);
+
+	fy_remove_all_simple_keys(fyp);
+
+	if (fyp_block_mode(fyp)) {
+		rc = fy_parse_unroll_indent(fyp, -1);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_unroll_indent() failed");
+	}
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_STREAM_END, 0);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_scan_tag_uri_length(struct fy_parser *fyp, int start)
+{
+	int c, cn, length;
+	ssize_t offset, offset1;
+
+	/* first find the utf8 length of the uri */
+	length = 0;
+	offset = -1;
+	while (fy_is_uri(c = fy_parse_peek_at_internal(fyp, start + length, &offset))) {
+
+		offset1 = offset;
+		cn = fy_parse_peek_at_internal(fyp, start + length + 1, &offset1);
+
+		/* special handling for detecting URIs ending in ,}] */
+		if (fyp_is_blankz(fyp, cn) && fy_utf8_strchr(",}]", c))
+			break;
+
+		length++;
+	}
+
+	return length;
+}
+
+bool fy_scan_tag_uri_is_valid(struct fy_parser *fyp, int start, int length)
+{
+	int i, j, k, width, c, w;
+	uint8_t octet, esc_octets[4];
+	ssize_t offset;
+
+	offset = -1;
+	for (i = 0; i < length; i++) {
+		c = fy_parse_peek_at_internal(fyp, start + i, &offset);
+		if (c != '%')
+			continue;
+		/* reset cursor */
+		offset = -1;
+
+		width = 0;
+		k = 0;
+		do {
+			/* % escape */
+			FYP_PARSE_ERROR_CHECK(fyp, start + i, 1, FYEM_SCAN,
+					(length - i) >= 3, err_out,
+					"short URI escape");
+
+			if (width > 0) {
+				c = fy_parse_peek_at(fyp, start + i);
+
+				FYP_PARSE_ERROR_CHECK(fyp, start + i, 1, FYEM_SCAN,
+						c == '%', err_out,
+						"missing URI escape");
+			}
+
+			octet = 0;
+
+			for (j = 0; j < 2; j++) {
+				c = fy_parse_peek_at(fyp, start + i + 1 + j);
+
+				FYP_PARSE_ERROR_CHECK(fyp, start + i + 1 + j, 1, FYEM_SCAN,
+						fy_is_hex(c), err_out,
+						"non hex URI escape");
+				octet <<= 4;
+				if (c >= '0' && c <= '9')
+					octet |= c - '0';
+				else if (c >= 'a' && c <= 'f')
+					octet |= 10 + c - 'a';
+				else
+					octet |= 10 + c - 'A';
+			}
+			if (!width) {
+				width = fy_utf8_width_by_first_octet(octet);
+
+				FYP_PARSE_ERROR_CHECK(fyp, start + i + 1 + j, 1, FYEM_SCAN,
+						width >= 1 && width <= 4, err_out,
+						"bad width for hex URI escape");
+				k = 0;
+			}
+			esc_octets[k++] = octet;
+
+			/* skip over the 3 character escape */
+			i += 3;
+
+		} while (--width > 0);
+
+		/* now convert to utf8 */
+		c = fy_utf8_get(esc_octets, k, &w);
+
+		FYP_PARSE_ERROR_CHECK(fyp, start + i,  1 + j, FYEM_SCAN,
+				c >= 0, err_out,
+				 "bad utf8 URI escape");
+	}
+	return true;
+err_out:
+	return false;
+}
+
+int fy_scan_tag_handle_length(struct fy_parser *fyp, int start, bool req_end_bang)
+{
+	int c, length, i, width;
+	ssize_t offset;
+	uint8_t octet;
+	bool first, was_esc;
+
+	length = 0;
+
+	offset = -1;
+	c = fy_parse_peek_at_internal(fyp, start + length, &offset);
+
+	FYP_PARSE_ERROR_CHECK(fyp, start + length, 1, FYEM_SCAN,
+			c == '!', err_out,
+			"invalid tag handle start");
+	length++;
+
+	/* get first character of the tag */
+	c = fy_parse_peek_at_internal(fyp, start + length, &offset);
+
+	if (fy_is_ws(c))
+		return length;
+
+	/* if first character is !, empty handle */
+	if (c == '!') {
+		length++;
+		return length;
+	}
+
+	first = true;
+	was_esc = false;
+
+	/* now loop while it's alphanumeric */
+	for (;;) {
+		if (c == '%') {
+
+			octet = 0;
+
+			for (i = 0; i < 2; i++) {
+				c = fy_parse_peek_at_internal(fyp, start + length + 1 + i, &offset);
+				FYP_PARSE_ERROR_CHECK(fyp, start + length + 1 + i, 1, FYEM_SCAN,
+						fy_is_hex(c), err_out,
+						"non hex URI escape");
+				octet <<= 4;
+				if (c >= '0' && c <= '9')
+					octet |= c - '0';
+				else if (c >= 'a' && c <= 'f')
+					octet |= 10 + c - 'a';
+				else
+					octet |= 10 + c - 'A';
+			}
+
+			width = fy_utf8_width_by_first_octet(octet);
+			FYP_PARSE_ERROR_CHECK(fyp, start + length, 3, FYEM_SCAN,
+					width == 1, err_out,
+					"Illegal non 1 byte utf8 tag handle character");
+			c = octet;
+			was_esc = true;
+
+		} else
+			was_esc = false;
+
+		if ((first && fy_is_first_alnum(c)) || (!first && fy_is_alnum(c)))
+			length += was_esc ? 3 : 1;
+		else
+			break;
+
+		first = false;
+		c = fy_parse_peek_at_internal(fyp, start + length, &offset);
+	}
+
+	FYP_PARSE_ERROR_CHECK(fyp, start + length, 1, FYEM_SCAN,
+			!req_end_bang || c == '!', err_out,
+			"Missing required ! at end of tag handle");
+
+	/* if last character is !, copy it */
+	if (c == '!')
+		length++;
+
+	return length;
+
+err_out:
+	return -1;
+}
+
+int fy_scan_yaml_version(struct fy_parser *fyp, struct fy_version *vers)
+{
+	int c, length, start_length, num;
+	ssize_t offset;
+
+	memset(vers, 0, sizeof(*vers));
+
+	/* now loop while it's numeric */
+	length = 0;
+	offset = -1;
+	num = 0;
+	while (fy_is_num(c = fy_parse_peek_at_internal(fyp, length, &offset))) {
+		length++;
+		num = num * 10;
+		num += c - '0';
+	}
+	vers->major = num;
+
+	FYP_PARSE_ERROR_CHECK(fyp, length, 1, FYEM_SCAN,
+			length > 0, err_out,
+			"version directive missing major number");
+
+	FYP_PARSE_ERROR_CHECK(fyp, length, 1, FYEM_SCAN,
+			c == '.', err_out,
+			"version directive missing dot separator");
+	length++;
+
+	start_length = length;
+	num = 0;
+	while (fy_is_num(c = fy_parse_peek_at_internal(fyp, length, &offset))) {
+		length++;
+		num = num * 10;
+		num += c - '0';
+	}
+	vers->minor = num;
+
+	/* note that the version is not checked for validity here */
+
+	FYP_PARSE_ERROR_CHECK(fyp, length, 1, FYEM_SCAN,
+			length > start_length, err_out,
+			"version directive missing minor number");
+
+	return length;
+
+err_out:
+	return -1;
+}
+
+int fy_scan_directive(struct fy_parser *fyp)
+{
+	int c, advance, version_length, tag_length, uri_length;
+	struct fy_version vers;
+	enum fy_reader_mode rdmode;
+	enum fy_token_type type = FYTT_NONE;
+	struct fy_atom handle;
+	bool is_uri_valid, only_ws;
+	struct fy_token *fyt;
+	int i, lastc;
+
+	if (!fy_parse_strcmp(fyp, "YAML") && fy_is_blank_lb_r_n(fy_parse_peek_at(fyp, 4)))
+		type = FYTT_VERSION_DIRECTIVE;
+	else if (!fy_parse_strcmp(fyp, "TAG") && fy_is_blank_lb_r_n(fy_parse_peek_at(fyp, 3)))
+		type = FYTT_TAG_DIRECTIVE;
+	else {
+		/* skip until linebreak (or #) */
+		i = 0;
+		lastc = -1;
+		only_ws = true;
+		while ((c = fy_parse_peek_at(fyp, i)) >= 0 && !fyp_is_lb(fyp, c)) {
+			if (fy_is_ws(lastc) && c == '#')
+				break;
+			if (!fy_is_ws(c))
+				only_ws = false;
+			lastc = c;
+			i++;
+		}
+
+		FYP_PARSE_ERROR_CHECK(fyp, i, 1, FYEM_SCAN, !only_ws, err_out,
+			"Directive indicator %% without a directive");
+
+		FYP_PARSE_WARNING(fyp, 0, i, FYEM_SCAN,
+			"Unsupported directive");
+
+		FYP_PARSE_ERROR_CHECK(fyp, i, 1, FYEM_SCAN, c >= 0 || c == FYUG_EOF, err_out,
+			"Bad UTF8 input while scanning unknown %%TAG directive");
+
+		if (fy_is_ws(lastc) && c == '#') {
+			while ((c = fy_parse_peek_at(fyp, i)) >= 0 && !fyp_is_lb(fyp, c))
+				i++;
+		}
+
+		fy_advance_by(fyp, i);
+
+		/* skip over linebreak too */
+		if (fyp_is_lb(fyp, c))
+			fy_advance(fyp, c);
+
+		/* bump activity counter */
+		fyp->token_activity_counter++;
+
+		return 0;
+	}
+
+	/* advance over the YAML/TAG part */
+	advance = type == FYTT_VERSION_DIRECTIVE ? 4 : 3;
+
+	/* advance */
+	fy_advance_by(fyp, advance);
+
+	/* must be a whitespace after YAML/TAG */
+	c = fy_parse_peek(fyp);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_is_ws(c), err_out,
+			"illegal empty %%%s directive",
+			type == FYTT_VERSION_DIRECTIVE ? "YAML" : "TAG");
+
+	fy_advance(fyp, c);
+
+	/* skip white space */
+	while (fy_is_ws(c = fy_parse_peek(fyp)))
+		fy_advance(fyp, c);
+
+	fy_fill_atom_start(fyp, &handle);
+
+	/* for version directive, parse it */
+	if (type == FYTT_VERSION_DIRECTIVE) {
+
+		version_length = fy_scan_yaml_version(fyp, &vers);
+		fyp_error_check(fyp, version_length > 0, err_out,
+				"fy_scan_yaml_version() failed");
+
+		/* save the version per stream */
+		fyp->stream_version = vers;
+
+		/* set the reader's mode according to the version just scanned */
+		rdmode = fy_reader_calculate_mode(&vers, false);
+		fy_reader_set_mode(fyp->reader, rdmode);
+
+		fy_advance_by(fyp, version_length);
+
+		fy_fill_atom_end(fyp, &handle);
+
+		fyt = fy_token_queue(fyp, FYTT_VERSION_DIRECTIVE, &handle, &vers);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue() failed");
+
+	} else {
+
+		tag_length = fy_scan_tag_handle_length(fyp, 0, true);
+		fyp_error_check(fyp, tag_length > 0, err_out,
+				"fy_scan_tag_handle_length() failed");
+
+		fy_advance_by(fyp, tag_length);
+
+		c = fy_parse_peek(fyp);
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				fy_is_ws(c), err_out,
+				"missing whitespace after TAG");
+
+		/* skip white space */
+		while (fy_is_ws(c = fy_parse_peek(fyp)))
+			fy_advance(fyp, c);
+
+		uri_length = fy_scan_tag_uri_length(fyp, 0);
+		fyp_error_check(fyp, uri_length > 0, err_out,
+				"fy_scan_tag_uri_length() failed");
+
+		is_uri_valid = fy_scan_tag_uri_is_valid(fyp, 0, uri_length);
+		fyp_error_check(fyp, is_uri_valid, err_out,
+				"tag URI is invalid");
+
+		fy_advance_by(fyp, uri_length);
+
+		fy_fill_atom_end(fyp, &handle);
+		handle.style = FYAS_URI;
+
+		fyt = fy_token_queue(fyp, FYTT_TAG_DIRECTIVE, &handle, tag_length, uri_length, false);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue() failed");
+	}
+
+	/* skip until linebreak (or #) */
+	i = 0;
+	lastc = -1;
+	while ((c = fy_parse_peek_at(fyp, i)) >= 0 && !fyp_is_lb(fyp, c)) {
+		if (fy_is_ws(lastc) && c == '#')
+			break;
+
+		FYP_PARSE_ERROR_CHECK(fyp, i, 1, FYEM_SCAN,
+				fy_is_ws(c) || fyp_is_lb(fyp, c), err_out,
+				"garbage after %s directive",
+				type == FYTT_VERSION_DIRECTIVE ? "version" : "tag");
+		lastc = c;
+		i++;
+	}
+
+	fy_advance_by(fyp, i);
+
+	/* skip over linebreak */
+	if (fyp_is_lb(fyp, c))
+		fy_advance(fyp, c);
+
+	return 0;
+err_out:
+	return -1;
+}
+
+int fy_fetch_directive(struct fy_parser *fyp)
+{
+	int rc;
+
+	fy_remove_all_simple_keys(fyp);
+
+	if (fyp_block_mode(fyp)) {
+		rc = fy_parse_unroll_indent(fyp, -1);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_unroll_indent() failed");
+	}
+
+	rc = fy_scan_directive(fyp);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_scan_directive() failed");
+
+	return 0;
+
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_document_indicator(struct fy_parser *fyp, enum fy_token_type type)
+{
+	int rc, c;
+	struct fy_token *fyt;
+
+	fy_remove_all_simple_keys(fyp);
+
+	if (fyp_block_mode(fyp)) {
+		rc = fy_parse_unroll_indent(fyp, -1);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_unroll_indent() failed");
+	}
+
+	fyp->simple_key_allowed = false;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, type, 3);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	/* skip whitespace after the indicator */
+	while (fy_is_ws(c = fy_parse_peek(fyp)))
+		fy_advance(fyp, c);
+
+	rc = fy_attach_comments_if_any(fyp, fyt);
+	fyp_error_check(fyp, rc >= 0, err_out_rc,
+			"fy_attach_right_hand_comment() failed");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+static inline bool fy_flow_indent_check_internal(struct fy_parser *fyp, int column, int indent)
+{
+	return (!fyp->flow_level || column > indent) ||
+		((fyp->cfg.flags & FYPCF_SLOPPY_FLOW_INDENTATION) && fyp->flow_level);
+}
+
+static inline bool fy_flow_indent_check(struct fy_parser *fyp)
+{
+	return fy_flow_indent_check_internal(fyp, fyp_column(fyp), fyp->indent);
+}
+
+static inline bool fy_block_indent_check(struct fy_parser *fyp)
+{
+	return fyp->flow_level > 0 || fyp_column(fyp) > fyp->indent;
+}
+
+int fy_fetch_flow_collection_mark_start(struct fy_parser *fyp, int c)
+{
+	enum fy_token_type type;
+	struct fy_simple_key_mark skm;
+	const char *typestr;
+	int rc = -1;
+	struct fy_token *fyt;
+
+	if (c == '[') {
+		type = FYTT_FLOW_SEQUENCE_START;
+		typestr = "sequence";
+	} else {
+		type = FYTT_FLOW_MAPPING_START;
+		typestr = "mapping";
+	}
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented %s start in flow mode", typestr);
+
+	fy_get_simple_key_mark(fyp, &skm);
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, type, 1);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	/* json does not have complex keys */
+	if (!fyp_json_mode(fyp)) {
+		rc = fy_save_simple_key_mark(fyp, &skm, type, NULL);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_save_simple_key_mark() failed");
+	}
+
+	/* if a last comment exists and is valid */
+	if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
+			(fy_atom_is_set(&fyp->override_comment) || fy_atom_is_set(&fyp->last_comment))) {
+
+		struct fy_atom *handle;
+
+		handle = fy_token_comment_handle(fyt, fycp_top, true);
+		fyp_error_check(fyp, handle, err_out,
+			"fy_token_comment_handle() failed");
+
+		fy_input_unref(handle->fyi);
+		fy_atom_reset(handle);
+
+		if (fy_atom_is_set(&fyp->override_comment)) {
+			*handle = fyp->override_comment;
+			fy_atom_reset(&fyp->override_comment);
+		} else if (fy_atom_is_set(&fyp->last_comment)) {
+			*handle = fyp->last_comment;
+			fy_atom_reset(&fyp->last_comment);
+		}
+	}
+
+	/* increase flow level */
+	fyp->flow_level++;
+	fyp_error_check(fyp, fyp->flow_level, err_out,
+			"overflow for the flow level counter");
+
+	/* push the current flow to the stack */
+	rc = fy_parse_flow_push(fyp);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_flow_push() failed");
+	/* set the current flow mode */
+	fyp->flow = c == '[' ? FYFT_SEQUENCE : FYFT_MAP;
+
+	fyp->simple_key_allowed = true;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	/* the comment indicator must have at least a space */
+	c = fy_parse_peek(fyp);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != '#', err_out,
+			"invalid comment after %s start", typestr);
+	return 0;
+
+err_out:
+	rc = -1;
+
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_flow_collection_mark_end(struct fy_parser *fyp, int c)
+{
+	enum fy_token_type type = FYTT_NONE;
+	enum fy_flow_type flow;
+	const char *typestr, *markerstr;
+	int i, rc;
+	bool did_purge;
+	struct fy_mark mark;
+	struct fy_token *fyt;
+
+	fy_get_mark(fyp, &mark);
+
+	if (c == ']') {
+		flow = FYFT_SEQUENCE;
+		type = FYTT_FLOW_SEQUENCE_END;
+		typestr = "sequence";
+		markerstr = "bracket";
+	} else {
+		flow = FYFT_MAP;
+		type = FYTT_FLOW_MAPPING_END;
+		typestr = "mapping";
+		markerstr = "brace";
+	}
+
+	FYP_MARK_ERROR_CHECK(fyp, &fyp->last_comma_mark, &fyp->last_comma_mark, FYEM_SCAN,
+			!fyp_json_mode(fyp) || !fyp->last_was_comma, err_out,
+			"JSON disallows trailing comma before closing %s", markerstr);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented %s end in flow mode", typestr);
+
+	rc = fy_remove_simple_key(fyp, type);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_remove_simple_key() failed");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fyp->flow_level, err_out,
+			"flow %s with invalid extra closing %s",
+				typestr, markerstr);
+
+	fyp->flow_level--;
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fyp->flow == flow, err_out,
+			"mismatched flow %s end", typestr);
+
+	/* pop the flow type */
+	rc = fy_parse_flow_pop(fyp);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_flow_pop() failed");
+
+	fyp->simple_key_allowed = false;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n",
+				fyp->simple_key_allowed ? "true" : "false");
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, type, 1);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	if (fyp->parse_flow_only && fyp->flow_level == 0) {
+		rc = fy_fetch_stream_end(fyp);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_stream_end() failed");
+		return 0;
+	}
+
+	/* the comment indicator must have at least a space */
+	c = fy_parse_peek(fyp);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != '#', err_out,
+			"invalid comment after end of flow %s", typestr);
+
+	/* due to the weirdness with simple keys and multiline flow keys scan forward
+	* until a linebreak, ';', or anything else */
+	for (i = 0; ; i++) {
+		c = fy_parse_peek_at(fyp, i);
+		if (c < 0 || c == ':' || fyp_is_lb(fyp, c) || !fy_is_ws(c))
+			break;
+	}
+
+	/* we must be a key, purge */
+	if (c == ':') {
+		if (fy_any_simple_keys(fyp)) {
+			rc = fy_purge_stale_simple_keys(fyp, &did_purge, type);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_purge_stale_simple_keys() failed");
+
+			/* if we did purge and the the list is now empty, we're hosed */
+			if (did_purge && fy_simple_key_list_empty(&fyp->simple_keys)) {
+				FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN,
+						"invalid multiline flow %s key ", typestr);
+				goto err_out;
+			}
+		}
+	}
+
+	rc = fy_parse_handle_comments_after_token(fyp, fyt);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_handle_comments_after_token() failed");
+
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_flow_collection_entry(struct fy_parser *fyp, int c)
+{
+	enum fy_token_type type = FYTT_NONE;
+	struct fy_token *fyt, *fyt_last;
+	struct fy_atom *handle;
+	int rc;
+
+	type = FYTT_FLOW_ENTRY;
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented entry seperator in flow mode");
+
+	/* transform '? a,' to '? a: ,' */
+	if (fyp->pending_complex_key_column >= 0) {
+
+		fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_VALUE, 0);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue_simple() failed");
+
+		fyp->pending_complex_key_column = -1;
+
+	}
+
+	rc = fy_remove_simple_key(fyp, type);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_remove_simple_key() failed");
+
+	fyp->simple_key_allowed = true;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	if (fyp->cfg.flags & FYPCF_PARSE_COMMENTS)
+		fyt_last = fy_token_list_tail(&fyp->queued_tokens);
+	else
+		fyt_last = NULL;
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, type, 1);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	/* the comment indicator must have at least a space */
+	c = fy_parse_peek(fyp);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != '#', err_out,
+			"invalid comment after comma");
+
+	/* skip white space */
+	if (fyt_last) {
+		while (fy_is_ws(c = fy_parse_peek(fyp)))
+			fy_advance(fyp, c);
+
+		if (c == '#') {
+			handle = fy_token_comment_handle(fyt_last, fycp_right, true);
+			fyp_error_check(fyp, handle, err_out,
+				"fy_token_comment_handle() failed");
+			fy_input_unref(handle->fyi);
+			fy_atom_reset(handle);
+
+			rc = fy_scan_comment(fyp, handle, true);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_scan_comment() failed");
+		}
+	}
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_block_entry(struct fy_parser *fyp, int c)
+{
+	int rc;
+	struct fy_mark mark;
+	struct fy_simple_key *fysk;
+	struct fy_token *fyt;
+	struct fy_atom *handle;
+
+	fyp_error_check(fyp, c == '-', err_out,
+			"illegal block entry");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			(!fyp->flow_level || (fyp_column(fyp) + 2) > fyp->indent) ||
+			((fyp->cfg.flags & FYPCF_SLOPPY_FLOW_INDENTATION) && fyp->flow_level), err_out,
+			"wrongly indented block sequence in flow mode");
+
+	if (!(fyp->flow_level || fyp->simple_key_allowed)) {
+		if (!fyp->simple_key_allowed && fyp->state == FYPS_BLOCK_MAPPING_VALUE)
+			FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN,
+					"block sequence on the same line as a mapping key");
+		else if (fyp->state == FYPS_BLOCK_SEQUENCE_FIRST_ENTRY ||
+			 fyp->state == FYPS_BLOCK_SEQUENCE_ENTRY)
+			FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN,
+					"block sequence on the same line as a previous item");
+		else
+			FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN,
+					"block sequence entries not allowed in this context");
+		goto err_out;
+	}
+
+	/* we have to save the start mark */
+	fy_get_mark(fyp, &mark);
+
+	if (fyp_block_mode(fyp) && fyp->indent < fyp_column(fyp)) {
+
+		int old_indent = fyp->indent;	/* save before push for comment delta */
+
+		/* push the new indent level */
+		rc = fy_push_indent(fyp, fyp_column(fyp), false, fyp_line(fyp));
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_push_indent() failed");
+
+		fyt = fy_token_queue_simple_internal(fyp, &fyp->queued_tokens, FYTT_BLOCK_SEQUENCE_START, 0);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue_simple_internal() failed");
+
+		/* if a last comment exists and is valid */
+		if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
+				(fy_atom_is_set(&fyp->override_comment) || fy_atom_is_set(&fyp->last_comment))) {
+			int ref_indent;
+
+			handle = fy_token_comment_handle(fyt, fycp_top, true);
+			fyp_error_check(fyp, handle, err_out,
+				"fy_token_comment_handle() failed");
+			fy_input_unref(handle->fyi);
+			fy_atom_reset(handle);
+
+			if (fy_atom_is_set(&fyp->override_comment)) {
+				*handle = fyp->override_comment;
+				fy_atom_reset(&fyp->override_comment);
+			} else if (fy_atom_is_set(&fyp->last_comment)) {
+				*handle = fyp->last_comment;
+				fy_atom_reset(&fyp->last_comment);
+			}
+
+			/* compute indent_delta — same logic as fy_attach_comments_if_any()
+			 * but using old_indent (before fy_push_indent) as reference, since
+			 * the emitter will use the pre-increase mapping indent as base */
+			ref_indent = old_indent > 0 ? old_indent : 0;
+			fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
+		}
+	}
+
+	/* always reset the override comment */
+	fy_input_unref(fyp->override_comment.fyi);
+	fy_atom_reset(&fyp->override_comment);
+
+	if (c == '-' && fyp->flow_level) {
+		/* this is an error, but we let the parser catch it */
+		;
+	}
+
+	fysk = fy_would_remove_required_simple_key(fyp);
+
+	if (fysk) {
+		if (fysk->token) {
+			if (fysk->token->type == FYTT_ANCHOR || fysk->token->type == FYTT_TAG)
+				FYP_TOKEN_ERROR(fyp, fysk->token, FYEM_SCAN,
+					"invalid %s indent for sequence",
+						fysk->token->type == FYTT_ANCHOR	?
+							"anchor" : "tag");
+			else
+				FYP_TOKEN_ERROR(fyp, fysk->token, FYEM_SCAN,
+					"missing ':'");
+		} else
+			FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN,
+				"missing ':'");
+		goto err_out;
+	}
+
+	rc = fy_remove_simple_key(fyp, FYTT_BLOCK_ENTRY);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_remove_simple_key() failed");
+
+	fyp->simple_key_allowed = true;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_BLOCK_ENTRY, 1);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	rc = fy_ws_indentation_check(fyp, NULL, NULL);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_ws_indentation_check() failed");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_key(struct fy_parser *fyp, int c)
+{
+	int rc;
+	struct fy_mark mark;
+	struct fy_simple_key_mark skm;
+	bool target_simple_key_allowed;
+	struct fy_token *fyt;
+	struct fy_atom *handle;
+	bool found_tab;
+	struct fy_mark tab_mark;
+
+	fyp_error_check(fyp, c == '?', err_out,
+			"illegal block entry or key mark");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented mapping key in flow mode");
+
+	fy_get_simple_key_mark(fyp, &skm);
+
+	/* we have to save the start mark */
+	fy_get_mark(fyp, &mark);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fyp->flow_level || fyp->simple_key_allowed, err_out,
+			"invalid mapping key (not allowed in this context)");
+
+	if (fyp_block_mode(fyp) && fyp->indent < fyp_column(fyp)) {
+
+		/* push the new indent level */
+		rc = fy_push_indent(fyp, fyp_column(fyp), true, fyp_line(fyp));
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_push_indent() failed");
+
+		fyt = fy_token_queue_simple_internal(fyp, &fyp->queued_tokens, FYTT_BLOCK_MAPPING_START, 0);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue_simple_internal() failed");
+
+		/* if a last comment exists and is valid */
+		if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
+				(fy_atom_is_set(&fyp->override_comment) || fy_atom_is_set(&fyp->last_comment))) {
+
+			handle = fy_token_comment_handle(fyt, fycp_top, true);
+			fyp_error_check(fyp, handle, err_out,
+				"fy_token_comment_handle() failed");
+
+			fy_input_unref(handle->fyi);
+			fy_atom_reset(handle);
+
+			if (fy_atom_is_set(&fyp->override_comment)) {
+				*handle = fyp->override_comment;
+				fy_atom_reset(&fyp->override_comment);
+			} else if (fy_atom_is_set(&fyp->last_comment)) {
+				*handle = fyp->last_comment;
+				fy_atom_reset(&fyp->last_comment);
+			}
+		}
+	}
+
+	rc = fy_remove_simple_key(fyp, FYTT_KEY);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_remove_simple_key() failed");
+
+	target_simple_key_allowed = !fyp->flow_level;
+
+	fyp->pending_complex_key_column = fyp_column(fyp);
+	fyp->pending_complex_key_mark = mark;
+	fyp_scan_debug(fyp, "pending_complex_key_column %d",
+			fyp->pending_complex_key_column);
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_KEY, 1);
+	fyp_error_check(fyp, fyt, err_out_rc,
+			"fy_token_queue_simple() failed");
+	/* extra KEY data */
+	fyt->key.flow_level = fyp->flow_level;
+
+	fyp->simple_key_allowed = target_simple_key_allowed;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	rc = fy_ws_indentation_check(fyp, &found_tab, &tab_mark);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_ws_indentation_check() failed");
+
+	/* record whether a tab was used for indentation */
+	if (fyp->simple_key_allowed && found_tab) {
+		fyp->tab_used_for_ws = true;
+		fyp->last_tab_used_for_ws_mark = tab_mark;
+	} else
+		fyp->tab_used_for_ws = false;	// XXX
+
+	/* comment which we care about? */
+	if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) && c == '#') {
+
+		handle = fy_token_comment_handle(fyt, fycp_right, true);
+		fyp_error_check(fyp, handle, err_out,
+			"fy_token_comment_handle() failed");
+
+		fy_input_unref(handle->fyi);
+		fy_atom_reset(handle);
+
+		rc = fy_scan_comment(fyp, handle, false);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_scan_comment() failed");
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_value(struct fy_parser *fyp, int c)
+{
+	struct fy_token_list sk_tl;
+	struct fy_simple_key *fysk = NULL;
+	struct fy_mark mark, mark_insert, mark_end_insert;
+	struct fy_token *fyt_insert, *fyt;
+	bool target_simple_key_allowed, is_complex, has_bmap;
+	bool push_bmap_start, push_key_only, did_purge, final_complex_key;
+	bool is_multiline __FY_DEBUG_UNUSED__;
+	struct fy_atom *chandle;
+	bool found_tab;
+	struct fy_mark tab_mark;
+	int rc;
+
+	fyp_error_check(fyp, c == ':', err_out,
+		"illegal value mark");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			!fyp_json_mode(fyp) || fyp->flow == FYFT_MAP, err_out,
+			"JSON considers keys when not in mapping context invalid");
+
+	/* special handling for :: weirdness */
+	if (!fyp_json_mode(fyp) && fyp->flow_level > 0) {
+		int adv, nextc, nextcol, tabsize, indent;
+
+		/* this requires some explanation...
+		 * we need to detect x::x, x: :x, and x:\n:x as the same
+		 */
+		adv = 1;
+		indent = fyp->indent;
+		nextcol = fyp_column(fyp) + 1;
+		tabsize = fyp_tabsize(fyp);
+
+		while ((nextc = fy_parse_peek_at(fyp, adv)) > 0) {
+
+			if (fyp_is_lb(fyp, nextc))
+				nextcol = 0;
+			else if (fy_is_tab(nextc)) {
+				if (tabsize)
+					nextcol += tabsize - (nextcol % tabsize);
+				else
+					nextcol++;
+			} else if (fy_is_space(nextc))
+				nextcol++;
+			else {
+				if (!fy_flow_indent_check_internal(fyp, nextcol, indent))
+					nextc = -1;
+				break;
+			}
+
+			adv++;
+		}
+
+		fyp->colon_follows_colon = nextc == ':';
+	} else
+		fyp->colon_follows_colon = false;
+
+	fy_get_mark(fyp, &mark);
+
+	fy_token_list_init(&sk_tl);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented mapping value in flow mode");
+
+	if (fy_any_simple_keys(fyp)) {
+		rc = fy_purge_stale_simple_keys(fyp, &did_purge, FYTT_VALUE);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_purge_stale_simple_keys() failed");
+	}
+
+	/* get the simple key (if available) for the value */
+	fysk = fy_simple_key_list_head(&fyp->simple_keys);
+	if (fysk && fysk->flow_level == fyp->flow_level)
+		fy_simple_key_list_del(&fyp->simple_keys, fysk);
+	else
+		fysk = NULL;
+
+	if (!fysk) {
+		fyp_scan_debug(fyp, "no simple key flow_level=%d", fyp->flow_level);
+
+		fyt_insert = fy_token_list_tail(&fyp->queued_tokens);
+		mark_insert = mark;
+		mark_end_insert = mark;
+	} else {
+		assert(fysk->flow_level == fyp->flow_level);
+		fyt_insert = fysk->token;
+		mark_insert = fysk->mark;
+		mark_end_insert = fysk->end_mark;
+
+		fyp_scan_debug(fyp, "have simple key flow_level=%d", fyp->flow_level);
+	}
+
+	fyp_scan_debug(fyp, "flow_level=%d, column=%d parse_indent=%d",
+			fyp->flow_level, mark_insert.column, fyp->indent);
+
+	is_complex = fyp->pending_complex_key_column >= 0;
+	final_complex_key = is_complex && (fyp->flow_level || fyp_column(fyp) <= fyp->pending_complex_key_mark.column);
+	is_multiline = mark_end_insert.line < fyp_line(fyp);
+	has_bmap = fyp->generated_block_map;
+	push_bmap_start = (!fyp->flow_level && mark_insert.column > fyp->indent);
+	push_key_only = (!is_complex && (fyp->flow_level || has_bmap)) ||
+		        (is_complex && !final_complex_key);
+
+	fyp_scan_debug(fyp, "mark_insert.line=%d/%d mark_end_insert.line=%d/%d fyp->line=%d",
+			mark_insert.line, mark_insert.column,
+			mark_end_insert.line, mark_end_insert.column,
+			fyp_line(fyp));
+
+	fyp_scan_debug(fyp, "simple_key_allowed=%s is_complex=%s final_complex_key=%s is_multiline=%s has_bmap=%s push_bmap_start=%s push_key_only=%s",
+			fyp->simple_key_allowed ? "true" : "false",
+			is_complex ? "true" : "false",
+			final_complex_key ? "true" : "false",
+			is_multiline ? "true" : "false",
+			has_bmap ? "true" : "false",
+			push_bmap_start ? "true" : "false",
+			push_key_only ? "true" : "false");
+
+	if (!is_complex && is_multiline && (!fyp->flow_level || fyp->flow != FYFT_MAP)) {
+		FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN, "Illegal placement of ':' indicator");
+		goto err_out;
+	}
+
+	/* special handling for ?: */
+	if (fyp->tab_used_for_ws) {
+		FYP_PARSE_ERROR(fyp, 0, 1, FYEM_SCAN, "Indentation used tabs for ':' indicator");
+		goto err_out;
+	}
+
+	if (push_bmap_start) {
+
+		assert(!fyp->flow_level);
+
+		fyp_scan_debug(fyp, "--- parse_roll");
+
+		/* push the new indent level */
+		rc = fy_push_indent(fyp, mark_insert.column, true, mark_insert.line);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_push_indent() failed");
+
+		fyt = fy_token_queue_simple_internal(fyp, &sk_tl, FYTT_BLOCK_MAPPING_START, 0);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue_simple_internal() failed");
+
+		/* if a last comment exists and is valid */
+		if (fyp->cfg.flags & FYPCF_PARSE_COMMENTS) {
+
+			struct fy_atom *key_handle, *handle;
+
+			if (fysk && fysk->token) {
+				key_handle = fy_token_comment_handle(fysk->token, fycp_top, true);
+				fyp_error_check(fyp, key_handle, err_out,
+					"fy_token_comment_handle() failed");
+
+				handle = fy_token_comment_handle(fyt, fycp_top, true);
+				fyp_error_check(fyp, handle, err_out,
+					"fy_token_comment_handle() failed");
+
+				/* move the comment to the block mapping start */
+				fy_input_unref(handle->fyi);
+				fy_atom_reset(handle);
+				*handle = *key_handle;
+				fy_atom_reset(key_handle);
+			}
+
+			if (fy_atom_is_set(&fyp->override_comment) ||
+			    fy_atom_is_set(&fyp->last_comment)) {
+
+				handle = fy_token_comment_handle(fyt, fycp_top, true);
+				fyp_error_check(fyp, handle, err_out,
+					"fy_token_comment_handle() failed");
+
+				fy_input_unref(handle->fyi);
+				fy_atom_reset(handle);
+
+				if (fy_atom_is_set(&fyp->override_comment)) {
+					*handle = fyp->override_comment;
+					fy_atom_reset(&fyp->override_comment);
+				} else if (fy_atom_is_set(&fyp->last_comment)) {
+					*handle = fyp->last_comment;
+					fy_atom_reset(&fyp->last_comment);
+				}
+			}
+		}
+
+		/* update with this mark */
+		fyt->handle.start_mark = fyt->handle.end_mark = mark_insert;
+	}
+
+	if (push_bmap_start || push_key_only) {
+
+		fyt = fy_token_queue_simple_internal(fyp, &sk_tl, FYTT_KEY, 0);
+		fyp_error_check(fyp, fyt, err_out,
+				"fy_token_queue_simple_internal() failed");
+
+		/* update with the flow level */
+		fyt->key.flow_level = fyp->flow_level;
+	}
+
+#ifdef FY_DEVMODE
+	fyp_debug_dump_token(fyp, fyt_insert, "insert-token: ");
+	fyp_debug_dump_token_list(fyp, &fyp->queued_tokens, fyt_insert, "fyp->queued_tokens (before): ");
+	fyp_debug_dump_token_list(fyp, &sk_tl, NULL, "sk_tl: ");
+#endif
+
+	if (fyt_insert) {
+
+		if (fysk)
+			fy_token_list_splice_before(&fyp->queued_tokens, fyt_insert, &sk_tl);
+		else
+			fy_token_list_splice_after(&fyp->queued_tokens, fyt_insert, &sk_tl);
+	} else
+		fy_token_lists_splice(&fyp->queued_tokens, &sk_tl);
+
+#ifdef FY_DEVMODE
+	fyp_debug_dump_token_list(fyp, &fyp->queued_tokens, fyt_insert, "fyp->queued_tokens (after): ");
+#endif
+
+	target_simple_key_allowed = fysk ? false : !fyp->flow_level;
+
+	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_VALUE, 1);
+	fyp_error_check(fyp, fyt, err_out,
+			"fy_token_queue_simple() failed");
+
+	if (fysk) {
+		fy_parse_simple_key_recycle(fyp, fysk);
+		fysk = NULL;
+	}
+
+
+	fyp->simple_key_allowed = target_simple_key_allowed;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	if (is_complex) {
+		rc = fy_ws_indentation_check(fyp, &found_tab, &tab_mark);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_ws_indentation_check() failed");
+
+		/* record whether a tab was used for indentation */
+		if (fyp->simple_key_allowed && found_tab) {
+			fyp->tab_used_for_ws = true;
+			fyp->last_tab_used_for_ws_mark = tab_mark;
+		} else
+			fyp->tab_used_for_ws = false;	// XXX
+	} else
+		fyp->tab_used_for_ws = false;
+
+	if (final_complex_key) {
+		fyp->pending_complex_key_column = -1;
+		fyp_scan_debug(fyp, "pending_complex_key_column -> %d",
+				fyp->pending_complex_key_column);
+	}
+
+	if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) && fyt_insert) {
+		/* eat whitespace */
+		while (fy_is_blank(c = fy_parse_peek(fyp)))
+			fy_advance(fyp, c);
+
+		/* comment? */
+		if (c == '#') {
+			chandle = fy_token_comment_handle(fyt_insert, fycp_right, true);
+			fyp_error_check(fyp, chandle, err_out,
+				"fy_token_comment_handle() failed");
+
+			fy_input_unref(chandle->fyi);
+			fy_atom_reset(chandle);
+
+			rc = fy_scan_comment(fyp, chandle, false);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_scan_comment() failed");
+		}
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	fy_parse_simple_key_recycle(fyp, fysk);
+	return rc;
+}
+
+int fy_fetch_anchor_or_alias(struct fy_parser *fyp, int c)
+{
+	struct fy_atom handle;
+	enum fy_token_type type;
+	int i = 0, rc = -1, length;
+	struct fy_simple_key_mark skm;
+	struct fy_token *fyt;
+	const char *typestr;
+
+	fyp_error_check(fyp, c == '*' || c == '&', err_out,
+			"illegal anchor mark (not '*' or '&')");
+
+	if (c == '*') {
+		type = FYTT_ALIAS;
+		typestr = "alias";
+	} else {
+		type = FYTT_ANCHOR;
+		typestr = "anchor";
+	}
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented %s in flow mode", typestr);
+
+	/* we have to save the start mark (including the anchor/alias start) */
+	fy_get_simple_key_mark(fyp, &skm);
+
+	/* skip over the anchor mark */
+	fy_advance(fyp, c);
+
+	/* start mark */
+	fy_fill_atom_start(fyp, &handle);
+
+	length = 0;
+
+	while ((c = fy_parse_peek(fyp)) >= 0) {
+		if (fyp_is_blankz(fyp, c) || fy_is_flow_indicator(c) ||
+		    fy_is_unicode_control(c) || fy_is_unicode_space(c))
+			break;
+		fy_advance(fyp, c);
+		length++;
+	}
+
+	if (!fyp_is_blankz(fyp, c) && !fy_is_flow_indicator(c)) {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				fy_is_unicode_control(c), err_out,
+				"illegal unicode control character in %s", typestr);
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				fy_is_unicode_space(c), err_out,
+				"illegal unicode space character in %s", typestr);
+	}
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != FYUG_INV, err_out,
+			"invalid character in %s", typestr);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != FYUG_PARTIAL, err_out,
+			"partial character in %s", typestr);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			length > 0, err_out,
+			"invalid %s detected", typestr);
+
+	fy_fill_atom_end(fyp, &handle);
+
+	handle.storage_hint = length;
+	handle.storage_hint_valid = true;
+	handle.direct_output = true;
+	handle.empty = false;
+	handle.has_lb = false;
+	handle.has_ws = false;
+	handle.starts_with_ws = false;
+	handle.starts_with_lb = false;
+	handle.ends_with_ws = false;
+	handle.ends_with_lb = false;
+	handle.trailing_lb = false;
+	handle.size0 = false;
+	handle.valid_anchor = true;
+
+	if (type == FYTT_ALIAS)
+		fyt = fy_token_queue(fyp, type, &handle, NULL);
+	else
+		fyt = fy_token_queue(fyp, type, &handle);
+	fyp_error_check(fyp, fyt, err_out_rc,
+			"fy_token_queue() failed");
+
+	if (type == FYTT_ALIAS)
+		fyt->alias.style_start = skm.mark;
+	else
+		fyt->anchor.style_start = skm.mark;
+
+	/* scan forward for '-' block sequence indicator */
+	if (type == FYTT_ANCHOR && !fyp->flow_level) {
+		for (i = 0; ; i++) {
+			c = fy_parse_peek_at(fyp, i);
+			if (c < 0 || fyp_is_lb(fyp, c) || !fy_is_ws(c))
+				break;
+		}
+
+		/* if it's '-' followed by ws we have a problem */
+		FYP_PARSE_ERROR_CHECK(fyp, i, 1, FYEM_SCAN,
+				!(c == '-' && fy_is_ws(fy_parse_peek_at(fyp, i + 1))), err_out,
+				"illegal block sequence on the same line as anchor");
+	}
+
+
+	rc = fy_save_simple_key_mark(fyp, &skm, type, NULL);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_save_simple_key_mark() failed");
+
+	fyp->simple_key_allowed = false;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_tag(struct fy_parser *fyp, int c)
+{
+	struct fy_atom handle;
+	int rc = -1, total_length, handle_length, uri_length, i, prefix_length, suffix_length;
+	const char *handlep;
+	bool is_valid;
+	struct fy_simple_key_mark skm;
+	struct fy_document_state *fyds;
+	struct fy_token *fyt_td;
+	struct fy_token *fyt;
+
+	fyp_error_check(fyp, c == '!', err_out,
+			"illegal tag mark (not '!')");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0 ,1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented tag in flow mode");
+
+	fyds = fyp->current_document_state;
+
+	fy_get_simple_key_mark(fyp, &skm);
+
+	if (fy_parse_peek_at(fyp, 1) == '<') {
+		/* skip over '!<' and '>' */
+		prefix_length = 2;
+		suffix_length = 1;
+	} else
+		prefix_length = suffix_length = 0;
+
+	if (prefix_length)
+		handle_length = 0; /* set the handle to '' */
+	else {
+		/* either !suffix or !handle!suffix */
+		/* we scan back to back, and split handle/suffix */
+		handle_length = fy_scan_tag_handle_length(fyp, prefix_length, false);
+		fyp_error_check(fyp, handle_length > 0, err_out,
+				"fy_scan_tag_handle_length() failed");
+	}
+
+	uri_length = fy_scan_tag_uri_length(fyp, prefix_length + handle_length);
+	fyp_error_check(fyp, uri_length >= 0, err_out,
+			"fy_scan_tag_uri_length() failed");
+
+	/* a handle? */
+	if (!prefix_length && (handle_length == 0 || fy_parse_peek_at(fyp, handle_length - 1) != '!')) {
+		/* special case, '!', handle set to '' and suffix to '!' */
+		if (handle_length == 1 && uri_length == 0) {
+			handle_length = 0;
+			uri_length = 1;
+		} else {
+			uri_length = handle_length - 1 + uri_length;
+			handle_length = 1;
+		}
+	}
+
+	is_valid = fy_scan_tag_uri_is_valid(fyp, prefix_length + handle_length, uri_length);
+	fyp_error_check(fyp, is_valid, err_out,
+			"tag URI is invalid");
+
+	if (suffix_length > 0) {
+		c = fy_parse_peek_at(fyp, prefix_length + handle_length + uri_length);
+
+		FYP_PARSE_ERROR_CHECK(fyp, prefix_length + handle_length + uri_length, 1, FYEM_SCAN,
+				c == '>', err_out,
+				"missing '>' uri terminator");
+	}
+
+	total_length = prefix_length + handle_length + uri_length + suffix_length;
+	fy_fill_atom(fyp, total_length, &handle);
+	handle.style = FYAS_URI;	/* this is a URI, need to handle URI escapes */
+
+	c = fy_parse_peek(fyp);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fyp_is_blankz(fyp, c) || fy_utf8_strchr(",}]", c), err_out,
+			"invalid tag terminator");
+
+	handlep = fy_atom_data(&handle) + prefix_length;
+
+	fyt_td = fy_document_state_lookup_tag_directive(fyds, handlep, handle_length);
+
+	FYP_MARK_ERROR_CHECK(fyp, &handle.start_mark, &handle.end_mark, FYEM_PARSE,
+			fyt_td, err_out,
+			"undefined tag prefix");
+
+	fyt = fy_token_queue(fyp, FYTT_TAG, &handle, prefix_length, handle_length, uri_length, fyt_td);
+	fyp_error_check(fyp, fyt, err_out_rc,
+			"fy_token_queue() failed");
+
+	/* scan forward for '-' block sequence indicator */
+	if (!fyp->flow_level) {
+		for (i = 0; ; i++) {
+			c = fy_parse_peek_at(fyp, i);
+			if (c < 0 || fyp_is_lb(fyp, c) || !fy_is_ws(c))
+				break;
+		}
+
+		/* if it's '-' followed by ws we have a problem */
+		FYP_PARSE_ERROR_CHECK(fyp, i ,1, FYEM_SCAN,
+				!(c == '-' && fy_is_ws(fy_parse_peek_at(fyp, i + 1))), err_out,
+				"illegal block sequence on the same line as the tag");
+	}
+
+	rc = fy_save_simple_key_mark(fyp, &skm, FYTT_TAG, NULL);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_save_simple_key_mark() failed");
+
+	fyp->simple_key_allowed = false;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_scan_block_scalar_indent(struct fy_parser *fyp, int indent, int *breaks, int *breaks_length,
+				int *presentation_breaks_length, int *first_break_length, int *lastc,
+				int *max_indentp, bool first_scan)
+{
+	int c, max_indent = 0, break_length, col;
+
+	*breaks = 0;
+	*breaks_length = 0;
+	*presentation_breaks_length = 0;
+	*first_break_length = 0;
+
+	max_indent = -1;
+
+	/* scan over the indentation spaces */
+	/* we don't format content for display */
+	for (;;) {
+
+		/* skip over indentation */
+
+		if (!fyp_tabsize(fyp)) {
+			/* we must respect the enclosed indent */
+			while (fyp_column(fyp) <= fyp->indent && fy_is_ws(c = fy_parse_peek(fyp))) {
+				FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+						!fy_is_tab(c), err_out,
+						"invalid tab character as indent instead of space");
+				fy_advance(fyp, c);
+			}
+
+			/* skip over spaces only */
+			while ((c = fy_parse_peek(fyp)) == ' ' &&
+					(!indent || fyp_column(fyp) < indent)) {
+				fy_advance(fyp, c);
+			}
+		} else {
+			while (fy_is_ws((c = fy_parse_peek(fyp))) &&
+				(!indent || fyp_column(fyp) < indent))
+				fy_advance(fyp, c);
+		}
+		col = fyp_column(fyp);
+
+		if (col > max_indent)
+			max_indent = col;
+
+		/* non-empty line or EOF */
+		if (!fyp_is_lb(fyp, c)) {
+			*lastc = c;
+			indent = col;
+
+			FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+					c < 0 || !first_scan || max_indent <= indent, err_out,
+					"block scalar with wrong indented line after spaces only");
+			break;
+		}
+
+		fy_advance(fyp, c);
+
+		break_length = (int)fy_utf8_width(c);
+
+		(*breaks)++;
+		(*breaks_length) += 1;
+
+		if (fy_is_lb_LS_PS(c))
+			(*presentation_breaks_length) += break_length;
+
+		if (!*first_break_length)
+			*first_break_length = break_length;
+	}
+
+	return indent;
+
+err_out:
+	return -1;
+}
+
+int fy_fetch_block_scalar(struct fy_parser *fyp, bool is_literal, int c)
+{
+	struct fy_atom handle;
+	enum fy_atom_chomp chomp = FYAC_CLIP;	/* default */
+	int lastc, rc, increment = 0, current_indent, new_indent, indent = 0, check_indent;
+	int breaks, breaks_length, presentation_breaks_length, first_break_length, max_indent, min_indent;
+	bool doc_start_end_detected, empty, empty_line, prev_empty_line, indented, prev_indented, first;
+	bool has_ws, has_lb, has_weird_nl, starts_with_ws, starts_with_lb, ends_with_ws, ends_with_lb, trailing_lb;
+	bool pending_nl, ends_with_eof, starts_with_eof, content_is_eof;
+	struct fy_token *fyt;
+	size_t length, line_length, trailing_ws, trailing_breaks_length;
+	size_t leading_ws;
+	size_t prefix_length, suffix_length;
+	unsigned int chomp_amt;
+	int actual_lb_length, pending_lb_length;
+	struct fy_mark indicator_mark;
+	bool generated_indent, final_lb;
+	size_t tlength;
+
+	fyp_error_check(fyp, c == '|' || c == '>', err_out,
+			"bad start of block scalar ('%s')",
+				fy_utf8_format_a(c, fyue_singlequote));
+
+	fy_get_mark(fyp, &indicator_mark);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented block scalar in flow mode");
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_block_indent_check(fyp), err_out,
+			"wrongly indented block scalar in block mode");
+
+	rc = fy_remove_simple_key(fyp, FYTT_SCALAR);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_remove_simple_key() failed");
+
+	fyp->simple_key_allowed = true;
+	fyp->tab_used_for_ws = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	/* skip over block scalar start */
+	fy_advance(fyp, c);
+
+	/* intentation indicator (either [-+]<digit> or <digit>[-+] */
+	c = fy_parse_peek(fyp);
+	if (c == '+' || c == '-') {
+
+		chomp = c == '+' ? FYAC_KEEP : FYAC_STRIP;
+
+		fy_advance(fyp, c);
+
+		c = fy_parse_peek(fyp);
+		if (fy_is_num(c)) {
+			increment = c - '0';
+			fyp_error_check(fyp, increment != 0, err_out,
+					"indentation indicator 0");
+			fy_advance(fyp, c);
+		}
+	} else if (fy_is_num(c)) {
+
+		increment = c - '0';
+		fyp_error_check(fyp, increment != 0, err_out,
+				"indentation indicator 0");
+		fy_advance(fyp, c);
+
+		c = fy_parse_peek(fyp);
+		if (c == '+' || c == '-') {
+			chomp = c == '+' ? FYAC_KEEP : FYAC_STRIP;
+			fy_advance(fyp, c);
+		}
+	}
+
+	/* the comment indicator must have at least a space */
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != '#', err_out,
+			"invalid comment without whitespace after block scalar indicator");
+
+	/* eat whitespace */
+	while (fy_is_blank(c = fy_parse_peek(fyp)))
+		fy_advance(fyp, c);
+
+	/* comment? */
+	if (c == '#') {
+		/* XXX just ignore this one */
+		rc = fy_scan_comment(fyp, NULL, true);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_scan_comment() failed");
+	}
+
+	c = fy_parse_peek(fyp);
+
+	/* end of the line? */
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fyp_is_lbz(fyp, c), err_out,
+			"block scalar no linebreak found");
+
+	/* if the block scalar indicator is on a different line we need a new indent */
+	generated_indent = false;
+	if (!increment && indicator_mark.line != fyp->indent_line) {
+		fyp_scan_debug(fyp, "generating indent %d/%d\n", indicator_mark.line, fyp->indent_line);
+		rc = fy_push_indent(fyp, indicator_mark.column, false, indicator_mark.line);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_push_indent() failed");
+		generated_indent = true;
+	}
+
+	/* advance */
+	if (fy_utf8_is_valid(c))
+		fy_advance(fyp, c);
+
+	fy_fill_atom_start(fyp, &handle);
+
+	starts_with_eof = c < 0;
+
+	c = fy_parse_peek(fyp);
+	content_is_eof = c < 0;	/* any error or EOF */
+
+	current_indent = fyp->indent >= 0 ? fyp->indent : 0;
+	indent = increment ? current_indent + increment : 0;
+
+	length = 0;
+	trailing_breaks_length = 0;
+
+	empty = true;
+	has_ws = false;
+	has_lb = false;
+	has_weird_nl = false;
+	starts_with_ws = false;
+	starts_with_lb = false;
+	ends_with_ws = false;
+	ends_with_lb = false;
+	trailing_lb = false;
+
+	new_indent = fy_scan_block_scalar_indent(fyp, indent, &breaks, &breaks_length,
+			&presentation_breaks_length, &first_break_length, &lastc, &max_indent, true);
+	fyp_error_check(fyp, new_indent >= 0, err_out,
+			"fy_scan_block_scalar_indent() failed");
+
+	min_indent = fyp->indent;
+
+	if (!(fyp->state == FYPS_IMPLICIT_DOCUMENT_START ||
+	     fyp->state == FYPS_DOCUMENT_START ||
+	     fyp->state == FYPS_DOCUMENT_CONTENT))
+		min_indent++;
+
+	if (new_indent < min_indent)
+		new_indent = min_indent;
+
+	length = breaks_length;
+	length += presentation_breaks_length;
+	indent = new_indent;
+
+	doc_start_end_detected = false;
+	prev_empty_line = true;
+
+	prefix_length = 0;
+	suffix_length = 0;
+
+	prev_indented = false;
+	first = true;
+	pending_nl = false;
+	pending_lb_length = 0;
+
+	chomp_amt = increment ? (unsigned int)(current_indent + increment) : (unsigned int)-1;
+
+	actual_lb_length = 1;
+	while ((c = fy_parse_peek(fyp)) > 0 && fyp_column(fyp) >= indent) {
+
+		lastc = c;
+
+		if (first) {
+			if (fy_is_ws(c))
+				starts_with_ws = true;
+			else if (fyp_is_lb(fyp, c))
+				starts_with_lb = true;
+		}
+
+		/* consume the list */
+		line_length = 0;
+		trailing_ws = 0;
+		empty_line = true;
+		leading_ws = 0;
+
+		indented = fy_is_ws(fy_parse_peek(fyp));
+
+		while (!(fyp_is_lbz(fyp, c = fy_parse_peek(fyp)))) {
+
+			lastc = c;
+
+			if (fyp_column(fyp) == 0 &&
+			    (!fy_parse_strncmp(fyp, "...", 3) ||
+			     !fy_parse_strncmp(fyp, "---", 3)) &&
+			    fy_is_blankz_at_offset(fyp, 3)) {
+				doc_start_end_detected = true;
+				break;
+			}
+
+			if (!fy_is_space(c)) {
+				empty = false;
+				empty_line = false;
+				trailing_ws = 0;
+				if (chomp_amt == (unsigned int)-1)
+					chomp_amt = fyp_column(fyp);
+			} else {
+				has_ws = true;
+				if (empty_line)
+					leading_ws++;
+				trailing_ws++;
+			}
+
+			fy_advance(fyp, c);
+
+			line_length += fy_utf8_width(c);
+		}
+		/* keep the variables without warning */
+		(void)trailing_ws;
+		(void)leading_ws;
+
+		if (doc_start_end_detected)
+			break;
+
+		if (!fy_is_z(c)) {
+			/* eat line break */
+			actual_lb_length = (int)fy_utf8_width(c);
+			fy_advance(fyp, c);
+
+			has_lb = true;
+			check_indent = fy_scan_block_scalar_indent(fyp, indent, &breaks,
+					&breaks_length, &presentation_breaks_length,
+					&first_break_length, &lastc,
+					&max_indent, false);
+			fyp_error_check(fyp, check_indent >= 0, err_out,
+					"fy_scan_block_scalar_indent() failed");
+			if (fy_is_lb_LS_PS(c))
+				presentation_breaks_length += actual_lb_length;
+
+			/* very simple heuristic, if we hit a '\r' then force size check */
+			has_weird_nl |= c != '\n';
+		} else {
+			has_lb = false;
+			// was chomp = FYAC_STRIP, very very wrong
+
+			breaks = 0;
+			breaks_length = 0;
+			presentation_breaks_length = 0;
+			first_break_length = 0;
+
+			actual_lb_length = 0;
+
+		}
+
+		if (is_literal) {
+
+			prefix_length = 0;
+
+			if (pending_nl) {
+				pending_nl = false;
+				prefix_length += pending_lb_length;
+				pending_lb_length = 0;
+			}
+
+			prefix_length += trailing_breaks_length;
+			trailing_breaks_length = 0;
+
+			suffix_length = 0;
+
+			if (fy_is_lb_LS_PS(c)) {
+				trailing_breaks_length += breaks_length;
+				trailing_breaks_length += presentation_breaks_length;
+
+				if (actual_lb_length > 1)
+					presentation_breaks_length -= actual_lb_length;
+
+				pending_nl = true;
+				pending_lb_length = 0;
+			} else {
+				trailing_breaks_length += breaks_length;
+				trailing_breaks_length += presentation_breaks_length;
+
+				pending_nl = !empty_line || indented;
+				pending_lb_length = pending_nl ? 1 : 0;
+			}
+
+		} else {
+
+			prefix_length = 0;
+
+			if (!trailing_breaks_length) {
+				if (prev_indented || (prev_empty_line && !first) || indented) {
+					/* previous line was indented or empty, force output newline */
+					if (pending_nl) {
+						pending_nl = false;
+						prefix_length += 1; // pending_lb_length;
+						pending_lb_length = 0;
+					}
+				} else if (!prev_empty_line && !prev_indented && !indented && !empty_line) {
+					/* previous line was not empty and not indented
+					* while this is not indented and not empty need sep */
+					if (pending_nl) {
+						pending_nl = false;
+						prefix_length += 1; // pending_lb_length;
+						pending_lb_length = 0;
+					}
+				}
+			} else {
+				prefix_length += trailing_breaks_length;
+				if (prev_indented || indented)
+					prefix_length++;
+			}
+			pending_nl = true;
+			pending_lb_length = actual_lb_length;
+
+			trailing_breaks_length = 0;
+
+			suffix_length = 0;
+			trailing_breaks_length += breaks_length;
+			trailing_breaks_length += presentation_breaks_length;
+		}
+
+
+		length += prefix_length + line_length + suffix_length;
+
+		prev_empty_line = empty_line;
+		prev_indented = indented;
+
+		prefix_length = 0;
+		suffix_length = 0;
+
+		first = false;
+	}
+
+	if (empty) {
+		trailing_breaks_length = breaks_length;
+		trailing_breaks_length += presentation_breaks_length;
+		length = 0;
+	}
+
+	/* end... */
+	fy_fill_atom_end(fyp, &handle);
+
+	if (c == FYUG_INV || c == FYUG_PARTIAL) {
+		FYP_MARK_ERROR(fyp, &handle.start_mark, &handle.end_mark, FYEM_SCAN,
+			"block scalar is malformed UTF8");
+		goto err_out;
+	}
+
+	/* are we ended with EOF? */
+	ends_with_eof = starts_with_eof || (c == FYUG_EOF && !fyp_is_lb(fyp, lastc) && !breaks);
+
+	/* detect wrongly indented block scalar */
+	if (c != FYUG_EOF && !(!empty || fyp_column(fyp) <= fyp->indent || c == '#' || doc_start_end_detected)) {
+		FYP_MARK_ERROR(fyp, &handle.start_mark, &handle.end_mark, FYEM_SCAN,
+			"block scalar with wrongly indented line after spaces only");
+		goto err_out;
+	}
+
+	if (empty && c == '#' && fyp_column(fyp) > fyp->indent) {
+		FYP_MARK_ERROR(fyp, &handle.start_mark, &handle.end_mark, FYEM_SCAN,
+			"empty block scalar with wrongly indented comment line after spaces only");
+		goto err_out;
+	}
+
+	if (chomp_amt == (unsigned int)-1)
+		chomp_amt = current_indent;
+
+	/* whether the final character is an lb (or implied to be one) */
+	final_lb = pending_nl || (!starts_with_eof && ends_with_eof);
+	trailing_lb = trailing_breaks_length > 0;
+	ends_with_ws = fy_is_ws(lastc);
+
+	switch (chomp) {
+	case FYAC_CLIP:
+	case FYAC_KEEP:
+		if (chomp == FYAC_KEEP)
+			length += breaks + presentation_breaks_length;
+
+		if (final_lb && !content_is_eof)
+			length += (actual_lb_length == 0 && pending_nl) ? 1 : actual_lb_length;
+
+		ends_with_lb = final_lb || trailing_lb;
+		break;
+	case FYAC_STRIP:
+		ends_with_lb = false;
+		break;
+	}
+
+	/* need to process to present */
+	handle.style = is_literal ? FYAS_LITERAL : FYAS_FOLDED;
+	handle.chomp = chomp;
+	handle.chomp_explicit = true;
+	handle.increment = increment ? (unsigned int)(current_indent + increment) : chomp_amt;
+
+	/* no point in trying to do direct output in a block scalar */
+	/* TODO maybe revisit in the future */
+	handle.direct_output = false;
+	handle.empty = empty;
+	handle.has_lb = has_lb;
+	handle.has_ws = has_ws;
+	handle.starts_with_ws = starts_with_ws;
+	handle.starts_with_lb = starts_with_lb;
+	handle.ends_with_ws = ends_with_ws;
+	handle.ends_with_lb = ends_with_lb;
+	handle.trailing_lb = trailing_lb;
+	handle.size0 = length == 0;
+	handle.valid_anchor = false;
+	handle.json_mode = fyp_json_mode(fyp);
+	handle.lb_mode = fyp_lb_mode(fyp);
+	handle.fws_mode = fyp_fws_mode(fyp);
+	handle.directive0_mode = fyp_directive0_mode(fyp);
+	handle.tabsize = fyp_tabsize(fyp);
+	handle.ends_with_eof = ends_with_eof;
+	handle.is_merge_key = false;
+
+	/* force calculation of length if we had a CR */
+	if (has_weird_nl || FORCE_ATOM_SIZE_CHECK_DEFAULT) {
+		tlength = fy_atom_format_text_length(&handle);
+		if (tlength != length) {
+			if (!has_weird_nl)
+				fyp_warning(fyp, "%s: storage hint calculation failed real %zu != hint %zu - \"%s\"", __func__,
+					tlength, length,
+					fy_utf8_format_text_a(fy_atom_data(&handle), fy_atom_size(&handle), fyue_doublequote));
+			length = tlength;
+		}
+	}
+
+	handle.storage_hint = length;
+	handle.storage_hint_valid = true;
+
+	fyt = fy_token_queue(fyp, FYTT_SCALAR, &handle, is_literal ? FYSS_LITERAL : FYSS_FOLDED);
+	fyp_error_check(fyp, fyt, err_out_rc,
+			"fy_token_queue() failed");
+
+	/* update the start of the style */
+	fyt->scalar.style_start = indicator_mark;
+
+	rc = fy_attach_comments_if_any(fyp, fyt);
+	fyp_error_check(fyp, rc >= 0, err_out_rc,
+			"fy_attach_right_hand_comment() failed");
+
+	if (generated_indent) {
+		rc = fy_pop_indent(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_pop_indent() failed");
+
+		/* the ident line has now moved */
+		fyp->indent_line = fyp_line(fyp);
+	}
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_reader_fetch_flow_scalar_handle(struct fy_reader *fyr, int c, int indent, struct fy_atom *handle, bool sloppy_indent)
+{
+	size_t length;
+	int code_length, i = 0, j, end_c, last_line, lastc;
+	int breaks_found, blanks_found, break_run, total_code_length;
+	int breaks_found_length, first_break_length, value;
+	uint32_t hi_surrogate, lo_surrogate;
+	bool is_single, is_multiline, esc_lb, ws_lb_only, has_ws, has_lb, has_weird_nl, has_esc;
+	bool first, starts_with_ws, starts_with_lb, ends_with_ws, ends_with_lb, trailing_lb = false;
+	bool unicode_esc, is_json_unesc, has_json_esc;
+	int last_esc_lb, break_length, presentation_breaks_length;
+	struct fy_mark mark, mark2;
+	char escbuf[1 + FY_UTF8_FORMAT_BUFMIN];
+	size_t escbuf_len;
+	enum fy_utf8_escape esc_mode;
+	const char *ep;
+	size_t tlength;
+
+	(void)last_esc_lb;
+
+	is_single = c == '\'';
+	end_c = c;
+
+	fyr_error_check(fyr, c == '\'' || c == '"', err_out,
+			"bad start of flow scalar ('%s')",
+				fy_utf8_format_a(c, fyue_singlequote));
+
+	fy_reader_get_mark(fyr, &mark);
+
+	/* skip over block scalar start */
+	fy_reader_advance(fyr, c);
+
+	fy_reader_fill_atom_start(fyr, handle);
+
+	length = 0;
+	breaks_found = 0;
+	breaks_found_length = 0;
+	first_break_length = 0;
+	presentation_breaks_length = 0;
+	blanks_found = 0;
+	esc_lb = false;
+	last_esc_lb = -1;
+	ws_lb_only = true;
+	has_ws = false;
+	has_lb = false;
+	has_weird_nl = false;
+	starts_with_ws = false;
+	starts_with_lb = false;
+	ends_with_ws = false;
+	ends_with_lb = false;
+	has_esc = false;
+	break_run = 0;
+	first = true;
+	has_json_esc = false;
+
+	esc_mode = fy_reader_json_mode(fyr) ? fyue_doublequote_json :
+			fy_reader_lb_mode(fyr) == fylb_cr_nl ? fyue_doublequote : fyue_doublequote_yaml_1_1;
+
+	last_line = -1;
+	lastc = -1;
+	for (;;) {
+		if (!fy_reader_json_mode(fyr)) {
+			/* no document indicators please */
+			FYR_PARSE_ERROR_CHECK(fyr, 0, 3, FYEM_SCAN,
+				!(fy_reader_column(fyr) == 0 &&
+					(!fy_reader_strncmp(fyr, "---", 3) ||
+					!fy_reader_strncmp(fyr, "...", 3)) &&
+					fy_reader_is_blankz_at_offset(fyr, 3)), err_out,
+				"invalid document-%s marker in %s scalar",
+					c == '-' ? "start" : "end",
+					is_single ? "single-quoted" : "double-quoted");
+		}
+
+		/* no EOF either */
+		c = fy_reader_peek(fyr);
+
+		if (c <= 0) {
+			fy_reader_get_mark(fyr, &mark);
+
+			if (!c || c == FYUG_EOF)
+				FYR_MARK_ERROR(fyr, &handle->start_mark, &mark, FYEM_SCAN,
+						"%s scalar without closing quote",
+							is_single ? "single-quoted" : "double-quoted");
+			else
+				FYR_MARK_ERROR(fyr, &handle->start_mark, &mark, FYEM_SCAN,
+						"%s scalar is malformed UTF8",
+							is_single ? "single-quoted" : "double-quoted");
+			goto err_out;
+		}
+
+		if (first) {
+			if (fy_reader_is_flow_ws(fyr, c))
+				starts_with_ws = true;
+			else if (fy_reader_is_lb(fyr, c))
+				starts_with_lb = true;
+		}
+
+		while (!fy_reader_is_flow_blankz(fyr, c = fy_reader_peek(fyr))) {
+
+			if (ws_lb_only && !(fy_reader_is_flow_ws(fyr, c) || fy_reader_is_lb(fyr, c)) && c != end_c)
+				ws_lb_only = false;
+
+			esc_lb = false;
+			last_esc_lb = -1;
+			/* track line change (and first non blank) */
+			if (last_line != fy_reader_line(fyr)) {
+				last_line = fy_reader_line(fyr);
+
+				if ((indent >= 0 && fy_reader_column(fyr) <= indent) && !sloppy_indent) {
+
+					fy_reader_advance(fyr, c);
+					fy_reader_get_mark(fyr, &mark2);
+					FYR_MARK_ERROR(fyr, &mark, &mark2, FYEM_SCAN,
+						"wrongly indented %s scalar",
+							is_single ? "single-quoted" : "double-quoted");
+					goto err_out;
+				}
+			}
+
+			if (breaks_found) {
+				length += breaks_found > 1 ? (breaks_found_length - first_break_length) : 1;
+				length += presentation_breaks_length;
+				breaks_found = 0;
+				blanks_found = 0;
+				presentation_breaks_length = 0;
+			} else if (blanks_found) {
+				length += blanks_found;
+				lastc = ' ';
+				blanks_found = 0;
+			}
+
+			if (c >= 0 && c <= 0x7f && (fy_utf8_low_ascii_flags[c] & F_SIMPLE_SCALAR)) {
+				size_t len, consumed;
+				const char *p, *s, *e;
+				int8_t cc;
+				size_t run;
+
+				run = 0;
+				while ((p = fy_reader_ensure_lookahead(fyr, 1, &len)) != NULL) {
+
+					s = p;
+					e = s + len;
+
+					while (s < e && (cc = (int8_t)*s) >= 0 && (fy_utf8_low_ascii_flags[cc] & F_SIMPLE_SCALAR))
+						s++;
+
+					consumed = s - p;
+					if (consumed) {
+						fy_reader_advance_octets(fyr, consumed);
+						fyr->column += (int)consumed;
+						lastc = (int)cc;
+					}
+					run += consumed;
+
+					/* we're done if stopped earlier */
+					if (s < e)
+						break;
+				}
+				length += run;
+				break_run = 0;
+				continue;
+			}
+
+			/* escaped single quote? */
+			if (is_single && c == '\'' && fy_reader_peek_at(fyr, 1) == '\'') {
+				length++;
+				fy_reader_advance_by(fyr, 2);
+				break_run = 0;
+				lastc = '\'';
+				continue;
+			}
+
+			/* right quote? */
+			if (c == end_c)
+				break;
+
+			/* escaped line break (any linebreak will do) */
+			if (!is_single && c == '\\' && fy_reader_is_lb(fyr, fy_reader_peek_at(fyr, 1))) {
+
+				esc_lb = true;
+				last_esc_lb = fy_reader_peek_at(fyr, 1);
+
+				fy_reader_advance_by(fyr, 2);
+
+				c = fy_reader_peek(fyr);
+				break_run = 0;
+				lastc = c;
+
+				has_esc = true;
+
+				break;
+			}
+
+			/* escaped sequence? */
+			if (!is_single && c == '\\') {
+
+				/* note we don't generate formatted output */
+				/* we are merely checking for validity */
+				c = fy_reader_peek_at(fyr, 1);
+
+				FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_SCAN,
+					c > 0, err_out,
+					"Unterminated or illegal UTF8 escape");
+
+				/* hex, unicode marks - json only supports u */
+				unicode_esc = !fy_reader_json_mode(fyr) ?
+						(c == 'x' || c == 'u' || c == 'U') :
+						c == 'u';
+				if (unicode_esc) {
+
+					total_code_length = 0;
+					j = 0;
+					hi_surrogate = lo_surrogate = 0;
+					for (;;) {
+						total_code_length += 2;
+
+						code_length = c == 'x' ? 2 :
+							c == 'u' ? 4 : 8;
+						value = 0;
+						for (i = 0; i < code_length; i++) {
+							c = fy_reader_peek_at(fyr, total_code_length + i);
+
+							FYR_PARSE_ERROR_CHECK(fyr, 0, total_code_length + i + 1, FYEM_SCAN,
+								fy_is_hex(c), err_out,
+								"double-quoted scalar has invalid hex escape");
+
+							value <<= 4;
+							if (c >= '0' && c <= '9')
+								value |= c - '0';
+							else if (c >= 'a' && c <= 'f')
+								value |= 10 + c - 'a';
+							else
+								value |= 10 + c - 'A';
+						}
+
+						total_code_length += code_length;
+						j++;
+
+						/* 0x10000 + (HI - 0xd800) * 0x400 + (LO - 0xdc00) */
+
+						/* high surrogate */
+						if (j == 1 && code_length == 4 && value >= 0xd800 && value <= 0xdbff &&
+						    fy_reader_peek_at(fyr, total_code_length) == '\\' &&
+						    fy_reader_peek_at(fyr, total_code_length + 1) == 'u') {
+							hi_surrogate = value;
+							c = 'u';
+							continue;
+						}
+
+						if (j == 2 && code_length == 4 && hi_surrogate) {
+
+							FYR_PARSE_ERROR_CHECK(fyr, total_code_length - 6, 6, FYEM_SCAN,
+								value >= 0xdc00 && value <= 0xdfff, err_out,
+								"Invalid low surrogate value");
+
+							lo_surrogate = value;
+							value = 0x10000 + (hi_surrogate - 0xd800) * 0x400 + (lo_surrogate - 0xdc00);
+						}
+
+						break;
+					}
+
+					/* check for validity */
+					FYR_PARSE_ERROR_CHECK(fyr, 0, total_code_length, FYEM_SCAN,
+						!(value < 0 || (value >= 0xd800 && value <= 0xdfff) ||
+							value > 0x10ffff), err_out,
+						"double-quoted scalar has invalid UTF8 escape");
+
+					fy_reader_advance_by(fyr, total_code_length);
+
+				} else {
+					escbuf[0] = '\\';
+					fy_utf8_put_unchecked(escbuf + 1, c);
+					escbuf_len = 1 + fy_utf8_width(c);
+
+					ep = escbuf;
+
+					value = fy_utf8_parse_escape(&ep, escbuf_len, esc_mode);
+					FYR_PARSE_ERROR_CHECK(fyr, 0, 2, FYEM_SCAN,
+						value >= 0, err_out,
+						"invalid escape '%s' in %s string",
+							fy_utf8_format_a(c, fyue_singlequote),
+							is_single ? "single-quoted" : "double-quoted");
+
+					fy_reader_advance_by(fyr, 2);
+				}
+
+				length += fy_utf8_width(value);
+
+				lastc = value;
+
+				if (lastc == '\n')
+					break_run++;
+
+				has_esc = true;
+
+				continue;
+			}
+
+			/* check whether we have a JSON unescaped character */
+			is_json_unesc = fy_is_json_unescaped_range_only(c);
+			if (!is_json_unesc)
+				has_json_esc = true;
+
+			if (!is_single && fy_reader_json_mode(fyr) && has_json_esc) {
+				FYR_PARSE_ERROR(fyr, 0, 2, FYEM_SCAN,
+					"Invalid JSON unescaped character");
+				goto err_out;
+			}
+
+			lastc = c;
+
+			/* regular character */
+			fy_reader_advance(fyr, c);
+
+			length += fy_utf8_width(c);
+			break_run = 0;
+		}
+
+		/* end of scalar */
+		if (c == end_c)
+			break;
+
+		/* consume blanks */
+		breaks_found = 0;
+		breaks_found_length = 0;
+		blanks_found = 0;
+		while (fy_reader_is_flow_blank(fyr, c = fy_reader_peek(fyr)) || fy_reader_is_lb(fyr, c)) {
+
+			if (!has_json_esc && !fy_is_json_unescaped(c))
+				has_json_esc = true;
+
+			break_run = 0;
+
+			/* check for tab used as indentation */
+			if (!fy_reader_tabsize(fyr) && fy_is_tab(c)) {
+				FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_SCAN,
+						fy_reader_column(fyr) > indent, err_out,
+						"invalid tab used as indentation");
+			}
+
+			fy_reader_advance(fyr, c);
+
+			if (fy_reader_is_lb(fyr, c)) {
+
+				if (!fy_is_lb_LS_PS(c)) {
+					break_length = 1;
+				} else {
+					break_length = (int)fy_utf8_width(c);
+					presentation_breaks_length += break_length;
+				}
+
+				has_lb = true;
+				if (!breaks_found)
+					first_break_length = break_length;
+				breaks_found++;
+				breaks_found_length += break_length;
+				blanks_found = 0;
+				esc_lb = false;
+
+				has_weird_nl |= c != '\n';
+			} else {
+				has_ws = true;
+				if (!esc_lb)
+					blanks_found++;
+			}
+		}
+		first = false;
+	}
+
+	if (break_run > 0)
+		ends_with_lb = true;
+	else if (fy_reader_is_flow_ws(fyr, lastc))
+		ends_with_ws = true;
+	trailing_lb = break_run > 1;
+
+	/* end... */
+	fy_reader_fill_atom_end(fyr, handle);
+
+	is_multiline = handle->end_mark.line > handle->start_mark.line;
+
+	/* need to process to present */
+	handle->style = is_single ? FYAS_SINGLE_QUOTED : FYAS_DOUBLE_QUOTED;
+	handle->direct_output = !is_multiline && !has_esc && !has_json_esc &&
+				fy_atom_size(handle) == length;
+	handle->empty = ws_lb_only;
+	handle->has_lb = has_lb;
+	handle->has_ws = has_ws;
+	handle->starts_with_ws = starts_with_ws;
+	handle->starts_with_lb = starts_with_lb;
+	handle->ends_with_ws = ends_with_ws;
+	handle->ends_with_lb = ends_with_lb;
+	handle->trailing_lb = trailing_lb;
+	handle->size0 = length == 0;
+	handle->valid_anchor = false;
+	handle->json_mode = fy_reader_json_mode(fyr);
+	handle->lb_mode = fy_reader_lb_mode(fyr);
+	handle->fws_mode = fy_reader_flow_ws_mode(fyr);
+	handle->directive0_mode = fy_reader_directive0_mode(fyr);
+	handle->tabsize = fy_reader_tabsize(fyr);
+	handle->ends_with_eof = false;	/* flow scalars never end with EOF and be valid */
+	handle->is_merge_key = false;
+	handle->simple_key_allowed = false;
+
+	/* skip over block scalar end */
+	fy_reader_advance_by(fyr, 1);
+
+	if (has_weird_nl || FORCE_ATOM_SIZE_CHECK_DEFAULT) {
+		tlength = fy_atom_format_text_length(handle);
+		if (tlength != length) {
+			if (!has_weird_nl)
+				fyr_warning(fyr, "%s: storage hint calculation failed real %zu != hint %zu - \"%s\"", __func__,
+					tlength, length,
+					fy_utf8_format_text_a(fy_atom_data(handle), fy_atom_size(handle), fyue_doublequote));
+			length = tlength;
+		}
+	}
+
+	handle->storage_hint = length;
+	handle->storage_hint_valid = true;
+
+	FYR_MARK_ERROR_CHECK(fyr, &handle->start_mark, &handle->end_mark, FYEM_SCAN,
+			!fy_reader_json_mode(fyr) || !is_multiline, err_out,
+			"Multi line double quoted scalars not supported in JSON mode");
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+struct fy_fetch_plain_state {
+	struct fy_mark last_mark;
+	size_t length;
+	int c;
+	int lastc;
+	bool has_lb;
+	bool has_ws;
+	bool has_json_esc;
+	bool has_high_ascii;
+	bool simple_key_allowed;
+	bool last_was_lb;
+	bool has_weird_nl;
+};
+
+static FY_ALWAYS_INLINE inline int
+fy_reader_fetch_plain_scalar_handle_inline(struct fy_reader *fyr, int c,
+					   const int indent, const int flow_level,
+					   struct fy_atom *handle,
+					   const bool directive0,
+					   const enum fy_lb_mode lb_mode,
+					   const bool json_mode,
+					   struct fy_fetch_plain_state *state)
+{
+	int nextc, width;
+	size_t length, length_advance;
+	int blanks_found_length, breaks_found_length, first_break_length;
+	union {
+		struct {
+			bool run_has_lb : 1;
+			bool run_has_ws : 1;
+			bool run_has_weird_nl : 1;
+			bool has_json_esc : 1;
+			bool has_high_ascii : 1;
+			bool has_lb : 1;
+			bool has_ws : 1;
+			bool has_weird_nl : 1;
+			bool had_run : 1;
+			bool flow_level_gt_0 : 1;
+			bool flow_level_le_0_indent_ge_0 : 1;
+			bool check_tab : 1;
+			bool last_was_lb : 1;
+		};
+		unsigned short flags;
+	} u;
+	size_t run, len;
+	const char *s;
+
+	u.flags = 0;
+
+	u.flow_level_gt_0 = flow_level > 0;
+	u.flow_level_le_0_indent_ge_0 = flow_level <= 0 && indent >= 0;
+	u.check_tab = fy_reader_tabsize(fyr) || indent < 0;
+
+	length = 0;
+	length_advance = 0;
+
+	for (;;) {
+		/* break for document indicators */
+		if (fy_reader_column(fyr) == 0 &&
+		    ((!fy_reader_strncmp(fyr, "---", 3) || !fy_reader_strncmp(fyr, "...", 3)) &&
+			fy_reader_is_blankz_at_offset(fyr, 3)))
+			break;
+
+		if (c == '#')
+			break;
+
+		/* for YAML 1.1 check % directive break */
+		if (directive0 && fy_reader_column(fyr) == 0 && c == '%')
+			break;
+
+		u.had_run = false;
+		u.last_was_lb = false;
+		while (!fy_is_blankz_m(c, lb_mode)) {
+
+			if (fy_utf8_is_simple_scalar(c)) {
+				s = fy_reader_ensure_lookahead(fyr, 1, &len);
+				run = 0;
+				while (run < len && fy_utf8_is_simple_scalar_no_check((int8_t)s[run]))
+					run++;
+
+				fyr->column += (int)run;
+				nextc = -1;
+			} else {
+
+				width = (int)fy_utf8_width(c);
+
+				if (c == ':') {
+
+					nextc = fy_reader_peek_at_offset(fyr, width);
+
+					/* ':' followed by space terminates */
+					if (fy_is_blankz_m(nextc, lb_mode))
+						break;
+
+					/* in flow context ':' followed by flow markers */
+					if (u.flow_level_gt_0 && fy_is_flow_indicator(nextc))
+						break;
+				} else
+					nextc = -1;
+
+				/* in flow context any or , [ ] { } */
+				if (u.flow_level_gt_0 && fy_is_flow_indicator(c))
+					break;
+
+				/* check whether we have a JSON unescaped character */
+				u.has_json_esc |= !fy_is_json_unescaped(c);
+				u.has_high_ascii |= c >= 0x80;
+
+				fyr->column++;
+
+				run = width;
+			}
+
+			u.had_run = true;
+			fy_reader_advance_octets(fyr, run);
+			length += run;
+
+			c = nextc >= 0 ? nextc : fy_reader_peek(fyr);
+		}
+
+		/* save end mark if we processed more than one non-blank */
+		if (u.had_run) {
+			length += length_advance;
+
+			u.has_lb |= u.run_has_lb;
+			u.has_ws |= u.run_has_ws;
+			u.has_weird_nl |= u.run_has_weird_nl;
+
+			fy_reader_get_mark(fyr, &state->last_mark);
+		}
+
+		/* end? */
+		if (!(fy_is_blank_lb_m(c, lb_mode)))
+			break;
+
+		/* consume blanks */
+		breaks_found_length = 0;
+		first_break_length = 0;
+		blanks_found_length = 0;
+		u.run_has_ws = u.run_has_lb = u.run_has_weird_nl = false;
+
+		width = (int)fy_utf8_width(c);
+		do {
+			fy_reader_advance_lb_mode(fyr, c, lb_mode);
+
+			if (u.check_tab) {
+				FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_SCAN,
+						c != '\t' || fy_reader_column(fyr) >= (indent + 1), err_out,
+						"invalid tab used as indentation");
+			}
+
+			u.last_was_lb = !fy_is_blank(c);
+
+			/* if it's a break */
+			if (!u.last_was_lb) {
+				blanks_found_length += width;
+				u.run_has_ws = true;
+			} else {
+				/* first break, turn on leading blanks */
+				if (!first_break_length)
+					first_break_length = width;
+				breaks_found_length += width;
+				u.run_has_lb = true;
+				u.run_has_weird_nl |= c != '\n';
+			}
+
+			c = fy_reader_peek_width(fyr, &width);
+
+		} while (fy_is_blank_lb_m(c, lb_mode));
+
+		/* break out if indentation is less */
+		if (u.flow_level_le_0_indent_ge_0 && fy_reader_column(fyr) <= indent)
+			break;
+
+		length_advance = u.run_has_lb ?
+					(breaks_found_length > first_break_length ? (breaks_found_length - first_break_length) : first_break_length) :
+					blanks_found_length;
+	}
+
+	state->c = c;
+	state->length = length;
+	state->simple_key_allowed = u.run_has_lb;	// simple key allowed if there was an lb
+	state->has_lb = u.has_lb;
+	state->has_ws = u.has_ws;
+	state->has_json_esc = u.has_json_esc;
+	state->has_high_ascii = u.has_high_ascii;
+	state->last_was_lb = u.last_was_lb;
+	state->has_weird_nl = u.has_weird_nl;
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+int fy_reader_fetch_plain_scalar_handle_yaml(struct fy_reader *fyr, int c,
+					   const int indent, const int flow_level,
+					   struct fy_atom *handle,
+					   struct fy_fetch_plain_state *state)
+{
+	return fy_reader_fetch_plain_scalar_handle_inline(fyr, c, indent, flow_level, handle,
+			false,		// directive0
+			fylb_cr_nl,	// lb_mode
+			false,		// json
+			state);
+}
+
+int fy_reader_fetch_plain_scalar_handle_json(struct fy_reader *fyr, int c,
+					   const int indent, const int flow_level,
+					   struct fy_atom *handle,
+					   struct fy_fetch_plain_state *state)
+{
+	return fy_reader_fetch_plain_scalar_handle_inline(fyr, c, indent, flow_level, handle,
+			false,		// directive0
+			fylb_cr_nl,	// lb_mode
+			true,		// json
+			state);
+}
+
+int fy_reader_fetch_plain_scalar_handle_yaml_1_1(struct fy_reader *fyr, int c,
+					   const int indent, const int flow_level,
+					   struct fy_atom *handle,
+					   struct fy_fetch_plain_state *state)
+{
+	return fy_reader_fetch_plain_scalar_handle_inline(fyr, c, indent, flow_level, handle,
+			true,			// directive0
+			fylb_cr_nl_N_L_P,	// lb_mode
+			false,			// json
+			state);
+}
+
+typedef int (*fy_reader_fetch_plain_scalar_handle_func)(struct fy_reader *fyr, int c,
+					   const int indent, const int flow_level,
+					   struct fy_atom *handle,
+					   struct fy_fetch_plain_state *state);
+
+static inline int
+fy_reader_fetch_plain_scalar_handle_switch(struct fy_reader *fyr, int c,
+					   const int indent, const int flow_level,
+					   struct fy_atom *handle,
+					   struct fy_fetch_plain_state *state)
+{
+
+	static const fy_reader_fetch_plain_scalar_handle_func funcs[] = {
+		[fyrm_yaml] = fy_reader_fetch_plain_scalar_handle_yaml,
+		[fyrm_json] = fy_reader_fetch_plain_scalar_handle_json,
+		[fyrm_yaml_1_1] = fy_reader_fetch_plain_scalar_handle_yaml_1_1,
+	};
+	fy_reader_fetch_plain_scalar_handle_func func;
+
+	assert((unsigned int)fyr->mode <= ARRAY_SIZE(funcs));
+	func = funcs[fyr->mode];
+	assert(func != NULL);
+
+	return func(fyr, c, indent, flow_level, handle, state);
+}
+
+int fy_reader_fetch_plain_scalar_handle(struct fy_reader *fyr, int c,
+					const int indent, int flow_level,
+					struct fy_atom *handle)
+{
+	struct fy_fetch_plain_state state_local, *state = &state_local;
+	const enum fy_lb_mode lb_mode = fy_reader_lb_mode(fyr);
+	bool is_merge_key, ends_with_eof, is_multiline;
+	int nextc, rc;
+	size_t tlength;
+
+	nextc = fy_reader_peek_at(fyr, 1);
+
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_SCAN,
+			!fy_is_blankz_m(c, lb_mode), err_out,
+			"plain scalar cannot start with blank or zero");
+
+	/* may not start with any of ,[]{}#&*!|>'\"%@` */
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_SCAN,
+			!fy_utf8_strchr(",[]{}#&*!|>'\"%@`", c), err_out,
+			"plain scalar cannot start with '%c'", c);
+
+	/* may not start with - not followed by blankz */
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 2, FYEM_SCAN,
+			c != '-' || !fy_is_blank(nextc), err_out,
+			"plain scalar cannot start with '%c' followed by blank", c);
+
+	/* may not start with -?: not followed by blankz (in block context) */
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 2, FYEM_SCAN,
+			flow_level > 0 || !((c == '?' || c == ':') && fy_is_blank(nextc)), err_out,
+			"plain scalar cannot start with '%c' followed by blank (in block context)", c);
+
+	/* may not start with - followed by ",[]{}" in flow context */
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 2, FYEM_SCAN,
+			flow_level == 0 || !(c == '-' && fy_is_flow_indicator(nextc)), err_out,
+			"plain scalar cannot start with '%c' followed by ,[]{} (in flow context)", c);
+
+	memset(state, 0, sizeof(*state));
+	state->last_mark.input_pos = (size_t)-1;
+
+	/* we can prime is_merge_key here */
+	is_merge_key = c == '<' && nextc == '<';
+
+	fy_reader_fill_atom_start(fyr, handle);
+
+	rc = fy_reader_fetch_plain_scalar_handle_switch(fyr, c, indent, flow_level, handle, state);
+	if (rc)
+		goto err_out;
+
+	/* end... */
+	if (state->last_mark.input_pos == (size_t)-1)
+		fy_reader_fill_atom_end(fyr, handle);
+	else
+		fy_reader_fill_atom_end_at(fyr, handle, &state->last_mark);
+
+	c = state->c;
+	if (c == FYUG_INV || c == FYUG_PARTIAL) {
+		FYR_MARK_ERROR(fyr, &handle->start_mark, &handle->end_mark, FYEM_SCAN,
+			"plain scalar is malformed UTF8");
+		goto err_out;
+	}
+
+	ends_with_eof = c == FYUG_EOF && !state->last_was_lb;
+
+	is_multiline = handle->end_mark.line > handle->start_mark.line;
+
+	handle->style = FYAS_PLAIN;
+	handle->chomp = FYAC_STRIP;
+	handle->direct_output = !is_multiline && !state->has_json_esc && fy_atom_size(handle) == state->length;
+	handle->empty = false;
+	handle->has_lb = state->has_lb;
+	handle->has_ws = state->has_ws;
+	handle->starts_with_ws = false;
+	handle->starts_with_lb = false;
+	handle->ends_with_ws = false;
+	handle->ends_with_lb = false;
+	handle->trailing_lb = false;
+	handle->size0 = state->length == 0;
+	handle->valid_anchor = false;
+	handle->json_mode = fy_reader_json_mode(fyr);
+	handle->lb_mode = fy_reader_lb_mode(fyr);
+	handle->fws_mode = fy_reader_flow_ws_mode(fyr);
+	handle->directive0_mode = fy_reader_directive0_mode(fyr);
+	handle->tabsize = fy_reader_tabsize(fyr);
+	handle->ends_with_eof = ends_with_eof;
+	handle->is_merge_key = is_merge_key && state->length == 2;
+	handle->simple_key_allowed = state->simple_key_allowed;
+	handle->high_ascii = state->has_high_ascii;
+
+	if (state->has_weird_nl || FORCE_ATOM_SIZE_CHECK_DEFAULT) {
+		tlength = fy_atom_format_text_length(handle);
+		if (tlength != state->length) {
+			if (!state->has_weird_nl)
+				fyr_warning(fyr, "%s: storage hint calculation failed real %zu != hint %zu - \"%s\"", __func__,
+					tlength, state->length,
+					fy_utf8_format_text_a(fy_atom_data(handle), fy_atom_size(handle), fyue_doublequote));
+			state->length = tlength;
+		}
+	}
+
+	handle->storage_hint = state->length;
+	handle->storage_hint_valid = true;
+
+	/* extra check in json mode */
+	if (fy_reader_json_mode(fyr)) {
+		FYR_MARK_ERROR_CHECK(fyr, &handle->start_mark, &handle->end_mark, FYEM_SCAN,
+				!is_multiline, err_out,
+				"Multi line plain scalars not supported in JSON mode");
+
+		FYR_MARK_ERROR_CHECK(fyr, &handle->start_mark, &handle->end_mark, FYEM_SCAN,
+				!fy_atom_strcmp(handle, "false") ||
+				!fy_atom_strcmp(handle, "true") ||
+				!fy_atom_strcmp(handle, "null") ||
+				fy_atom_is_number(handle), err_out,
+				"Invalid JSON plain scalar");
+	}
+
+
+	return 0;
+
+err_out:
+	rc = -1;
+	return rc;
+}
+
+int fy_fetch_flow_scalar(struct fy_parser *fyp, int c)
+{
+	struct fy_atom handle;
+	bool is_single, is_complex, is_multiline;
+	struct fy_mark mark;
+	struct fy_simple_key_mark skm;
+	struct fy_token *fyt;
+	int i = 0, rc = -1;
+
+	is_single = c == '\'';
+
+	fyp_error_check(fyp, c == '\'' || c == '"', err_out,
+			"bad start of flow scalar ('%s')",
+				fy_utf8_format_a(c, fyue_singlequote));
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented %s scalar in flow mode",
+				is_single ? "single-quoted" : "double-quoted");
+
+	fy_get_mark(fyp, &mark);
+	fy_get_simple_key_mark(fyp, &skm);
+
+	/* errors are generated by reader */
+	rc = fy_reader_fetch_flow_scalar_handle(fyp->reader, c, fyp->indent, &handle, !!(fyp->cfg.flags & FYPCF_SLOPPY_FLOW_INDENTATION));
+	if (rc) {
+		fyp->stream_error = true;
+		goto err_out_rc;
+	}
+
+	/* and we're done */
+	fyt = fy_token_queue(fyp, FYTT_SCALAR, &handle, is_single ? FYSS_SINGLE_QUOTED : FYSS_DOUBLE_QUOTED);
+	fyp_error_check(fyp, fyt, err_out_rc,
+			"fy_token_queue() failed");
+
+	/* update style marks */
+	fyt->scalar.style_start = mark;
+	fy_get_mark(fyp, &fyt->scalar.style_end);
+
+	if (fyp->parse_flow_only && fyp->flow_level == 0) {
+		rc = fy_fetch_stream_end(fyp);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_stream_end() failed");
+		return 0;
+	}
+
+	is_complex = fyp->pending_complex_key_column >= 0;
+	is_multiline = handle.end_mark.line > handle.start_mark.line;
+
+	if (!fyp->flow_level) {
+		/* due to the weirdness with simple keys scan forward
+		* until a linebreak, ';', or anything else */
+		for (i = 0; ; i++) {
+			c = fy_parse_peek_at(fyp, i);
+			if (c < 0 || c == ':' || fyp_is_lb(fyp, c) || !fyp_is_flow_ws(fyp, c))
+				break;
+		}
+
+		/* if we're a multiline key that's bad */
+		FYP_MARK_ERROR_CHECK(fyp, &mark, &mark, FYEM_SCAN,
+			!(is_multiline && !is_complex && c == ':'), err_out,
+				"invalid multiline %s scalar used as key",
+					is_single ? "single-quoted" : "double-quoted");
+
+		FYP_PARSE_ERROR_CHECK(fyp, i, 1, FYEM_SCAN,
+				c < 0 || c == ':' || c == '#' || fyp_is_lb(fyp, c), err_out,
+				"invalid trailing content after %s scalar",
+					is_single ? "single-quoted" : "double-quoted");
+	}
+
+	/* a plain scalar could be simple key */
+	rc = fy_save_simple_key_mark(fyp, &skm, FYTT_SCALAR, &handle.end_mark);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_save_simple_key_mark() failed");
+
+	/* cannot follow a flow scalar */
+	fyp->simple_key_allowed = false;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	/* make sure that no comment follows directly afterwards */
+	c = fy_parse_peek(fyp);
+
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			c != '#', err_out,
+			"invalid comment without whitespace after %s scalar",
+				is_single ? "single-quoted" : "double-quoted");
+
+	rc = fy_parse_handle_comments_after_token(fyp, fyt);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_handle_comments_after_token() failed");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+void fy_reader_skip_ws_cr_nl(struct fy_reader *fyr)
+{
+	const char *p, *s, *e;
+	char cc;
+	size_t len;
+	int line, column;
+
+	assert(fyr);
+
+	column = fyr->column;
+	line = fyr->line;
+	while ((p = fy_reader_ensure_lookahead(fyr, 1, &len)) != NULL) {
+
+		s = p;
+		e = s + len;
+
+		while (s < e) {
+			cc = *s;
+			if (cc == ' ') {
+				column++;
+			} else if (cc == '\n') {
+				column = 0;
+				line++;
+			} else if (cc == '\t') {
+				if (fyr->tabsize)
+					column += (fyr->tabsize - (column % fyr->tabsize));
+				else
+					column++;
+			} else if (cc == '\r') {
+				column = 0;
+				line++;
+
+				if (s + 1 > e) {
+					/* we have a dangling cr at the end of a block */
+
+					/* advance up to the point here */
+					fy_reader_advance_octets(fyr, s - p);
+
+					/* try again (should return enough or NULL) */
+					p = fy_reader_ensure_lookahead(fyr, 1, &len);
+
+					/* if we couldn't pull enough we're done */
+					if (!p || len < 1)
+						goto done;
+
+					s = p;
+					e = s + len;
+
+					if (*s == '\n')
+						s++;
+				}
+				/* \n followed, gulp it down */
+				if (*s == '\n')
+					s++;
+			} else {
+				if (s > p)
+					fy_reader_advance_octets(fyr, s - p);
+				goto done;
+			}
+
+			s++;
+		}
+
+		fy_reader_advance_octets(fyr, s - p);
+	}
+
+done:
+	fyr->line = line;
+	fyr->column = column;
+}
+
+void fy_reader_skip_ws(struct fy_reader *fyr)
+{
+	const char *p, *s, *e;
+	size_t len, consumed;
+	int column;
+
+	assert(fyr);
+
+	while ((p = fy_reader_ensure_lookahead(fyr, 1, &len)) != NULL) {
+
+		s = p;
+		e = s + len;
+
+		column = fyr->column;
+		if (!fyr->tabsize) {
+			while (s < e && fy_is_ws(*s)) {
+				column++;
+				s++;
+			}
+		} else {
+			while (s < e && fy_is_ws(*s)) {
+				if (fy_is_tab(*s))
+					column += fyr->tabsize - (column % fyr->tabsize);
+				else
+					column++;
+				s++;
+			}
+		}
+
+		consumed = s - p;
+		if (consumed) {
+			fy_reader_advance_octets(fyr, consumed);
+			fyr->column = column;
+		}
+
+		/* we're done if stopped earlier */
+		if (s < e)
+			break;
+	}
+}
+
+void fy_reader_skip_space(struct fy_reader *fyr)
+{
+	const char *p, *s, *e;
+	size_t len, consumed;
+
+	assert(fyr);
+
+	while ((p = fy_reader_ensure_lookahead(fyr, 1, &len)) != NULL) {
+
+		s = p;
+		e = s + len;
+
+		while (s < e && fy_is_space(*s))
+			s++;
+
+		consumed = s - p;
+		if (consumed) {
+			fy_reader_advance_octets(fyr, consumed);
+			fyr->column += (int)consumed;
+		}
+
+		if (s < e)
+			break;
+	}
+}
+
+void fy_reader_skip_ws_lb(struct fy_reader *fyr)
+{
+	const char *p, *s, *e;
+	size_t len, consumed;
+	int line, column, c, w;
+	bool dangling_cr;
+	enum fy_lb_mode lb_mode;
+
+	assert(fyr);
+
+	/* punt to json mode */
+	lb_mode = fy_reader_lb_mode(fyr);
+
+	if (fy_reader_json_mode(fyr) || lb_mode == fylb_cr_nl) {
+		fy_reader_skip_ws_cr_nl(fyr);
+		return;
+	}
+
+	column = fyr->column;
+	line = fyr->line;
+	dangling_cr = false;
+	while ((p = fy_reader_ensure_lookahead(fyr, 1, &len)) != NULL) {
+
+		s = p;
+		e = s + len;
+
+		if (dangling_cr) {
+			if (*s == '\n')
+				s++;
+			dangling_cr = false;
+		}
+
+		while (s < e) {
+			c = (int)*s;
+
+			/* single byte utf8? */
+			if (c < 0x80) {
+				if (c == ' ') {
+					column++;
+				} else if (c == '\n') {
+					column = 0;
+					line++;
+				} else if (c == '\t') {
+					if (fyr->tabsize)
+						column += (fyr->tabsize - (column % fyr->tabsize));
+					else
+						column++;
+				} else if (c == '\r') {
+					column = 0;
+					line++;
+					/* check for '\n' following */
+					if (s < e) {
+						if (*s == '\n')
+							s++;
+					} else {
+						/* we have a dangling cr at the end of a block */
+						dangling_cr = true;
+					}
+				} else {
+					consumed = s - p;
+					if (consumed)
+						fy_reader_advance_octets(fyr, consumed);
+					goto done;
+				}
+				s++;
+			} else {
+				c = fy_utf8_get(s, (size_t)(e - s), &w);
+
+				if (c == FYUG_PARTIAL) {
+					/* get the width (from the first octet */
+					w = fy_utf8_width_by_first_octet((uint8_t)*s);
+					/* copy the partial utf8 in the buffer */
+
+					/* advance up to the point here */
+					consumed = s - p;
+					if (consumed)
+						fy_reader_advance_octets(fyr, consumed);
+
+					/* try again (should return enough or NULL) */
+					p = fy_reader_ensure_lookahead(fyr, w, &len);
+					if (!p)
+						break;
+
+					/* if we couldn't pull enough we're done */
+					if (len < (size_t)w)
+						goto done;
+
+					continue;
+				}
+
+				if (lb_mode == fylb_cr_nl_N_L_P && fy_is_unicode_lb(c)) {
+					column = 0;
+					line++;
+				} else {
+					consumed = s - p;
+					if (consumed)
+						fy_reader_advance_octets(fyr, consumed);
+					goto done;
+				}
+
+				s += w;
+			}
+		}
+
+		consumed = s - p;
+		if (consumed)
+			fy_reader_advance_octets(fyr, consumed);
+	}
+
+done:
+	fyr->line = line;
+	fyr->column = column;
+}
+
+int fy_fetch_plain_scalar(struct fy_parser *fyp, int c)
+{
+	struct fy_atom handle;
+	struct fy_simple_key_mark skm;
+	struct fy_token *fyt;
+	bool is_multiline, is_complex, is_tab_start = false;
+	struct fy_mark tab_mark;
+	int rc = -1, i;
+
+	/* Extremely bad case, a tab... so, either an indentation or separation space in block mode */
+	if (!fyp->flow && fy_is_tab(c)) {
+
+		fy_get_mark(fyp, &tab_mark);
+		is_tab_start = true;
+
+		/* skip all whitespace now */
+		fy_reader_skip_ws(fyp->reader);
+		c = fy_parse_peek(fyp);
+
+		/* if it's a linebreak or a comment start, just try again */
+		if (fyp_is_lb(fyp, c) || c == '#') {
+			/* will need to scan more */
+			fyp->token_activity_counter++;
+			return 0;
+		}
+	}
+
+	/* check indentation */
+	FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+			fy_flow_indent_check(fyp), err_out,
+			"wrongly indented flow %s",
+				fyp->flow == FYFT_SEQUENCE ? "sequence" : "mapping");
+
+	fy_get_simple_key_mark(fyp, &skm);
+
+	rc = fy_reader_fetch_plain_scalar_handle(fyp->reader, c, fyp->indent, fyp->flow_level, &handle);
+	if (rc) {
+		fyp->stream_error = true;
+		goto err_out_rc;
+	}
+
+	is_multiline = handle.end_mark.line > handle.start_mark.line;
+	is_complex = fyp->pending_complex_key_column >= 0;
+
+	/* and we're done */
+	fyt = fy_token_queue(fyp, FYTT_SCALAR, &handle, FYSS_PLAIN);
+	fyp_error_check(fyp, fyt, err_out_rc,
+			"fy_token_queue() failed");
+
+	if (fyp->parse_flow_only && fyp->flow_level == 0) {
+		rc = fy_fetch_stream_end(fyp);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_stream_end() failed");
+		return 0;
+	}
+
+	if (!fyp->flow_level && !is_complex && (is_multiline || is_tab_start)) {
+		/* due to the weirdness with simple keys scan forward
+		* until a linebreak, ':', or anything else */
+		for (i = 0; ; i++) {
+			c = fy_parse_peek_at(fyp, i);
+			if (c < 0 || (c == ':' && fy_is_blankz_at_offset(fyp, i + 1)) ||
+					fyp_is_lb(fyp, c) || !fy_is_ws(c))
+				break;
+		}
+
+		/* if we're a key, that's invalid */
+		if (c == ':') {
+
+			if (is_multiline)
+				FYP_MARK_ERROR(fyp, &handle.start_mark, &handle.end_mark, FYEM_SCAN,
+						"invalid multiline plain key");
+			else
+				FYP_MARK_ERROR(fyp, &tab_mark, &tab_mark, FYEM_SCAN,
+						"invalid tab as indendation in a mapping");
+
+			goto err_out;
+		}
+	}
+
+	rc = fy_save_simple_key_mark(fyp, &skm, FYTT_SCALAR, &handle.end_mark);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_save_simple_key_mark() failed");
+
+	fyp->simple_key_allowed = handle.simple_key_allowed;
+	fyp_scan_debug(fyp, "simple_key_allowed -> %s\n", fyp->simple_key_allowed ? "true" : "false");
+
+	rc = fy_parse_handle_comments_after_token(fyp, fyt);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_handle_comments_after_token() failed");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_fetch_tokens(struct fy_parser *fyp)
+{
+	bool was_double_colon;
+	int c, rc;
+
+	/* do not fetch any more when stream end is reached */
+	if (fyp->stream_end_reached)
+		return 0;
+
+	if (!fyp->stream_start_produced) {
+		rc = fy_parse_get_next_input(fyp);
+		fyp_error_check(fyp, rc >= 0, err_out_rc,
+			"fy_parse_get_next_input() failed");
+
+		if (rc > 0) {
+			rc = fy_fetch_stream_start(fyp);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_fetch_stream_start() failed");
+		}
+		return 0;
+	}
+
+	fyp_scan_debug(fyp, "-------------------------------------------------");
+	rc = fy_scan_to_next_token(fyp);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_scan_to_next_token() failed");
+
+	if (fyp_block_mode(fyp)) {
+		if (fyp->parse_block_only && fyp->starting_indent >= 0 &&
+		    fyp_column(fyp) < fyp->starting_indent) {
+			rc = fy_fetch_stream_end(fyp);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_fetch_stream_end() failed");
+			return 0;
+		}
+		rc = fy_parse_unroll_indent(fyp, fyp_column(fyp));
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_parse_unroll_indent() failed");
+	}
+
+	c = fy_parse_peek(fyp);
+	if (c <= 0) {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				c == FYUG_EOF, err_out,
+				"Invalid UTF8 %s in the input stream",
+					c == '\0' ? "(null \\0)" :
+					c == FYUG_INV ? "(invalid)" :
+					c == FYUG_PARTIAL ? "(partial)" : "(unspecified)");
+
+		fyp->stream_end_reached = true;
+
+		rc = fy_fetch_stream_end(fyp);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_stream_end() failed");
+		return 0;
+	}
+
+	if (fyp_column(fyp) == 0 && c == '%') {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"directives not supported in JSON mode");
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp->bare_document_only, err_out,
+				"invalid directive in bare document mode");
+
+		fy_advance(fyp, c);
+		rc = fy_fetch_directive(fyp);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_directive() failed");
+		goto out;
+	}
+
+	/* probable document start/end indicator */
+	if (fyp_column(fyp) == 0 &&
+	    (!fy_parse_strncmp(fyp, "---", 3) ||
+	     !fy_parse_strncmp(fyp, "...", 3)) &&
+	    fy_is_blankz_at_offset(fyp, 3)) {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 3, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"document %s indicator not supported in JSON mode",
+					c == '-' ? "start" : "end");
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 3, FYEM_SCAN,
+				!fyp->bare_document_only, err_out,
+				"invalid document %s indicator in bare document mode",
+					c == '-' ? "start" : "end");
+
+		rc = fy_fetch_document_indicator(fyp,
+				c == '-' ? FYTT_DOCUMENT_START :
+					FYTT_DOCUMENT_END);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_document_indicator() failed");
+
+		fyp->indent_line = fyp_line(fyp);
+
+		/* for document end, nothing must follow except whitespace and comment */
+		if (c == '.') {
+			c = fy_parse_peek(fyp);
+
+			FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+					c == -1 || c == '#' || fyp_is_lb(fyp, c), err_out,
+					"invalid content after document end marker");
+		}
+
+		goto out;
+	}
+
+	fyp_scan_debug(fyp, "indent=%d, parent indent=%d\n",
+			fyp->indent, fyp->parent_indent);
+
+	if (c == '[' || c == '{') {
+
+		fyp->indent_line = fyp_line(fyp);
+
+		fyp_scan_debug(fyp, "calling fy_fetch_flow_collection_mark_start(%c)", c);
+		rc = fy_fetch_flow_collection_mark_start(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_flow_collection_mark_start() failed");
+		goto out;
+	}
+
+	if (c == ']' || c == '}') {
+
+		fyp->indent_line = fyp_line(fyp);
+
+		fyp_scan_debug(fyp, "fy_fetch_flow_collection_mark_end(%c)", c);
+		rc = fy_fetch_flow_collection_mark_end(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_flow_collection_mark_end() failed");
+		goto out;
+	}
+
+
+	if (c == ',') {
+
+		rc = fy_parse_handle_comma(fyp, ',');
+		fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_handle_comma() failed");
+
+		goto out;
+	}
+
+	if (c == '-' && fy_is_blankz_at_offset(fyp, 1)) {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"block entries not supported in JSON mode");
+
+		fyp->indent_line = fyp_line(fyp);
+
+		fyp_scan_debug(fyp, "fy_fetch_block_entry(%c)", c);
+		rc = fy_fetch_block_entry(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_block_entry() failed");
+		goto out;
+	}
+
+	if (c == '?' && fy_is_blankz_at_offset(fyp, 1)) {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"complex keys not supported in JSON mode");
+
+		fyp->indent_line = fyp_line(fyp);
+
+		fyp_scan_debug(fyp, "fy_fetch_key(%c)", c);
+		rc = fy_fetch_key(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_key() failed");
+		goto out;
+	}
+
+	if (c == ':') {
+		was_double_colon = c == ':' && fyp->colon_follows_colon && fyp->flow_level > 0;
+		fyp->colon_follows_colon = false;
+
+		if (((fyp->flow_level && !fyp->simple_key_allowed) || fy_is_blankz_at_offset(fyp, 1)) &&
+				!was_double_colon) {
+
+			fyp->indent_line = fyp_line(fyp);
+
+			fyp_scan_debug(fyp, "fy_fetch_value(%c)", c);
+			rc = fy_fetch_value(fyp, c);
+			fyp_error_check(fyp, !rc, err_out_rc,
+					"fy_fetch_value() failed");
+			goto out;
+		}
+	}
+
+	if (c == '*' || c == '&') {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"%s not supported in JSON mode",
+					c == '&' ? "anchor" : "alias");
+
+		fyp_scan_debug(fyp, "fy_fetch_anchor_or_alias(%c)", c);
+		rc = fy_fetch_anchor_or_alias(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_anchor_or_alias() failed");
+		goto out;
+	}
+
+	if (c == '!') {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"tag not supported in JSON mode");
+
+		fyp_scan_debug(fyp, "fy_fetch_tag(%c)", c);
+		rc = fy_fetch_tag(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_tag() failed");
+		goto out;
+	}
+
+	if (!fyp->flow_level && (c == '|' || c == '>')) {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				!fyp_json_mode(fyp), err_out,
+				"block scalars not supported in JSON mode");
+
+		fyp_scan_debug(fyp, "fy_fetch_block_scalar(%c)", c);
+		rc = fy_fetch_block_scalar(fyp, c == '|', c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_block_scalar() failed");
+		goto out;
+	}
+
+	if (c == '\'' || c == '"') {
+
+		FYP_PARSE_ERROR_CHECK(fyp, 0, 1, FYEM_SCAN,
+				c == '"' || !fyp_json_mode(fyp), err_out,
+				"single quoted scalars not supported in JSON mode");
+
+		fyp_scan_debug(fyp, "fy_fetch_flow_scalar(%c)", c);
+		rc = fy_fetch_flow_scalar(fyp, c);
+		fyp_error_check(fyp, !rc, err_out_rc,
+				"fy_fetch_flow_scalar() failed");
+		goto out;
+	}
+
+	fyp_scan_debug(fyp, "fy_fetch_plain_scalar(%c)", c);
+	rc = fy_fetch_plain_scalar(fyp, c);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_fetch_plain_scalar() failed");
+
+out:
+	if (c != ',' && fyp->last_was_comma)
+		fyp->last_was_comma = false;
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+struct fy_token *fy_scan_peek(struct fy_parser *fyp)
+{
+	struct fy_token *fyt;
+	int rc, last_token_activity_counter;
+	bool have_simple_keys;
+
+	/* do not try to peek */
+	if (fy_reader_generates_events(fyp->reader))
+		return NULL;
+
+	/* nothing if stream end produced (and no stream end token in queue) */
+	if (fyp->stream_end_produced) {
+		fyt = fy_token_list_head(&fyp->queued_tokens);
+		if (fyt && fyt->type == FYTT_STREAM_END)
+			return fyt;
+
+		/* OK, we're done, flush everything */
+		fy_token_list_unref_all(&fyp->queued_tokens);
+
+		/* try to get the next input */
+		rc = fy_parse_get_next_input(fyp);
+		fyp_error_check(fyp, rc >= 0, err_out,
+			"fy_parse_get_next_input() failed");
+
+		/* no more inputs */
+		if (rc == 0) {
+			fyp_scan_debug(fyp, "token stream ends");
+			return NULL;
+		}
+
+		fyp_scan_debug(fyp, "starting new token stream");
+
+		fyp->stream_start_produced = false;
+		fyp->stream_end_produced = false;
+		fyp->stream_end_reached = false;
+	}
+
+	/* we loop until we have a token and the simple key list is empty */
+	for (;;) {
+		fyt = fy_token_list_head(&fyp->queued_tokens);
+		have_simple_keys = !fy_simple_key_list_empty(&fyp->simple_keys);
+
+		/* we can produce a token when:
+		* a) one exists
+		* b) no simple keys exist at all
+		*/
+		if (fyt && !have_simple_keys)
+			break;
+
+		/* on stream error we're done */
+		if (fyp->stream_error)
+			return NULL;
+
+		/* keep track of token activity, if it didn't change
+		* after the fetch tokens call, the state machine is stuck
+		*/
+		last_token_activity_counter = fyp->token_activity_counter;
+
+		/* fetch more then */
+		rc = fy_fetch_tokens(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_fetch_tokens() failed");
+
+		if (fy_reader_generates_events(fyp->reader))
+			return NULL;
+
+		fyp_error_check(fyp, last_token_activity_counter != fyp->token_activity_counter, err_out,
+				"out of tokens and failed to produce anymore");
+	}
+
+	switch (fyt->type) {
+	case FYTT_STREAM_START:
+		fyp_scan_debug(fyp, "setting stream_start_produced to true");
+		fyp->stream_start_produced = true;
+		break;
+	case FYTT_STREAM_END:
+		fyp_scan_debug(fyp, "setting stream_end_produced to true");
+		fyp->stream_end_produced = true;
+
+		if (!fyp->parse_flow_only && !fyp->parse_block_only) {
+			rc = fy_reader_input_done(fyp->reader);
+			fyp_error_check(fyp, !rc, err_out,
+					"fy_parse_input_done() failed");
+		}
+		break;
+	default:
+		break;
+	}
+
+	return fyt;
+
+err_out:
+	return NULL;
+}
+
+static inline struct fy_token *
+fy_scan_remove(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	if (!fyp || !fyt)
+		return NULL;
+
+	fy_token_list_del(&fyp->queued_tokens, fyt);
+
+	return fyt;
+}
+
+static inline struct fy_token *
+fy_scan_remove_peek(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	if (fyt != NULL) {
+		(void)fy_scan_remove(fyp, fyt);
+		fy_token_unref_rl(fyp->recycled_token_list, fyt);
+	}
+
+	return fy_scan_peek(fyp);
+}
+
+struct fy_token *fy_scan(struct fy_parser *fyp)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_scan_remove(fyp, fy_scan_peek(fyp));
+
+	if (fyt && (fyt->type == FYTT_VERSION_DIRECTIVE || fyt->type == FYTT_TAG_DIRECTIVE)) {
+
+		/*
+		* NOTE: we need to update the document state with the contents of
+		* directives, so that tags etc, work correctly.
+		* This is arguably a big hack, but so is using the scanner in such
+		* a low level.
+		*
+		* This is not very good because we don't keep track of parser state
+		* so tag directives in the middle of the document are AOK.
+		* But we don't really care, if you care about stream validity do
+		* a proper parse.
+		*/
+
+		/* we take a reference because the parse methods take ownership */
+		fy_token_ref(fyt);
+
+		/* we ignore errors, because... they are parse errors, not scan errors */
+
+		if (fyt->type == FYTT_VERSION_DIRECTIVE)
+			(void)fy_parse_version_directive(fyp, fyt, true);
+		else
+			(void)fy_parse_tag_directive(fyp, fyt, true);
+	}
+
+#ifdef FY_DEVMODE
+	if (fyt)
+		fyp_debug_dump_token(fyp, fyt, "producing: ");
+#endif
+	return fyt;
+}
+
+void fy_scan_token_free(struct fy_parser *fyp, struct fy_token *fyt)
+{
+	fy_token_unref_rl(fyp->recycled_token_list, fyt);
+}
+
+int fy_parse_state_push(struct fy_parser *fyp, enum fy_parser_state state)
+{
+	struct fy_parse_state_log *fypsl;
+
+	fypsl = fy_parse_parse_state_log_alloc(fyp);
+	fyp_error_check(fyp, fypsl != NULL, err_out,
+			"fy_parse_state_log_alloc() failed!");
+	fypsl->state = state;
+	fy_parse_state_log_list_push(&fyp->state_stack, fypsl);
+
+	return 0;
+err_out:
+	return -1;
+}
+
+enum fy_parser_state fy_parse_state_pop(struct fy_parser *fyp)
+{
+	struct fy_parse_state_log *fypsl;
+	enum fy_parser_state state;
+
+	fypsl = fy_parse_state_log_list_pop(&fyp->state_stack);
+	if (!fypsl)
+		return FYPS_NONE;
+
+	state = fypsl->state;
+
+	fy_parse_parse_state_log_recycle(fyp, fypsl);
+
+	return state;
+}
+
+void fy_parse_state_set(struct fy_parser *fyp, enum fy_parser_state state)
+{
+	fyp_parse_debug(fyp, "state %s -> %s\n", state_txt[fyp->state], state_txt[state]);
+	fyp->state = state;
+}
+
+enum fy_parser_state fy_parse_state_get(struct fy_parser *fyp)
+{
+	return fyp->state;
+}
+
+static struct fy_eventp *
+fy_parse_node(struct fy_parser *fyp, struct fy_token *fyt, bool is_block)
+{
+	struct fy_eventp *fyep = NULL;
+	struct fy_event *fye = NULL;
+	struct fy_document_state *fyds = NULL;
+	struct fy_token *anchor = NULL, *tag = NULL;
+	const char *handle;
+	size_t handle_size;
+	struct fy_token *fyt_td;
+	struct fy_token *fytn;
+	struct fy_atom *ev_handle = NULL;
+	int rc;
+
+	fyds = fyp->current_document_state;
+	assert(fyds);
+
+	fyp_parse_debug(fyp, "parse_node: is_block=%s - fyt %s",
+			is_block ? "true" : "false",
+			fy_token_type_txt[fyt->type]);
+
+	if (fyt->type == FYTT_ALIAS) {
+		fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_ALIAS;
+		fye->alias.anchor = fy_scan_remove(fyp, fyt);
+
+		ev_handle = &fye->alias.anchor->handle;
+		goto return_ok;
+	}
+
+	while ((!anchor && fyt->type == FYTT_ANCHOR) || (!tag && fyt->type == FYTT_TAG)) {
+		if (fyt->type == FYTT_ANCHOR)
+			anchor = fy_scan_remove(fyp, fyt);
+		else
+			tag = fy_scan_remove(fyp, fyt);
+
+		fyt = fy_scan_peek(fyp);
+		fyp_error_check(fyp, fyt, err_out,
+				"failed to peek token");
+
+		fyp_parse_debug(fyp, "parse_node: ANCHOR|TAG got -  fyt %s",
+			fy_token_type_txt[fyt->type]);
+
+		FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				fyt->type != FYTT_ALIAS, err_out,
+				"unexpected alias");
+	}
+
+	/* check tag prefix */
+	if (tag && tag->tag.handle_length) {
+		handle = fy_atom_data(&tag->handle) + tag->tag.skip;
+		handle_size = tag->tag.handle_length;
+
+		fyt_td = fy_document_state_lookup_tag_directive(fyds, handle, handle_size);
+
+		FYP_TOKEN_ERROR_CHECK(fyp, tag, FYEM_PARSE,
+				fyt_td, err_out,
+				"undefined tag prefix '%.*s'", (int)handle_size, handle);
+	}
+
+	if ((fyp->state == FYPS_BLOCK_MAPPING_VALUE ||
+	     fyp->state == FYPS_BLOCK_MAPPING_FIRST_KEY)
+		&& fyt->type == FYTT_BLOCK_ENTRY) {
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_SEQUENCE_START;
+		fye->sequence_start.anchor = anchor;
+		fye->sequence_start.tag = tag;
+
+		/* allocate and copy in place */
+		fytn = fy_token_alloc_rl(fyp->recycled_token_list);
+		fyp_error_check(fyp, fytn, err_out,
+				"fy_token_alloc_rl() failed!");
+		fytn->type = FYTT_BLOCK_SEQUENCE_START;
+		fytn->handle = fyt->handle;
+		fytn->handle.end_mark = fytn->handle.start_mark;	/* no extent */
+		fy_input_ref(fytn->handle.fyi);
+
+		fye->sequence_start.sequence_start = fytn;
+
+		rc = fy_attach_comments_if_any(fyp, fye->sequence_start.sequence_start);
+		fyp_error_check(fyp, rc >= 0, err_out,
+				"fy_attach_comments_if_any() failed");
+
+		fy_parse_state_set(fyp, FYPS_INDENTLESS_SEQUENCE_ENTRY);
+
+		ev_handle = &fye->sequence_start.sequence_start->handle;
+		goto return_ok;
+	}
+
+	if (fyt->type == FYTT_SCALAR) {
+		fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_SCALAR;
+		fye->scalar.anchor = anchor;
+		fye->scalar.tag = tag;
+		fye->scalar.value = fy_scan_remove(fyp, fyt);
+
+		ev_handle = &fye->scalar.value->handle;
+		goto return_ok;
+	}
+
+	if (fyt->type == FYTT_FLOW_SEQUENCE_START) {
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_SEQUENCE_START;
+		fye->sequence_start.anchor = anchor;
+		fye->sequence_start.tag = tag;
+		fye->sequence_start.sequence_start = fy_scan_remove(fyp, fyt);
+		fy_parse_state_set(fyp, FYPS_FLOW_SEQUENCE_FIRST_ENTRY);
+
+		ev_handle = &fye->sequence_start.sequence_start->handle;
+		goto return_ok;
+	}
+
+	if (fyt->type == FYTT_FLOW_MAPPING_START) {
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_MAPPING_START;
+		fye->mapping_start.anchor = anchor;
+		fye->mapping_start.tag = tag;
+		fye->mapping_start.mapping_start = fy_scan_remove(fyp, fyt);
+		fy_parse_state_set(fyp, FYPS_FLOW_MAPPING_FIRST_KEY);
+
+		ev_handle = &fye->mapping_start.mapping_start->handle;
+		goto return_ok;
+	}
+
+	if (is_block && fyt->type == FYTT_BLOCK_SEQUENCE_START) {
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_SEQUENCE_START;
+		fye->sequence_start.anchor = anchor;
+		fye->sequence_start.tag = tag;
+		fye->sequence_start.sequence_start = fy_scan_remove(fyp, fyt);
+		fy_parse_state_set(fyp, FYPS_BLOCK_SEQUENCE_FIRST_ENTRY);
+
+		ev_handle = &fye->sequence_start.sequence_start->handle;
+		goto return_ok;
+	}
+
+	if (is_block && fyt->type == FYTT_BLOCK_MAPPING_START) {
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_MAPPING_START;
+		fye->mapping_start.anchor = anchor;
+		fye->mapping_start.tag = tag;
+		fye->mapping_start.mapping_start = fy_scan_remove(fyp, fyt);
+		fy_parse_state_set(fyp, FYPS_BLOCK_MAPPING_FIRST_KEY);
+
+		ev_handle = &fye->mapping_start.mapping_start->handle;
+		goto return_ok;
+	}
+
+	/* handle really weird cases of empty block sequences */
+	if (fyp->state == FYPS_INDENTLESS_SEQUENCE_ENTRY) {
+		switch (fyt->type) {
+		case FYTT_BLOCK_ENTRY:
+			/* mark that we're in this weird state */
+			fyp_parse_debug(fyp, "BARE -\n");
+			goto do_empty_scalar;
+		case FYTT_KEY:
+			fyp_parse_debug(fyp, "BARE - followed by KEY\n");
+			goto do_empty_scalar;
+		default:
+			break;
+		}
+	}
+
+	if (!anchor && !tag) {
+
+		if (fyt->type == FYTT_FLOW_ENTRY &&
+			(fyp->state == FYPS_FLOW_SEQUENCE_FIRST_ENTRY ||
+			fyp->state == FYPS_FLOW_SEQUENCE_ENTRY))
+
+			FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+					"flow sequence with invalid %s",
+						fyp->state == FYPS_FLOW_SEQUENCE_FIRST_ENTRY ?
+						"comma in the beginning" : "extra comma");
+
+		else if ((fyt->type == FYTT_DOCUMENT_START || fyt->type == FYTT_DOCUMENT_END) &&
+				(fyp->state == FYPS_FLOW_SEQUENCE_FIRST_ENTRY ||
+				fyp->state == FYPS_FLOW_SEQUENCE_ENTRY))
+
+			FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+					"invalid document %s indicator in a flow sequence",
+						fyt->type == FYTT_DOCUMENT_START ?
+							"start" : "end");
+		else
+			FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+					"did not find expected node content");
+
+		goto err_out;
+	}
+
+do_empty_scalar:
+
+	fyp_parse_debug(fyp, "parse_node: empty scalar...");
+
+	/* empty scalar */
+	fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+	fyep = fy_parse_eventp_alloc(fyp);
+	fyp_error_check(fyp, fyep, err_out,
+			"fy_eventp_alloc() failed!");
+	fye = &fyep->e;
+
+	fye->type = FYET_SCALAR;
+	fye->scalar.anchor = anchor;
+	fye->scalar.tag = tag;
+
+	/* copy atom from the token and set to zero size at start */
+	fye->scalar.value = fy_token_create_rl(
+		fyp->recycled_token_list,  FYTT_SCALAR, &fyp->last_event_handle, FYSS_PLAIN);
+	fyp_error_check(fyp, fye->scalar.value, err_out,
+			"failed to allocate SCALAR token()");
+	/* mark it as a special value */
+	fye->scalar.value->scalar.is_null = true;
+
+return_ok:
+	if (ev_handle) {
+		fy_input_unref(fyp->last_event_handle.fyi);
+		fyp->last_event_handle = *ev_handle;
+		fyp->last_event_handle.start_mark = fyp->last_event_handle.end_mark;
+		fy_atom_reset_storage_hints(&fyp->last_event_handle);
+		fy_input_ref(fyp->last_event_handle.fyi);
+	}
+
+	fyp_parse_debug(fyp, "parse_node: > %s",
+			fy_event_type_txt[fye->type]);
+
+	return fyep;
+
+err_out:
+	fy_token_unref_rl(fyp->recycled_token_list, anchor);
+	fy_token_unref_rl(fyp->recycled_token_list, tag);
+	fy_parse_eventp_recycle(fyp, fyep);
+
+	return NULL;
+}
+
+static struct fy_eventp *
+fy_parse_empty_scalar(struct fy_parser *fyp)
+{
+	struct fy_eventp *fyep;
+	struct fy_event *fye;
+
+	fyep = fy_parse_eventp_alloc(fyp);
+	fyp_error_check(fyp, fyep, err_out,
+			"fy_eventp_alloc() failed!");
+	fye = &fyep->e;
+
+	fye->type = FYET_SCALAR;
+	fye->scalar.anchor = NULL;
+	fye->scalar.tag = NULL;
+
+	/* for empty scalar the last event handle does not change, only  */
+	fye->scalar.value = fy_token_create_rl(
+		fyp->recycled_token_list,  FYTT_SCALAR, &fyp->last_event_handle, FYSS_PLAIN);
+	fyp_error_check(fyp, fye->scalar.value, err_out,
+			"failed to allocate SCALAR token()");
+	/* mark it as a special value */
+	fye->scalar.value->scalar.is_null = true;
+	return fyep;
+
+err_out:
+	return NULL;
+}
+
+int fy_parse_stream_start(struct fy_parser *fyp)
+{
+	fyp->indent = -2;
+	fyp->indent_line = -1;
+	fyp->starting_indent = -1;
+	fyp->generated_block_map = false;
+	fyp->last_was_comma = false;
+	fyp->flow = FYFT_NONE;
+	fyp->pending_complex_key_column = -1;
+
+	fy_parse_indent_list_recycle_all(fyp, &fyp->indent_stack);
+	fy_parse_simple_key_list_recycle_all(fyp, &fyp->simple_keys);
+	fy_parse_parse_state_log_list_recycle_all(fyp, &fyp->state_stack);
+	fy_parse_flow_list_recycle_all(fyp, &fyp->flow_stack);
+
+	fy_token_unref_rl(fyp->recycled_token_list, fyp->stream_end_token);
+	fyp->stream_end_token = NULL;
+
+	return 0;
+}
+
+int fy_parse_stream_end(struct fy_parser *fyp)
+{
+	fy_token_unref_rl(fyp->recycled_token_list, fyp->stream_end_token);
+	fyp->stream_end_token = NULL;
+
+	return 0;
+}
+
+static struct fy_eventp *fy_parse_internal(struct fy_parser *fyp)
+{
+	struct fy_eventp *fyep = NULL;
+	struct fy_event *fye = NULL;
+	struct fy_token *fyt = NULL;
+	struct fy_document_state *fyds = NULL;
+	bool is_block, is_seq, is_value, is_first, had_doc_end, had_directives;
+	enum fy_parser_state orig_state;
+	struct fy_token *version_directive;
+	struct fy_token_list tag_directives;
+	const struct fy_mark *fym;
+	struct fy_atom handle, *ev_handle;
+	struct fy_token *fytn;
+	char tbuf[16] __FY_DEBUG_UNUSED__;
+	int rc;
+
+	(void)tbuf;
+	version_directive = NULL;
+	fy_token_list_init(&tag_directives);
+
+	/* are we done? */
+	if (fyp->stream_error || fyp->state == FYPS_END) {
+		fy_parser_debug(fyp, "%s: NULL: fyp->stream_error=%s fyp->state=%s", __func__,
+			fyp->stream_error ? "true" : "false", state_txt[fyp->state]);
+		return NULL;
+	}
+
+	fyt = fy_scan_peek(fyp);
+#ifdef FY_DEVMODE
+	fy_parser_debug(fyp, "[%s]", state_txt[fyp->state]);
+	fyp_debug_dump_token(fyp, fyt, "scan_peek: ");
+#endif
+
+	if (!fyt && fy_reader_generates_events(fyp->reader)) {
+		fye = fy_reader_generate_next_event(fyp->reader);
+		if (!fye) {
+			rc = fy_reader_input_done(fyp->reader);
+			fyp_error_check(fyp, !rc, err_out,
+					"fy_parse_input_done() failed");
+
+			fy_parser_debug(fyp, "%s: NULL: !fyt && fy_reader_generates_events(fyp->reader)", __func__);
+			return NULL;
+		}
+		return container_of(fye, struct fy_eventp, e);
+	}
+
+	/* special case without an error message for start */
+	if (!fyt && fyp->state == FYPS_NONE) {
+		fy_parser_debug(fyp, "%s: NULL: !fyt && fyp->state==FYPS_NONE", __func__);
+		return NULL;
+	}
+
+	/* keep a copy of stream end */
+	if (fyt && fyt->type == FYTT_STREAM_END && !fyp->stream_end_token) {
+		fyp->stream_end_token = fy_token_ref(fyt);
+		fyp_parse_debug(fyp, "kept copy of STRM-");
+	}
+
+	/* keep on producing STREAM_END */
+	if (!fyt && fyp->stream_end_token) {
+		fyt = fyp->stream_end_token;
+		fy_token_list_add_tail(&fyp->queued_tokens, fyt);
+
+		fyp_parse_debug(fyp, "generated copy of STRM-");
+	}
+
+	fyp_error_check(fyp, fyt, err_out,
+			"failed to peek token");
+
+	assert(fyt->handle.fyi);
+
+	fyp_parse_debug(fyp, "[%s] <- %s", state_txt[fyp->state],
+			fy_token_dump_format(fyt, tbuf, sizeof(tbuf)));
+
+	is_first = false;
+	had_doc_end = false;
+
+	fyep = NULL;
+	fye = NULL;
+	ev_handle = NULL;
+
+	orig_state = fyp->state;
+	switch (fyp->state) {
+	case FYPS_NONE:
+		fy_parse_state_set(fyp, FYPS_STREAM_START);
+		/* fallthrough */
+
+	case FYPS_STREAM_START:
+
+		fyp_error_check(fyp, fyt->type == FYTT_STREAM_START, err_out,
+				"failed to get valid stream start token");
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_STREAM_START;
+
+		fye->stream_start.stream_start = fy_scan_remove(fyp, fyt);
+
+		rc = fy_parse_stream_start(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"stream start failed");
+
+		fy_parse_state_set(fyp, FYPS_IMPLICIT_DOCUMENT_START);
+
+		fyp->stream_has_content = false;
+
+		ev_handle = &fye->stream_start.stream_start->handle;
+		break;
+
+	case FYPS_IMPLICIT_DOCUMENT_START:
+
+		/* fallthrough */
+
+	case FYPS_DOCUMENT_START:
+
+		had_doc_end = false;
+
+		if (!fyp->stream_has_content && fyt->type != FYTT_STREAM_END)
+			fyp->stream_has_content = true;
+
+		/* remove all extra document end indicators */
+		while (fyt->type == FYTT_DOCUMENT_END) {
+
+			/* reset document has content flag */
+			fyp->document_has_content = false;
+			fyp->document_first_content_token = true;
+
+			/* explicit end indicator, no more directives checking */
+			fyp->had_directives = false;
+
+			fyt = fy_scan_remove_peek(fyp, fyt);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+			had_doc_end = true;
+		}
+
+		if (!fyp->current_document_state) {
+
+			rc = fy_reset_document_state(fyp);
+			fyp_error_check(fyp, !rc, err_out,
+					"fy_reset_document_state() failed");
+		}
+
+		fyds = fyp->current_document_state;
+		fyp_error_check(fyp, fyds, err_out,
+				"no current document state error");
+
+		/* process directives */
+		had_directives = false;
+		while (fyt->type == FYTT_VERSION_DIRECTIVE ||
+			fyt->type == FYTT_TAG_DIRECTIVE) {
+
+			had_directives = true;
+			fyp->had_directives = true;
+
+			if (fyt->type == FYTT_VERSION_DIRECTIVE) {
+
+				rc = fy_parse_version_directive(fyp, fy_scan_remove(fyp, fyt), false);
+				fyt = NULL;
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to fy_parse_version_directive()");
+			} else {
+				rc = fy_parse_tag_directive(fyp, fy_scan_remove(fyp, fyt), false);
+				fyt = NULL;
+
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to fy_parse_tag_directive()");
+			}
+
+			fyt = fy_scan_peek(fyp);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+		}
+
+		/* the end */
+		if (fyt->type == FYTT_STREAM_END) {
+
+			/* empty content is not allowed in JSON mode */
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					!fyp_json_mode(fyp) ||
+						fyp->stream_has_content, err_out,
+					"JSON does not allow empty root content");
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					!fyp->had_directives || fyp->document_has_content ||
+					!fyds->start_implicit, err_out,
+					"stream with directives without content");
+
+			rc = fy_parse_stream_end(fyp);
+			fyp_error_check(fyp, !rc, err_out,
+					"stream end failed");
+
+			fyep = fy_parse_eventp_alloc(fyp);
+			fyp_error_check(fyp, fyep, err_out,
+					"fy_eventp_alloc() failed!");
+			fye = &fyep->e;
+
+			fye->type = FYET_STREAM_END;
+			fye->stream_end.stream_end = fy_scan_remove(fyp, fyt);
+
+			fy_parse_state_set(fyp,
+				fy_parse_have_more_inputs(fyp) ? FYPS_NONE : FYPS_END);
+
+			ev_handle = &fye->stream_end.stream_end->handle;
+			break;
+		}
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		/* document start */
+		fye->type = FYET_DOCUMENT_START;
+		fye->document_start.document_start = NULL;
+		fye->document_start.document_state = NULL;
+
+		if (!(fyp->state == FYPS_IMPLICIT_DOCUMENT_START || had_doc_end || fyt->type == FYTT_DOCUMENT_START)) {
+			fyds = fyp->current_document_state;
+
+			/* not BLOCK_MAPPING_START */
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					fyt->type == FYTT_BLOCK_MAPPING_START, err_out,
+					"missing document start");
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					fyds->start_implicit ||
+					fyds->start_mark.line != fy_token_start_line(fyt), err_out,
+					"invalid mapping starting at --- line");
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					false, err_out,
+					"invalid mapping in plain multiline");
+		}
+
+		fym = fy_token_start_mark(fyt);
+		if (fym)
+			fyds->start_mark = *fym;
+		else
+			memset(&fyds->start_mark, 0, sizeof(fyds->start_mark));
+
+		if (fyt->type != FYTT_DOCUMENT_START) {
+
+			/* copy atom from the token and set to zero size at start */
+			handle = fyt->handle;
+			handle.end_mark = handle.start_mark;
+			fy_atom_reset_storage_hints(&handle);
+
+			fye->document_start.document_start = fy_token_create_rl(
+					fyp->recycled_token_list, FYTT_DOCUMENT_START, &handle);
+			fyp_error_check(fyp, fye->document_start.document_start, err_out,
+					"failed to allocate DOCUMENT_START token()");
+
+			fyds->start_implicit = true;
+			fyp_parse_debug(fyp, "document_start_implicit=true");
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					!had_directives, err_out,
+					"missing required document start indicator after directives");
+
+			fy_parse_state_set(fyp, FYPS_BLOCK_NODE);
+		} else {
+			fye->document_start.document_start = fy_scan_remove(fyp, fyt);
+
+			fyds->start_implicit = false;
+			fyp_parse_debug(fyp, "document_start_implicit=false");
+
+			fy_parse_state_set(fyp, FYPS_DOCUMENT_CONTENT);
+		}
+
+		rc = fy_parse_state_push(fyp, FYPS_DOCUMENT_END);
+		fyp_error_check(fyp, !rc, err_out,
+				"failed to fy_parse_state_push()");
+
+		// update document state with json mode
+		fyds->json_mode = fyp_json_mode(fyp);
+		fye->document_start.document_state = fy_document_state_ref(fyds);
+		fye->document_start.implicit = fyds->start_implicit;
+
+		/* update the handle of the document start token */
+		fytn = fyds->fyt_ds;
+		fyds->fyt_ds = fy_token_ref(fye->document_start.document_start);
+		fy_token_unref(fytn);
+
+		ev_handle = &fye->document_start.document_start->handle;
+		break;
+
+	case FYPS_DOCUMENT_END:
+
+		fyds = fyp->current_document_state;
+		fyp_error_check(fyp, fyds, err_out,
+				"no current document state error");
+
+		if (fyt && (fyt->type == FYTT_VERSION_DIRECTIVE ||
+			    fyt->type == FYTT_TAG_DIRECTIVE)) {
+			int cmpval = fy_document_state_version_compare(fyds, fy_version_make(1, 1));
+
+			fyp_scan_debug(fyp, "version %d.%d %s %d.%d\n",
+				fyds->version.major, fyds->version.minor,
+				cmpval == 0 ? "=" : cmpval > 0 ? ">" : "<",
+				1, 1);
+
+			/* YAML 1.1 allows directives without document end */
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				cmpval <= 0, err_out,
+				"missing explicit document end marker before directive(s)");
+
+		}
+
+		fym = fy_token_end_mark(fyt);
+		if (fym)
+			fyds->end_mark = *fym;
+		else
+			memset(&fyds->end_mark, 0, sizeof(fyds->end_mark));
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		/* document end */
+		fye->type = FYET_DOCUMENT_END;
+		if (fyt->type == FYTT_DOCUMENT_END) {
+
+			handle = fyt->handle;
+			fy_atom_reset_storage_hints(&handle);
+
+			fye->document_end.document_end = fy_token_create_rl(
+					fyp->recycled_token_list, FYTT_DOCUMENT_END, &handle);
+			fyp_error_check(fyp, fye->document_end.document_end, err_out,
+					"failed to allocate DOCUMENT_END token()");
+			fyds->end_implicit = false;
+
+			/* reset document has content flag */
+			fyp->document_has_content = false;
+			fyp->document_first_content_token = true;
+
+			/* reset directives */
+			fyp->had_directives = false;
+
+		} else {
+
+			handle = fyt->handle;
+			handle.end_mark = handle.start_mark;
+			fy_atom_reset_storage_hints(&handle);
+
+			fye->document_end.document_end = fy_token_create_rl(
+					fyp->recycled_token_list, FYTT_DOCUMENT_END, &handle);
+			fyp_error_check(fyp, fye->document_end.document_end, err_out,
+					"failed to allocate DOCUMENT_END token()");
+			fyds->end_implicit = true;
+		}
+
+		fye->document_end.implicit = fyds->end_implicit;
+
+		if (!fyp->next_single_document) {
+			/* multi document mode */
+			fy_parse_state_set(fyp, FYPS_DOCUMENT_START);
+			fyp->had_directives = false;
+
+			/* and reset document state */
+			rc = fy_reset_document_state(fyp);
+			fyp_error_check(fyp, !rc, err_out,
+					"fy_reset_document_state() failed");
+		} else {
+			/* single document mode */
+			fyp->next_single_document = false;
+
+			fy_parse_state_set(fyp, FYPS_SINGLE_DOCUMENT_END);
+		}
+
+		ev_handle = &fye->document_end.document_end->handle;
+		break;
+
+	case FYPS_DOCUMENT_CONTENT:
+
+		if (fyt->type == FYTT_VERSION_DIRECTIVE ||
+		    fyt->type == FYTT_TAG_DIRECTIVE ||
+		    fyt->type == FYTT_DOCUMENT_START ||
+		    fyt->type == FYTT_DOCUMENT_END ||
+		    fyt->type == FYTT_STREAM_END) {
+
+			if (fyt->type == FYTT_DOCUMENT_START ||
+			    fyt->type == FYTT_DOCUMENT_END) {
+				fyp->document_has_content = false;
+				fyp->document_first_content_token = true;
+				fyp->had_directives = false;
+			}
+
+			fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+			fyep = fy_parse_empty_scalar(fyp);
+			fyp_error_check(fyp, fyep, err_out,
+					"fy_parse_empty_scalar() failed");
+			break;
+		}
+
+		fyp->document_has_content = true;
+		fyp_parse_debug(fyp, "document has content now");
+		/* fallthrough */
+
+	case FYPS_BLOCK_NODE:
+
+		fyep = fy_parse_node(fyp, fyt,
+				fyp->state == FYPS_BLOCK_NODE ||
+				fyp->state == FYPS_DOCUMENT_CONTENT);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_parse_node() failed");
+		break;
+
+	case FYPS_BLOCK_SEQUENCE_FIRST_ENTRY:
+		is_first = true;
+		/* fallthrough */
+
+	case FYPS_BLOCK_SEQUENCE_ENTRY:
+	case FYPS_INDENTLESS_SEQUENCE_ENTRY:
+
+		if ((fyp->state == FYPS_BLOCK_SEQUENCE_ENTRY ||
+		     fyp->state == FYPS_BLOCK_SEQUENCE_FIRST_ENTRY) &&
+		    !(fyt->type == FYTT_BLOCK_ENTRY ||
+		      fyt->type == FYTT_BLOCK_END)) {
+
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					!(fyt->type == FYTT_SCALAR), err_out,
+					"invalid scalar at the end of block sequence");
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					!(fyt->type == FYTT_BLOCK_SEQUENCE_START), err_out,
+					"wrongly indented sequence item");
+
+			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+					false, err_out,
+					"did not find expected '-' indicator");
+		}
+
+		if (fyt->type == FYTT_BLOCK_ENTRY) {
+
+			/* BLOCK entry */
+			fyt = fy_scan_remove_peek(fyp, fyt);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+			/* check whether it's a sequence entry or not */
+			is_seq = fyt->type != FYTT_BLOCK_ENTRY && fyt->type != FYTT_BLOCK_END;
+			if (!is_seq && fyp->state == FYPS_INDENTLESS_SEQUENCE_ENTRY)
+				is_seq = fyt->type != FYTT_KEY && fyt->type != FYTT_VALUE;
+
+			if (is_seq) {
+				rc = fy_parse_state_push(fyp, fyp->state);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, true);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+			fy_parse_state_set(fyp, FYPS_BLOCK_SEQUENCE_ENTRY);
+
+			fyep = fy_parse_empty_scalar(fyp);
+			fyp_error_check(fyp, fyep, err_out,
+					"fy_parse_empty_scalar() failed");
+			break;
+		}
+
+		/* FYTT_BLOCK_END */
+		fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_SEQUENCE_END;
+		if (orig_state == FYPS_INDENTLESS_SEQUENCE_ENTRY) {
+
+			/* allocate and copy in place */
+			fytn = fy_token_alloc_rl(fyp->recycled_token_list);
+			fyp_error_check(fyp, fytn, err_out,
+					"fy_token_alloc_rl() failed!");
+			fytn->type = FYTT_BLOCK_END;
+			fytn->handle = fyt->handle;
+			fytn->handle.end_mark = fytn->handle.start_mark;	/* no extent */
+			fy_input_ref(fytn->handle.fyi);
+
+			fye->sequence_end.sequence_end = fytn;
+		} else
+			fye->sequence_end.sequence_end = fy_scan_remove(fyp, fyt);
+
+		ev_handle = &fye->sequence_end.sequence_end->handle;
+		break;
+
+	case FYPS_BLOCK_MAPPING_FIRST_KEY:
+		is_first = true;
+		/* fallthrough */
+
+	case FYPS_BLOCK_MAPPING_KEY:
+
+		if (!(fyt->type == FYTT_KEY || fyt->type == FYTT_BLOCK_END || fyt->type == FYTT_STREAM_END)) {
+
+			if (fyt->type == FYTT_SCALAR)
+				FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+						!fyp->simple_key_allowed && !fyp->flow_level && fy_parse_peek(fyp) == ':' ?
+							"invalid block mapping key on same line as previous key" :
+							"invalid value after mapping");
+			else if (fyt->type == FYTT_BLOCK_SEQUENCE_START)
+				FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+						"wrong indendation in sequence while in mapping");
+			else if (fyt->type == FYTT_ANCHOR)
+				FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+						"two anchors for a single value while in mapping");
+			else if (fyt->type == FYTT_BLOCK_MAPPING_START)
+				FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+						!fyp->flow_level && fyp->last_block_mapping_key_line == fy_token_start_line(fyt) ?
+							"invalid nested block mapping on the same line" :
+							"invalid indentation in mapping");
+			else if (fyt->type == FYTT_ALIAS)
+				FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+						"invalid combination of anchor plus alias");
+			else
+				FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+						"did not find expected key");
+			goto err_out;
+		}
+
+		if (fyt->type == FYTT_KEY) {
+
+			fyp->last_block_mapping_key_line = fy_token_end_line(fyt);
+
+			/* KEY entry */
+			fyt = fy_scan_remove_peek(fyp, fyt);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+			/* check whether it's a block entry or not */
+			is_block = fyt->type != FYTT_KEY && fyt->type != FYTT_VALUE &&
+				fyt->type != FYTT_BLOCK_END;
+
+			if (is_block) {
+				rc = fy_parse_state_push(fyp, FYPS_BLOCK_MAPPING_VALUE);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, true);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+			fy_parse_state_set(fyp, FYPS_BLOCK_MAPPING_VALUE);
+
+			fyep = fy_parse_empty_scalar(fyp);
+			fyp_error_check(fyp, fyep, err_out,
+					"fy_parse_empty_scalar() failed");
+			break;
+		}
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		/* FYTT_BLOCK_END */
+		fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+		fye->type = FYET_MAPPING_END;
+		fye->mapping_end.mapping_end = fy_scan_remove(fyp, fyt);
+
+		ev_handle = &fye->mapping_end.mapping_end->handle;
+		break;
+
+	case FYPS_BLOCK_MAPPING_VALUE:
+
+		if (fyt->type == FYTT_VALUE) {
+
+			/* VALUE entry */
+			fyt = fy_scan_remove_peek(fyp, fyt);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+			/* check whether it's a block entry or not */
+			is_value = fyt->type != FYTT_KEY && fyt->type != FYTT_VALUE &&
+				fyt->type != FYTT_BLOCK_END;
+
+			if (is_value) {
+				rc = fy_parse_state_push(fyp, FYPS_BLOCK_MAPPING_KEY);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, true);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+		}
+
+		fy_parse_state_set(fyp, FYPS_BLOCK_MAPPING_KEY);
+
+		fyep = fy_parse_empty_scalar(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_parse_empty_scalar() failed");
+		break;
+
+	case FYPS_FLOW_SEQUENCE_FIRST_ENTRY:
+		is_first = true;
+		/* fallthrough */
+
+	case FYPS_FLOW_SEQUENCE_ENTRY:
+
+		if (fyt->type != FYTT_FLOW_SEQUENCE_END &&
+		    fyt->type != FYTT_STREAM_END) {
+
+			if (!is_first) {
+				FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+						fyt->type == FYTT_FLOW_ENTRY, err_out,
+						"missing comma in flow %s",
+							fyp->state == FYPS_FLOW_SEQUENCE_ENTRY ?
+								"sequence" : "mapping");
+
+				fyt = fy_scan_remove_peek(fyp, fyt);
+				fyp_error_check(fyp, fyt, err_out,
+						"failed to peek token");
+#ifdef FY_DEVMODE
+				fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+			}
+
+			if (fyt->type == FYTT_KEY) {
+				fy_parse_state_set(fyp, FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_KEY);
+
+				fyep = fy_parse_eventp_alloc(fyp);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_eventp_alloc() failed!");
+				fye = &fyep->e;
+
+				/* convert KEY token to either block or flow mapping start */
+				if (!fyt->key.flow_level)
+					fyt->type = FYTT_BLOCK_MAPPING_START;
+				else
+					fyt->type = FYTT_FLOW_MAPPING_START;
+
+				fye->type = FYET_MAPPING_START;
+				fye->mapping_start.anchor = NULL;
+				fye->mapping_start.tag = NULL;
+				fye->mapping_start.mapping_start = fy_scan_remove(fyp, fyt);
+
+				ev_handle = &fye->mapping_start.mapping_start->handle;
+				break;
+			}
+
+			if (fyt->type != FYTT_FLOW_SEQUENCE_END) {
+				rc = fy_parse_state_push(fyp, FYPS_FLOW_SEQUENCE_ENTRY);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, false);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+		}
+
+		if (fyt->type == FYTT_STREAM_END && fyp->flow_level) {
+			FYP_TOKEN_ERROR(fyp, fyt, FYEM_PARSE,
+					"flow sequence without a closing bracket");
+			goto err_out;
+		}
+
+		/* FYTT_FLOW_SEQUENCE_END */
+		fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_SEQUENCE_END;
+		fye->sequence_end.sequence_end = fy_scan_remove(fyp, fyt);
+
+		ev_handle = &fye->sequence_end.sequence_end->handle;
+		break;
+
+	case FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_KEY:
+		if (fyt->type != FYTT_VALUE && fyt->type != FYTT_FLOW_ENTRY &&
+		    fyt->type != FYTT_FLOW_SEQUENCE_END) {
+			rc = fy_parse_state_push(fyp, FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE);
+			fyp_error_check(fyp, !rc, err_out,
+					"failed to push state");
+
+			fyep = fy_parse_node(fyp, fyt, false);
+			fyp_error_check(fyp, fyep, err_out,
+					"fy_parse_node() failed");
+			break;
+		}
+
+		/* empty keys are not allowed in JSON mode */
+		FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				!fyp_json_mode(fyp), err_out,
+				"JSON does not allow empty keys of a mapping");
+
+		fy_parse_state_set(fyp, FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE);
+
+		fyep = fy_parse_empty_scalar(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_parse_empty_scalar() failed");
+		break;
+
+	case FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE:
+		if (fyt->type == FYTT_VALUE) {
+			fyt = fy_scan_remove_peek(fyp, fyt);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+			if (fyt->type != FYTT_FLOW_ENTRY && fyt->type != FYTT_FLOW_SEQUENCE_END) {
+				rc = fy_parse_state_push(fyp, FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_END);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, false);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+		}
+
+		/* empty values are not allowed in JSON mode */
+		FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				!fyp_json_mode(fyp), err_out,
+				"JSON does not allow empty values in a mapping");
+
+		fy_parse_state_set(fyp, FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_END);
+
+		fyep = fy_parse_empty_scalar(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_parse_empty_scalar() failed");
+		break;
+
+	case FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_END:
+		fy_parse_state_set(fyp, FYPS_FLOW_SEQUENCE_ENTRY);
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_MAPPING_END;
+
+		/* allocate and copy in place */
+		fytn = fy_token_alloc_rl(fyp->recycled_token_list);
+		fyp_error_check(fyp, fytn, err_out,
+				"fy_token_alloc_rl() failed!");
+		fytn->type = FYTT_BLOCK_END;
+		fytn->handle = fyt->handle;
+		fytn->handle.end_mark = fytn->handle.start_mark;	/* no extent */
+		fy_input_ref(fytn->handle.fyi);
+
+		fye->mapping_end.mapping_end = fytn;
+
+		ev_handle = &fye->mapping_end.mapping_end->handle;
+		break;
+
+	case FYPS_FLOW_MAPPING_FIRST_KEY:
+		is_first = true;
+		/* fallthrough */
+
+	case FYPS_FLOW_MAPPING_KEY:
+		if (fyt->type != FYTT_FLOW_MAPPING_END) {
+
+			if (!is_first) {
+				FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+						fyt->type == FYTT_FLOW_ENTRY, err_out,
+						"missing comma in flow %s",
+							fyp->state == FYPS_FLOW_SEQUENCE_ENTRY ?
+								"sequence" : "mapping");
+
+				fyt = fy_scan_remove_peek(fyp, fyt);
+				fyp_error_check(fyp, fyt, err_out,
+						"failed to peek token");
+#ifdef FY_DEVMODE
+				fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+			}
+
+			if (fyt->type == FYTT_KEY) {
+				/* next token */
+				fyt = fy_scan_remove_peek(fyp, fyt);
+				fyp_error_check(fyp, fyt, err_out,
+						"failed to peek token");
+#ifdef FY_DEVMODE
+				fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+				/* JSON key checks */
+				FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+						!fyp_json_mode(fyp) || fyt->type != FYTT_VALUE,
+						err_out, "JSON does not allow empty keys");
+				FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+						!fyp_json_mode(fyp) ||
+							(fyt->type == FYTT_SCALAR &&
+							 fyt->scalar.style == FYSS_DOUBLE_QUOTED),
+						err_out, "JSON only allows double quoted scalar keys");
+
+				if (fyt->type != FYTT_VALUE &&
+				    fyt->type != FYTT_FLOW_ENTRY &&
+				    fyt->type != FYTT_FLOW_MAPPING_END) {
+
+					rc = fy_parse_state_push(fyp, FYPS_FLOW_MAPPING_VALUE);
+					fyp_error_check(fyp, !rc, err_out,
+							"failed to push state");
+
+					fyep = fy_parse_node(fyp, fyt, false);
+					fyp_error_check(fyp, fyep, err_out,
+							"fy_parse_node() failed");
+					break;
+				}
+
+				fy_parse_state_set(fyp, FYPS_FLOW_MAPPING_VALUE);
+
+				fyep = fy_parse_empty_scalar(fyp);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_empty_scalar() failed");
+				break;
+			}
+
+			if (fyt->type != FYTT_FLOW_MAPPING_END) {
+
+				/* empty values are not allowed in JSON mode */
+				FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+						!fyp_json_mode(fyp), err_out,
+						"JSON does not allow empty values in a mapping");
+
+				rc = fy_parse_state_push(fyp, FYPS_FLOW_MAPPING_EMPTY_VALUE);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, false);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+		}
+
+		/* FYTT_FLOW_MAPPING_END */
+		fy_parse_state_set(fyp, fy_parse_state_pop(fyp));
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out, "fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_MAPPING_END;
+		fye->mapping_end.mapping_end = fy_scan_remove(fyp, fyt);
+
+		ev_handle = &fye->mapping_end.mapping_end->handle;
+		break;
+
+	case FYPS_FLOW_MAPPING_VALUE:
+		if (fyt->type == FYTT_VALUE) {
+			/* next token */
+			fyt = fy_scan_remove_peek(fyp, fyt);
+			fyp_error_check(fyp, fyt, err_out,
+					"failed to peek token");
+#ifdef FY_DEVMODE
+			fyp_debug_dump_token(fyp, fyt, "next: ");
+#endif
+
+			if (fyt->type != FYTT_FLOW_ENTRY &&
+			    fyt->type != FYTT_FLOW_MAPPING_END) {
+
+				rc = fy_parse_state_push(fyp, FYPS_FLOW_MAPPING_KEY);
+				fyp_error_check(fyp, !rc, err_out,
+						"failed to push state");
+
+				fyep = fy_parse_node(fyp, fyt, false);
+				fyp_error_check(fyp, fyep, err_out,
+						"fy_parse_node() failed");
+				break;
+			}
+		}
+
+		/* empty values are not allowed in JSON mode */
+		FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				!fyp_json_mode(fyp), err_out,
+				"JSON does not allow empty values in a mapping");
+
+		fy_parse_state_set(fyp, FYPS_FLOW_MAPPING_KEY);
+
+		fyep = fy_parse_empty_scalar(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_parse_empty_scalar() failed");
+		break;
+
+	case FYPS_FLOW_MAPPING_EMPTY_VALUE:
+		fy_parse_state_set(fyp, FYPS_FLOW_MAPPING_KEY);
+
+		fyep = fy_parse_empty_scalar(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_parse_empty_scalar() failed");
+		break;
+
+	case FYPS_SINGLE_DOCUMENT_END:
+
+		FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
+				fyt->type == FYTT_STREAM_END, err_out,
+				"Did not find expected stream end");
+
+		rc = fy_parse_stream_end(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"stream end failed");
+
+		fyep = fy_parse_eventp_alloc(fyp);
+		fyp_error_check(fyp, fyep, err_out,
+				"fy_eventp_alloc() failed!");
+		fye = &fyep->e;
+
+		fye->type = FYET_STREAM_END;
+		fye->stream_end.stream_end = fy_scan_remove(fyp, fyt);
+
+		fy_parse_state_set(fyp,
+			fy_parse_have_more_inputs(fyp) ? FYPS_NONE : FYPS_END);
+
+		ev_handle = &fye->stream_end.stream_end->handle;
+		break;
+
+	case FYPS_END:
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+	assert(fyep);
+
+	if (ev_handle) {
+		fy_input_unref(fyp->last_event_handle.fyi);
+		fyp->last_event_handle = *ev_handle;
+		fyp->last_event_handle.start_mark = fyp->last_event_handle.end_mark;
+		fy_atom_reset_storage_hints(&handle);
+		fy_input_ref(fyp->last_event_handle.fyi);
+	}
+
+	return fyep;
+
+err_out:
+	fy_token_unref_rl(fyp->recycled_token_list, version_directive);
+	fy_token_list_unref_all_rl(fyp->recycled_token_list, &tag_directives);
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyp->stream_error = true;
+
+	fy_parser_debug(fyp, "%s: NULL: stream_error=true", __func__);
+	return NULL;
+}
+
+const char *fy_event_type_txt[] = {
+	[FYET_NONE]		= "NONE",
+	[FYET_STREAM_START]	= "+STR",
+	[FYET_STREAM_END]	= "-STR",
+	[FYET_DOCUMENT_START]	= "+DOC",
+	[FYET_DOCUMENT_END]	= "-DOC",
+	[FYET_MAPPING_START]	= "+MAP",
+	[FYET_MAPPING_END]	= "-MAP",
+	[FYET_SEQUENCE_START]	= "+SEQ",
+	[FYET_SEQUENCE_END]	= "-SEQ",
+	[FYET_SCALAR]		= "=VAL",
+	[FYET_ALIAS]		= "=ALI",
+};
+
+const char *fy_event_type_get_text(enum fy_event_type type)
+{
+	if ((unsigned int)type >= ARRAY_SIZE(fy_event_type_txt))
+		return "*BAD";
+	return fy_event_type_txt[type];
+}
+
+#ifndef NDEBUG
+
+static void fy_parse_dump_eventp(struct fy_parser *fyp, struct fy_eventp *fyep, const char *pfx)
+{
+	char *mbuf = NULL;
+
+	if (!fyep)
+		return;
+
+	/* perform the enable tests early to avoid the overhead */
+	if ((FYET_DEBUG >> FYDF_LEVEL_SHIFT) < fyp->diag->cfg.level)
+		return;
+
+	mbuf = fy_event_to_string(&fyep->e);
+	if (!mbuf)
+		return;
+
+	fyp_parse_debug(fyp, "%s%s", pfx, mbuf);
+	free(mbuf);
+}
+
+#else
+static inline void
+fy_parse_dump_eventp(struct fy_parser *fyp, struct fy_eventp *fyep, const char *pfx) { }
+#endif
+
+struct fy_eventp *fy_parse_private(struct fy_parser *fyp)
+{
+	struct fy_eventp *fyep = NULL;
+
+	fyep = fy_parse_internal(fyp);
+	fy_parse_dump_eventp(fyp, fyep, "gen> ");
+
+	return fyep;
+}
+
+struct fy_parser *fy_parser_create(const struct fy_parse_cfg *cfg)
+{
+	struct fy_parser *fyp;
+	int rc;
+
+	fyp = malloc(sizeof(*fyp));
+	if (!fyp)
+		return NULL;
+
+	rc = fy_parse_setup(fyp, cfg);
+	if (rc) {
+		free(fyp);
+		return NULL;
+	}
+
+	return fyp;
+}
+
+void fy_parser_destroy(struct fy_parser *fyp)
+{
+	if (!fyp)
+		return;
+
+	fy_parse_cleanup(fyp);
+
+	free(fyp);
+}
+
+const struct fy_parse_cfg *fy_parser_get_cfg(struct fy_parser *fyp)
+{
+	if (!fyp)
+		return NULL;
+	return &fyp->cfg;
+}
+
+struct fy_diag *fy_parser_get_diag(struct fy_parser *fyp)
+{
+	if (!fyp || !fyp->diag)
+		return NULL;
+	return fy_diag_ref(fyp->diag);
+}
+
+int fy_parser_set_diag(struct fy_parser *fyp, struct fy_diag *diag)
+{
+	struct fy_diag_cfg dcfg;
+
+	if (!fyp)
+		return -1;
+
+	/* default? */
+	if (!diag) {
+		fy_diag_cfg_default(&dcfg);
+		diag = fy_diag_create(&dcfg);
+		if (!diag)
+			return -1;
+	}
+
+	fy_diag_unref(fyp->diag);
+	fyp->diag = fy_diag_ref(diag);
+
+	return 0;
+}
+
+static void fy_parse_input_reset(struct fy_parser *fyp)
+{
+	struct fy_input *fyi, *fyin;
+
+	for (fyi = fy_input_list_head(&fyp->queued_inputs); fyi; fyi = fyin) {
+		fyin = fy_input_next(&fyp->queued_inputs, fyi);
+		fy_input_unref(fyi);
+	}
+	fy_input_list_init(&fyp->queued_inputs);
+
+	fy_parse_parse_state_log_list_recycle_all(fyp, &fyp->state_stack);
+
+	fyp->stream_start_produced = false;
+	fyp->stream_end_produced = false;
+	fyp->stream_end_reached = false;
+	fyp->state = FYPS_NONE;
+
+	fyp->pending_complex_key_column = -1;
+	fyp->last_block_mapping_key_line = -1;
+
+	fy_input_unref(fyp->last_event_handle.fyi);
+	fy_atom_reset(&fyp->last_event_handle);
+}
+
+int fy_parser_set_input_file(struct fy_parser *fyp, const char *file)
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || !file)
+		return -1;
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	if (!strcmp(file, "-")) {
+		fyic.type = fyit_stream;
+		fyic.stream.name = "stdin";
+		fyic.stream.fp = stdin;
+	} else {
+		fyic.type = fyit_file;
+		fyic.file.filename = file;
+	}
+	fyic.ignore_stdio = !!(fyp->cfg.flags & FYPCF_DISABLE_BUFFERING);
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_set_string(struct fy_parser *fyp, const char *str, size_t len)
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || !str)
+		return -1;
+
+	if (len == (size_t)-1)
+		len = strlen(str);
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	fyic.type = fyit_memory;
+	fyic.memory.data = str;
+	fyic.memory.size = len;
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_set_malloc_string(struct fy_parser *fyp, char *str, size_t len)
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || !str)
+		return -1;
+
+	if (len == (size_t)-1)
+		len = strlen(str);
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	fyic.type = fyit_alloc;
+	fyic.alloc.data = str;
+	fyic.alloc.size = len;
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_set_input_fp(struct fy_parser *fyp, const char *name, FILE *fp)
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || !fp)
+		return -1;
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	fyic.type = fyit_stream;
+	fyic.stream.name = name ? name : "<stream>";
+	fyic.stream.fp = fp;
+	fyic.ignore_stdio = !!(fyp->cfg.flags & FYPCF_DISABLE_BUFFERING);
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_set_input_callback(struct fy_parser *fyp, void *user,
+		ssize_t (*callback)(void *user, void *buf, size_t count))
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || !callback)
+		return -1;
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	fyic.type = fyit_callback;
+	fyic.userdata = user;
+	fyic.callback.input = callback;
+	fyic.ignore_stdio = !!(fyp->cfg.flags & FYPCF_DISABLE_BUFFERING);
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_set_input_fd(struct fy_parser *fyp, int fd)
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || fd < 0)
+		return -1;
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	fyic.type = fyit_fd;
+	fyic.fd.fd = fd;
+	fyic.ignore_stdio = !!(fyp->cfg.flags & FYPCF_DISABLE_BUFFERING);
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_set_document_iterator(struct fy_parser *fyp, enum fy_parser_event_generator_flags flags,
+				    struct fy_document_iterator *fydi)
+{
+	struct fy_input_cfg fyic;
+	int rc;
+
+	if (!fyp || !fydi)
+		return -1;
+
+	memset(&fyic, 0, sizeof(fyic));
+
+	fyic.type = fyit_dociter;
+	fyic.dociter.flags = flags;
+	fyic.dociter.fydi = fydi;
+	fyic.dociter.owns_iterator = false;
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, fyp->state == FYPS_NONE || fyp->state == FYPS_END,
+			err_out, "parser cannot be reset at state '%s'",
+				state_txt[fyp->state]);
+
+	fy_parse_input_reset(fyp);
+
+	rc = fy_parse_input_append(fyp, &fyic);
+	fyp_error_check(fyp, !rc, err_out_rc,
+			"fy_parse_input_append() failed");
+
+	return 0;
+err_out:
+	rc = -1;
+err_out_rc:
+	return rc;
+}
+
+int fy_parser_reset(struct fy_parser *fyp)
+{
+	if (!fyp)
+		return -1;
+
+	fy_parse_input_reset(fyp);
+
+	fy_reader_reset(fyp->reader);
+
+	fyp->next_single_document = false;
+	fyp->stream_error = false;
+	fyp->generated_block_map = false;
+	fyp->last_was_comma = false;
+	fyp->document_has_content = false;
+	fyp->document_first_content_token = false;
+	fyp->bare_document_only = false;
+	fyp->stream_has_content = false;
+	fyp->had_directives = false;
+
+	assert(fyp->diag);
+	fyp->diag->on_error = false;
+
+	fy_document_state_unref(fyp->current_document_state);
+	fyp->current_document_state = NULL;
+
+	fy_document_state_unref(fyp->default_document_state);
+	fyp->default_document_state = NULL;
+
+	fy_parse_streaming_aliases_reset(fyp);
+
+	fy_input_unref(fyp->last_event_handle.fyi);
+	fy_atom_reset(&fyp->last_event_handle);
+
+	fy_parse_indent_list_recycle_all(fyp, &fyp->indent_stack);
+	fy_parse_simple_key_list_recycle_all(fyp, &fyp->simple_keys);
+	fy_token_list_unref_all(&fyp->queued_tokens);
+
+	fy_parse_parse_state_log_list_recycle_all(fyp, &fyp->state_stack);
+	fy_parse_flow_list_recycle_all(fyp, &fyp->flow_stack);
+	fy_parse_streaming_alias_list_recycle_all(fyp, &fyp->streaming_aliases);
+
+	fy_token_unref_rl(fyp->recycled_token_list, fyp->stream_end_token);
+	fyp->stream_end_token = NULL;
+
+	return 0;
+}
+
+struct fy_event *fy_parser_parse(struct fy_parser *fyp)
+{
+	struct fy_eventp *fyep, *fyep2;
+	enum fy_composer_return ret;
+
+	if (!fyp)
+		return NULL;
+
+	if (fyp->fyep_peek) {
+		fyep = fyp->fyep_peek;
+		fyp->fyep_peek = NULL;
+		fy_parse_dump_eventp(fyp, fyep, "peek> ");
+		return &fyep->e;
+	}
+
+	if ((fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT) && fy_reader_get_mode(fyp->reader) != fyrm_json) {
+		fyep = fy_parser_parse_resolve_prolog(fyp);
+		if (fyep)
+			return &fyep->e;
+	}
+
+	fyep = fy_parse_private(fyp);
+	if (!fyep)
+		return NULL;
+
+	if ((fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT) && fy_reader_get_mode(fyp->reader) != fyrm_json) {
+		fyep2 = fy_parser_parse_resolve_epilog(fyp, fyep);
+		if (!fyep2)
+			return NULL;
+		fyep = fyep2;
+	}
+
+	if (fyp->fyc) {
+		ret = fy_composer_process_event(fyp->fyc, &fyep->e);
+		if (ret == FYCR_ERROR) {
+			fyp->stream_error = true;
+			fy_parse_eventp_recycle(fyp, fyep);
+			return NULL;
+		}
+		/* note that the stop should be handled by
+		 * an out of band mechanism */
+	}
+
+	return &fyep->e;
+}
+
+const struct fy_event *fy_parser_parse_peek(struct fy_parser *fyp)
+{
+	struct fy_event *fye;
+
+	if (!fyp->fyep_peek) {
+		fye = fy_parser_parse(fyp);
+		if (!fye)
+			return NULL;
+
+		fyp->fyep_peek = container_of(fye, struct fy_eventp, e);
+	}
+	return &fyp->fyep_peek->e;
+}
+
+int fy_parser_skip(struct fy_parser *fyp)
+{
+	struct fy_event *fye = 0;
+	enum fy_event_type start_type, end_type;
+	int nest, map_nest, seq_nest;
+
+	/* check that we start on a scalar/seq/map */
+	fye = fy_parser_parse(fyp);
+	if (!fye)
+		goto err_out;
+
+	start_type = fye->type;
+	fy_parser_event_free(fyp, fye);
+	fye = NULL;
+
+	if (start_type == FYET_SCALAR)
+		return 0;
+
+	map_nest = 0;
+	seq_nest = 0;
+	if (start_type == FYET_SEQUENCE_START) {
+		end_type = FYET_SEQUENCE_END;
+		seq_nest = 1;
+	} else if (start_type == FYET_MAPPING_START) {
+		end_type = FYET_MAPPING_END;
+		map_nest = 1;
+	} else
+		goto err_out;
+
+	nest = 1;
+	do {
+		fye = fy_parser_parse(fyp);
+		if (!fye)
+			goto err_out;
+
+		switch (fye->type) {
+		case FYET_SEQUENCE_START:
+			seq_nest++;
+			break;
+		case FYET_MAPPING_START:
+			map_nest++;
+			break;
+		case FYET_SEQUENCE_END:
+			seq_nest--;
+			break;
+		case FYET_MAPPING_END:
+			map_nest--;
+			break;
+		default:
+			break;
+		}
+
+		if (fye->type == start_type)
+			nest++;
+		else if (fye->type == end_type)
+			nest--;
+
+		if (map_nest < 0 || seq_nest < 0) {
+			fy_event_report(fyp, fye, FYEP_VALUE, FYET_ERROR,
+					"unbalanced collection while skipping");
+			goto err_out;
+		}
+
+		fy_parser_event_free(fyp, fye);
+		fye = NULL;
+
+	} while (nest > 0);
+
+	return 0;
+
+err_out:
+	fy_parser_event_free(fyp, fye);
+	return -1;
+}
+
+bool fy_parser_get_stream_error(struct fy_parser *fyp)
+{
+	if (!fyp)
+		return true;
+
+	return fyp->stream_error;
+}
+
+enum fy_parse_cfg_flags fy_parser_get_cfg_flags(const struct fy_parser *fyp)
+{
+	if (!fyp)
+		return 0;
+
+	return fyp->cfg.flags;
+}
+
+struct fy_document_state *fy_parser_get_document_state(struct fy_parser *fyp)
+{
+	return fyp ? fyp->current_document_state : NULL;
+}
+
+static enum fy_composer_return
+parse_process_event(struct fy_composer *fyc, struct fy_path *path, struct fy_event *fye)
+{
+	struct fy_parser *fyp = fy_composer_get_cfg_userdata(fyc);
+
+	assert(fyp);
+	assert(fyp->fyc_cb);
+	return fyp->fyc_cb(fyp, fye, path, fyp->fyc_userdata);
+}
+
+static struct fy_document_builder *
+parse_create_document_builder(struct fy_composer *fyc)
+{
+	struct fy_parser *fyp = fy_composer_get_cfg_userdata(fyc);
+	struct fy_document_builder *fydb = NULL;
+	struct fy_document_builder_cfg cfg;
+	struct fy_document_state *fyds;
+	int rc;
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.parse_cfg = fyp->cfg;
+	cfg.diag = fy_diag_ref(fyp->diag);
+
+	fydb = fy_document_builder_create(&cfg);
+	fyp_error_check(fyp, fydb, err_out,
+			"fy_document_builder_create() failed\n");
+
+	/* start with this document state */
+	fyds = fy_parser_get_document_state(fyp);
+	rc = fy_document_builder_set_in_document(fydb, fyds, true);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_document_builder_set_in_document() failed\n");
+
+	return fydb;
+
+err_out:
+	fy_document_builder_destroy(fydb);
+	return NULL;
+}
+
+static const struct fy_composer_ops parser_composer_ops = {
+	.process_event = parse_process_event,
+	.create_document_builder = parse_create_document_builder,
+};
+
+int fy_parse_set_composer(struct fy_parser *fyp, fy_parse_composer_cb cb, void *userdata)
+{
+	struct fy_composer_cfg ccfg;
+	bool can_change_composer;
+
+	if (!fyp)
+		return -1;
+
+	can_change_composer = fyp->state == FYPS_NONE ||
+			      fyp->state == FYPS_END ||
+			      fyp->state == FYPS_DOCUMENT_START;
+
+	/* must not be in the middle of something */
+	fyp_error_check(fyp, can_change_composer, err_out,
+			"cannot change composer state at state '%s'", state_txt[fyp->state]);
+
+	/* clear */
+	if (!cb) {
+		if (fyp->fyc) {
+			fy_composer_destroy(fyp->fyc);
+			fyp->fyc = NULL;
+		}
+		fyp->fyc_cb = NULL;
+		fyp->fyc_userdata = NULL;
+		return 0;
+	}
+
+	/* already exists */
+	if (fyp->fyc) {
+		fyp->fyc_cb = cb;
+		fyp->fyc_userdata = userdata;
+		return 0;
+	}
+
+	/* prepare the composer configuration */
+	memset(&ccfg, 0, sizeof(ccfg));
+	ccfg.ops = &parser_composer_ops;
+	ccfg.userdata = fyp;
+	ccfg.diag = fy_parser_get_diag(fyp);
+	fyp->fyc = fy_composer_create(&ccfg);
+	fyp_error_check(fyp, fyp->fyc, err_out,
+			"fy_composer_create() failed");
+
+	fyp->fyc_cb = cb;
+	fyp->fyc_userdata = userdata;
+
+	return 0;
+err_out:
+	return -1;
+}
+
+static enum fy_composer_return fy_parse_compose_internal(struct fy_parser *fyp)
+{
+	struct fy_composer *fyc;
+	struct fy_document_iterator *fydi;
+	struct fy_event *fye;
+	struct fy_eventp *fyep;
+	struct fy_document *fyd = NULL;
+	enum fy_composer_return ret;
+
+	assert(fyp);
+
+	fyc = fyp->fyc;
+	assert(fyc);
+
+	/* simple, without resolution */
+	if (!(fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT)) {
+
+		ret = FYCR_OK_STOP;
+		while ((fyep = fy_parse_private(fyp)) != NULL) {
+			ret = fy_composer_process_event(fyc, &fyep->e);
+			fy_parse_eventp_recycle(fyp, fyep);
+			if (ret != FYCR_OK_CONTINUE)
+				break;
+		}
+		if (fyp->stream_error)
+			fy_composer_halt(fyc, FYCR_ERROR);
+
+		return ret;
+	}
+
+	fydi = fy_document_iterator_create();
+	fyp_error_check(fyp, fydi, err_out,
+			"fy_document_iterator_create() failed");
+
+	/* stream start event generation and processing */
+	fye = fy_document_iterator_stream_start(fydi);
+	fyp_error_check(fyp, fye, err_out,
+			"fy_document_iterator_stream_start() failed");
+	ret = fy_composer_process_event(fyc, fye);
+	fy_document_iterator_event_free(fydi, fye);
+	fye = NULL;
+	if (ret != FYCR_OK_CONTINUE)
+		goto out;
+
+	/* convert to document and then process the generator event stream it */
+	while ((fyd = fy_parse_load_document(fyp)) != NULL) {
+
+		/* document start event generation and processing */
+		fye = fy_document_iterator_document_start(fydi, fyd);
+		fyp_error_check(fyp, fye, err_out,
+				"fy_document_iterator_document_start() failed");
+		ret = fy_composer_process_event(fyc, fye);
+		fy_document_iterator_event_free(fydi, fye);
+		fye = NULL;
+		if (ret != FYCR_OK_CONTINUE)
+			goto out;
+
+		/* and now process the body */
+		ret = FYCR_OK_CONTINUE;
+		while ((fye = fy_document_iterator_body_next(fydi)) != NULL) {
+			ret = fy_composer_process_event(fyc, fye);
+			fy_document_iterator_event_free(fydi, fye);
+			fye = NULL;
+			if (ret != FYCR_OK_CONTINUE)
+				goto out;
+		}
+
+		/* document end event generation and processing */
+		fye = fy_document_iterator_document_end(fydi);
+		fyp_error_check(fyp, fye, err_out,
+				"fy_document_iterator_document_end() failed");
+		ret = fy_composer_process_event(fyc, fye);
+		fy_document_iterator_event_free(fydi, fye);
+		fye = NULL;
+		if (ret != FYCR_OK_CONTINUE)
+			goto out;
+
+		/* and destroy the document */
+		fy_parse_document_destroy(fyp, fyd);
+		fyd = NULL;
+	}
+
+	/* stream end event generation and processing */
+	fye = fy_document_iterator_stream_end(fydi);
+	fyp_error_check(fyp, fye, err_out,
+			"fy_document_iterator_stream_end() failed");
+	ret = fy_composer_process_event(fyc, fye);
+	fy_document_iterator_event_free(fydi, fye);
+	fye = NULL;
+	if (ret != FYCR_OK_CONTINUE)
+		goto out;
+
+out:
+	/* NULLs are OK */
+	fy_parse_document_destroy(fyp, fyd);
+	fy_document_iterator_destroy(fydi);
+	return ret;
+
+err_out:
+	ret = FYCR_ERROR;
+	goto out;
+}
+
+int fy_parse_compose(struct fy_parser *fyp, fy_parse_composer_cb cb, void *userdata)
+{
+	enum fy_composer_return ret;
+	int rc, rc_out;
+
+	if (!fyp || !cb)
+		return -1;
+
+	/* set the composer callback */
+	rc = fy_parse_set_composer(fyp, cb, userdata);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parse_set_composer() failed\n");
+
+	/* use the composer to parse */
+	ret = fy_parse_compose_internal(fyp);
+	/* on error set the stream error */
+	if (ret == FYCR_ERROR) {
+		fyp->stream_error = true;
+		rc_out = -1;
+	} else
+		rc_out = 0;
+
+	/* reset the parser; the composer clear must always succeed */
+	if (ret == FYCR_ERROR)
+		fy_parser_reset(fyp);
+
+	/* clear composer */
+	rc = fy_parse_set_composer(fyp, NULL, NULL);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parse_set_composer() failed\n");
+
+	return rc_out;
+
+err_out:
+	return -1;
+}
+
+struct fy_streaming_alias *
+fy_parser_streaming_alias_lookup(struct fy_parser *fyp, struct fy_token *fyt_anchor)
+{
+	struct fy_streaming_alias *fysa;
+
+	/* XXX todo hashing */
+	for (fysa = fy_streaming_alias_list_head(&fyp->streaming_aliases); fysa != NULL; fysa = fy_streaming_alias_next(&fyp->streaming_aliases, fysa)) {
+		if (fy_token_cmp(fyt_anchor, fysa->anchor) == 0)
+			return fysa;
+	}
+	return NULL;
+}
+
+struct fy_streaming_alias *
+fy_parser_streaming_alias_lookup_pivot(struct fy_parser *fyp, struct fy_streaming_alias *fysa_pivot, struct fy_token *fyt_anchor)
+{
+	struct fy_streaming_alias *fysa;
+
+	assert(fysa_pivot);
+	/* at first do forwards starting at the pivot */
+	for (fysa = fy_streaming_alias_next(&fyp->streaming_aliases, fysa_pivot); fysa != NULL; fysa = fy_streaming_alias_next(&fyp->streaming_aliases, fysa)) {
+		if (fysa->anchor && fy_token_cmp(fyt_anchor, fysa->anchor) == 0)
+			return fysa;
+	}
+	/* not found? do backwards (more recent) */
+	for (fysa = fy_streaming_alias_prev(&fyp->streaming_aliases, fysa_pivot); fysa != NULL; fysa = fy_streaming_alias_prev(&fyp->streaming_aliases, fysa)) {
+		if (fysa->anchor && fy_token_cmp(fyt_anchor, fysa->anchor) == 0)
+			return fysa;
+	}
+	return NULL;
+}
+
+struct fy_streaming_alias *
+fy_parse_streaming_alias_create(struct fy_parser *fyp, struct fy_token *fyt_anchor)
+{
+	struct fy_streaming_alias *fysa;
+
+	fysa = fy_parse_streaming_alias_alloc(fyp);
+	fyp_error_check(fyp, fysa != NULL, err_out,
+			"fy_parse_streaming_alias_alloc() failed!");
+	fysa->anchor = fyt_anchor;
+	fysa->collecting = false;
+	fysa->mapping_nest = 0;
+	fysa->sequence_nest = 0;
+	fy_eventp_list_init(&fysa->events);
+
+	return fysa;
+
+err_out:
+	return NULL;
+}
+
+void
+fy_parse_streaming_alias_clean(struct fy_parser *fyp, struct fy_streaming_alias *fysa)
+{
+	struct fy_eventp *fyep;
+
+	if (!fyp || !fysa)
+		return;
+
+	fy_token_unref(fysa->anchor);
+	fysa->anchor = NULL;
+	fysa->collecting = false;
+	fysa->mapping_nest = 0;
+	fysa->sequence_nest = 0;
+	while ((fyep = fy_eventp_list_pop(&fysa->events)) != NULL)
+		fy_parse_eventp_recycle(fyp, fyep);
+}
+
+void fy_parse_streaming_aliases_reset(struct fy_parser *fyp)
+{
+	struct fy_streaming_alias *fysa;
+	struct fy_eventp *fyep;
+
+	if (!fyp)
+		return;
+
+	while ((fysa = fy_streaming_alias_list_pop(&fyp->streaming_aliases)) != NULL) {
+		fy_parse_streaming_alias_clean(fyp, fysa);
+		fy_parse_streaming_alias_recycle(fyp, fysa);
+	}
+	if (fyp->sas.stack != NULL && fyp->sas.stack != fyp->sas.local)
+		free(fyp->sas.stack);
+	memset(&fyp->sas, 0, sizeof(fyp->sas));
+	if (fyp->cts.stack != NULL && fyp->cts.stack != fyp->cts.local)
+		free(fyp->cts.stack);
+	memset(&fyp->cts, 0, sizeof(fyp->cts));
+
+	while ((fyep = fy_eventp_list_pop(&fyp->mks.args)) != NULL)
+		fy_parse_eventp_recycle(fyp, fyep);
+	memset(&fyp->mks, 0, sizeof(fyp->mks));
+	fy_eventp_list_init(&fyp->mks.args);
+}
+
+struct fy_streaming_alias_state *
+fy_parse_streaming_alias_state_push(struct fy_parser *fyp, struct fy_streaming_alias *fysa)
+{
+	struct fy_streaming_alias_state *new_stack;
+	struct fy_streaming_alias_state *fysas;
+
+	/* if first one, just point to the local area */
+	if (fyp->sas.stack == NULL) {
+		fyp->sas.stack = fyp->sas.local;
+		fyp->sas.top = 0;
+		fyp->sas.alloc = ARRAY_SIZE(fyp->sas.local);
+	}
+	/* grow the stack if required */
+	if (fyp->sas.top >= fyp->sas.alloc) {
+		assert(fyp->sas.alloc > 0);
+		assert(fyp->sas.stack);
+		new_stack = malloc(sizeof(*new_stack) * fyp->sas.alloc * 2);
+		fyp_error_check(fyp, new_stack != NULL, err_out,
+				"realloc() failed!");
+		memcpy(new_stack, fyp->sas.stack, sizeof(*new_stack) * fyp->sas.alloc);
+		fyp->sas.alloc *= 2;
+		if (fyp->sas.stack != fyp->sas.local)
+			free(fyp->sas.stack);
+		fyp->sas.stack = new_stack;
+	}
+	/* finally push it */
+	fysas = &fyp->sas.stack[fyp->sas.top++];
+
+	fysas->fysa = fysa;
+	fysas->next = fy_eventp_list_head(&fysa->events);
+
+	return fysas;
+err_out:
+	return NULL;
+}
+
+struct fy_streaming_alias_state *
+fy_parse_streaming_alias_state_pop(struct fy_parser *fyp)
+{
+	struct fy_streaming_alias_state *fysas;
+
+	if (fyp->sas.top <= 0)
+		return NULL;
+
+	fysas = &fyp->sas.stack[--fyp->sas.top];
+	fysas->fysa = NULL;
+	fysas->next = NULL;
+	if (fyp->sas.top <= 0)
+		return NULL;
+	return &fyp->sas.stack[fyp->sas.top - 1];
+}
+
+struct fy_streaming_alias_state *
+fy_parse_streaming_alias_state_top(struct fy_parser *fyp)
+{
+	if (fyp->sas.top <= 0)
+		return NULL;
+	return &fyp->sas.stack[fyp->sas.top - 1];
+}
+
+void
+fy_parse_streaming_alias_state_next_event(struct fy_parser *fyp)
+{
+	struct fy_streaming_alias_state *fysas;
+
+	fysas = fy_parse_streaming_alias_state_top(fyp);
+	if (!fysas)
+		return;
+
+	fysas->next = fy_eventp_next(&fysas->fysa->events, fysas->next);
+	while (!fysas->next) {
+		fysas = fy_parse_streaming_alias_state_pop(fyp);
+		if (!fysas)
+			break;
+	}
+}
+
+static inline int
+fy_parse_streaming_alias_collection_state_set_top(struct fy_parser *fyp, int cts)
+{
+	int pos, off, old_cts;
+
+	if (fyp->cts.top < 2)
+		return -1;
+
+	cts &= 3;	/* keep 2 bits */
+
+	/* get position and offset */
+	pos = (fyp->cts.top - 2) / (sizeof(*fyp->cts.stack) * 8);
+	off = (fyp->cts.top - 2) % (sizeof(*fyp->cts.stack) * 8);
+
+	old_cts = (int)((fyp->cts.stack[pos] >> off) & 3);
+
+	/* clear the bits first */
+	fyp->cts.stack[pos] &= ~(3 << off);
+	/* set the state */
+	fyp->cts.stack[pos] |= (cts & 3) << off;
+
+	return old_cts;
+}
+
+static inline int
+fy_parse_streaming_alias_collection_state_top(struct fy_parser *fyp)
+{
+	int pos, off;
+
+	if (fyp->cts.top < 2)
+		return -1;
+
+	/* get position and offset */
+	pos = (fyp->cts.top - 2) / (sizeof(*fyp->cts.stack) * 8);
+	off = (fyp->cts.top - 2) % (sizeof(*fyp->cts.stack) * 8);
+
+	return (int)((fyp->cts.stack[pos] >> off) & 3);
+}
+
+static inline bool
+fy_parse_streaming_alias_collection_state_in_map_key(struct fy_parser *fyp)
+{
+	int cts = fy_parse_streaming_alias_collection_state_top(fyp);
+	return cts == FYCTS_MAP_KEY;
+}
+
+static inline void
+fy_parse_streaming_alias_collection_state_toggle_map(struct fy_parser *fyp)
+{
+	int cts = fy_parse_streaming_alias_collection_state_top(fyp);
+	if (cts >= 0 && (cts & FYCTS_MAP))
+		fy_parse_streaming_alias_collection_state_set_top(fyp, cts ^ FYCTS_MAP_TOGGLE);
+}
+
+int
+fy_parse_streaming_alias_collection_state_push(struct fy_parser *fyp, int cts)
+{
+	uint32_t *new_stack;
+	int size;
+
+	assert(cts >= 0);
+
+	/* if first one, just point to the local area */
+	if (fyp->cts.stack == NULL) {
+		fyp->cts.stack = fyp->cts.local;
+		fyp->cts.top = 0;
+		fyp->cts.alloc = sizeof(fyp->cts.local) * 8;	/* in bits */
+	}
+	/* grow the stack if required */
+	if (fyp->cts.top + 2 >= fyp->cts.alloc) {
+		assert(fyp->cts.alloc > 0);
+		assert(fyp->cts.stack);
+		size = fyp->cts.alloc / 8;	/* convert to bytes */
+		new_stack = malloc(size * 2);
+		fyp_error_check(fyp, new_stack != NULL, err_out,
+				"realloc() failed!");
+		memcpy(new_stack, fyp->cts.stack, size);
+		memset((uint8_t *)new_stack + size, 0, size);
+		fyp->cts.alloc *= 2;
+		if (fyp->cts.stack != fyp->cts.local)
+			free(fyp->cts.stack);
+		fyp->cts.stack = new_stack;
+	}
+
+	fyp->cts.top += 2;
+	fy_parse_streaming_alias_collection_state_set_top(fyp, cts);
+	return cts;
+err_out:
+	return -1;
+}
+
+int
+fy_parse_streaming_alias_collection_state_pop(struct fy_parser *fyp)
+{
+	int ret;
+
+	ret = fy_parse_streaming_alias_collection_state_top(fyp);
+	if (ret >= 0)
+		fyp->cts.top -= 2;
+	return ret;
+}
+
+static int
+fy_parser_event_resolve_hook_collect(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_eventp *fyep_clone = NULL;
+	struct fy_streaming_alias *fysa;
+	long map_add, seq_add;
+
+	if (!fyp || !fyep)
+		return -1;
+
+	map_add = seq_add = 0;
+	switch (fyep->e.type) {
+	case FYET_MAPPING_START:
+		map_add = 1;
+		break;
+	case FYET_MAPPING_END:
+		map_add = -1;
+		break;
+	case FYET_SEQUENCE_START:
+		seq_add = 1;
+		break;
+	case FYET_SEQUENCE_END:
+		seq_add = -1;
+		break;
+	default:
+		break;
+	}
+
+	/* for all streaming aliases that are collecting... */
+	for (fysa = fy_streaming_alias_list_head(&fyp->streaming_aliases); fysa != NULL; fysa = fy_streaming_alias_next(&fyp->streaming_aliases, fysa)) {
+		if (!fysa->collecting)
+			continue;
+
+		/* clone event, stripping the anchors */
+		fyep_clone = fy_parse_eventp_clone(fyp, fyep, true);
+		fyp_error_check(fyp, fyep_clone != NULL, err_out,
+				"fy_parse_eventp_clone() failed!");
+
+		/* add to the list */
+		fy_eventp_list_add_tail(&fysa->events, fyep_clone);
+		fyep_clone = NULL;
+
+		/* the scalar will be collected every time */
+		fysa->mapping_nest += map_add;
+		fysa->sequence_nest += seq_add;
+
+		if (fysa->mapping_nest == 0 && fysa->sequence_nest == 0)
+			fysa->collecting = false;
+	}
+
+	return 0;
+
+err_out:
+	fy_parse_eventp_recycle(fyp, fyep_clone);
+	fyp->stream_error = true;
+	return -1;
+}
+
+struct fy_eventp *fy_parser_event_resolve_hook_alias(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_token *fyt_anchor = NULL;
+	struct fy_streaming_alias *fysa;
+	struct fy_streaming_alias_state *fysas;
+
+	if (!fyp || !fyep)
+		return NULL;
+
+	/* if it's not an alias, continue normal processing */
+	if (fyep->e.type != FYET_ALIAS)
+		return fyep;
+
+	/* it's an alias, get the token and dispose the event */
+	fyt_anchor = fyep->e.alias.anchor;
+	fyep->e.alias.anchor = NULL;
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyep = NULL;
+
+	/* start generation of alias events */
+	fysa = fy_parser_streaming_alias_lookup(fyp, fyt_anchor);
+
+	/* we don't support forward aliases for now like we do in document mode ... */
+	FYP_TOKEN_ERROR_CHECK(fyp, fyt_anchor, FYEM_PARSE,
+			fysa, err_out,
+			"alias not found; note streaming mode does not support forward alias references");
+
+	/* if this is a reference to a collecting alias, then it's recursive */
+	FYP_TOKEN_ERROR_CHECK(fyp, fyt_anchor, FYEM_PARSE,
+			!fysa->collecting, err_out,
+			"Recursive alias reference detected");
+
+	fy_token_unref(fyt_anchor);
+	fyt_anchor = NULL;
+
+	fysas = fy_parse_streaming_alias_state_push(fyp, fysa);
+	fyp_error_check(fyp, fysas, err_out,
+			"fy_parse_streaming_alias_push() failed!");
+	assert(fysas->next);
+
+	fyep = fy_parse_eventp_clone(fyp, fysas->next, true);
+	fyp_error_check(fyp, fyep != NULL, err_out,
+			"fy_parse_eventp_clone() failed!");
+
+	/* advance event */
+	fy_parse_streaming_alias_state_next_event(fyp);
+
+	return fyep;
+
+err_out:
+	fy_token_unref(fyt_anchor);
+	fyp->stream_error = true;
+	return NULL;
+}
+
+struct fy_eventp *fy_parser_event_resolve_hook_anchor_start(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_token *fyt_anchor = NULL;
+	struct fy_streaming_alias *fysa = NULL;
+
+	if (!fyep)
+		return NULL;
+
+	/* is there an anchor?, is so get it and clear it */
+	fyt_anchor = fy_event_get_and_clear_anchor_token(&fyep->e);
+	if (!fyt_anchor)
+		return fyep;
+
+	fysa = fy_parse_streaming_alias_create(fyp, fyt_anchor);
+	fyp_error_check(fyp, fysa != NULL, err_out,
+		"fy_parser_streaming_alias_create() failed!");
+	fyt_anchor = NULL;
+
+	/* we just mark that we're collecting
+	 * the collection hook will pick up the first event
+	 * including the scalar one
+	 */
+	fysa->collecting = true;
+	fysa->sequence_nest = 0;
+	fysa->mapping_nest = 0;
+
+	/* always add to the head of the list (overrides what follows with the same name) */
+	fy_streaming_alias_list_add(&fyp->streaming_aliases, fysa);
+
+	return fyep;
+
+err_out:
+	fy_token_unref(fyt_anchor);
+	fy_parse_streaming_alias_clean(fyp, fysa);
+	fy_parse_streaming_alias_recycle(fyp, fysa);
+	fy_parse_eventp_recycle(fyp, fyep);
+	return NULL;
+}
+
+static struct fy_document *
+fy_parser_get_merge_key_argument(struct fy_parser *fyp, struct fy_document_builder *fydb, struct fy_node *fyn)
+{
+	struct fy_streaming_alias *fysa;
+	struct fy_document *fyd_new = NULL;
+	struct fy_document_state *fyds = NULL;
+	int rc;
+
+	if (!fy_node_is_alias(fyn))
+		return NULL;
+
+	/* get the alias */
+	fysa = fy_parser_streaming_alias_lookup(fyp, fyn->scalar);
+	FYP_TOKEN_ERROR_CHECK(fyp, fyn->scalar, FYEM_PARSE,
+			fysa, err_out,
+			"Unable to find merge key argument alias");
+
+	/* if this is a reference to a collecting alias, then it's recursive */
+	FYP_TOKEN_ERROR_CHECK(fyp, fyn->scalar, FYEM_PARSE,
+			!fysa->collecting, err_out,
+			"merge key recursive alias reference detected");
+
+	fyds = fy_parser_get_document_state(fyp);
+	fyp_error_check(fyp, fyds, err_out,
+			"fy_parser_get_document_state() failed");
+
+	rc = fy_document_builder_set_in_document(fydb, fyds, true);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_document_builder_set_target_document() failed\n");
+
+	/* build a document from the events of the alias (must be the same) */
+	fyd_new = fy_document_builder_event_document(fydb, &fysa->events);
+	fyp_error_check(fyp, fyd_new, err_out,
+			"fy_document_builder_event_document() failed\n");
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fyn->scalar, FYEM_PARSE,
+			fy_node_is_mapping(fyd_new->root), err_out,
+			"alias argument does not refer to mapping");
+
+	return fyd_new;
+
+err_out:
+	fy_document_destroy(fyd_new);
+	return NULL;
+}
+
+static struct fy_document *
+fy_parser_get_merge_key_document(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_event *fye;
+	struct fy_document_builder_cfg cfg;
+	struct fy_document_builder *fydb = NULL;
+	struct fy_document *fyd = NULL, *fyd_arg = NULL;
+	struct fy_document_state *fyds;
+	struct fy_node *fyn = NULL, *fyn_src = NULL;
+	struct fy_node *new_root = NULL;
+	struct fy_node_pair *fynp, *fynp_exists;
+	void *iters, *iterm;
+	int rc;
+
+	fye = &fyep->e;
+
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.parse_cfg = fyp->cfg;
+	cfg.diag = fy_diag_ref(fyp->diag);
+
+	fydb = fy_document_builder_create(&cfg);
+	fyp_error_check(fyp, fydb, err_out,
+			"fy_document_builder_create() failed\n");
+
+	fyds = fy_parser_get_document_state(fyp);
+	/* start with this document state */
+	fyds = fy_parser_get_document_state(fyp);
+	rc = fy_document_builder_set_in_document(fydb, fyds, true);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_document_builder_set_in_document() failed\n");
+
+	fyd = fy_document_builder_load_document(fydb, fyp);
+	fyp_error_check(fyp, fyd, err_out,
+			"fy_document_builder_load_document() failed\n");
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fy_event_get_token(fye), FYEM_PARSE,
+			fyd->root, err_out,
+			"merge key arguments must exist");
+
+	/* single alias, replace */
+	if (fy_node_is_alias(fyd->root)) {
+		fyd_arg = fy_parser_get_merge_key_argument(fyp, fydb, fyd->root);
+		fyp_error_check(fyp, fyd_arg, err_out,
+				"fy_parser_get_merge_key_argument() failed\n");
+		fy_node_free(fyd->root);
+		fyd->root = fy_node_copy(fyd, fyd_arg->root);
+
+		fy_document_destroy(fyd_arg);
+		fyd_arg = NULL;
+
+	} else if (fy_node_is_mapping(fyd->root)) {
+
+		/* nothing, already a mapping */
+
+	} else if (fy_node_is_sequence(fyd->root)) {
+
+		new_root = fy_node_create_mapping(fyd);
+		fyp_error_check(fyp, new_root, err_out,
+				"fy_node_create_mapping() failed\n");
+
+		iters = NULL;
+		while ((fyn_src = fy_node_sequence_iterate(fyd->root, &iters)) != NULL) {
+
+			if (fy_node_is_alias(fyn_src)) {
+				fyd_arg = fy_parser_get_merge_key_argument(fyp, fydb, fyn_src);
+				fyp_error_check(fyp, fyd_arg, err_out,
+						"fy_parser_get_merge_key_argument() failed\n");
+
+				fyn = fy_node_copy(fyd, fyd_arg->root);
+				fyp_error_check(fyp, fyn, err_out,
+						"fy_node_copy() failed\n");
+				fy_document_destroy(fyd_arg);
+				fyd_arg = NULL;
+
+			} else {
+				FYP_NODE_ERROR_CHECK(fyp, fyn_src, FYEM_PARSE,
+						fy_node_is_mapping(fyn_src), err_out,
+						"merge key argument is not a mapping or an alias to such");
+				fyn = fy_node_copy(fyd, fyn_src);
+				fyp_error_check(fyp, fyn, err_out,
+						"fy_node_copy() failed\n");
+			}
+
+			iterm = NULL;
+			while ((fynp = fy_node_mapping_iterate(fyn, &iterm)) != NULL) {
+				fynp_exists = fy_node_mapping_lookup_pair(new_root, fynp->key);
+
+				/* do not override existing keys */
+				if (fynp_exists)
+					continue;
+
+				/* add it to the mapping */
+				rc = fy_node_mapping_append(new_root, fy_node_copy(fyd, fynp->key), fy_node_copy(fyd, fynp->value));
+				fyp_error_check(fyp, !rc, err_out,
+						"fy_node_mapping_append() failed\n");
+			}
+
+			/* and we're done with it */
+			fy_node_free(fyn);
+			fyn = NULL;
+		}
+		fy_node_free(fyd->root);
+		fyd->root = new_root;
+
+	} else {
+		FYP_TOKEN_ERROR(fyp, fy_event_get_token(fye), FYEM_PARSE,
+				"merge key argument is neither an alias or a mapping");
+		goto err_out;
+	}
+
+	fy_document_builder_destroy(fydb);
+	fydb = NULL;
+
+	return fyd;
+
+err_out:
+	fy_node_free(new_root);
+	fy_document_destroy(fyd_arg);
+	fy_document_destroy(fyd);
+	fy_document_builder_destroy(fydb);
+	return NULL;
+}
+
+struct fy_eventp *fy_parser_event_resolve_hook_merge_key_start(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	struct fy_document *fyd = NULL;
+	struct fy_document_iterator *fydi = NULL;
+	struct fy_eventp *fyep_next = NULL;
+	struct fy_event *fye;
+	struct fy_streaming_alias *fysa = NULL;
+	struct fy_streaming_alias_state *fysas = NULL;
+	bool fysa_added = false, fysas_pushed = false;
+
+	FYP_TOKEN_ERROR_CHECK(fyp, fyep->e.scalar.value, FYEM_PARSE,
+			!fyp->mks.active, err_out,
+			"No recursive merge key processing is supported");
+
+	fyd = fy_parser_get_merge_key_document(fyp, fyep);
+	FYP_TOKEN_ERROR_CHECK(fyp, fyep->e.scalar.value, FYEM_PARSE,
+			fyd, err_out,
+			"No merge key argument document");
+
+	fysa = fy_parse_streaming_alias_create(fyp, NULL);
+	fyp_error_check(fyp, fysa, err_out,
+			"fy_parse_streaming_alias_create() failed");
+
+	fydi = fy_document_iterator_create();
+	fyp_error_check(fyp, fydi, err_out,
+			"fy_document_iterator_create() failed");
+
+	fy_document_iterator_node_start(fydi, fyd->root);
+
+	/* now append all to the (fake) streaming anchor */
+	while ((fye = fy_document_iterator_body_next(fydi)) != NULL) {
+		fyep_next = container_of(fye, struct fy_eventp, e);
+		fy_eventp_list_add_tail(&fysa->events, fyep_next);
+	}
+
+	fy_document_iterator_destroy(fydi);
+	fydi = NULL;
+	fy_document_destroy(fyd);
+	fyd = NULL;
+
+	/* and add it to the start of the list */
+	fy_streaming_alias_list_add(&fyp->streaming_aliases, fysa);
+	fysa_added = true;
+
+	/* OK, trim mapping start and end */
+	fyep_next = fy_eventp_list_head(&fysa->events);
+	fyp_error_check(fyp, fyep_next->e.type == FYET_MAPPING_START, err_out,
+			"not a mapping merge key start");
+	fy_eventp_list_del(&fysa->events, fyep_next);
+	fy_eventp_free(fyep_next);
+	fyep_next = NULL;
+
+	fyep_next = fy_eventp_list_tail(&fysa->events);
+	fyp_error_check(fyp, fyep_next->e.type == FYET_MAPPING_END, err_out,
+			"not a mapping merge key end");
+	fy_eventp_list_del(&fysa->events, fyep_next);
+	fy_eventp_free(fyep_next);
+	fyep_next = NULL;
+
+	/* An empty merge mapping contributes no events, so skip it and
+	 * continue with the next parser event instead of pushing empty state.
+	 */
+	if (fy_eventp_list_empty(&fysa->events)) {
+		fy_streaming_alias_list_del(&fyp->streaming_aliases, fysa);
+		fysa_added = false;
+		fy_parse_streaming_alias_clean(fyp, fysa);
+		fy_parse_streaming_alias_recycle(fyp, fysa);
+		fysa = NULL;
+
+		fy_parse_eventp_recycle(fyp, fyep);
+		fyep = fy_parse_private(fyp);
+		if (!fyep)
+			return NULL;
+
+		return fy_parser_event_resolve_hook_merge_key(fyp, fyep);
+	}
+
+	/* OK, push the new state */
+	fysas = fy_parse_streaming_alias_state_push(fyp, fysa);
+	fyp_error_check(fyp, fysas, err_out,
+			"fy_parse_streaming_alias_push() failed!");
+	fysas_pushed = true;
+	assert(fysas->next);
+
+	/* dispose of the event */
+	fy_parse_eventp_recycle(fyp, fyep);
+	fyep = NULL;
+
+	fyep = fy_parse_eventp_clone(fyp, fysas->next, true);
+	fyp_error_check(fyp, fyep != NULL, err_out,
+			"fy_parse_eventp_clone() failed!");
+
+	/* advance event */
+	fy_parse_streaming_alias_state_next_event(fyp);
+
+	return fyep;
+
+err_out:
+	fy_document_iterator_destroy(fydi);
+	fy_document_destroy(fyd);
+	if (fysas_pushed)
+		fy_parse_streaming_alias_state_pop(fyp);
+	if (fysa_added)
+		fy_streaming_alias_list_del(&fyp->streaming_aliases, fysa);
+	fy_parse_streaming_alias_clean(fyp, fysa);
+	fy_parse_streaming_alias_recycle(fyp, fysa);
+	fy_parse_eventp_recycle(fyp, fyep_next);
+	fy_parse_eventp_recycle(fyp, fyep);
+	return NULL;
+}
+
+struct fy_eventp *fy_parser_event_resolve_hook_merge_key(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	/* will toggle the map key bit if it is in a mapping */
+	fy_parse_streaming_alias_collection_state_toggle_map(fyp);
+	switch (fyep->e.type) {
+	case FYET_SCALAR:
+		/* if a merge key is detected do the dance */
+		if (fy_parse_streaming_alias_collection_state_in_map_key(fyp) &&
+		    fy_token_scalar_style(fyep->e.scalar.value) == FYSS_PLAIN &&
+		    fy_plain_atom_streq(fy_token_atom(fyep->e.scalar.value), "<<"))
+			return fy_parser_event_resolve_hook_merge_key_start(fyp, fyep);
+		break;
+	case FYET_ALIAS:
+		/* nothing for alias */
+		break;
+	case FYET_MAPPING_START:
+		fy_parse_streaming_alias_collection_state_push(fyp, FYCTS_MAP_VAL);	/* it will toggle to key at the first one */
+		break;
+	case FYET_SEQUENCE_START:
+		fy_parse_streaming_alias_collection_state_push(fyp, FYCTS_SEQ);
+		break;
+	case FYET_MAPPING_END:
+	case FYET_SEQUENCE_END:
+		fy_parse_streaming_alias_collection_state_pop(fyp);
+		break;
+	default:
+		break;
+	}
+
+	return fyep;
+}
+
+/* NOTE: order is _very_ important, do not re-arrange if you're not sure */
+struct fy_eventp *fy_parser_event_resolve_hook(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	int rc;
+
+	/* merge key processing for version 1.1 only! */
+	if (fy_reader_get_mode(fyp->reader) == fyrm_yaml_1_1) {
+		fyep = fy_parser_event_resolve_hook_merge_key(fyp, fyep);
+		fyp_error_check(fyp, fyep != NULL, err_out,
+				"fy_parser_event_resolve_hook_collection_tracking() failed!");
+	}
+
+	/* anchor marking */
+	fyep = fy_parser_event_resolve_hook_anchor_start(fyp, fyep);
+	fyp_error_check(fyp, fyep != NULL, err_out,
+			"fy_parser_event_resolve_hook_anchor_start() failed!");
+
+	/* collect afterwards */
+	rc = fy_parser_event_resolve_hook_collect(fyp, fyep);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parser_event_resolve_hook_collect() failed!");
+
+	/* finally do first entry into alias processing */
+	fyep = fy_parser_event_resolve_hook_alias(fyp, fyep);
+	fyp_error_check(fyp, fyep != NULL, err_out,
+			"fy_parser_event_resolve_hook_alias() failed!");
+
+	return fyep;
+
+err_out:
+	return NULL;
+}
+
+struct fy_eventp *fy_parser_parse_resolve_prolog(struct fy_parser *fyp)
+{
+	struct fy_streaming_alias *fysa;
+	struct fy_streaming_alias_state *fysas;
+	struct fy_eventp *fyep, *fyep_src;
+	bool was_merge_key;
+	int rc;
+
+	if (!(fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT))
+		return NULL;
+
+	fysas = fy_parse_streaming_alias_state_top(fyp);
+	if (!fysas)
+		return NULL;
+
+	was_merge_key = false;
+	for (;;) {
+		fysa = fysas->fysa;
+		assert(fysa);
+
+		assert(fysas->next != NULL);
+
+		/* keep track of it */
+		fyep_src = fysas->next;
+
+		/* merge key entries don't have an anchor */
+		was_merge_key = fysa->anchor == NULL;
+
+		/* advance event */
+		fy_parse_streaming_alias_state_next_event(fyp);
+
+		/* not an alias, continue normally */
+		if (fyep_src->e.type != FYET_ALIAS)
+			break;
+
+		/* get the anchor that was defined closest to this one */
+		fysa = fy_parser_streaming_alias_lookup_pivot(fyp, fysa, fyep_src->e.alias.anchor);
+		fyp_error_check(fyp, fysa, err_out,
+				"fy_parser_streaming_alias_lookup_pivot() failed!");
+
+		/* and push */
+		fysas = fy_parse_streaming_alias_state_push(fyp, fysa);
+		fyp_error_check(fyp, fysas, err_out,
+				"fy_parse_streaming_alias_state_push() failed!");
+	}
+
+	fyep = fy_parse_eventp_clone(fyp, fyep_src, true);
+	fyp_error_check(fyp, fyep != NULL, err_out,
+			"fy_parse_eventp_clone() failed!");
+
+	if (was_merge_key) {
+		rc = fy_parser_event_resolve_hook_collect(fyp, fyep_src);
+		fyp_error_check(fyp, !rc, err_out,
+			"fy_parser_event_resolve_hook_collect() failed!");
+	}
+
+	return fyep;
+
+err_out:
+	fyp->stream_error = true;
+	return NULL;
+}
+
+struct fy_eventp *fy_parser_parse_resolve_epilog(struct fy_parser *fyp, struct fy_eventp *fyep)
+{
+	if (!(fyp->cfg.flags & FYPCF_RESOLVE_DOCUMENT))
+		return fyep;
+
+	fyep = fy_parser_event_resolve_hook(fyp, fyep);
+	if (!fyep)
+		fyp->stream_error = true;
+
+	return fyep;
+}
+
+struct fy_parser_checkpoint *fy_parser_checkpoint_create(struct fy_parser *fyp)
+{
+	struct fy_parser_checkpoint *fypchk = NULL;
+	struct fy_parser *fypc = NULL;
+	struct fy_reader *fyr, *fyrc;
+	struct fy_streaming_alias *fysa, *fysac;
+	struct fy_eventp *fyep, *fyepc;
+	struct fy_indent *fyit, *fyitc;
+	struct fy_simple_key *fysk, *fyskc;
+	struct fy_parse_state_log *fypsl, *fypslc;
+	struct fy_flow *fyf, *fyfc;
+	struct fy_token *fyt;
+	struct fy_input *fyi;
+	int i;
+
+	/* must be a parser, in a document and not a checkpoint of one,
+	 * with no composer or builder, neither in a merge key state */
+	if (!fyp || /* fyp->state != FYPS_DOCUMENT_CONTENT || */
+	    fyp->is_checkpoint || fyp->fydb || fyp->fyc ||
+	    fyp->mks.active) {
+		fyp_parse_debug(fyp, "cannot take checkpoint at this state");
+		return NULL;
+	}
+
+	/* no queued inputs */
+	if (!fy_input_list_empty(&fyp->queued_inputs))
+		return NULL;
+
+	fyp_parse_debug(fyp, "taking checkpoint");
+
+	fypchk = malloc(sizeof(*fypchk));
+	fyp_error_check(fyp, fypchk != NULL, err_out,
+			"fy_parse_input_create() failed!");
+	memset(fypchk, 0, sizeof(*fypchk));
+	fypc = &fypchk->fyp_checkpoint;
+
+	/* copy everything over and then fill out the pointer */
+	*fypc = *fyp;
+
+	fypc->is_checkpoint = true;	/* mark it as a checkpoint */
+
+	/* all recycled lists are initialized */
+	fy_indent_list_init(&fypc->recycled_indent);
+	fy_parse_state_log_list_init(&fypc->recycled_parse_state_log);
+	fy_eventp_list_init(&fypc->recycled_eventp);
+	fy_token_list_init(&fypc->recycled_token);
+	fy_flow_list_init(&fypc->flow_stack);
+	fy_flow_list_init(&fypc->recycled_flow);
+	fy_streaming_alias_list_init(&fypc->recycled_streaming_alias);
+	fy_simple_key_list_init(&fypc->recycled_simple_key);
+	fy_eventp_list_init(&fypc->mks.args);
+	fypc->recycled_eventp_list = NULL;
+	fypc->recycled_token_list = NULL;
+
+	fy_input_list_init(&fypc->queued_inputs);
+	fypc->stream_end_token = fy_token_ref(fyp->stream_end_token);
+
+	fypc->last_comment.fyi = fy_input_ref(fyp->last_comment.fyi);
+	fypc->override_comment.fyi = fy_input_ref(fyp->override_comment.fyi);
+	fypc->current_document_state = fy_document_state_ref(fyp->current_document_state);
+	fypc->default_document_state = fy_document_state_ref(fyp->default_document_state);
+	fypc->next_single_document = fyp->next_single_document;
+	fypc->diag = NULL;
+	fypc->last_event_handle.fyi = fy_input_ref(fyp->last_event_handle.fyi);
+
+	if (fyp->fyep_peek) {
+		fypc->fyep_peek = fy_parse_eventp_clone(fyp, fyp->fyep_peek, false);
+		fyp_parse_debug(fyp, "checkpoint has a peeked event");
+	}
+
+	/* copy the current state of the reader to the builtin reader space */
+	fyr = fyp->reader;
+	assert(fyr);
+	fyrc = &fypc->builtin_reader;
+	fypc->reader = fyrc;
+
+	*fyrc = *fyr;
+	fyrc->current_input = fy_input_ref(fyr->current_input);
+	assert(fyrc->current_input);
+	fyrc->diag = NULL;	/* no diag */
+
+	/* copy the streaming alias list */
+	if (fyp->sas.stack) {
+		fyp_parse_debug(fyp, "checkpoint has a streaming alias list");
+		if (fyp->sas.alloc <= (int)ARRAY_SIZE(fyp->sas.local))
+			fypc->sas.stack = fypc->sas.local;
+		else {
+			fypc->sas.stack = malloc(sizeof(*fyp->sas.stack) * fyp->sas.alloc);
+			assert(fypc->sas.stack);
+			memcpy(fypc->sas.stack, fyp->sas.stack, sizeof(*fyp->sas.stack) * fyp->sas.top);
+		}
+	}
+
+	fy_streaming_alias_list_init(&fypc->streaming_aliases);
+	for (fysa = fy_streaming_alias_list_head(&fyp->streaming_aliases); fysa != NULL;
+	     fysa = fy_streaming_alias_next(&fyp->streaming_aliases, fysa)) {
+
+		fysac = fy_parse_streaming_alias_create(fyp, NULL);
+		assert(fysac);
+		fysac->anchor = fy_token_ref(fysa->anchor);
+		for (fyep = fy_eventp_list_head(&fysa->events); fyep;
+		     fyep = fy_eventp_next(&fysa->events, fyep)) {
+
+			fyepc = fy_parse_eventp_clone(fyp, fyep, false);
+			assert(fyepc);
+			fy_eventp_list_add_tail(&fysac->events, fyepc);
+
+			/* scan stack and replace pointers */
+			for (i = 0; i < fypc->sas.top; i++) {
+				if (fypc->sas.stack[i].fysa == fysa)
+					fypc->sas.stack[i].fysa = fysac;
+				if (fypc->sas.stack[i].next == fyep)
+					fypc->sas.stack[i].next = fyepc;
+			}
+		}
+	}
+
+	if (fyp->cts.stack) {
+		fyp_parse_debug(fyp, "checkpoint has a cts stack");
+		if (fyp->cts.alloc <= (int)ARRAY_SIZE(fyp->cts.local))
+			fypc->cts.stack = fypc->cts.local;
+		else {
+			fypc->cts.stack = malloc(sizeof(*fyp->cts.stack) * fyp->cts.alloc);
+			assert(fypc->cts.stack);
+			memcpy(fypc->cts.stack, fyp->cts.stack, sizeof(*fyp->cts.stack) * fyp->cts.top);
+		}
+	}
+
+	/* copy all remaining lists */
+	fy_indent_list_init(&fypc->indent_stack);
+	for (fyit = fy_indent_list_head(&fyp->indent_stack); fyit != NULL;
+	     fyit = fy_indent_next(&fyp->indent_stack, fyit)) {
+
+		fyitc = fy_parse_indent_alloc(fyp);
+		assert(fyitc);
+
+		*fyitc = *fyit;
+
+		fy_indent_list_add_tail(&fypc->indent_stack, fyitc);
+	}
+
+	fy_parse_state_log_list_init(&fypc->state_stack);
+	for (fypsl = fy_parse_state_log_list_head(&fyp->state_stack); fypsl != NULL;
+	     fypsl = fy_parse_state_log_next(&fyp->state_stack, fypsl)) {
+
+		fypslc = fy_parse_parse_state_log_alloc(fyp);
+		assert(fypslc);
+
+		fypslc->state = fypsl->state;
+
+		fyp_parse_debug(fyp, "checkpoint saving parse_state %s\n", state_txt[fypslc->state]);
+
+		fy_parse_state_log_list_add_tail(&fypc->state_stack, fypslc);
+	}
+
+	/* queued tokens and simple keys are 'special' */
+	fy_token_list_init(&fypc->queued_tokens);
+	/* count, and take refs */
+	for (fyt = fy_token_list_head(&fyp->queued_tokens), i = 0; fyt != NULL;
+	     fyt = fy_token_next(&fyp->queued_tokens, fyt), i++) { }
+	fypchk->queued_token_count = i;
+	fypchk->queued_tokens = malloc(i * sizeof(*fypchk->queued_tokens));
+	assert(fypchk->queued_tokens);
+	for (fyt = fy_token_list_head(&fyp->queued_tokens), i = 0; fyt != NULL;
+	     fyt = fy_token_next(&fyp->queued_tokens, fyt), i++) {
+		fypchk->queued_tokens[i] = fy_token_ref(fyt);
+	}
+	fyp_parse_debug(fyp, "checkpoint has #%d queued tokens", fypchk->queued_token_count);
+
+	fy_simple_key_list_init(&fypc->simple_keys);
+
+	if (!fy_simple_key_list_empty(&fyp->simple_keys))
+		fyp_parse_debug(fyp, "checkpoint has pending simple keys");
+
+	for (fysk = fy_simple_key_list_head(&fyp->simple_keys); fysk != NULL;
+	     fysk = fy_simple_key_next(&fyp->simple_keys, fysk)) {
+
+		fyskc = fy_parse_simple_key_alloc(fyp);
+		assert(fyskc);
+
+		*fyskc = *fysk;
+		fyskc->token = fy_token_ref(fysk->token);
+
+		fy_simple_key_list_add_tail(&fypc->simple_keys, fyskc);
+	}
+
+	fy_input_list_init(&fypc->queued_inputs);
+	/* count, and take refs */
+	for (fyi = fy_input_list_head(&fyp->queued_inputs), i = 0; fyi != NULL;
+	     fyi = fy_input_next(&fyp->queued_inputs, fyi), i++) { }
+	fypchk->queued_input_count = i;
+	fypchk->queued_inputs = malloc(i * sizeof(*fypchk->queued_inputs));
+	assert(fypchk->queued_inputs);
+	for (fyi = fy_input_list_head(&fyp->queued_inputs), i = 0; fyi != NULL;
+	     fyi = fy_input_next(&fyp->queued_inputs, fyi), i++) {
+		fypchk->queued_inputs[i] = fy_input_ref(fyi);
+	}
+
+	fyp_parse_debug(fyp, "checkpoint flow_level=%d", fypc->flow_level);
+	fypc->flow = fyp->flow;
+	if (!fy_flow_list_empty(&fyp->flow_stack))
+		fyp_parse_debug(fyp, "checkpoint has flow state");
+
+	for (fyf = fy_flow_list_head(&fyp->flow_stack); fyf != NULL;
+	     fyf = fy_flow_next(&fyp->flow_stack, fyf)) {
+
+		fyfc = fy_parse_flow_alloc(fyp);
+		assert(fyfc);
+
+		*fyfc = *fyf;
+
+		fy_flow_list_add_tail(&fypc->flow_stack, fyfc);
+	}
+
+	fypchk->diag_on_error = fyp->diag && fyp->diag->on_error;
+
+	fyp_parse_debug(fyp, "took checkpoint");
+	return fypchk;
+
+err_out:
+	if (fypchk)
+		free(fypchk);
+	return NULL;
+}
+
+void fy_parser_checkpoint_destroy(struct fy_parser_checkpoint *fypchk)
+{
+	struct fy_parser *fypc;
+	int i;
+
+	if (!fypchk)
+		return;
+
+	if (fypchk->queued_inputs) {
+		for (i = 0; i < fypchk->queued_input_count; i++)
+			fy_input_unref(fypchk->queued_inputs[i]);
+		free(fypchk->queued_inputs);
+	}
+
+	if (fypchk->queued_tokens) {
+		for (i = 0; i < fypchk->queued_token_count; i++)
+			fy_token_unref(fypchk->queued_tokens[i]);
+		free(fypchk->queued_tokens);
+	}
+
+	fypc = &fypchk->fyp_checkpoint;
+
+	fy_parse_cleanup(fypc);
+
+	free(fypchk);
+}
+
+int fy_parser_rollback(struct fy_parser *fyp, struct fy_parser_checkpoint *fypchk)
+{
+	struct fy_parser *fypc = NULL;
+	struct fy_reader *fyr, *fyrc;
+	struct fy_indent *fyit, *fyitc;
+	struct fy_flow *fyf, *fyfc;
+	struct fy_parse_state_log *fypsl, *fypslc;
+	struct fy_input *fyi, *fyic;
+	struct fy_token *fyt;
+	int i;
+
+	if (!fypchk)
+		return -1;
+
+	fyp_parse_debug(fyp, "rolling back checkpoint");
+
+	fypc = &fypchk->fyp_checkpoint;
+
+	if (fyp->diag)
+		fyp->diag->on_error = fypchk->diag_on_error;
+
+	/* reader restore */
+	fyr = fyp->reader;
+	fyrc = fypc->reader;
+
+	assert(fyr->ops == fyrc->ops);
+	fy_input_unref(fyr->current_input);
+	fyr->current_input = fy_input_ref(fyrc->current_input);
+	fyr->mode = fyrc->mode;
+	fyr->this_input_start = fyrc->this_input_start;
+	fyr->current_ptr = fyrc->current_ptr;
+	fyr->current_ptr_start =fyrc->current_ptr_start;
+	fyr->current_ptr_end =fyrc->current_ptr_end;
+	fyr->line = fyrc->line;
+	fyr->column = fyrc->column;
+	fyr->tabsize = fyrc->tabsize;
+	fyr->json_mode = fyrc->json_mode;
+	fyr->lb_mode = fyrc->lb_mode;
+	fyr->fws_mode = fyrc->fws_mode;
+	fyr->directive0_mode = fyrc->directive0_mode;
+
+	fy_token_unref(fyp->stream_end_token);
+	fyp->stream_end_token = fy_token_ref(fypc->stream_end_token);
+
+	/* inputs restore */
+	while ((fyi = fy_input_list_pop(&fyp->queued_inputs)) != NULL)
+		fy_input_unref(fyi);
+	for (i = 0; i < fypchk->queued_input_count; i++) {
+		fyic = fypchk->queued_inputs[i];
+		fy_input_list_add_tail(&fyp->queued_inputs, fy_input_ref(fyic));
+	}
+	fyp->token_activity_counter = fypc->token_activity_counter;
+
+	fy_input_unref(fyp->last_comment.fyi);
+	fyp->last_comment = fypc->last_comment;
+	fyp->last_comment.fyi = fy_input_ref(fypc->last_comment.fyi);
+
+	fy_input_unref(fyp->override_comment.fyi);
+	fyp->override_comment = fypc->override_comment;
+	fyp->override_comment.fyi = fy_input_ref(fypc->override_comment.fyi);
+
+	/* indents */
+	while ((fyit = fy_indent_list_pop(&fyp->indent_stack)) != NULL)
+		fy_parse_indent_recycle(fyp, fyit);
+	for (fyitc = fy_indent_list_head(&fypc->indent_stack); fyitc != NULL;
+	     fyitc = fy_indent_next(&fypc->indent_stack, fyitc)) {
+
+		fyit = fy_parse_indent_alloc(fyp);
+		assert(fyit);
+
+		*fyit = *fyitc;
+
+		fy_indent_list_add_tail(&fyp->indent_stack, fyit);
+	}
+	fyp->indent = fypc->indent;
+	fyp->parent_indent = fypc->parent_indent;
+	fyp->indent_line = fypc->indent_line;
+	fyp->starting_indent = fypc->starting_indent;
+
+	/* parse state */
+	fyp->state = fypc->state;
+	while ((fypsl = fy_parse_state_log_list_pop(&fyp->state_stack)) != NULL)
+		fy_parse_parse_state_log_recycle(fyp, fypsl);
+	for (fypslc = fy_parse_state_log_list_head(&fypc->state_stack); fypslc != NULL;
+	     fypslc = fy_parse_state_log_next(&fypc->state_stack, fypslc)) {
+
+		fypsl = fy_parse_parse_state_log_alloc(fyp);
+		assert(fypsl);
+
+		fypsl->state = fypslc->state;
+
+		fy_parse_state_log_list_add_tail(&fyp->state_stack, fypsl);
+	}
+
+#ifndef NDEBUG
+	for (fypsl = fy_parse_state_log_list_head(&fyp->state_stack); fypsl != NULL;
+	     fypsl = fy_parse_state_log_next(&fyp->state_stack, fypsl)) {
+		fyp_parse_debug(fyp, "checkpoint restored parse_state %s\n", state_txt[fypsl->state]);
+	}
+#endif
+
+	while ((fyt = fy_token_list_pop(&fyp->queued_tokens)) != NULL)
+		fy_token_unref(fyt);
+	for (i = 0; i < fypchk->queued_token_count; i++) {
+		fyt = fypchk->queued_tokens[i];
+		fy_token_list_add_tail(&fyp->queued_tokens, fy_token_ref(fyt));
+	}
+	assert(fy_simple_key_list_empty(&fypc->simple_keys));
+	assert(fy_streaming_alias_list_empty(&fypc->streaming_aliases));
+
+	fyp->default_version = fypc->default_version;
+	fyp->stream_version = fypc->stream_version;
+	fyp->parser_bitflags = fypc->parser_bitflags;
+	fyp->is_checkpoint = false;
+
+	fyp_parse_debug(fyp, "checkpoint restoring flow_level=%d", fypc->flow_level);
+
+	fyp->flow_level = fypc->flow_level;
+	fyp->flow = fypc->flow;
+	while ((fyf = fy_flow_list_pop(&fyp->flow_stack)) != NULL)
+		fy_parse_flow_recycle(fyp, fyf);
+	for (fyfc = fy_flow_list_head(&fypc->flow_stack); fyfc != NULL;
+	     fyfc = fy_flow_next(&fypc->flow_stack, fyfc)) {
+
+		fyf = fy_parse_flow_alloc(fyp);
+		assert(fyf);
+
+		*fyf = *fyfc;
+
+		fy_flow_list_add_tail(&fyp->flow_stack, fyf);
+	}
+
+	fyp->pending_complex_key_column = fypc->pending_complex_key_column;
+	fyp->pending_complex_key_mark = fypc->pending_complex_key_mark;
+	fyp->last_block_mapping_key_line = fypc->last_block_mapping_key_line;
+	fyp->last_comma_mark = fypc->last_comma_mark;
+	fyp->last_tab_used_for_ws_mark = fypc->last_tab_used_for_ws_mark;
+
+	fy_document_state_unref(fyp->current_document_state);
+	fyp->current_document_state = fy_document_state_ref(fypc->current_document_state);
+	fy_document_state_unref(fyp->default_document_state);
+	fyp->default_document_state = fy_document_state_ref(fypc->default_document_state);
+
+	fyp->next_single_document = fypc->next_single_document;
+	fyp->last_event_handle = fypc->last_event_handle;
+	fy_input_unref(fyp->last_event_handle.fyi);
+	fyp->last_event_handle.fyi = fy_input_ref(fypc->last_event_handle.fyi);
+
+	fy_parse_eventp_recycle(fyp, fyp->fyep_peek);
+	fyp->fyep_peek = NULL;
+	if (fypc->fyep_peek) {
+		fyp->fyep_peek = fy_parse_eventp_clone(fyp, fypc->fyep_peek, false);
+		assert(fypc->fyep_peek);
+	}
+
+	assert(fyp->sas.top == 0);
+
+	return 0;
+}
+
+enum fy_parser_mode
+fy_parser_get_mode(struct fy_parser *fyp)
+{
+	struct fy_version *versp;
+	int major, minor;
+
+	if (!fyp)
+		return fypm_invalid;
+
+	versp = fyp->current_document_state ? &fyp->current_document_state->version : &fyp->stream_version;
+
+	switch (fy_reader_get_mode(fyp->reader)) {
+	case fyrm_yaml:
+	case fyrm_yaml_1_1:
+		major = versp->major;
+		minor = versp->minor;
+		/* 1.1, 1.2, 1.3 */
+		if (major != 1 || minor < 1 || minor > 3)
+			break;
+		return fypm_yaml_1_1 + (minor - 1);
+
+	case fyrm_json:
+		return fypm_json;
+	}
+
+	return fypm_none;
+}
+
+int fy_parser_count_sequence_items(struct fy_parser *fyp)
+{
+	const struct fy_event *fye_peek;
+	struct fy_parser_checkpoint *fypchk = NULL;
+	int rc, count;
+
+	if (!fyp)
+		return -1;
+
+	/* take a checkpoint and race ahead to find the size */
+	fypchk = fy_parser_checkpoint_create(fyp);
+	fyp_error_check(fyp, fypchk != NULL, err_out,
+			"fy_parser_checkpoint_create() failed!");
+	count = 0;
+	for (;;) {
+		fye_peek = fy_parser_parse_peek(fyp);
+		if (!fye_peek)
+			goto err_out;
+		if (fye_peek->type != FYET_SCALAR &&
+		    fye_peek->type != FYET_MAPPING_START &&
+		    fye_peek->type != FYET_SEQUENCE_START &&
+		    fye_peek->type != FYET_SEQUENCE_END)
+			goto err_out;
+
+		if (fye_peek->type == FYET_SEQUENCE_END)
+			break;
+
+		/* skip the item */
+		rc = fy_parser_skip(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_parser_skip() failed!");
+		count++;
+	}
+
+	rc = fy_parser_rollback(fyp, fypchk);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parser_rollback() failed!");
+out:
+	fy_parser_checkpoint_destroy(fypchk);
+	return count;
+
+err_out:
+	count = -1;
+	goto out;
+}
+
+int fy_parser_count_mapping_items(struct fy_parser *fyp)
+{
+	const struct fy_event *fye_peek;
+	struct fy_parser_checkpoint *fypchk = NULL;
+	int rc, count;
+
+	if (!fyp)
+		return -1;
+
+	/* take a checkpoint and race ahead to find the size */
+	fypchk = fy_parser_checkpoint_create(fyp);
+	fyp_error_check(fyp, fypchk != NULL, err_out,
+			"fy_parser_checkpoint_create() failed!");
+	count = 0;
+	for (;;) {
+		fye_peek = fy_parser_parse_peek(fyp);
+		if (!fye_peek)
+			goto err_out;
+		if (fye_peek->type != FYET_SCALAR &&
+		    fye_peek->type != FYET_MAPPING_START &&
+		    fye_peek->type != FYET_SEQUENCE_START &&
+		    fye_peek->type != FYET_MAPPING_END)
+			goto err_out;
+
+		if (fye_peek->type == FYET_MAPPING_END)
+			break;
+
+		/* skip the key item */
+		rc = fy_parser_skip(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_parser_skip() failed!");
+
+		/* skip the value item */
+		rc = fy_parser_skip(fyp);
+		fyp_error_check(fyp, !rc, err_out,
+				"fy_parser_skip() failed!");
+		count++;
+	}
+
+	rc = fy_parser_rollback(fyp, fypchk);
+	fyp_error_check(fyp, !rc, err_out,
+			"fy_parser_rollback() failed!");
+out:
+	fy_parser_checkpoint_destroy(fypchk);
+	return count;
+
+err_out:
+	count = -1;
+	goto out;
+}
+
+// just for LLVMShutdown
+#if defined(HAVE_LIBCLANG) && HAVE_LIBCLANG && defined(HAVE_LLVM_C_CORE_H)
+#include <llvm-c/Core.h>
+#endif
+
+void fy_shutdown(void)
+{
+#if defined(HAVE_LIBCLANG) && HAVE_LIBCLANG && defined(HAVE_LLVM_C_CORE_H)
+	LLVMShutdown();
+#endif
+}
+
+#ifdef FY_HAS_DESTRUCTOR
+FY_DESTRUCTOR void fy_do_cleanup(void)
+{
+	fy_shutdown();
+}
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-parse.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-parse.h
@@ -1,0 +1,871 @@
+/*
+ * fy-parse.h - YAML parser internal header file
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_PARSE_H
+#define FY_PARSE_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <libfyaml.h>
+
+#include "fy-ctype.h"
+#include "fy-utf8.h"
+#include "fy-list.h"
+#include "fy-typelist.h"
+#include "fy-types.h"
+#include "fy-diag.h"
+#include "fy-dump.h"
+#include "fy-atom.h"
+#include "fy-input.h"
+#include "fy-ctype.h"
+#include "fy-token.h"
+#include "fy-event.h"
+#include "fy-docstate.h"
+#include "fy-doc.h"
+#include "fy-docbuilder.h"
+#include "fy-emit.h"
+#include "fy-accel.h"
+#include "fy-emit-accum.h"
+#include "fy-path.h"
+#include "fy-composer.h"
+
+struct fy_parser;
+struct fy_input;
+
+/* for the event */
+FY_PARSE_TYPE_DECL_ALLOC(eventp);
+
+enum fy_flow_type {
+	FYFT_NONE,
+	FYFT_MAP,
+	FYFT_SEQUENCE,
+};
+
+struct fy_flow {
+	struct list_head node;
+	enum fy_flow_type flow;
+	int pending_complex_key_column;
+	struct fy_mark pending_complex_key_mark;
+	int parent_indent;
+};
+FY_PARSE_TYPE_DECL(flow);
+
+struct fy_indent {
+	struct list_head node;
+	int indent;
+	int indent_line;
+	bool generated_block_map : 1;
+};
+FY_PARSE_TYPE_DECL(indent);
+
+struct fy_token;
+
+struct fy_simple_key {
+	struct list_head node;
+	struct fy_mark mark;
+	struct fy_mark end_mark;
+	struct fy_token *token;	/* associated token */
+	int flow_level;
+	bool required : 1;
+	bool implicit_complex : 1;
+};
+FY_PARSE_TYPE_DECL(simple_key);
+
+struct fy_document_state;
+
+enum fy_parser_state {
+	/** none state */
+	FYPS_NONE,
+	/** Expect STREAM-START. */
+	FYPS_STREAM_START,
+	/** Expect the beginning of an implicit document. */
+	FYPS_IMPLICIT_DOCUMENT_START,
+	/** Expect DOCUMENT-START. */
+	FYPS_DOCUMENT_START,
+	/** Expect the content of a document. */
+	FYPS_DOCUMENT_CONTENT,
+	/** Expect DOCUMENT-END. */
+	FYPS_DOCUMENT_END,
+	/** Expect a block node. */
+	FYPS_BLOCK_NODE,
+	/** Expect the first entry of a block sequence. */
+	FYPS_BLOCK_SEQUENCE_FIRST_ENTRY,
+	/** Expect an entry of a block sequence. */
+	FYPS_BLOCK_SEQUENCE_ENTRY,
+	/** Expect an entry of an indentless sequence. */
+	FYPS_INDENTLESS_SEQUENCE_ENTRY,
+	/** Expect the first key of a block mapping. */
+	FYPS_BLOCK_MAPPING_FIRST_KEY,
+	/** Expect a block mapping key. */
+	FYPS_BLOCK_MAPPING_KEY,
+	/** Expect a block mapping value. */
+	FYPS_BLOCK_MAPPING_VALUE,
+	/** Expect the first entry of a flow sequence. */
+	FYPS_FLOW_SEQUENCE_FIRST_ENTRY,
+	/** Expect an entry of a flow sequence. */
+	FYPS_FLOW_SEQUENCE_ENTRY,
+	/** Expect a key of an ordered mapping. */
+	FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_KEY,
+	/** Expect a value of an ordered mapping. */
+	FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_VALUE,
+	/** Expect the and of an ordered mapping entry. */
+	FYPS_FLOW_SEQUENCE_ENTRY_MAPPING_END,
+	/** Expect the first key of a flow mapping. */
+	FYPS_FLOW_MAPPING_FIRST_KEY,
+	/** Expect a key of a flow mapping. */
+	FYPS_FLOW_MAPPING_KEY,
+	/** Expect a value of a flow mapping. */
+	FYPS_FLOW_MAPPING_VALUE,
+	/** Expect an empty value of a flow mapping. */
+	FYPS_FLOW_MAPPING_EMPTY_VALUE,
+	/** Expect only stream end */
+	FYPS_SINGLE_DOCUMENT_END,
+	/** Expect nothing. */
+	FYPS_END
+};
+
+struct fy_parse_state_log {
+	struct list_head node;
+	enum fy_parser_state state;
+};
+FY_PARSE_TYPE_DECL(parse_state_log);
+
+struct fy_streaming_alias {
+	struct list_head node;
+	struct fy_token *anchor;
+	bool collecting;
+	long mapping_nest;
+	long sequence_nest;
+	struct fy_eventp_list events;
+};
+FY_PARSE_TYPE_DECL(streaming_alias);
+
+struct fy_streaming_alias_state {
+	struct fy_streaming_alias *fysa;
+	struct fy_eventp *next;
+};
+
+/* 2 bits per collection tracking state
+ * pos: * 2
+ * bit 0 - 0 map, 1 seq
+ * bit 1 - 0 key, 1 val (if map)
+ */
+#define FYCTS_SCALAR  0
+#define FYCTS_SEQ     1
+#define FYCTS_MAP     2
+#define FYCTS_MAP_KEY 2
+#define FYCTS_MAP_VAL 3
+#define FYCTS_MAP_TOGGLE 1
+
+struct fy_parser {
+	struct fy_parse_cfg cfg;
+
+	struct fy_input_list queued_inputs;	/* all the inputs queued */
+	struct fy_reader builtin_reader;	/* the builtin reader */
+	struct fy_reader *reader;		/* the external reader, or ptr to builtin_reader */
+
+	struct fy_version default_version;
+	struct fy_version stream_version;	/* last version set in stream */
+
+	union {
+		struct {
+			bool suppress_recycling : 1;
+			bool stream_start_produced : 1;
+			bool stream_end_produced : 1;
+			bool stream_end_reached : 1;
+			bool simple_key_allowed : 1;
+			bool tab_used_for_ws : 1;
+			bool stream_error : 1;
+			bool generated_block_map : 1;
+			bool last_was_comma : 1;
+			bool document_has_content : 1;
+			bool document_first_content_token : 1;
+			bool bare_document_only : 1;		/* no document start indicators allowed, no directives */
+			bool stream_has_content : 1;
+			bool parse_flow_only : 1;	/* document is in flow form, and stop parsing at the end */
+			bool parse_block_only : 1;	/* document is in embedded block form, and stop parsing at the end */
+			bool colon_follows_colon : 1;	/* "foo"::bar -> "foo": :bar */
+			bool had_directives : 1;	/* document had directives */
+			bool is_checkpoint : 1;		/* a parser checkpoint (not a real parser) */
+		};
+		unsigned int parser_bitflags;
+	};
+
+	int flow_level;
+	int pending_complex_key_column;
+	struct fy_mark pending_complex_key_mark;
+	int last_block_mapping_key_line;
+	struct fy_mark last_comma_mark;
+	struct fy_mark last_tab_used_for_ws_mark;
+
+	/* copy of stream_end token */
+	struct fy_token *stream_end_token;
+
+	/* produced tokens, but not yet consumed */
+	struct fy_token_list queued_tokens;
+	int token_activity_counter;
+
+	/* last comment */
+	struct fy_atom last_comment;
+	/* next comment */
+	struct fy_atom override_comment;
+
+	/* indent stack */
+	struct fy_indent_list indent_stack;
+	int indent;
+	int parent_indent;
+	int indent_line;
+	int starting_indent;
+	/* simple key stack */
+	struct fy_simple_key_list simple_keys;
+	/* state stack */
+	enum fy_parser_state state;
+	struct fy_parse_state_log_list state_stack;
+
+	/* current parse document */
+	struct fy_document_state *current_document_state;
+	struct fy_document_state *default_document_state;
+	bool next_single_document;
+
+	/* flow stack */
+	enum fy_flow_type flow;
+	struct fy_flow_list flow_stack;
+
+	/* recycling lists */
+	struct fy_indent_list recycled_indent;
+	struct fy_simple_key_list recycled_simple_key;
+	struct fy_parse_state_log_list recycled_parse_state_log;
+	struct fy_flow_list recycled_flow;
+	struct fy_streaming_alias_list recycled_streaming_alias;
+
+	struct fy_eventp_list recycled_eventp;
+	struct fy_token_list recycled_token;
+
+	struct fy_eventp_list *recycled_eventp_list;
+	struct fy_token_list *recycled_token_list;
+
+	/* the diagnostic object */
+	struct fy_diag *diag;
+
+	int err_term_width;
+	int err_term_height;
+
+	/* for when using the built-in document builder */
+	struct fy_document_builder *fydb;
+
+	/* when using the composer interface */
+	struct fy_composer *fyc;
+	fy_parse_composer_cb fyc_cb;
+	void *fyc_userdata;
+
+	/* last generated event atom */
+	struct fy_atom last_event_handle;
+
+	struct fy_streaming_alias_list streaming_aliases;
+	/* streaming alias state */
+	struct {
+		int alloc;
+		int top;
+		struct fy_streaming_alias_state *stack;
+		struct fy_streaming_alias_state local[8];
+	} sas;
+	/* collection tracking state */
+	struct {
+		int alloc;
+		int top;
+		uint32_t *stack;
+		uint32_t local[8];	/* 8 * 32 = 256 / 2 = 128 levels before needing dynamic allocation */
+	} cts;
+	/* merge key state */
+	struct {
+		bool active;
+		struct fy_eventp_list args;
+		struct fy_document *fyd;
+	} mks;
+	struct fy_eventp *fyep_peek;
+};
+
+static inline struct fy_input *
+fyp_current_input(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_current_input(fyp->reader);
+}
+
+static inline uint64_t
+fyp_current_input_generation(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_current_input_generation(fyp->reader);
+}
+
+static inline int fyp_column(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_column(fyp->reader);
+}
+
+static inline int fyp_line(const struct fy_parser *fyp)
+{
+	return fy_reader_line(fyp->reader);
+}
+
+static inline int fyp_tabsize(const struct fy_parser *fyp)
+{
+	return fy_reader_tabsize(fyp->reader);
+}
+
+static inline bool fyp_json_mode(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_json_mode(fyp->reader);
+}
+
+static inline enum fy_lb_mode fyp_lb_mode(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_lb_mode(fyp->reader);
+}
+
+static inline enum fy_flow_ws_mode fyp_fws_mode(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_flow_ws_mode(fyp->reader);
+}
+
+static inline bool fyp_directive0_mode(const struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_directive0_mode(fyp->reader);
+}
+
+static inline bool fyp_block_mode(struct fy_parser *fyp)
+{
+	return !fyp_json_mode(fyp) && !fyp->flow_level;
+}
+
+static inline bool fyp_is_lb(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_lb(fyp->reader, c);
+}
+
+static inline bool fyp_is_lbz(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_lbz(fyp->reader, c);
+}
+
+static inline bool fyp_is_blankz(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_blankz(fyp->reader, c);
+}
+
+static inline bool fyp_is_generic_lb(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_generic_lb(fyp->reader, c);
+}
+
+static inline bool fyp_is_generic_lbz(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_generic_lbz(fyp->reader, c);
+}
+
+static inline bool fyp_is_generic_blankz(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_generic_blankz(fyp->reader, c);
+}
+
+static inline bool fyp_is_flow_ws(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_flow_ws(fyp->reader, c);
+}
+
+static inline bool fyp_is_flow_blank(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_flow_blank(fyp->reader, c);
+}
+
+static inline bool fyp_is_flow_blankz(const struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	return fy_reader_is_flow_blankz(fyp->reader, c);
+}
+
+static inline const void *
+fy_ensure_lookahead_slow_path(struct fy_parser *fyp, size_t size, size_t *leftp)
+{
+	assert(fyp);
+	return fy_reader_ensure_lookahead_slow_path(fyp->reader, size, leftp);
+}
+
+/* only allowed if input does not update */
+static inline void
+fy_get_mark(struct fy_parser *fyp, struct fy_mark *fym)
+{
+	assert(fyp);
+	fy_reader_get_mark(fyp->reader, fym);
+}
+
+static inline const void *
+fy_ptr(struct fy_parser *fyp, size_t *leftp)
+{
+	assert(fyp);
+	return fy_reader_ptr(fyp->reader, leftp);
+}
+
+static inline const void *
+fy_ensure_lookahead(struct fy_parser *fyp, size_t size, size_t *leftp)
+{
+	assert(fyp);
+	return fy_reader_ensure_lookahead(fyp->reader, size, leftp);
+}
+
+/* advance the given number of ascii characters, not utf8 */
+static inline void
+fy_advance_octets(struct fy_parser *fyp, size_t advance)
+{
+	assert(fyp);
+	fy_reader_advance_octets(fyp->reader, advance);
+}
+
+/* compare string at the current point (n max) */
+static inline int
+fy_parse_strncmp(struct fy_parser *fyp, const char *str, size_t n)
+{
+	assert(fyp);
+	return fy_reader_strncmp(fyp->reader, str, n);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_at_offset_width(struct fy_parser *fyp, size_t offset, int *wp)
+{
+	assert(fyp);
+	return fy_reader_peek_at_offset_width(fyp->reader, offset, wp);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_at_offset(struct fy_parser *fyp, size_t offset)
+{
+	assert(fyp);
+	return fy_reader_peek_at_offset(fyp->reader, offset);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_at_width_internal(struct fy_parser *fyp, int pos, ssize_t *offsetp, int *wp)
+{
+	assert(fyp);
+	return fy_reader_peek_at_width_internal(fyp->reader, pos, offsetp, wp);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_at_internal(struct fy_parser *fyp, int pos, ssize_t *offsetp)
+{
+	assert(fyp);
+	return fy_reader_peek_at_internal(fyp->reader, pos, offsetp);
+}
+
+static inline bool
+fy_is_blank_at_offset(struct fy_parser *fyp, size_t offset)
+{
+	assert(fyp);
+	return fy_is_blank(fy_reader_peek_at_offset(fyp->reader, offset));
+}
+
+static inline bool
+fy_is_blankz_at_offset(struct fy_parser *fyp, size_t offset)
+{
+	assert(fyp);
+	return fy_reader_is_blankz(fyp->reader, fy_reader_peek_at_offset(fyp->reader, offset));
+}
+
+static inline bool
+fy_is_generic_blankz_at_offset(struct fy_parser *fyp, size_t offset)
+{
+	assert(fyp);
+	return fy_reader_is_generic_blankz(fyp->reader, fy_reader_peek_at_offset(fyp->reader, offset));
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_at_width(struct fy_parser *fyp, int pos, int *wp)
+{
+	assert(fyp);
+	return fy_reader_peek_at_width(fyp->reader, pos, wp);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_at(struct fy_parser *fyp, int pos)
+{
+	assert(fyp);
+	return fy_reader_peek_at(fyp->reader, pos);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek_width(struct fy_parser *fyp, int *wp)
+{
+	assert(fyp);
+	return fy_reader_peek_width(fyp->reader, wp);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_peek(struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_peek(fyp->reader);
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_advance(struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	fy_reader_advance(fyp->reader, c);
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_advance_ws(struct fy_parser *fyp, int c)
+{
+	assert(fyp);
+	fy_reader_advance_ws(fyp->reader, c);
+}
+
+static FY_ALWAYS_INLINE inline void
+fy_advance_space(struct fy_parser *fyp)
+{
+	assert(fyp);
+	fy_reader_advance_space(fyp->reader);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_parse_get(struct fy_parser *fyp)
+{
+	assert(fyp);
+	return fy_reader_get(fyp->reader);
+}
+
+static FY_ALWAYS_INLINE inline int
+fy_advance_by(struct fy_parser *fyp, int count)
+{
+	assert(fyp);
+	return fy_reader_advance_by(fyp->reader, count);
+}
+
+/* compare string at the current point */
+static inline bool
+fy_parse_strcmp(struct fy_parser *fyp, const char *str)
+{
+	assert(fyp);
+	return fy_reader_strcmp(fyp->reader, str);
+}
+
+static inline void
+fy_fill_atom_start(struct fy_parser *fyp, struct fy_atom *handle)
+{
+	assert(fyp);
+	fy_reader_fill_atom_start(fyp->reader, handle);
+}
+
+static inline void
+fy_fill_atom_end_at(struct fy_parser *fyp, struct fy_atom *handle, struct fy_mark *end_mark)
+{
+	assert(fyp);
+	fy_reader_fill_atom_end_at(fyp->reader, handle, end_mark);
+}
+
+static inline void
+fy_fill_atom_end(struct fy_parser *fyp, struct fy_atom *handle)
+{
+	assert(fyp);
+	fy_reader_fill_atom_end(fyp->reader, handle);
+}
+
+static inline struct fy_atom *
+fy_fill_atom(struct fy_parser *fyp, int advance, struct fy_atom *handle)
+{
+	assert(fyp);
+	return fy_reader_fill_atom(fyp->reader, advance, handle);
+}
+
+static inline struct fy_atom *
+fy_fill_atom_mark(struct fy_parser *fyp, const struct fy_mark *start_mark,
+		  const struct fy_mark *end_mark, struct fy_atom *handle)
+{
+	assert(fyp);
+	return fy_reader_fill_atom_mark(fyp->reader, start_mark, end_mark, handle);
+}
+
+static inline struct fy_atom *
+fy_fill_atom_at(struct fy_parser *fyp, int advance, int count, struct fy_atom *handle)
+{
+	assert(fyp);
+	return fy_reader_fill_atom_at(fyp->reader, advance, count, handle);
+}
+
+static inline void
+fy_parser_set_reader(struct fy_parser *fyp, struct fy_reader *fyr)
+{
+	if (!fyp)
+		return;
+	fyp->reader = fyr ? fyr : &fyp->builtin_reader;
+}
+
+static inline void
+fy_parser_set_flow_only_mode(struct fy_parser *fyp, bool flow_only_mode)
+{
+	fyp->parse_flow_only = flow_only_mode;
+}
+
+static inline void
+fy_parser_set_block_only_mode(struct fy_parser *fyp, bool block_only_mode)
+{
+	fyp->parse_block_only = block_only_mode;
+}
+
+#define fy_fill_atom_a(_fyp, _advance) \
+	fy_fill_atom((_fyp), (_advance), alloca(sizeof(struct fy_atom)))
+
+struct fy_token *fy_token_vqueue(struct fy_parser *fyp, enum fy_token_type type, va_list ap);
+struct fy_token *fy_token_queue(struct fy_parser *fyp, enum fy_token_type type, ...);
+
+struct fy_token *
+fy_token_vqueue_internal(struct fy_parser *fyp, struct fy_token_list *fytl,
+			 enum fy_token_type type, va_list ap);
+struct fy_token *
+fy_token_queue_internal(struct fy_parser *fyp, struct fy_token_list *fytl,
+			enum fy_token_type type, ...);
+
+int fy_parse_setup(struct fy_parser *fyp, const struct fy_parse_cfg *cfg);
+void fy_parse_cleanup(struct fy_parser *fyp);
+
+int fy_parse_input_append(struct fy_parser *fyp, const struct fy_input_cfg *fyic);
+ssize_t fy_parse_estimate_queued_input_size(struct fy_parser *fyp);
+
+struct fy_eventp *fy_parse_private(struct fy_parser *fyp);
+
+extern const char *fy_event_type_txt[];
+
+enum fy_parse_cfg_flags fy_parser_get_cfg_flags(const struct fy_parser *fyp);
+
+extern const struct fy_tag * const fy_default_tags[];
+
+extern const struct fy_version fy_default_version;	/* usually highest stable */
+
+bool fy_tag_handle_is_default(const char *handle, size_t handle_size);
+bool fy_tag_is_default_internal(const char *handle, size_t handle_size,
+				const char *prefix, size_t prefix_size);
+bool fy_token_tag_directive_is_overridable(struct fy_token *fyt_td);
+
+int fy_parser_set_default_document_state(struct fy_parser *fyp,
+					 struct fy_document_state *fyds);
+void fy_parser_set_next_single_document(struct fy_parser *fyp);
+
+void *fy_alloc_default(void *userdata, size_t size);
+void fy_free_default(void *userdata, void *ptr);
+void *fy_realloc_default(void *userdata, void *ptr, size_t size);
+
+int fy_reader_fetch_flow_scalar_handle(struct fy_reader *fyr, int c, int indent, struct fy_atom *handle, bool sloppy_indent);
+int fy_reader_fetch_plain_scalar_handle(struct fy_reader *fyr, int c, int indent, int flow_level, struct fy_atom *handle);
+
+void fy_reader_skip_ws_cr_nl(struct fy_reader *fyr);
+
+void fy_reader_skip_ws(struct fy_reader *fyr);
+void fy_reader_skip_space(struct fy_reader *fyr);
+
+static inline int fy_document_state_version_compare(struct fy_document_state *fyds, const struct fy_version *vb)
+{
+	return fy_version_compare(fy_document_state_version(fyds), vb);
+}
+
+int fy_parse_set_composer(struct fy_parser *fyp, fy_parse_composer_cb cb, void *userdata);
+
+struct fy_streaming_alias *
+fy_parse_streaming_alias_create(struct fy_parser *fyp, struct fy_token *fyt_anchor);
+void fy_parse_streaming_alias_clean(struct fy_parser *fyp, struct fy_streaming_alias *fysa);
+void fy_parse_streaming_aliases_reset(struct fy_parser *fyp);
+
+struct fy_eventp *fy_parser_parse_resolve_prolog(struct fy_parser *fyp);
+struct fy_eventp *fy_parser_parse_resolve_epilog(struct fy_parser *fyp, struct fy_eventp *fyep);
+
+struct fy_parser_checkpoint {
+	struct fy_parser fyp_checkpoint;
+	int queued_token_count;
+	struct fy_token **queued_tokens;
+	int queued_input_count;
+	struct fy_input **queued_inputs;
+	bool diag_on_error;
+};
+
+/* diagnostics */
+
+static inline bool
+fyp_debug_log_level_is_enabled(struct fy_parser *fyp, enum fy_error_module module)
+{
+	return fyp && fy_diag_log_level_is_enabled(fyp->diag, FYET_DEBUG, module);
+}
+
+int fy_parser_vdiag(struct fy_parser *fyp, unsigned int flags,
+		    const char *file, int line, const char *func,
+		    const char *fmt, va_list ap);
+
+int fy_parser_diag(struct fy_parser *fyp, unsigned int flags,
+		   const char *file, int line, const char *func,
+		   const char *fmt, ...)
+	FY_FORMAT(printf, 6, 7);
+
+void fy_parser_diag_vreport(struct fy_parser *fyp,
+			    const struct fy_diag_report_ctx *fydrc,
+			    const char *fmt, va_list ap);
+void fy_parser_diag_report(struct fy_parser *fyp,
+			   const struct fy_diag_report_ctx *fydrc,
+			   const char *fmt, ...)
+	FY_FORMAT(printf, 3, 4);
+
+#ifdef FY_DEVMODE
+
+#define fyp_debug(_fyp, _module, _fmt, ...) \
+	do { \
+		struct fy_parser *__fyp = (_fyp); \
+		enum fy_error_module __module = (_module); \
+		\
+		if (fyp_debug_log_level_is_enabled(__fyp, __module)) \
+			fy_parser_diag(__fyp, FYET_DEBUG | FYDF_MODULE(__module), \
+					__FILE__, __LINE__, __func__, \
+					(_fmt) , ## __VA_ARGS__); \
+	} while(0)
+#else
+
+#define fyp_debug(_fyp, _module, _fmt, ...) \
+	do { } while(0)
+
+#endif
+
+#define fyp_info(_fyp, _fmt, ...) \
+	fy_parser_diag((_fyp), FYET_INFO, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyp_notice(_fyp, _fmt, ...) \
+	fy_parser_diag((_fyp), FYET_NOTICE, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyp_warning(_fyp, _fmt, ...) \
+	fy_parser_diag((_fyp), FYET_WARNING, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+#define fyp_error(_fyp, _fmt, ...) \
+	fy_parser_diag((_fyp), FYET_ERROR, __FILE__, __LINE__, __func__, \
+			(_fmt) , ## __VA_ARGS__)
+
+#define fyp_scan_debug(_fyp, _fmt, ...) \
+	fyp_debug((_fyp), FYEM_SCAN, (_fmt) , ## __VA_ARGS__)
+#define fyp_parse_debug(_fyp, _fmt, ...) \
+	fyp_debug((_fyp), FYEM_PARSE, (_fmt) , ## __VA_ARGS__)
+#define fyp_doc_debug(_fyp, _fmt, ...) \
+	fyp_debug((_fyp), FYEM_DOC, (_fmt) , ## __VA_ARGS__)
+
+#define fyp_error_check(_fyp, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			fyp_error((_fyp), _fmt, ## __VA_ARGS__); \
+			goto _label ; \
+		} \
+	} while(0)
+
+#define _FYP_TOKEN_DIAG(_fyp, _fyt, _type, _module, _fmt, ...) \
+	do { \
+		struct fy_diag_report_ctx _drc; \
+		memset(&_drc, 0, sizeof(_drc)); \
+		_drc.type = (_type); \
+		_drc.module = (_module); \
+		_drc.fyt = (_fyt); \
+		fy_parser_diag_report((_fyp), &_drc, (_fmt) , ## __VA_ARGS__); \
+	} while(0)
+
+#define FYP_TOKEN_DIAG(_fyp, _fyt, _type, _module, _fmt, ...) \
+	_FYP_TOKEN_DIAG(_fyp, fy_token_ref(_fyt), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_PARSE_DIAG(_fyp, _adv, _cnt, _type, _module, _fmt, ...) \
+	_FYP_TOKEN_DIAG(_fyp, \
+		fy_token_create(FYTT_INPUT_MARKER, \
+			fy_fill_atom_at((_fyp), (_adv), (_cnt), \
+			alloca(sizeof(struct fy_atom)))), \
+		_type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_MARK_DIAG(_fyp, _sm, _em, _type, _module, _fmt, ...) \
+	_FYP_TOKEN_DIAG(_fyp, \
+		fy_token_create(FYTT_INPUT_MARKER, \
+			fy_fill_atom_mark(((_fyp)), (_sm), (_em), \
+				alloca(sizeof(struct fy_atom)))), \
+		_type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_NODE_DIAG(_fyp, _fyn, _type, _module, _fmt, ...) \
+	_FYP_TOKEN_DIAG(_fyp, fy_node_token(_fyn), _type, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_TOKEN_ERROR(_fyp, _fyt, _module, _fmt, ...) \
+	FYP_TOKEN_DIAG(_fyp, _fyt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_PARSE_ERROR(_fyp, _adv, _cnt, _module, _fmt, ...) \
+	FYP_PARSE_DIAG(_fyp, _adv, _cnt, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_MARK_ERROR(_fyp, _sm, _em, _module, _fmt, ...) \
+	FYP_MARK_DIAG(_fyp, _sm, _em, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_NODE_ERROR(_fyp, _fyn, _module, _fmt, ...) \
+	FYP_NODE_DIAG(_fyp, _fyn, FYET_ERROR, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_TOKEN_ERROR_CHECK(_fyp, _fyt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYP_TOKEN_ERROR(_fyp, _fyt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYP_PARSE_ERROR_CHECK(_fyp, _adv, _cnt, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYP_PARSE_ERROR(_fyp, _adv, _cnt, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYP_MARK_ERROR_CHECK(_fyp, _sm, _em, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYP_MARK_ERROR(_fyp, _sm, _em, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYP_NODE_ERROR_CHECK(_fyp, _fyn, _module, _cond, _label, _fmt, ...) \
+	do { \
+		if (!(_cond)) { \
+			FYP_NODE_ERROR(_fyp, _fyn, _module, _fmt, ## __VA_ARGS__); \
+			goto _label; \
+		} \
+	} while(0)
+
+#define FYP_TOKEN_WARNING(_fyp, _fyt, _module, _fmt, ...) \
+	FYP_TOKEN_DIAG(_fyp, _fyt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_PARSE_WARNING(_fyp, _adv, _cnt, _module, _fmt, ...) \
+	FYP_PARSE_DIAG(_fyp, _adv, _cnt, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_MARK_WARNING(_fyp, _sm, _em, _module, _fmt, ...) \
+	FYP_MARK_DIAG(_fyp, _sm, _em, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#define FYP_NODE_WARNING(_fyp, _fyn, _type, _module, _fmt, ...) \
+	FYP_NODE_DIAG(_fyp, _fyn, FYET_WARNING, _module, _fmt, ## __VA_ARGS__)
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-path.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-path.c
@@ -1,0 +1,717 @@
+/*
+ * fy-path.c - Internal ypath support
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+
+#include "fy-utils.h"
+
+#undef DBG
+// #define DBG fyp_notice
+#define DBG fyp_scan_debug
+
+static int fy_path_setup(struct fy_path *fypp)
+{
+	memset(fypp, 0, sizeof(*fypp));
+
+	fy_path_component_list_init(&fypp->recycled_component);
+	fy_path_component_list_init(&fypp->components);
+
+	return 0;
+}
+
+static void fy_path_cleanup(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+
+	if (!fypp)
+		return;
+
+	if (fypp->fydb) {
+		fy_document_builder_destroy(fypp->fydb);
+		fypp->fydb = NULL;
+	}
+
+	while ((fypc = fy_path_component_list_pop(&fypp->components)) != NULL)
+		fy_path_component_free(fypc);
+
+	while ((fypc = fy_path_component_list_pop(&fypp->recycled_component)) != NULL)
+		fy_path_component_free(fypc);
+}
+
+struct fy_path *fy_path_create(void)
+{
+	struct fy_path *fypp;
+	int rc;
+
+	fypp = malloc(sizeof(*fypp));
+	if (!fypp)
+		return NULL;
+
+	rc = fy_path_setup(fypp);
+	if (rc)
+		return NULL;
+
+	return fypp;
+}
+
+void fy_path_destroy(struct fy_path *fypp)
+{
+	if (!fypp)
+		return;
+
+	fy_path_cleanup(fypp);
+
+	free(fypp);
+}
+
+void fy_path_reset(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+
+	if (!fypp)
+		return;
+
+	while ((fypc = fy_path_component_list_pop(&fypp->components)) != NULL)
+		fy_path_component_free(fypc);
+}
+
+struct fy_path_component *fy_path_component_alloc(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+
+	if (!fypp)
+		return NULL;
+
+	fypc = fy_path_component_list_pop(&fypp->recycled_component);
+	if (!fypc) {
+		fypc = malloc(sizeof(*fypc));
+		if (!fypc)
+			return NULL;
+		memset(fypc, 0, sizeof(*fypc));
+	}
+
+	/* not yet instantiated */
+	fypc->type = FYPCT_NONE;
+
+	return fypc;
+}
+
+void fy_path_component_clear_state(struct fy_path_component *fypc)
+{
+	if (!fypc)
+		return;
+
+	switch (fypc->type) {
+	case FYPCT_NONE:
+		/* nothing */
+		break;
+
+	case FYPCT_MAP:
+		if (fypc->map.has_key) {
+			if (fypc->map.is_complex_key) {
+				if (fypc->map.complex_key_complete)
+					fy_document_destroy(fypc->map.complex_key);
+				fypc->map.complex_key = NULL;
+			} else {
+				fy_token_unref(fypc->map.scalar.tag);
+				fy_token_unref(fypc->map.scalar.key);
+				fypc->map.scalar.tag = NULL;
+				fypc->map.scalar.key = NULL;
+			}
+		}
+		fypc->map.root = true;
+		fypc->map.has_key = false;
+		fypc->map.await_key = true;
+		fypc->map.is_complex_key = false;
+		fypc->map.accumulating_complex_key = false;
+		fypc->map.complex_key_complete = false;
+		break;
+
+	case FYPCT_SEQ:
+		fypc->seq.idx = -1;
+		break;
+	}
+}
+
+void fy_path_component_cleanup(struct fy_path_component *fypc)
+{
+	if (!fypc)
+		return;
+
+	fy_path_component_clear_state(fypc);
+	fypc->type = FYPCT_NONE;
+}
+
+void fy_path_component_free(struct fy_path_component *fypc)
+{
+	if (!fypc)
+		return;
+
+	fy_path_component_cleanup(fypc);
+	free(fypc);
+}
+
+void fy_path_component_destroy(struct fy_path_component *fypc)
+{
+	if (!fypc)
+		return;
+
+	fy_path_component_cleanup(fypc);
+	fy_path_component_free(fypc);
+}
+
+void fy_path_component_recycle(struct fy_path *fypp, struct fy_path_component *fypc)
+{
+	if (!fypc)
+		return;
+
+	fy_path_component_cleanup(fypc);
+
+	if (!fypp)
+		fy_path_component_free(fypc);
+	else
+		fy_path_component_list_push(&fypp->recycled_component, fypc);
+}
+
+struct fy_path_component *fy_path_component_create_mapping(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+
+	if (!fypp)
+		return NULL;
+
+	fypc = fy_path_component_alloc(fypp);
+	if (!fypc)
+		return NULL;
+
+	fypc->type = FYPCT_MAP;
+
+	fypc->map.root = true;
+	fypc->map.await_key = true;
+	fypc->map.is_complex_key = false;
+	fypc->map.accumulating_complex_key = false;
+	fypc->map.complex_key_complete = false;
+
+	return fypc;
+}
+
+struct fy_path_component *fy_path_component_create_sequence(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+
+	if (!fypp)
+		return NULL;
+
+	fypc = fy_path_component_alloc(fypp);
+	if (!fypc)
+		return NULL;
+
+	fypc->type = FYPCT_SEQ;
+
+	fypc->seq.idx = -1;
+
+	return fypc;
+}
+
+bool fy_path_component_is_mapping(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_MAP;
+}
+
+int fy_path_component_sequence_get_index(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_SEQ ? fypc->seq.idx : -1;
+}
+
+struct fy_token *fy_path_component_mapping_get_scalar_key(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_MAP &&
+	       fypc->map.has_key && !fypc->map.is_complex_key ? fypc->map.scalar.key : NULL;
+}
+
+struct fy_token *fy_path_component_mapping_get_scalar_key_tag(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_MAP &&
+	       fypc->map.has_key && !fypc->map.is_complex_key ? fypc->map.scalar.tag : NULL;
+}
+
+struct fy_document *fy_path_component_mapping_get_complex_key(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_MAP &&
+	       fypc->map.has_key && fypc->map.is_complex_key ? fypc->map.complex_key : NULL;
+}
+
+bool fy_path_component_is_sequence(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_SEQ;
+}
+
+static int fy_path_component_get_text_internal(struct fy_emit_accum *ea, struct fy_path_component *fypc)
+{
+	char *doctxt;
+	const char *text;
+	size_t len;
+
+	switch (fypc->type) {
+	case FYPCT_NONE:
+		FY_IMPOSSIBLE_ABORT();
+
+	case FYPCT_MAP:
+
+		/* we don't handle transitionals */
+		if (!fypc->map.has_key || fypc->map.await_key || fypc->map.root)
+			return -1;
+
+		if (!fypc->map.is_complex_key && fypc->map.scalar.key) {
+			text = fy_token_get_text(fypc->map.scalar.key, &len);
+			if (!text)
+				return -1;
+
+			if (fypc->map.scalar.key->type == FYTT_ALIAS)
+				fy_emit_accum_utf8_put_raw(ea, '*');
+			fy_emit_accum_utf8_write_raw(ea, text, len);
+
+		} else if (fypc->map.complex_key) {
+			/* complex key */
+			doctxt = fy_emit_document_to_string(fypc->map.complex_key,
+				FYECF_WIDTH_INF | FYECF_INDENT_DEFAULT |
+				FYECF_MODE_FLOW_ONELINE | FYECF_NO_ENDING_NEWLINE);
+			fy_emit_accum_utf8_write_raw(ea, doctxt, strlen(doctxt));
+			free(doctxt);
+		}
+		break;
+
+	case FYPCT_SEQ:
+
+		/* not started filling yet */
+		if (fypc->seq.idx < 0)
+			return -1;
+
+		fy_emit_accum_utf8_printf_raw(ea, "%d", fypc->seq.idx);
+		break;
+	}
+
+	return 0;
+}
+
+static int fy_path_get_text_internal(struct fy_emit_accum *ea, struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+	struct fy_document *fyd;
+	char *doctxt;
+	const char *text;
+	size_t len;
+	bool local_key = false;
+	int rc, count;
+
+	if (fypp->parent) {
+		rc = fy_path_get_text_internal(ea, fypp->parent);
+		assert(!rc);
+		if (rc)
+			return -1;
+	}
+
+	/* OK, we have to iterate and rebuild the paths */
+	for (fypc = fy_path_component_list_head(&fypp->components), count = 0; fypc;
+			fypc = fy_path_component_next(&fypp->components, fypc), count++) {
+
+		fy_emit_accum_utf8_put_raw(ea, '/');
+
+		switch (fypc->type) {
+		case FYPCT_NONE:
+			FY_IMPOSSIBLE_ABORT();
+
+		case FYPCT_MAP:
+
+			if (!fypc->map.has_key || fypc->map.root)
+				break;
+
+			/* key reference ? wrap in .key(X)*/
+			local_key = false;
+			if (fypc->map.await_key)
+				local_key = true;
+
+			if (local_key)
+				fy_emit_accum_utf8_write_raw(ea, ".key(", 5);
+
+			if (!fypc->map.is_complex_key) {
+
+				if (fypc->map.scalar.key) {
+					text = fy_token_get_text(fypc->map.scalar.key, &len);
+					assert(text);
+					if (!text)
+						return -1;
+					if (fypc->map.scalar.key->type == FYTT_ALIAS)
+						fy_emit_accum_utf8_put_raw(ea, '*');
+					fy_emit_accum_utf8_write_raw(ea, text, len);
+				} else {
+					fy_emit_accum_utf8_write_raw(ea, ".null()", 7);
+				}
+			} else {
+				if (fypc->map.complex_key)
+					fyd = fypc->map.complex_key;
+				else
+					fyd = fy_document_builder_peek_document(fypp->fydb);
+
+				/* complex key */
+				if (fyd) {
+					doctxt = fy_emit_document_to_string(fyd,
+						FYECF_WIDTH_INF | FYECF_INDENT_DEFAULT |
+						FYECF_MODE_FLOW_ONELINE | FYECF_NO_ENDING_NEWLINE);
+				} else
+					doctxt = NULL;
+
+				if (doctxt) {
+					fy_emit_accum_utf8_write_raw(ea, doctxt, strlen(doctxt));
+					free(doctxt);
+				} else {
+					fy_emit_accum_utf8_write_raw(ea, "<X>", 3);
+				}
+			}
+
+			if (local_key)
+				fy_emit_accum_utf8_put_raw(ea, ')');
+
+			break;
+
+		case FYPCT_SEQ:
+
+			/* not started filling yet */
+			if (fypc->seq.idx < 0)
+				break;
+
+			fy_emit_accum_utf8_printf_raw(ea, "%d", fypc->seq.idx);
+			break;
+		}
+	}
+
+	return 0;
+}
+
+char *fy_path_get_text(struct fy_path *fypp)
+{
+	struct fy_emit_accum ea;	/* use an emit accumulator */
+	char *path = NULL;
+	size_t len;
+	int rc;
+
+	/* no inplace buffer; we will need the malloc'ed contents anyway */
+	fy_emit_accum_init(&ea, NULL, 0, 0, fylb_cr_nl);
+
+	fy_emit_accum_start(&ea, 0, fylb_cr_nl);
+
+	rc = fy_path_get_text_internal(&ea, fypp);
+	if (rc)
+		goto err_out;
+
+	if (fy_emit_accum_empty(&ea))
+		fy_emit_accum_utf8_printf_raw(&ea, "/");
+
+	fy_emit_accum_make_0_terminated(&ea);
+
+	path = fy_emit_accum_steal(&ea, &len);
+
+err_out:
+	fy_emit_accum_cleanup(&ea);
+
+	return path;
+}
+
+char *fy_path_component_get_text(struct fy_path_component *fypc)
+{
+	struct fy_emit_accum ea;	/* use an emit accumulator */
+	char *text = NULL;
+	size_t len;
+	int rc;
+
+	/* no inplace buffer; we will need the malloc'ed contents anyway */
+	fy_emit_accum_init(&ea, NULL, 0, 0, fylb_cr_nl);
+
+	fy_emit_accum_start(&ea, 0, fylb_cr_nl);
+
+	rc = fy_path_component_get_text_internal(&ea, fypc);
+	if (rc)
+		goto err_out;
+
+	fy_emit_accum_make_0_terminated(&ea);
+
+	text = fy_emit_accum_steal(&ea, &len);
+
+err_out:
+	fy_emit_accum_cleanup(&ea);
+
+	return text;
+}
+
+int fy_path_depth(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc;
+	int depth;
+
+	if (!fypp)
+		return 0;
+
+	depth = fy_path_depth(fypp->parent);
+	for (fypc = fy_path_component_list_head(&fypp->components); fypc;
+			fypc = fy_path_component_next(&fypp->components, fypc)) {
+
+		depth++;
+	}
+
+	return depth;
+}
+
+struct fy_path *fy_path_parent(struct fy_path *fypp)
+{
+	if (!fypp)
+		return NULL;
+	return fypp->parent;
+}
+
+struct fy_path_component *
+fy_path_last_component(struct fy_path *fypp)
+{
+	return fy_path_component_list_tail(&fypp->components);
+}
+
+struct fy_path_component *
+fy_path_last_not_collection_root_component(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	fypc_last = fy_path_component_list_tail(&fypp->components);
+	if (!fypc_last)
+		return NULL;
+
+	if (!fy_path_component_is_collection_root(fypc_last))
+		return fypc_last;
+
+	fypc_last = fy_path_component_prev(&fypp->components, fypc_last);
+	if (fypc_last)
+		return fypc_last;
+
+	if (fypp->parent)
+		return fy_path_component_list_tail(&fypp->parent->components);
+
+	return NULL;
+}
+
+bool fy_path_in_root(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	if (!fypp)
+		return true;
+
+	fypc_last = fy_path_last_not_collection_root_component(fypp);
+	return fypc_last == NULL;
+}
+
+
+bool fy_path_in_mapping(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	if (!fypp)
+		return false;
+
+	fypc_last = fy_path_last_not_collection_root_component(fypp);
+	if (!fypc_last)
+		return false;
+
+	return fypc_last->type == FYPCT_MAP;
+}
+
+bool fy_path_in_sequence(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	if (!fypp)
+		return false;
+
+	fypc_last = fy_path_last_not_collection_root_component(fypp);
+	if (!fypc_last)
+		return false;
+
+	return fypc_last->type == FYPCT_SEQ;
+}
+
+bool fy_path_in_mapping_key(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	if (!fypp)
+		return false;
+
+	fypc_last = fy_path_last_not_collection_root_component(fypp);
+	if (!fypc_last)
+		return false;
+
+	return fypc_last->type == FYPCT_MAP && fypc_last->map.await_key;
+}
+
+bool fy_path_in_mapping_value(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	if (!fypp)
+		return false;
+
+	fypc_last = fy_path_last_not_collection_root_component(fypp);
+	if (!fypc_last)
+		return false;
+
+	return fypc_last->type == FYPCT_MAP && !fypc_last->map.await_key;
+}
+
+bool fy_path_in_collection_root(struct fy_path *fypp)
+{
+	struct fy_path_component *fypc_last;
+
+	if (!fypp)
+		return false;
+
+	fypc_last = fy_path_component_list_tail(&fypp->components);
+	if (!fypc_last)
+		return false;
+
+	return fy_path_component_is_collection_root(fypc_last);
+}
+
+void *fy_path_get_root_user_data(struct fy_path *fypp)
+{
+	if (!fypp)
+		return NULL;
+
+	if (!fypp->parent)
+		return fypp->user_data;
+
+	return fy_path_get_root_user_data(fypp->parent);
+}
+
+void fy_path_set_root_user_data(struct fy_path *fypp, void *data)
+{
+	if (!fypp)
+		return;
+
+	if (!fypp->parent) {
+		fypp->user_data = data;
+		return;
+	}
+
+	fy_path_set_root_user_data(fypp->parent, data);
+}
+
+void *fy_path_component_get_mapping_user_data(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_MAP ? fypc->user_data : NULL;
+}
+
+void *fy_path_component_get_mapping_key_user_data(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_MAP ? fypc->map.key_user_data : NULL;
+}
+
+void *fy_path_component_get_sequence_user_data(struct fy_path_component *fypc)
+{
+	return fypc && fypc->type == FYPCT_SEQ ? fypc->user_data : NULL;
+}
+
+void fy_path_component_set_mapping_user_data(struct fy_path_component *fypc, void *data)
+{
+	if (!fypc || fypc->type != FYPCT_MAP)
+		return;
+
+	fypc->user_data = data;
+}
+
+void fy_path_component_set_mapping_key_user_data(struct fy_path_component *fypc, void *data)
+{
+	if (!fypc || fypc->type != FYPCT_MAP)
+		return;
+
+	fypc->map.key_user_data = data;
+}
+
+void fy_path_component_set_sequence_user_data(struct fy_path_component *fypc, void *data)
+{
+	if (!fypc || fypc->type != FYPCT_SEQ)
+		return;
+
+	fypc->user_data = data;
+}
+
+void *fy_path_get_parent_user_data(struct fy_path *fypp)
+{
+	struct fy_path_component *parent;
+
+	if (fy_path_in_root(fypp))
+		return fy_path_get_root_user_data(fypp);
+
+	parent = fy_path_last_not_collection_root_component(fypp);
+	if (fy_path_in_sequence(fypp))
+		return fy_path_component_get_sequence_user_data(parent);
+	else
+		return fy_path_component_get_mapping_user_data(parent);
+}
+
+void fy_path_set_parent_user_data(struct fy_path *fypp, void *data)
+{
+	struct fy_path_component *parent;
+
+	if (fy_path_in_root(fypp)) {
+		fy_path_set_root_user_data(fypp, data);
+	} else {
+		parent = fy_path_last_not_collection_root_component(fypp);
+		if (fy_path_in_sequence(fypp))
+			fy_path_component_set_sequence_user_data(parent, data);
+		else
+			fy_path_component_set_mapping_user_data(parent, data);
+	}
+}
+
+void *fy_path_get_last_user_data(struct fy_path *fypp)
+{
+	struct fy_path_component *last;
+
+	last = fy_path_last_component(fypp);
+	if (!last)
+		return NULL;
+
+	if (last->type == FYPCT_SEQ)
+		return fy_path_component_get_sequence_user_data(last);
+	else
+		return fy_path_component_get_mapping_user_data(last);
+}
+
+void fy_path_set_last_user_data(struct fy_path *fypp, void *data)
+{
+	struct fy_path_component *last;
+
+	last = fy_path_last_component(fypp);
+	if (!last)
+		return;
+
+	if (last->type == FYPCT_SEQ)
+		fy_path_component_set_sequence_user_data(last, data);
+	else
+		fy_path_component_set_mapping_user_data(last, data);
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-path.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-path.h
@@ -1,0 +1,114 @@
+/*
+ * fy-path.h - YAML parser private path definitions
+ *
+ * Copyright (c) 2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_PATH_H
+#define FY_PATH_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+#include "fy-typelist.h"
+
+#include "fy-emit-accum.h"
+
+FY_TYPE_FWD_DECL_LIST(path_component);
+
+enum fy_path_component_type {
+	FYPCT_NONE,	/* not yet instantiated */
+	FYPCT_MAP,	/* it's a mapping */
+	FYPCT_SEQ,	/* it's a sequence */
+};
+
+/* fwd declaration */
+struct fy_document;
+struct fy_document_builder;
+
+#define FY_PATH_MAPPING_SHORT_KEY	32
+
+struct fy_path_mapping_state {
+	bool root : 1;		/* no keys, values yet */
+	bool await_key : 1;
+	bool accumulating_complex_key : 1;
+	bool has_key : 1;			/* has a key */
+	bool is_complex_key : 1;
+	bool complex_key_complete : 1;
+	union {
+		struct {
+			struct fy_token *tag;
+			struct fy_token *key;
+		} scalar;
+		struct fy_document *complex_key;
+	};
+	void *key_user_data;
+};
+
+struct fy_path_sequence_state {
+	int idx;
+};
+
+struct fy_path_component {
+	struct list_head node;
+	enum fy_path_component_type type;
+	union {
+		struct fy_path_mapping_state map;
+		struct fy_path_sequence_state seq;
+	};
+	void *user_data;
+};
+FY_TYPE_DECL_LIST(path_component);
+
+static inline bool
+fy_path_component_is_collection_root(struct fy_path_component *fypc)
+{
+	if (!fypc)
+		return false;
+
+	switch (fypc->type) {
+	case FYPCT_NONE:
+		break;
+	case FYPCT_SEQ:
+		return fypc->seq.idx < 0;
+	case FYPCT_MAP:
+		return fypc->map.root;
+	}
+
+	return false;
+}
+
+FY_TYPE_FWD_DECL_LIST(path);
+struct fy_path {
+	struct list_head node;
+	struct fy_path_component_list recycled_component;
+	struct fy_path_component_list components;
+	struct fy_document_builder *fydb;	/* for complex keys */
+	struct fy_path *parent;			/* when we have a parent */
+	void *user_data;
+};
+FY_TYPE_DECL_LIST(path);
+
+struct fy_path *fy_path_create(void);
+void fy_path_destroy(struct fy_path *fypp);
+
+void fy_path_reset(struct fy_path *fypp);
+
+struct fy_path_component *fy_path_component_alloc(struct fy_path *fypp);
+void fy_path_component_cleanup(struct fy_path_component *fypc);
+void fy_path_component_free(struct fy_path_component *fypc);
+void fy_path_component_destroy(struct fy_path_component *fypc);
+void fy_path_component_recycle(struct fy_path *fypp, struct fy_path_component *fypc);
+void fy_path_component_clear_state(struct fy_path_component *fypc);
+
+struct fy_path_component *fy_path_component_create_mapping(struct fy_path *fypp);
+struct fy_path_component *fy_path_component_create_sequence(struct fy_path *fypp);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-token.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-token.c
@@ -1,0 +1,2128 @@
+/*
+ * fy-token.c - YAML token methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+
+#include "fy-ctype.h"
+#include "fy-utf8.h"
+#include "fy-emit-accum.h"
+
+#include "fy-walk.h"
+
+#include "fy-token.h"
+
+enum fy_scalar_style fy_token_scalar_style(struct fy_token *fyt)
+{
+	return fy_token_scalar_style_inline(fyt);
+}
+
+enum fy_collection_style fy_token_collection_style(struct fy_token *fyt)
+{
+	if (!fyt)
+		return FYCS_ANY;
+
+	switch (fyt->type) {
+	case FYTT_FLOW_SEQUENCE_START:
+	case FYTT_FLOW_SEQUENCE_END:
+	case FYTT_FLOW_MAPPING_START:
+	case FYTT_FLOW_MAPPING_END:
+		return FYCS_FLOW;
+
+	case FYTT_BLOCK_SEQUENCE_START:
+	case FYTT_BLOCK_MAPPING_START:
+	case FYTT_BLOCK_END:
+		return FYCS_BLOCK;
+
+	default:
+		break;
+	}
+
+	return FYCS_ANY;
+}
+
+enum fy_token_type fy_token_get_type(struct fy_token *fyt)
+{
+	return fy_token_get_type_inline(fyt);
+}
+
+void fy_token_clean_rl(struct fy_token_list *fytl, struct fy_token *fyt)
+{
+	struct fy_token_comment *tk;
+
+	if (!fyt)
+		return;
+
+	/* release reference */
+	fy_input_unref(fyt->handle.fyi);
+	fyt->handle.fyi = NULL;
+
+	/* release the token comments */
+	while ((tk = fyt->token_comment) != NULL) {
+		fyt->token_comment = tk->next;
+		fy_input_unref(tk->handle.fyi);
+		fy_atom_reset(&tk->handle);
+		if (tk->comment)
+			free(tk->comment);
+		free(tk);
+	}
+
+	if (fyt->comments) {
+		free(fyt->comments);
+		fyt->comments = NULL;
+	}
+
+	switch (fyt->type) {
+	case FYTT_TAG:
+		fy_token_unref(fyt->tag.fyt_td);
+		fyt->tag.fyt_td = NULL;
+		if (fyt->tag.handle0) {
+			free(fyt->tag.handle0);
+			fyt->tag.handle0 = NULL;
+		}
+		if (fyt->tag.suffix0) {
+			free(fyt->tag.suffix0);
+			fyt->tag.suffix0 = NULL;
+		}
+		if (fyt->tag.short0) {
+			free(fyt->tag.short0);
+			fyt->tag.short0 = NULL;
+		}
+		break;
+
+	case FYTT_TAG_DIRECTIVE:
+		if (fyt->tag_directive.prefix0) {
+			free(fyt->tag_directive.prefix0);
+			fyt->tag_directive.prefix0 = NULL;
+		}
+		if (fyt->tag_directive.handle0) {
+			free(fyt->tag_directive.handle0);
+			fyt->tag_directive.handle0 = NULL;
+		}
+		break;
+
+	case FYTT_PE_MAP_KEY:
+		fy_document_destroy(fyt->map_key.fyd);
+		fyt->map_key.fyd = NULL;
+		break;
+
+	case FYTT_SCALAR:
+		if (fyt->scalar.path_key_storage) {
+			free(fyt->scalar.path_key_storage);
+			fyt->scalar.path_key_storage = NULL;
+		}
+		break;
+
+	case FYTT_ALIAS:
+		if (fyt->alias.expr) {
+			fy_path_expr_free(fyt->alias.expr);
+			fyt->alias.expr = NULL;
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	if (fyt->text0) {
+		free(fyt->text0);
+		fyt->text0 = NULL;
+	}
+
+	fyt->type = FYTT_NONE;
+	memset(&fyt->analysis, 0, sizeof(fyt->analysis));
+	fyt->text_len = 0;
+	fyt->text = NULL;
+}
+
+void fy_token_list_unref_all_rl(struct fy_token_list *fytl, struct fy_token_list *fytl_tofree)
+{
+	struct fy_token *fyt;
+
+	while ((fyt = fy_token_list_pop(fytl_tofree)) != NULL)
+		fy_token_unref_rl(fytl, fyt);
+}
+
+static bool fy_token_text_needs_rebuild(struct fy_token *fyt)
+{
+	const struct fy_atom *fya;
+
+	if (!fy_token_text_is_direct(fyt))
+		return false;
+
+	fya = fy_token_atom(fyt);
+	if (!fya || !fya->fyi)
+		return false;
+
+	return fya->fyi_generation != fya->fyi->generation;
+}
+
+#define O_CPY(_src, _len) \
+	do { \
+		size_t _l = (_len); \
+		if (o && _l) { \
+			size_t _cl = _l; \
+			if (_cl > (size_t)(oe - o)) \
+				_cl = (size_t)(oe - o); \
+			memcpy(o, (_src), _cl); \
+			o += _cl; \
+		} \
+		len += _l; \
+	} while(0)
+
+static size_t fy_tag_token_format_internal(const struct fy_token *fyt, void *out, size_t *outszp)
+{
+	char *o = NULL, *oe = NULL;
+	size_t outsz;
+	const char *handle, *suffix;
+	size_t len, rlen, handle_size, suffix_size;
+	int code_length;
+	uint8_t code[4];
+	const char *t, *s, *e;
+
+	if (!fyt || fyt->type != FYTT_TAG)
+		return 0;
+
+	if (out && *outszp <= 0)
+		return 0;
+
+	if (out) {
+		outsz = *outszp;
+		o = out;
+		oe = (char *)out + outsz;
+	}
+
+	if (!fyt->tag.fyt_td)
+		return 0;
+
+	handle = fy_tag_directive_token_prefix(fyt->tag.fyt_td, &handle_size);
+	if (!handle)
+		return 0;
+
+	suffix = fy_atom_data(&fyt->handle) + fyt->tag.skip + fyt->tag.handle_length;
+	suffix_size = fyt->tag.suffix_length;
+
+	len = 0;
+	O_CPY(handle, handle_size);
+
+	/* escape suffix as a URI */
+	s = suffix;
+	e = s + suffix_size;
+	while (s < e) {
+		/* find next escape */
+		t = memchr(s, '%', e - s);
+		rlen = (size_t)((t ? t : e) - s);
+		O_CPY(s, rlen);
+
+		/* end of string */
+		if (!t)
+			break;
+		s = t;
+
+		code_length = sizeof(code);
+		t = fy_uri_esc(s, e - s, code, &code_length);
+		if (!t)
+			break;
+
+		/* output escaped utf8 */
+		O_CPY(code, code_length);
+		s = t;
+	}
+
+	return len;
+}
+
+size_t fy_tag_token_format_text_length(const struct fy_token *fyt)
+{
+	return fy_tag_token_format_internal(fyt, NULL, NULL);
+}
+
+const char *fy_tag_token_format_text(const struct fy_token *fyt, char *buf, size_t maxsz)
+{
+	if (maxsz > 0)
+		buf[0] = '\0';
+	fy_tag_token_format_internal(fyt, buf, &maxsz);
+	return buf;
+}
+
+static size_t fy_tag_directive_token_format_internal(const struct fy_token *fyt,
+			void *out, size_t *outszp)
+{
+	char *o = NULL, *oe = NULL;
+	size_t outsz;
+	size_t len;
+	const char *handle, *prefix;
+	size_t handle_size, prefix_size;
+
+	if (!fyt || fyt->type != FYTT_TAG_DIRECTIVE)
+		return 0;
+
+	if (out && *outszp <= 0)
+		return 0;
+
+	if (out) {
+		outsz = *outszp;
+		o = out;
+		oe = (char *)out + outsz;
+	}
+
+	len = 0;
+
+	handle = fy_atom_data(&fyt->handle);
+	handle_size = fy_atom_size(&fyt->handle);
+
+	prefix = handle + handle_size - fyt->tag_directive.uri_length;
+	prefix_size = fyt->tag_directive.uri_length;
+	handle_size = fyt->tag_directive.tag_length;
+
+	if (handle_size)
+		O_CPY(handle, handle_size);
+	else
+		O_CPY("!<", 2);
+	O_CPY(prefix, prefix_size);
+	if (!handle_size)
+		O_CPY(">", 1);
+
+	return len;
+}
+#undef O_CPY
+
+size_t fy_tag_directive_token_format_text_length(const struct fy_token *fyt)
+{
+	return fy_tag_directive_token_format_internal(fyt, NULL, NULL);
+}
+
+const char *fy_tag_directive_token_format_text(const struct fy_token *fyt, char *buf, size_t maxsz)
+{
+	fy_tag_directive_token_format_internal(fyt, buf, &maxsz);
+	return buf;
+}
+
+const char *fy_tag_directive_token_prefix(struct fy_token *fyt, size_t *lenp)
+{
+	const char *ptr;
+	size_t len, tmplen;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyt || fyt->type != FYTT_TAG_DIRECTIVE) {
+		*lenp = 0;
+		return NULL;
+	}
+	ptr = fy_atom_data(&fyt->handle);
+	len = fy_atom_size(&fyt->handle);
+	ptr = ptr + len - fyt->tag_directive.uri_length;
+	*lenp = fyt->tag_directive.uri_length;
+
+	return ptr;
+}
+
+const char *fy_tag_directive_token_prefix0(struct fy_token *fyt)
+{
+	char *text0;
+	const char *text;
+	size_t len;
+
+	if (!fyt || fyt->type != FYTT_TAG_DIRECTIVE)
+		return NULL;
+
+	/* use the cache if it's there (and doesn't need a rebuild) */
+	if (fyt->tag_directive.prefix0 && !fy_token_text_needs_rebuild(fyt))
+		return fyt->tag_directive.prefix0;
+
+	if (fyt->tag_directive.prefix0) {
+		free(fyt->tag_directive.prefix0);
+		fyt->tag_directive.prefix0 = NULL;
+	}
+
+	text = fy_tag_directive_token_prefix(fyt, &len);
+	if (!text)
+		return NULL;
+
+	text0 = malloc(len + 1);
+	if (!text0)
+		return NULL;
+	memcpy(text0, text, len);
+	text0[len] = '\0';
+
+	fyt->tag_directive.prefix0 = text0;
+
+	return fyt->tag_directive.prefix0;
+}
+
+const char *fy_tag_directive_token_handle(struct fy_token *fyt, size_t *lenp)
+{
+	const char *ptr;
+	size_t tmplen;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyt || fyt->type != FYTT_TAG_DIRECTIVE) {
+		*lenp = 0;
+		return NULL;
+	}
+	ptr = fy_atom_data(&fyt->handle);
+	*lenp = fyt->tag_directive.tag_length;
+	return ptr;
+}
+
+const char *fy_tag_directive_token_handle0(struct fy_token *fyt)
+{
+	char *text0;
+	const char *text;
+	size_t len;
+
+	if (!fyt || fyt->type != FYTT_TAG_DIRECTIVE)
+		return NULL;
+
+	/* use the cache if it's there (and doesn't need a rebuild) */
+	if (fyt->tag_directive.handle0 && !fy_token_text_needs_rebuild(fyt))
+		return fyt->tag_directive.handle0;
+
+	if (fyt->tag_directive.handle0) {
+		free(fyt->tag_directive.handle0);
+		fyt->tag_directive.handle0 = NULL;
+	}
+
+	text = fy_tag_directive_token_handle(fyt, &len);
+	if (!text)
+		return NULL;
+
+	text0 = malloc(len + 1);
+	if (!text0)
+		return NULL;
+	memcpy(text0, text, len);
+	text0[len] = '\0';
+
+	fyt->tag_directive.handle0 = text0;
+
+	return fyt->tag_directive.handle0;
+}
+
+struct fy_token *fy_token_vcreate_rl(struct fy_token_list *fytl, enum fy_token_type type, va_list ap)
+{
+	struct fy_token *fyt = NULL;
+	struct fy_atom *handle;
+	struct fy_token *fyt_td;
+
+	if ((unsigned int)type >= FYTT_COUNT)
+		goto err_out;
+
+	fyt = fy_token_alloc_rl(fytl);
+	if (!fyt)
+		goto err_out;
+	fyt->type = type;
+	fyt->handle.fyi = NULL;
+
+	handle = va_arg(ap, struct fy_atom *);
+	if (handle) {
+		fyt->handle = *handle;
+		fy_input_ref(fyt->handle.fyi);
+	} else
+		fy_atom_reset(&fyt->handle);
+
+	switch (fyt->type) {
+	case FYTT_TAG_DIRECTIVE:
+		fyt->tag_directive.tag_length = va_arg(ap, unsigned int);
+		fyt->tag_directive.uri_length = va_arg(ap, unsigned int);
+		fyt->tag_directive.is_default = va_arg(ap, int) ? true : false;
+		fyt->tag_directive.prefix0 = NULL;
+		fyt->tag_directive.handle0 = NULL;
+		break;
+	case FYTT_SCALAR:
+		fyt->scalar.path_key = NULL;
+		fyt->scalar.path_key_len = 0;
+		fyt->scalar.path_key_storage = NULL;
+		fyt->scalar.is_null = false;	/* by default the scalar is not NULL */
+		fyt->scalar.style = va_arg(ap, enum fy_scalar_style);
+		/* by default it's the same as the content */
+		fyt->scalar.style_start = handle->start_mark;
+		fyt->scalar.style_end = handle->end_mark;
+		if (fyt->scalar.style != FYSS_ANY && (unsigned int)fyt->scalar.style >= FYSS_MAX)
+			goto err_out;
+		break;
+	case FYTT_TAG:
+		fyt->tag.skip = va_arg(ap, unsigned int);
+		fyt->tag.handle_length = va_arg(ap, unsigned int);
+		fyt->tag.suffix_length = va_arg(ap, unsigned int);
+
+		fyt_td = va_arg(ap, struct fy_token *);
+		if (!fyt_td)
+			goto err_out;
+		fyt->tag.fyt_td = fy_token_ref(fyt_td);
+		fyt->tag.handle0 = NULL;
+		fyt->tag.suffix0 = NULL;
+		fyt->tag.short0 = NULL;
+		break;
+
+	case FYTT_VERSION_DIRECTIVE:
+		fyt->version_directive.vers = *va_arg(ap, struct fy_version *);
+		break;
+
+	case FYTT_ALIAS:
+		fyt->alias.expr = va_arg(ap, struct fy_path_expr *);
+		fyt->alias.style_start = fyt->handle.start_mark;
+		break;
+
+	case FYTT_KEY:
+		fyt->key.flow_level = va_arg(ap, int);
+		break;
+
+	case FYTT_PE_MAP_KEY:
+		fyt->map_key.fyd = va_arg(ap, struct fy_document *);
+		break;
+
+	case FYTT_PE_SEQ_INDEX:
+		fyt->seq_index.index = va_arg(ap, int);
+		break;
+
+	case FYTT_PE_SEQ_SLICE:
+		fyt->seq_slice.start_index = va_arg(ap, int);
+		fyt->seq_slice.end_index = va_arg(ap, int);
+		break;
+
+	case FYTT_NONE:
+		goto err_out;
+
+	case FYTT_ANCHOR:
+		fyt->anchor.style_start = fyt->handle.start_mark;
+		break;
+
+	default:
+		break;
+	}
+
+	return fyt;
+
+err_out:
+	fy_token_unref(fyt);
+
+	return NULL;
+}
+
+struct fy_token *fy_token_create_rl(struct fy_token_list *fytl, enum fy_token_type type, ...)
+{
+	struct fy_token *fyt;
+	va_list ap;
+
+	va_start(ap, type);
+	fyt = fy_token_vcreate_rl(fytl, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+struct fy_token *fy_token_vcreate(enum fy_token_type type, va_list ap)
+{
+	return fy_token_vcreate_rl(NULL, type, ap);
+}
+
+struct fy_token *fy_token_create(enum fy_token_type type, ...)
+{
+	struct fy_token *fyt;
+	va_list ap;
+
+	va_start(ap, type);
+	fyt = fy_token_vcreate_rl(NULL, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+struct fy_token *fy_parse_token_create(struct fy_parser *fyp, enum fy_token_type type, ...)
+{
+	struct fy_token *fyt;
+	va_list ap;
+
+	if (!fyp)
+		return NULL;
+
+	va_start(ap, type);
+	fyt = fy_token_vcreate_rl(fyp->recycled_token_list, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+size_t fy_token_format_text_length(struct fy_token *fyt)
+{
+	ssize_t length;
+
+	if (!fyt)
+		return 0;
+
+	switch (fyt->type) {
+
+	case FYTT_TAG:
+		return fy_tag_token_format_text_length(fyt);
+
+	case FYTT_TAG_DIRECTIVE:
+		return fy_tag_directive_token_format_text_length(fyt);
+
+	default:
+		break;
+	}
+
+	length = fy_atom_format_text_length(&fyt->handle);
+
+	/* when something is seriously wrong cop out */
+	if (length < 0)
+		return 0;
+
+	return (size_t)length;
+}
+
+const char *fy_token_format_text(struct fy_token *fyt, char *buf, size_t maxsz)
+{
+	const char *str;
+
+	if (maxsz == 0)
+		return buf;
+
+	if (!fyt) {
+		if (maxsz > 0)
+			buf[0] = '\0';
+		return buf;
+	}
+
+	switch (fyt->type) {
+
+	case FYTT_TAG:
+		return fy_tag_token_format_text(fyt, buf, maxsz);
+
+	case FYTT_TAG_DIRECTIVE:
+		return fy_tag_directive_token_format_text(fyt, buf, maxsz);
+
+	default:
+		break;
+	}
+
+	str = fy_atom_format_text(&fyt->handle, buf, maxsz);
+
+	return str;
+}
+
+size_t fy_token_format_utf8_length(struct fy_token *fyt)
+{
+	const char *str;
+	size_t len;
+
+	if (!fyt)
+		return 0;
+
+	switch (fyt->type) {
+
+	case FYTT_TAG:
+	case FYTT_TAG_DIRECTIVE:
+		str = fy_token_get_text(fyt, &len);
+		if (!str)
+			return 0;
+		return fy_utf8_count(str, len);
+
+	default:
+		break;
+	}
+
+	return fy_atom_format_utf8_length(&fyt->handle);
+}
+
+struct fy_atom *fy_token_atom(struct fy_token *fyt)
+{
+	return fyt ? &fyt->handle : NULL;
+}
+
+const struct fy_mark *fy_token_start_mark(struct fy_token *fyt)
+{
+	const struct fy_atom *atom;
+
+	atom = fy_token_atom(fyt);
+	if (atom)
+		return &atom->start_mark;
+
+	/* something we don't track */
+	return NULL;
+}
+
+const struct fy_mark *fy_token_end_mark(struct fy_token *fyt)
+{
+	const struct fy_atom *atom;
+
+	atom = fy_token_atom(fyt);
+	if (atom)
+		return &atom->end_mark;
+
+	/* something we don't track */
+	return NULL;
+}
+
+const struct fy_token_analysis *
+fy_token_text_analyze(struct fy_token *fyt)
+{
+	static const struct fy_token_analysis null_analysis = {
+		.flags = FYTTAF_CAN_BE_SIMPLE_KEY | FYTTAF_DIRECT_OUTPUT |
+		         FYTTAF_EMPTY | FYTTAF_CAN_BE_DOUBLE_QUOTED |
+		         FYTTAF_ANALYZED,
+		.maxspan = 0,
+		.maxcol = 0,
+	};
+	if (!fyt)
+		return &null_analysis;
+
+	if (fyt->analysis.flags & FYTTAF_ANALYZED)
+		return &fyt->analysis;
+
+	/* only tokens that can generate text */
+	if (fyt->type == FYTT_SCALAR || fyt->type == FYTT_TAG ||
+	    fyt->type == FYTT_ANCHOR || fyt->type == FYTT_ALIAS) {
+		fyt->analysis.flags = fy_atom_text_analyze(fy_token_atom(fyt), fy_token_atom_style(fyt),
+				&fyt->analysis.maxspan, &fyt->analysis.maxcol);
+	} else {
+		fyt->analysis.flags = FYTTAF_NO_TEXT_TOKEN;
+		fyt->analysis.maxspan = 0;
+		fyt->analysis.maxcol = 0;
+	}
+
+	fyt->analysis.flags |= FYTTAF_ANALYZED;
+	return &fyt->analysis;
+}
+
+const char *fy_tag_token_get_directive_handle(struct fy_token *fyt, size_t *td_handle_sizep)
+{
+	if (!fyt || fyt->type != FYTT_TAG || !fyt->tag.fyt_td)
+		return NULL;
+
+	return fy_tag_directive_token_handle(fyt->tag.fyt_td, td_handle_sizep);
+}
+
+const char *fy_tag_token_get_directive_prefix(struct fy_token *fyt, size_t *td_prefix_sizep)
+{
+	if (!fyt || fyt->type != FYTT_TAG || !fyt->tag.fyt_td)
+		return NULL;
+
+	return fy_tag_directive_token_prefix(fyt->tag.fyt_td, td_prefix_sizep);
+}
+
+const char *fy_token_get_direct_output(struct fy_token *fyt, size_t *sizep)
+{
+	const struct fy_atom *fya;
+
+	fya = fy_token_atom(fyt);
+	if (!fya || !fya->direct_output ||
+	    (fyt->type == FYTT_TAG || fyt->type == FYTT_TAG_DIRECTIVE) ) {
+		*sizep = 0;
+		return NULL;
+	}
+	*sizep = fy_atom_size(fya);
+	return fy_atom_data(fya);
+}
+
+const char *fy_token_get_direct_simple_output(struct fy_token *fyt, size_t *sizep)
+{
+	const struct fy_atom *handle;
+
+	handle = fy_token_atom(fyt);
+
+	if (!(handle->style == FYAS_PLAIN && handle->storage_hint_valid &&
+	      handle->direct_output && !handle->high_ascii &&
+	      !handle->has_lb && !handle->has_ws && !handle->empty)) {
+		*sizep = 0;
+		return NULL;
+	}
+
+	*sizep = fy_atom_size(handle);
+	return fy_atom_data(handle);
+}
+
+const char *fy_tag_token_handle(struct fy_token *fyt, size_t *lenp)
+{
+	return fy_tag_token_get_directive_handle(fyt, lenp);
+}
+
+const char *fy_tag_token_suffix(struct fy_token *fyt, size_t *lenp)
+{
+	const char *tag, *prefix, *handle, *suffix;
+	size_t tag_len, prefix_len, handle_len, suffix_len, tmplen;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyt || fyt->type != FYTT_TAG) {
+		*lenp = 0;
+		return NULL;
+	}
+
+	tag = fy_token_get_text(fyt, &tag_len);
+	if (!tag)
+		return NULL;
+	prefix = fy_tag_token_get_directive_prefix(fyt, &prefix_len);
+	if (!prefix)
+		return NULL;
+	handle = fy_tag_token_handle(fyt, &handle_len);
+	if (!handle || !handle_len) {
+		suffix = tag;
+		suffix_len = tag_len;
+	} else {
+		assert(prefix_len <= tag_len);
+		assert(tag_len >= prefix_len);
+		suffix = tag + prefix_len;
+		suffix_len = tag_len - prefix_len;
+	}
+	*lenp = suffix_len;
+	return suffix;
+}
+
+const char *fy_tag_token_handle0(struct fy_token *fyt)
+{
+	char *text0;
+	const char *text;
+	size_t len;
+
+	if (!fyt || fyt->type != FYTT_TAG)
+		return NULL;
+
+	/* use the cache if it's there (and doesn't need a rebuild) */
+	if (fyt->tag.handle0 && !fy_token_text_needs_rebuild(fyt))
+		return fyt->tag.handle0;
+
+	if (fyt->tag.handle0) {
+		free(fyt->tag.handle0);
+		fyt->tag.handle0 = NULL;
+	}
+
+	text = fy_tag_token_handle(fyt, &len);
+	if (!text)
+		return NULL;
+
+	text0 = malloc(len + 1);
+	if (!text0)
+		return NULL;
+	memcpy(text0, text, len);
+	text0[len] = '\0';
+
+	fyt->tag.handle0 = text0;
+
+	return fyt->tag.handle0;
+}
+
+const char *fy_tag_token_suffix0(struct fy_token *fyt)
+{
+	char *text0;
+	const char *text;
+	size_t len;
+
+	if (!fyt || fyt->type != FYTT_TAG)
+		return NULL;
+
+	/* use the cache if it's there (and doesn't need a rebuild) */
+	if (fyt->tag.suffix0 && !fy_token_text_needs_rebuild(fyt))
+		return fyt->tag.suffix0;
+
+	if (fyt->tag.suffix0) {
+		free(fyt->tag.suffix0);
+		fyt->tag.suffix0 = NULL;
+	}
+
+	text = fy_tag_token_suffix(fyt, &len);
+	if (!text)
+		return NULL;
+
+	text0 = malloc(len + 1);
+	if (!text0)
+		return NULL;
+	memcpy(text0, text, len);
+	text0[len] = '\0';
+
+	fyt->tag.suffix0 = text0;
+
+	return fyt->tag.suffix0;
+}
+
+const char *fy_tag_token_short(struct fy_token *fyt, size_t *lenp)
+{
+	const char *handle, *suffix;
+	size_t handle_len, suffix_len, tmplen;
+	char *text0;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyt || fyt->type != FYTT_TAG)
+		return NULL;
+
+	/* use the cache if it's there (and doesn't need a rebuild) */
+	if (fyt->tag.short0 && !fy_token_text_needs_rebuild(fyt))
+		return fyt->tag.short0;
+
+	if (fyt->tag.short0) {
+		free(fyt->tag.short0);
+		fyt->tag.short0 = NULL;
+	}
+
+	handle = fy_tag_token_handle(fyt, &handle_len);
+	if (!handle)
+		return NULL;
+
+	suffix = fy_tag_token_suffix(fyt, &suffix_len);
+	if (!suffix)
+		return NULL;
+
+	text0 = malloc(handle_len + suffix_len + 1);
+	if (!text0)
+		return NULL;
+	memcpy(text0, handle, handle_len);
+	memcpy(text0 + handle_len, suffix, suffix_len);
+	text0[handle_len + suffix_len] = '\0';
+
+	fyt->tag.short0 = text0;
+	fyt->tag.short_length = (unsigned int)(handle_len + suffix_len);
+
+	*lenp = fyt->tag.short_length;
+
+	return fyt->tag.short0;
+}
+
+const char *fy_tag_token_short0(struct fy_token *fyt)
+{
+	const char *text;
+	size_t len;
+
+	text = fy_tag_token_short(fyt, &len);
+	if (!text)
+		return NULL;
+	return text;
+}
+
+const struct fy_version * fy_version_directive_token_version(struct fy_token *fyt)
+{
+	if (!fyt || fyt->type != FYTT_VERSION_DIRECTIVE)
+		return NULL;
+	return &fyt->version_directive.vers;
+}
+
+static void fy_token_prepare_text(struct fy_token *fyt)
+{
+	size_t ret;
+
+	assert(fyt);
+
+	/* get text length of this token */
+	ret = fy_token_format_text_length(fyt);
+
+	/* no text on this token? */
+	if (ret == 0) {
+		fyt->text_len = 0;
+		fyt->text = fyt->text0 = strdup("");
+		return;
+	}
+
+	fyt->text0 = malloc(ret + 1);
+	if (!fyt->text0) {
+		fyt->text_len = 0;
+		fyt->text = fyt->text0 = strdup("");
+		return;
+	}
+
+	fyt->text0[0] = '\0';
+
+	fyt->text_len = ret;
+
+	fy_token_format_text(fyt, fyt->text0, ret + 1);
+	fyt->text0[ret] = '\0';
+
+	fyt->text_len = ret;
+	fyt->text = fyt->text0;
+}
+
+const char *fy_token_get_text(struct fy_token *fyt, size_t *lenp)
+{
+	size_t tmplen;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	/* return empty */
+	if (!fyt) {
+		*lenp = 0;
+		return "";
+	}
+
+	/* already found something */
+	if (fyt->text && !fy_token_text_needs_rebuild(fyt)) {
+		*lenp = fyt->text_len;
+		return fyt->text;
+	}
+
+	/* try direct output first */
+	fyt->text = fy_token_get_direct_output(fyt, &fyt->text_len);
+	if (!fyt->text)
+		fy_token_prepare_text(fyt);
+
+	*lenp = fyt->text_len;
+	return fyt->text;
+}
+
+const char *fy_token_get_text0(struct fy_token *fyt)
+{
+	/* return empty */
+	if (!fyt)
+		return "";
+
+	/* created text is always zero terminated */
+	if (!fyt->text0)
+		fy_token_prepare_text(fyt);
+
+	return fyt->text0;
+}
+
+size_t fy_token_get_text_length(struct fy_token *fyt)
+{
+	return fy_token_format_text_length(fyt);
+}
+
+enum comment_out_state {
+	cos_normal,
+	cos_lastnl,
+	cos_lastnlhash,
+	cos_lastnlhashspc,
+};
+
+const char *
+fy_token_get_comment(struct fy_token *fyt, enum fy_comment_placement which)
+{
+	struct fy_token_comment *tk;
+	struct fy_atom *handle;
+	struct fy_atom_iter iter;
+	const struct fy_iter_chunk *ic;
+	char *s, *e;
+	const char *ss, *ee;
+	int c, w, ret, pass;
+	size_t size;
+	enum comment_out_state state;
+	bool output;
+
+	if (!fyt || (unsigned int)which >= fycp_max)
+		return NULL;
+
+	for (tk = fyt->token_comment; tk; tk = tk->next) {
+		if (tk->placement == which && fy_atom_is_set(&tk->handle))
+			break;
+	}
+
+	/* not found, we're done */
+	if (!tk)
+		return NULL;
+
+	/* found and already generated */
+	if (tk->comment)
+		return tk->comment;
+
+	handle = &tk->handle;
+
+	s = e = NULL;
+	size = 0;
+	for (pass = 0; pass < 2; pass++) {
+
+		if (pass) {
+			tk->comment = malloc(size + 1);
+			if (!tk->comment)
+				return NULL;
+			s = tk->comment;
+			e = s + size + 1;
+		}
+
+		/* start expecting # */
+		state = cos_lastnl;
+		fy_atom_iter_start(handle, &iter);
+		ic = NULL;
+		while ((ic = fy_atom_iter_chunk_next(&iter, ic, &ret)) != NULL) {
+			ss = ic->str;
+			ee = ss + ic->len;
+
+			while ((c = fy_utf8_get(ss, ee - ss, &w)) > 0) {
+
+				output = true;
+				switch (state) {
+				case cos_normal:
+					if (fy_is_lb_m(c, handle->lb_mode))
+						state = cos_lastnl;
+					break;
+
+				case cos_lastnl:
+					if (c == '#') {
+						state = cos_lastnlhash;
+						output = false;
+						break;
+					}
+					state = cos_normal;
+					break;
+
+				case cos_lastnlhash:
+					if (c == ' ') {
+						state = cos_lastnlhashspc;
+						output = false;
+						break;
+					}
+					if (fy_is_lb_m(c, handle->lb_mode)) {
+						state = cos_lastnl;
+						output = true;
+						break;
+					}
+					state = cos_normal;
+					break;
+
+				case cos_lastnlhashspc:
+					state = cos_normal;
+					break;
+				}
+
+				if (output) {
+					if (s) {
+						s = fy_utf8_put(s, (size_t)(e - s), c);
+						if (!s)
+							return NULL;
+					}
+					size += w;
+				}
+
+				ss += w;
+			}
+		}
+		fy_atom_iter_finish(&iter);
+	}
+
+	assert(s);
+	assert(s < e);
+	*s = '\0';
+
+	return tk->comment;
+}
+
+const char *
+fy_token_get_comments(struct fy_token *fyt)
+{
+	enum fy_comment_placement placement;
+	const char *str;
+	char *accum, *new_accum;
+	size_t size, accum_size, new_accum_size;
+	bool has_nl;
+
+	if (!fyt)
+		return NULL;
+
+	/* quick exit if no comments */
+	if (!fyt->token_comment)
+		return NULL;
+
+	/* already have it generated? */
+	if (fyt->comments)
+		return fyt->comments;
+
+	str = NULL;
+	accum = NULL;
+	accum_size = 0;
+	for (placement = fycp_top; placement < fycp_max; placement++) {
+
+		str = fy_token_get_comment(fyt, placement);
+		if (!str)
+			continue;
+
+		size = strlen(str);
+		has_nl = size > 0 && str[size-1] == '\n';
+		new_accum_size = accum_size + size + !has_nl + 1;
+		new_accum = realloc(accum, new_accum_size);
+		if (!new_accum)
+			goto err_out;
+		accum = new_accum;
+		memcpy(accum + accum_size, str, size);
+		accum_size += size;
+		if (!has_nl)
+			accum[accum_size++] = '\n';
+		accum[accum_size] = '\0';
+	}
+	return fyt->comments = accum;
+
+err_out:
+	if (accum)
+		free(accum);
+	return NULL;
+}
+
+int
+fy_token_set_comment(struct fy_token *fyt, enum fy_comment_placement which,
+		     const char *text, size_t len)
+{
+	struct fy_token_comment *tk, *tk_prev;
+	struct fy_input *fyi = NULL;
+	char *data = NULL;
+	const char *s, *e;
+	char utf8buf[FY_UTF8_MAX_WIDTH];
+	int c, lastc, w;
+	size_t sz;
+	struct fy_atom *handle;
+	struct fy_memstream *fyms = NULL;
+	FILE *fp;
+
+	if (!fyt || (unsigned int)which >= fycp_max)
+		return -1;
+
+	tk_prev = NULL;
+	for (tk = fyt->token_comment; tk; tk = tk->next) {
+		if (tk->placement == which)
+			break;
+		tk_prev = tk;
+	}
+
+	/* removal of comment */
+	if (!text && tk) {
+		if (!tk_prev)
+			fyt->token_comment = tk->next;
+		else
+			tk_prev = tk->next;
+
+		fy_input_unref(tk->handle.fyi);
+		fy_atom_reset(&tk->handle);
+		if (tk->comment)
+			free(tk->comment);
+		free(tk);
+		return 0;
+	}
+
+	if (len == FY_NT)
+		len = strlen(text);
+
+	data = NULL;
+
+	fyms = fy_memstream_open(&fp);
+	if (!fyms)
+		goto err_out;
+
+	s = text;
+	e = text + len;
+	lastc = -1;
+	fputs("# ", fp);
+	while ((c = fy_utf8_get(s, e - s, &w)) > 0) {
+		s += w;
+		if (lastc == '\n')
+			fputs("\n# ", fp);
+		if (fy_token_is_lb(fyt, c)) {
+			c = '\n';
+		} else {
+			assert((size_t)w <= sizeof(utf8buf));
+			fy_utf8_put_unchecked(utf8buf, c);
+			fwrite(utf8buf, 1, w, fp);
+		}
+		lastc = c;
+	}
+
+	data = fy_memstream_close(fyms, &sz);
+	fyms = NULL;
+
+	len = sz;
+
+	handle = tk ? &tk->handle : fy_token_comment_handle(fyt, which, true);
+	if (!handle)
+		goto err_out;
+
+	fy_input_unref(handle->fyi);
+	fy_atom_reset(handle);
+
+	fyi = fy_input_from_malloc_data(data, len, handle, true);
+	if (!fyi)
+		goto err_out;
+
+	return 0;
+
+err_out:
+	if (fyms) {
+		data = fy_memstream_close(fyms, &sz);
+		fyms = NULL;
+	}
+	fy_input_unref(fyi);
+	if (data)
+		free(data);
+	return -1;
+}
+
+const char *fy_token_get_scalar_path_key(struct fy_token *fyt, size_t *lenp)
+{
+	struct fy_atom *atom;
+	struct fy_atom_iter iter;
+	struct fy_emit_accum ea;	/* use an emit accumulator */
+	uint8_t non_utf8[4];
+	size_t non_utf8_len, k, tmplen;
+	int c, i, w, digit;
+	const struct fy_token_analysis *ta;
+
+	if (!lenp)
+		lenp = &tmplen;
+
+	if (!fyt || fyt->type != FYTT_SCALAR) {
+		*lenp = 0;
+		return NULL;
+	}
+
+	/* was it cached? return */
+	if (fyt->scalar.path_key) {
+		*lenp = fyt->scalar.path_key_len;
+		return fyt->scalar.path_key;
+	}
+
+	/* analyze the token */
+	ta = fy_token_text_analyze(fyt);
+
+	/* simple one? perfect */
+	if ((ta->flags & FYTTAF_CAN_BE_UNQUOTED_PATH_KEY) == FYTTAF_CAN_BE_UNQUOTED_PATH_KEY) {
+		fyt->scalar.path_key = fy_token_get_text(fyt, &fyt->scalar.path_key_len);
+		*lenp = fyt->scalar.path_key_len;
+		return fyt->scalar.path_key;
+	}
+
+	/* not possible, need to quote (and escape) */
+
+	/* no atom? i.e. empty */
+	atom = fy_token_atom(fyt);
+	if (!atom) {
+		fyt->scalar.path_key = "";
+		fyt->scalar.path_key_len = 0;
+		*lenp = 0;
+		return fyt->scalar.path_key;
+	}
+
+	/* no inplace buffer; we will need the malloc'ed contents anyway */
+	fy_emit_accum_init(&ea, NULL, 0, 0, fylb_cr_nl);
+
+	fy_atom_iter_start(atom, &iter);
+	fy_emit_accum_start(&ea, 0, fy_token_atom_lb_mode(fyt));
+
+	/* output in quoted form */
+	fy_emit_accum_utf8_put(&ea, '"');
+
+	for (;;) {
+		non_utf8_len = sizeof(non_utf8);
+		c = fy_atom_iter_utf8_quoted_get(&iter, &non_utf8_len, non_utf8);
+		if (c < 0)
+			break;
+
+		if (c == 0 && non_utf8_len > 0) {
+			for (k = 0; k < non_utf8_len; k++) {
+				c = (int)non_utf8[k] & 0xff;
+				fy_emit_accum_utf8_put(&ea, '\\');
+				fy_emit_accum_utf8_put(&ea, 'x');
+				digit = ((unsigned int)c >> 4) & 15;
+				fy_emit_accum_utf8_put(&ea,
+						digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+				digit = (unsigned int)c & 15;
+				fy_emit_accum_utf8_put(&ea,
+						digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+			}
+			continue;
+		}
+
+		if (!fy_is_printq(c) || c == '"' || c == '\\') {
+
+			fy_emit_accum_utf8_put(&ea, '\\');
+
+			switch (c) {
+
+			/* common YAML & JSON escapes */
+			case '\b':
+				fy_emit_accum_utf8_put(&ea, 'b');
+				break;
+			case '\f':
+				fy_emit_accum_utf8_put(&ea, 'f');
+				break;
+			case '\n':
+				fy_emit_accum_utf8_put(&ea, 'n');
+				break;
+			case '\r':
+				fy_emit_accum_utf8_put(&ea, 'r');
+				break;
+			case '\t':
+				fy_emit_accum_utf8_put(&ea, 't');
+				break;
+			case '"':
+				fy_emit_accum_utf8_put(&ea, '"');
+				break;
+			case '\\':
+				fy_emit_accum_utf8_put(&ea, '\\');
+				break;
+
+			/* YAML only escapes */
+			case '\0':
+				fy_emit_accum_utf8_put(&ea, '0');
+				break;
+			case '\a':
+				fy_emit_accum_utf8_put(&ea, 'a');
+				break;
+			case '\v':
+				fy_emit_accum_utf8_put(&ea, 'v');
+				break;
+			case '\x1b':
+				fy_emit_accum_utf8_put(&ea, 'e');
+				break;
+			case 0x85:
+				fy_emit_accum_utf8_put(&ea, 'N');
+				break;
+			case 0xa0:
+				fy_emit_accum_utf8_put(&ea, '_');
+				break;
+			case 0x2028:
+				fy_emit_accum_utf8_put(&ea, 'L');
+				break;
+			case 0x2029:
+				fy_emit_accum_utf8_put(&ea, 'P');
+				break;
+
+			default:
+				/* any kind of binary value */
+				if ((unsigned int)c <= 0xff) {
+					fy_emit_accum_utf8_put(&ea, 'x');
+					w = 2;
+				} else if ((unsigned int)c <= 0xffff) {
+					fy_emit_accum_utf8_put(&ea, 'u');
+					w = 4;
+				} else if ((unsigned int)c <= 0xffffffff) {
+					fy_emit_accum_utf8_put(&ea, 'U');
+					w = 8;
+				}
+
+				for (i = w - 1; i >= 0; i--) {
+					digit = ((unsigned int)c >> (i * 4)) & 15;
+					fy_emit_accum_utf8_put(&ea,
+							digit <= 9 ? ('0' + digit) : ('A' + digit - 10));
+				}
+				break;
+			}
+
+			continue;
+		}
+
+		/* regular character */
+		fy_emit_accum_utf8_put(&ea, c);
+	}
+
+	fy_atom_iter_finish(&iter);
+
+	/* closing quote */
+	fy_emit_accum_utf8_put(&ea, '"');
+
+	fy_emit_accum_make_0_terminated(&ea);
+
+	/* get the output (note it's now NULL terminated) */
+	fyt->scalar.path_key_storage = fy_emit_accum_steal(&ea, &fyt->scalar.path_key_len);
+	fyt->scalar.path_key = fyt->scalar.path_key_storage;
+	fy_emit_accum_cleanup(&ea);
+
+	*lenp = fyt->scalar.path_key_len;
+
+	return fyt->scalar.path_key;
+}
+
+size_t fy_token_get_scalar_path_key_length(struct fy_token *fyt)
+{
+	const char *text;
+	size_t len;
+
+	text = fy_token_get_scalar_path_key(fyt, &len);
+	if (!text)
+		return 0;
+	return len;
+}
+
+const char *fy_token_get_scalar_path_key0(struct fy_token *fyt)
+{
+	const char *text;
+	size_t len;
+
+	if (!fyt || fyt->type != FYTT_SCALAR) {
+		return NULL;
+	}
+
+	/* storage is \0 terminated */
+	if (fyt->scalar.path_key_storage)
+		return fyt->scalar.path_key_storage;
+
+	text = fyt->scalar.path_key;
+	len = fyt->scalar.path_key_len;
+	if (!text)
+		text = fy_token_get_scalar_path_key(fyt, &len);
+
+	/* something is catastrophically wrong */
+	if (!text)
+		return NULL;
+
+	if (fyt->scalar.path_key_storage)
+		return fyt->scalar.path_key_storage;
+
+	fyt->scalar.path_key_storage = malloc(len + 1);
+	if (!fyt->scalar.path_key_storage)
+		return NULL;
+
+	memcpy(fyt->scalar.path_key_storage, text, len);
+	fyt->scalar.path_key_storage[len] = '\0';
+
+	return fyt->scalar.path_key_storage;
+}
+
+unsigned int fy_analyze_scalar_content(const char *data, size_t size,
+		bool json_mode, enum fy_lb_mode lb_mode, enum fy_flow_ws_mode fws_mode)
+{
+	const char *s, *e;
+	int c, lastc, nextc, w, ww, col, break_run;
+	unsigned int flags;
+	bool first;
+
+	if (!size)
+		return FYACF_EMPTY | FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN | FYACF_SIZE0;
+
+	flags = FYACF_EMPTY | FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN |
+		FYACF_PRINTABLE | FYACF_SINGLE_QUOTED | FYACF_DOUBLE_QUOTED |
+		FYACF_SIZE0 | FYACF_VALID_ANCHOR;
+
+	s = data;
+	e = data + size;
+
+	/* if it ends in : can't be a plain */
+	if (e > s && e[-1] == ':') {
+		flags &= ~(FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN);
+		flags |= FYACF_ENDS_WITH_COLON;
+	}
+
+	col = 0;
+	first = true;
+	lastc = -1;
+	break_run = 0;
+	while (s < e && (c = fy_utf8_get(s, e - s, &w)) >= 0) {
+
+		flags &= ~FYACF_SIZE0;
+
+		lastc = c;
+
+		if (first) {
+			if (fy_is_ws(c))
+				flags |= FYACF_STARTS_WITH_WS;
+			else if (fy_is_generic_lb_m(c, lb_mode))
+				flags |= FYACF_STARTS_WITH_LB;
+			/* scalars starting with & or * must be quoted */
+			if (c == '&' || c == '*')
+				flags &= ~(FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN);
+			first = false;
+		}
+		nextc = fy_utf8_get(s + w, e - (s + w), &ww);
+
+		/* anything other than white space or linebreak */
+		if ((flags & FYACF_EMPTY) &&
+		    !fy_is_ws(c) && !fy_is_generic_lb_m(c, lb_mode))
+			flags &= ~FYACF_EMPTY;
+
+		if ((flags & FYACF_VALID_ANCHOR) &&
+		    (fy_utf8_strchr(",[]{}&*:", c) || fy_is_ws(c) ||
+		     fy_is_any_lb(c) || fy_is_unicode_control(c) ||
+		     fy_is_unicode_space(c)))
+			flags &= ~FYACF_VALID_ANCHOR;
+
+		/* linebreak */
+		if (fy_is_generic_lb_m(c, lb_mode)) {
+			flags |= FYACF_LB;
+			if (!(flags & FYACF_CONSECUTIVE_LB) &&
+			    fy_is_generic_lb_m(nextc, lb_mode))
+				flags |= FYACF_CONSECUTIVE_LB;
+			break_run++;
+		} else
+			break_run = 0;
+
+		/* white space */
+		if (!(flags & FYACF_WS) && fy_is_ws(c)) {
+			flags |= FYACF_WS;
+			flags &= ~FYACF_VALID_ANCHOR;
+		}
+
+		/* anything not printable (or \r, \n) */
+		if ((flags & FYACF_PRINTABLE) &&
+		    !fy_is_printq(c)) {
+			flags &= ~FYACF_PRINTABLE;
+			flags &= ~(FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN |
+				   FYACF_SINGLE_QUOTED | FYACF_VALID_ANCHOR);
+		}
+
+		/* check for document indicators (at column 0) */
+		if (!(flags & FYACF_DOC_IND) &&
+		    ((col == 0 && (e - s) >= 3 &&
+		      (!strncmp(s, "---", 3) || !strncmp(s, "...", 3))))) {
+			flags |= FYACF_DOC_IND;
+			flags &= ~(FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN | FYACF_VALID_ANCHOR);
+		}
+
+		/* comment indicator can't be present after a space or lb */
+		/* : followed by blank can't be any plain */
+		if ((flags & (FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN)) &&
+		    (((fy_is_blank(c) || fy_is_generic_lb_m(c, lb_mode)) && nextc == '#') ||
+		     (c == ':' && fy_is_blankz_m(nextc, lb_mode))))
+			flags &= ~(FYACF_BLOCK_PLAIN | FYACF_FLOW_PLAIN);
+
+		/* : followed by flow markers can't be a plain in flow context */
+		if ((flags & FYACF_FLOW_PLAIN) &&
+		    (fy_utf8_strchr(",[]{}", c) || (c == ':' && fy_utf8_strchr(",[]{}", nextc))))
+			flags &= ~FYACF_FLOW_PLAIN;
+
+		/* , followed by space can't be a plain in flow context */
+		if ((flags & FYACF_FLOW_PLAIN) && c == ',')
+			flags &= ~FYACF_FLOW_PLAIN;
+
+		if (!(flags & FYACF_JSON_ESCAPE) && !fy_is_json_unescaped(c))
+			flags |= FYACF_JSON_ESCAPE;
+
+		if (fy_is_generic_lb_m(c, lb_mode))
+			col = 0;
+		else
+			col++;
+
+		s += w;
+	}
+
+	/* this contains arbitrary binany values, mark it as such */
+	if (s < e)
+		return FYACF_DOUBLE_QUOTED;
+
+	if (fy_is_ws(lastc))
+		flags |= FYACF_ENDS_WITH_WS;
+	else if (fy_is_generic_lb_m(lastc, lb_mode))
+		flags |= FYACF_ENDS_WITH_LB;
+
+	if (break_run > 1)
+		flags |= FYACF_TRAILING_LB;
+
+	/* if it's empty it can be plain */
+	if (!(flags & FYACF_EMPTY) && (flags & (FYACF_STARTS_WITH_WS | FYACF_STARTS_WITH_LB |
+		      FYACF_ENDS_WITH_WS | FYACF_ENDS_WITH_LB)))
+		flags &= ~(FYACF_FLOW_PLAIN | FYACF_BLOCK_PLAIN);
+
+	return flags;
+}
+
+char *fy_token_debug_text(struct fy_token *fyt)
+{
+	const char *typetxt;
+	const char *text;
+	char *buf;
+	size_t length;
+	int wlen;
+	int rc __FY_DEBUG_UNUSED__;
+
+	if (!fyt || !fy_token_type_is_valid(fyt->type)) {
+		typetxt = "<NULL>";
+		goto out;
+	}
+	typetxt = fy_token_type_txt[fyt->type];
+
+	/* should never happen really */
+	assert(typetxt);
+
+out:
+	text = fy_token_get_text(fyt, &length);
+
+	wlen = length > 8 ? 8 : (int)length;
+
+	rc = asprintf(&buf, "%s:%.*s%s", typetxt, wlen, text, wlen < (int)length ? "..." : "");
+	assert(rc != -1);
+
+	return buf;
+}
+
+int fy_token_memcmp(struct fy_token *fyt, const void *ptr, size_t len)
+{
+	const char *value = NULL;
+	size_t tlen = 0;
+
+	/* special zero length handling */
+	if (len == 0 && fyt && fy_token_get_text_length(fyt) == 0)
+		return 0;
+
+	/* handle NULL cases */
+	if (!fyt && (!ptr || !len))
+		return 0;
+
+	if (!fyt && (ptr || len))
+		return -1;
+
+	if (fyt && (!ptr || !len))
+		return 1;
+
+	/* those two are special */
+	if (fyt->type == FYTT_TAG || fyt->type == FYTT_TAG_DIRECTIVE) {
+		value = fy_token_get_text(fyt, &tlen);
+		if (!value)
+			return -1;
+		return tlen == len ? memcmp(value, ptr, tlen) : tlen < len ? -1 : 1;
+	}
+
+	return fy_atom_memcmp(fy_token_atom(fyt), ptr, len);
+}
+
+int fy_token_strcmp(struct fy_token *fyt, const char *str)
+{
+	size_t len;
+
+	len = str ? strlen(str) : 0;
+
+	return fy_token_memcmp(fyt, str, len);
+}
+
+int fy_token_cmp(struct fy_token *fyt1, struct fy_token *fyt2)
+{
+	const char *t1, *t2;
+	size_t l1, l2, l;
+	int ret;
+	bool aoa;	/* anchor or alias */
+
+	/* handles both NULL */
+	if (fyt1 == fyt2)
+		return 0;
+
+	/* fyt1 is null, 2 wins */
+	if (!fyt1 && fyt2)
+		return -1;
+
+	/* fyt2 is null, 1 wins */
+	if (fyt1 && !fyt2)
+		return 1;
+
+	/* special case for comparing anchors and aliases */
+	aoa = (fyt1->type == FYTT_ANCHOR || fyt1->type == FYTT_ALIAS) &&
+	      (fyt2->type == FYTT_ANCHOR || fyt2->type == FYTT_ALIAS);
+
+	/* tokens with different types can't be equal */
+	if (!aoa && fyt1->type != fyt2->type)
+		return fyt2->type > fyt1->type ? -1 : 1;
+
+	/* special case, these can't use the atom comparisons */
+	if (fyt1->type == FYTT_TAG || fyt1->type == FYTT_TAG_DIRECTIVE) {
+		t1 = fy_token_get_text(fyt1, &l1);
+		t2 = fy_token_get_text(fyt2, &l2);
+		l = l1 > l2 ? l2 : l1;
+		ret = memcmp(t1, t2, l);
+		if (ret)
+			return ret;
+		return l1 == l2 ? 0 : l2 > l1 ? -1 : 1;
+	}
+
+	/* just pass it to the atom comparison methods */
+	return fy_atom_cmp(fy_token_atom(fyt1), fy_token_atom(fyt2));
+}
+
+void fy_token_iter_start(struct fy_token *fyt, struct fy_token_iter *iter)
+{
+	if (!iter)
+		return;
+
+	memset(iter, 0, sizeof(*iter));
+
+	iter->unget_c = -1;
+
+	if (!fyt)
+		return;
+
+	iter->fyt = fyt;
+
+	/* TAG or TAG_DIRECTIVE may only work by getting the text */
+	if (fyt->type == FYTT_TAG || fyt->type == FYTT_TAG_DIRECTIVE)
+		iter->ic.str = fy_token_get_text(fyt, &iter->ic.len);
+	else /* try the direct output next  */
+		iter->ic.str = fy_token_get_direct_output(fyt, &iter->ic.len);
+
+	/* got it */
+	if (iter->ic.str) {
+		memset(&iter->atom_iter, 0, sizeof(iter->atom_iter));
+		return;
+	}
+
+	assert(fyt->type != FYTT_TAG && fyt->type != FYTT_TAG_DIRECTIVE);
+
+	/* fall back to the atom iterator */
+	fy_atom_iter_start(fy_token_atom(fyt), &iter->atom_iter);
+}
+
+void fy_token_iter_finish(struct fy_token_iter *iter)
+{
+	if (!iter)
+		return;
+
+	if (!iter->ic.str)
+		fy_atom_iter_finish(&iter->atom_iter);
+}
+
+struct fy_token_iter *
+fy_token_iter_create(struct fy_token *fyt)
+{
+	struct fy_token_iter *iter;
+
+	iter = malloc(sizeof(*iter));
+	if (!iter)
+		return NULL;
+	fy_token_iter_start(fyt, iter);
+	return iter;
+}
+
+void fy_token_iter_destroy(struct fy_token_iter *iter)
+{
+	if (!iter)
+		return;
+
+	fy_token_iter_finish(iter);
+	free(iter);
+}
+
+const struct fy_iter_chunk *fy_token_iter_peek_chunk(struct fy_token_iter *iter)
+{
+	if (!iter)
+		return NULL;
+
+	/* direct mode? */
+	if (iter->ic.str)
+		return &iter->ic;
+
+	/* fallback to the atom iterator */
+	return fy_atom_iter_peek_chunk(&iter->atom_iter);
+}
+
+void fy_token_iter_advance(struct fy_token_iter *iter, size_t len)
+{
+	if (!iter)
+		return;
+
+	/* direct mode? */
+	if (iter->ic.str) {
+		if (len > iter->ic.len)
+			len = iter->ic.len;
+		iter->ic.str += len;
+		iter->ic.len -= len;
+		return;
+	}
+
+	/* fallback to the atom iterator */
+	fy_atom_iter_advance(&iter->atom_iter, len);
+}
+
+const struct fy_iter_chunk *
+fy_token_iter_chunk_next(struct fy_token_iter *iter, const struct fy_iter_chunk *curr, int *errp)
+{
+	if (!iter)
+		return NULL;
+
+	if (errp)
+		*errp = 0;
+
+	/* first time in */
+	if (!curr) {
+		if (iter->ic.str)
+			return iter->ic.len ? &iter->ic : NULL;
+		return fy_atom_iter_chunk_next(&iter->atom_iter, NULL, errp);
+	}
+
+	/* direct, all consumed */
+	if (curr == &iter->ic) {
+		iter->ic.str += iter->ic.len;
+		iter->ic.len = 0;
+		return NULL;
+	}
+
+	/* fallback */
+	return fy_atom_iter_chunk_next(&iter->atom_iter, curr, errp);
+}
+
+ssize_t fy_token_iter_read(struct fy_token_iter *iter, void *buf, size_t count)
+{
+	if (!iter || !buf)
+		return -1;
+
+	/* direct mode */
+	if (iter->ic.str) {
+		if (count > iter->ic.len)
+			count = iter->ic.len;
+		memcpy(buf, iter->ic.str, count);
+		iter->ic.str += count;
+		iter->ic.len -= count;
+		return count;
+	}
+
+	return fy_atom_iter_read(&iter->atom_iter, buf, count);
+}
+
+int fy_token_iter_getc(struct fy_token_iter *iter)
+{
+	int c;
+
+	if (!iter)
+		return -1;
+
+	/* first try the pushed ungetc */
+	if (iter->unget_c >= 0) {
+		c = iter->unget_c;
+		/* unmatched getc/ungetc */
+		if (fy_utf8_width(c) != 1)
+			return -1;
+		iter->unget_c = -1;
+		return c;
+	}
+
+	/* direct mode */
+	if (iter->ic.str) {
+		if (!iter->ic.len)
+			return -1;
+		c = *iter->ic.str++;
+		iter->ic.len--;
+		return c;
+	}
+
+	return fy_atom_iter_getc(&iter->atom_iter);
+}
+
+int fy_token_iter_ungetc(struct fy_token_iter *iter, int c)
+{
+	if (!iter || c >= 0x80)
+		return -1;
+
+	if (iter->unget_c >= 0)
+		return -1;
+
+	if (c < 0) {
+		iter->unget_c = -1;
+		return 0;
+	}
+	iter->unget_c = c;
+	return c;
+}
+
+int fy_token_iter_peekc(struct fy_token_iter *iter)
+{
+	int c;
+
+	c = fy_token_iter_getc(iter);
+	if (c == -1)
+		return -1;
+
+	return fy_token_iter_ungetc(iter, c);
+}
+
+int fy_token_iter_utf8_get(struct fy_token_iter *iter)
+{
+	int c, w, w1;
+
+	if (!iter)
+		return -1;
+
+	/* first try the pushed ungetc */
+	if (iter->unget_c >= 0) {
+		c = iter->unget_c;
+		iter->unget_c = -1;
+		return c;
+	}
+
+	/* direct */
+	if (iter->ic.str) {
+
+		/* not even 1 octet */
+		if (!iter->ic.len)
+			return -1;
+
+		/* get width by the first octet */
+		w = fy_utf8_width_by_first_octet((uint8_t)*iter->ic.str);
+		if (!w || (unsigned int)w > iter->ic.len)
+			return -1;
+
+		/* get the next character */
+		c = fy_utf8_get(iter->ic.str, w, &w1);
+
+		iter->ic.str += w;
+		iter->ic.len -= w;
+
+		return c;
+	}
+
+	return fy_atom_iter_utf8_get(&iter->atom_iter);
+}
+
+int fy_token_iter_utf8_unget(struct fy_token_iter *iter, int c)
+{
+	if (!iter)
+		return -1;
+
+	if (iter->unget_c >= 0)
+		return -1;
+
+	if (c < 0) {
+		iter->unget_c = -1;
+		return 0;
+	}
+	if (!fy_utf8_is_valid(c))
+		return -1;
+
+	iter->unget_c = c;
+	return c;
+}
+
+int fy_token_iter_utf8_peek(struct fy_token_iter *iter)
+{
+	int c;
+
+	c = fy_token_iter_utf8_get(iter);
+	if (c == -1)
+		return -1;
+
+	return fy_token_iter_utf8_unget(iter, c);
+}
+
+enum fy_scalar_style
+fy_scalar_token_get_style(struct fy_token *fyt)
+{
+	if (!fyt || fyt->type != FYTT_SCALAR)
+		return FYSS_ANY;
+	return fyt->scalar.style;
+}
+
+const struct fy_tag *fy_tag_token_tag(struct fy_token *fyt)
+{
+	if (!fyt || fyt->type != FYTT_TAG)
+		return NULL;
+
+	/* always refresh, should be relatively infrequent */
+	fyt->tag.tag.handle = fy_tag_token_handle0(fyt);
+	fyt->tag.tag.prefix = fy_tag_token_suffix0(fyt);
+
+	return &fyt->tag.tag;
+}
+
+const struct fy_tag *
+fy_tag_directive_token_tag(struct fy_token *fyt)
+{
+	if (!fyt || fyt->type != FYTT_TAG_DIRECTIVE)
+		return NULL;
+
+	/* always refresh, should be relatively infrequent */
+	fyt->tag_directive.tag.handle = fy_tag_directive_token_handle0(fyt);
+	fyt->tag_directive.tag.prefix = fy_tag_directive_token_prefix0(fyt);
+
+	return &fyt->tag_directive.tag;
+}
+
+struct fy_atom *fy_token_comment_handle(struct fy_token *fyt, enum fy_comment_placement placement, bool alloc)
+{
+	struct fy_token_comment *tk;
+
+	if (!fyt || (unsigned int)placement >= fycp_max)
+		return NULL;
+
+	for (tk = fyt->token_comment; tk; tk = tk->next) {
+		if (tk->placement == placement)
+			return &tk->handle;
+	}
+
+	if (!alloc)
+		return NULL;
+
+	tk = malloc(sizeof(*tk));
+	if (!tk)
+		return NULL;
+	memset(tk, 0, sizeof(*tk));
+	tk->placement = placement;
+
+	/* simple list add */
+	tk->next = fyt->token_comment;
+	fyt->token_comment = tk;
+
+	return &tk->handle;
+}
+
+bool fy_token_has_any_comment(struct fy_token *fyt)
+{
+	struct fy_token_comment *tk;
+
+	if (!fyt)
+		return false;
+
+	for (tk = fyt->token_comment; tk; tk = tk->next) {
+		if (fy_atom_is_set(&tk->handle))
+			return true;
+	}
+	return false;
+}
+
+bool
+fy_token_scalar_is_null(struct fy_token *fyt)
+{
+	return !fyt || fyt->type != FYTT_SCALAR || fyt->scalar.is_null;
+}
+
+const struct fy_mark *
+fy_token_style_start_mark(struct fy_token *fyt)
+{
+	if (!fyt)
+		return NULL;
+
+	switch (fyt->type) {
+	case FYTT_SCALAR:
+		return &fyt->scalar.style_start;
+	case FYTT_ALIAS:
+		return &fyt->alias.style_start;
+	case FYTT_ANCHOR:
+		return &fyt->anchor.style_start;
+	default:
+		break;
+	}
+	return fy_token_start_mark(fyt);
+}
+
+const struct fy_mark *
+fy_token_style_end_mark(struct fy_token *fyt)
+{
+	if (!fyt)
+		return NULL;
+
+	if (fyt->type != FYTT_SCALAR)
+		return fy_token_end_mark(fyt);
+	return &fyt->scalar.style_end;
+}
+
+struct fy_atom *
+fy_token_get_style_atom(struct fy_token *fyt, struct fy_atom *dst_handle)
+{
+	const struct fy_atom *handle;
+	const struct fy_mark *mark;
+
+	if (!fyt || !dst_handle)
+		return NULL;
+
+	handle = fy_token_atom(fyt);
+	if (!handle)
+		return NULL;
+	*dst_handle = *handle;
+	fy_input_ref(dst_handle->fyi);
+	mark = fy_token_style_start_mark(fyt);
+	if (mark)
+		dst_handle->start_mark = *mark;
+	mark = fy_token_style_end_mark(fyt);
+	if (mark)
+		dst_handle->end_mark = *mark;
+
+	return dst_handle;
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-token.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-token.h
@@ -1,0 +1,582 @@
+/*
+ * fy-token.h - YAML token methods header
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_TOKEN_H
+#define FY_TOKEN_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include <libfyaml.h>
+
+#include "fy-typelist.h"
+#include "fy-utils.h"
+#include "fy-atom.h"
+
+extern const char *fy_token_type_txt[FYTT_COUNT];
+
+struct fy_document;
+struct fy_path_expr;
+
+static inline bool fy_token_type_is_sequence_start(enum fy_token_type type)
+{
+	return type == FYTT_BLOCK_SEQUENCE_START || type == FYTT_FLOW_SEQUENCE_START;
+}
+
+static inline bool fy_token_type_is_sequence_end(enum fy_token_type type)
+{
+	return type == FYTT_BLOCK_SEQUENCE_START || type == FYTT_FLOW_SEQUENCE_START;
+}
+
+static inline bool fy_token_type_is_sequence_marker(enum fy_token_type type)
+{
+	return fy_token_type_is_sequence_start(type) || fy_token_type_is_sequence_end(type);
+}
+
+static inline bool fy_token_type_is_mapping_start(enum fy_token_type type)
+{
+	return type == FYTT_BLOCK_MAPPING_START || type == FYTT_FLOW_MAPPING_START;
+}
+
+static inline bool fy_token_type_is_mapping_end(enum fy_token_type type)
+{
+	return type == FYTT_BLOCK_MAPPING_START || type == FYTT_FLOW_MAPPING_START;
+}
+
+static inline bool fy_token_type_is_mapping_marker(enum fy_token_type type)
+{
+	return fy_token_type_is_mapping_start(type) || fy_token_type_is_mapping_end(type);
+}
+
+/* analyze content flags */
+#define FYACF_EMPTY		0x000001	/* is empty (only ws & lb) */
+#define FYACF_LB		0x000002	/* has a linebreak */
+#define FYACF_BLOCK_PLAIN	0x000004	/* can be a plain scalar in block context */
+#define FYACF_FLOW_PLAIN	0x000008	/* can be a plain scalar in flow context */
+#define FYACF_PRINTABLE		0x000010	/* every character is printable */
+#define FYACF_SINGLE_QUOTED	0x000020	/* can be a single quoted scalar */
+#define FYACF_DOUBLE_QUOTED	0x000040	/* can be a double quoted scalar */
+#define FYACF_CONTAINS_ZERO	0x000080	/* contains a zero */
+#define FYACF_DOC_IND		0x000100	/* contains document indicators */
+#define FYACF_CONSECUTIVE_LB 	0x000200	/* has consecutive linebreaks */
+#define FYACF_SIMPLE_KEY	0x000400	/* can be a simple key */
+#define FYACF_WS		0x000800	/* has at least one whitespace */
+#define FYACF_STARTS_WITH_WS	0x001000	/* starts with whitespace */
+#define FYACF_STARTS_WITH_LB	0x002000	/* starts with whitespace */
+#define FYACF_ENDS_WITH_WS	0x004000	/* ends with whitespace */
+#define FYACF_ENDS_WITH_LB	0x008000	/* ends with linebreak */
+#define FYACF_TRAILING_LB	0x010000	/* ends with trailing lb > 1 */
+#define FYACF_SIZE0		0x020000	/* contains absolutely nothing */
+#define FYACF_VALID_ANCHOR	0x040000	/* contains valid anchor (without & prefix) */
+#define FYACF_JSON_ESCAPE	0x080000	/* contains a character that JSON escapes */
+#define FYACF_ENDS_WITH_COLON	0x100000	/* ends with : */
+
+/* analysis flags */
+#define FYTTAF_HAS_LB			FY_BIT(0)
+#define FYTTAF_HAS_WS			FY_BIT(1)
+#define FYTTAF_HAS_CONSECUTIVE_LB	FY_BIT(2)
+#define FYTTAF_HAS_CONSECUTIVE_WS	FY_BIT(4)
+#define FYTTAF_EMPTY			FY_BIT(5)
+#define FYTTAF_CAN_BE_SIMPLE_KEY	FY_BIT(6)
+#define FYTTAF_DIRECT_OUTPUT		FY_BIT(7)
+#define FYTTAF_NO_TEXT_TOKEN		FY_BIT(8)
+#define FYTTAF_TEXT_TOKEN		FY_BIT(9)
+#define FYTTAF_CAN_BE_PLAIN		FY_BIT(10)
+#define FYTTAF_CAN_BE_SINGLE_QUOTED	FY_BIT(11)
+#define FYTTAF_CAN_BE_DOUBLE_QUOTED	FY_BIT(12)
+#define FYTTAF_CAN_BE_LITERAL		FY_BIT(13)
+#define FYTTAF_CAN_BE_FOLDED		FY_BIT(14)
+#define FYTTAF_CAN_BE_PLAIN_FLOW	FY_BIT(15)
+#define FYTTAF_QUOTE_AT_0		FY_BIT(16)
+#define FYTTAF_CAN_BE_UNQUOTED_PATH_KEY	FY_BIT(17)
+#define FYTTAF_HAS_ANY_LB		FY_BIT(18)	/* any LB including unicode, not per input */
+#define FYTTAF_HAS_START_IND		FY_BIT(19)	/* has --- at col 0 */
+#define FYTTAF_HAS_END_IND		FY_BIT(20)	/* has ... at col 0 */
+#define FYTTAF_HAS_NON_PRINT		FY_BIT(21)	/* has any non printable utf8 */
+#define FYTTAF_ENDS_WITH_COLON		FY_BIT(22)	/* ends with a colon */
+#define FYTTAF_ALL_WS_LB		FY_BIT(23)	/* everything is ws or linebreak */
+#define FYTTAF_ALL_PRINT_ASCII		FY_BIT(24)	/* everything is >= '!' && <= '~' */
+#define FYTTAF_HAS_START_WS		FY_BIT(25)	/* leads with whitespace */
+#define FYTTAF_SIZE0			FY_BIT(26)	/* zero sized */
+#define FYTTAF_HAS_ZERO			FY_BIT(27)	/* contains a zero byte */
+#define FYTTAF_HAS_NON_NL_LB		FY_BIT(28)	/* if it has a linebreak which is not \n */
+
+#define FYTTAF_ANALYZED			FY_BIT(31)	/* analyzed mark */
+
+struct fy_token_analysis {
+	unsigned int flags;
+	int maxspan;
+	int maxcol;
+};
+
+struct fy_token_comment {
+	struct fy_token_comment *next;
+	enum fy_comment_placement placement;
+	struct fy_atom handle;
+	char *comment;
+};
+
+FY_TYPE_FWD_DECL_LIST(token);
+struct fy_token {
+	struct list_head node;
+	enum fy_token_type type;
+	int refs;		/* when on document, we switch to reference counting */
+	struct fy_token_analysis analysis;
+	size_t text_len;
+	const char *text;
+	char *text0;		/* this is allocated */
+	struct fy_atom handle;
+	struct fy_token_comment *token_comment;
+	char *comments;		/* this is allocated */
+	union  {
+		struct {
+			unsigned int tag_length;	/* from start */
+			unsigned int uri_length;	/* from end */
+			char *prefix0;
+			char *handle0;
+			struct fy_tag tag;
+			bool is_default;		/* true when default */
+		} tag_directive;
+		struct {
+			enum fy_scalar_style style;
+			/* path key (if requested only) */
+			struct fy_mark style_start;
+			struct fy_mark style_end;
+			const char *path_key;
+			size_t path_key_len;
+			char *path_key_storage;	/* if this is not null, it's \0 terminated */
+			bool is_null;		/* special case; the scalar was NULL */
+		} scalar;
+		struct {
+			unsigned int skip;
+			unsigned int handle_length;
+			unsigned int suffix_length;
+			struct fy_token *fyt_td;
+			char *handle0;	/* zero terminated and allocated, only used by binding */
+			char *suffix0;
+			unsigned int short_length;
+			char *short0;	/* zero terminated and allocated for when the short tag is requested */
+			struct fy_tag tag;	/* prefix is now suffix */
+		} tag;
+		struct {
+			struct fy_version vers;		/* parsed version number */
+		} version_directive;
+		/* path expressions */
+		struct {
+			struct fy_document *fyd;	/* when key is complex */
+		} map_key;
+		struct {
+			int index;
+		} seq_index;
+		struct {
+			int start_index;
+			int end_index;
+		} seq_slice;
+		struct {
+			struct fy_mark style_start;
+			struct fy_path_expr *expr;
+		} alias;
+		struct {
+			struct fy_mark style_start;
+		} anchor;
+		struct {
+			int flow_level;
+		} key;
+	};
+};
+FY_TYPE_DECL_LIST(token);
+
+static inline bool fy_token_text_is_direct(struct fy_token *fyt)
+{
+	if (!fyt || !fyt->text)
+		return false;
+	return fyt->text && fyt->text != fyt->text0;
+}
+
+void fy_token_clean_rl(struct fy_token_list *fytl, struct fy_token *fyt);
+void fy_token_list_unref_all_rl(struct fy_token_list *fytl, struct fy_token_list *fytl_tofree);
+
+static inline FY_ALWAYS_INLINE struct fy_token *
+fy_token_alloc_rl(struct fy_token_list *fytl)
+{
+	struct fy_token *fyt;
+
+	fyt = NULL;
+	if (fytl)
+		fyt = fy_token_list_pop(fytl);
+	if (!fyt) {
+		fyt = malloc(sizeof(*fyt));
+		if (!fyt)
+			return NULL;
+	}
+
+	fyt->type = FYTT_NONE;
+	fyt->refs = 1;
+	memset(&fyt->analysis, 0, sizeof(fyt->analysis));
+	fyt->text_len = 0;
+	fyt->text = NULL;
+	fyt->text0 = NULL;
+	fyt->handle.fyi = NULL;
+	fyt->token_comment = NULL;
+	fyt->comments = NULL;
+
+	return fyt;
+}
+
+static inline FY_ALWAYS_INLINE void
+fy_token_free_rl(struct fy_token_list *fytl, struct fy_token *fyt)
+{
+	if (!fyt)
+		return;
+
+	fy_token_clean_rl(fytl, fyt);
+
+	if (fytl)
+		fy_token_list_push(fytl, fyt);
+	else
+		free(fyt);
+}
+
+static inline FY_ALWAYS_INLINE void
+fy_token_unref_rl(struct fy_token_list *fytl, struct fy_token *fyt)
+{
+	if (!fyt)
+		return;
+
+	assert(fyt->refs > 0);
+
+	if (--fyt->refs == 0)
+		fy_token_free_rl(fytl, fyt);
+}
+
+static inline FY_ALWAYS_INLINE struct fy_token *
+fy_token_alloc(void)
+{
+	return fy_token_alloc_rl(NULL);
+}
+
+static inline FY_ALWAYS_INLINE void
+fy_token_clean(struct fy_token *fyt)
+{
+	fy_token_clean_rl(NULL, fyt);
+}
+
+static inline FY_ALWAYS_INLINE void
+fy_token_free(struct fy_token *fyt)
+{
+	fy_token_free_rl(NULL, fyt);
+}
+
+static inline FY_ALWAYS_INLINE struct fy_token *
+fy_token_ref(struct fy_token *fyt)
+{
+	/* take care of overflow */
+	if (!fyt)
+		return NULL;
+	assert(fyt->refs + 1 > 0);
+	fyt->refs++;
+
+	return fyt;
+}
+
+static inline FY_ALWAYS_INLINE void
+fy_token_unref(struct fy_token *fyt)
+{
+	fy_token_unref_rl(NULL, fyt);
+}
+
+static inline void
+fy_token_list_unref_all(struct fy_token_list *fytl_tofree)
+{
+	fy_token_list_unref_all_rl(NULL, fytl_tofree);
+}
+
+/* recycling aware */
+struct fy_token *fy_token_vcreate_rl(struct fy_token_list *fytl, enum fy_token_type type, va_list ap);
+struct fy_token *fy_token_create_rl(struct fy_token_list *fytl, enum fy_token_type type, ...);
+
+struct fy_token *fy_token_vcreate(enum fy_token_type type, va_list ap);
+struct fy_token *fy_token_create(enum fy_token_type type, ...);
+
+static inline struct fy_token *
+fy_token_list_vqueue(struct fy_token_list *fytl, enum fy_token_type type, va_list ap)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_token_vcreate(type, ap);
+	if (!fyt)
+		return NULL;
+	fy_token_list_add_tail(fytl, fyt);
+	return fyt;
+}
+
+static inline struct fy_token *
+fy_token_list_queue(struct fy_token_list *fytl, enum fy_token_type type, ...)
+{
+	va_list ap;
+	struct fy_token *fyt;
+
+	va_start(ap, type);
+	fyt = fy_token_list_vqueue(fytl, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+size_t fy_tag_token_format_text_length(const struct fy_token *fyt);
+const char *fy_tag_token_format_text(const struct fy_token *fyt, char *buf, size_t maxsz);
+size_t fy_token_format_utf8_length(struct fy_token *fyt);
+
+size_t fy_token_format_text_length(struct fy_token *fyt);
+const char *fy_token_format_text(struct fy_token *fyt, char *buf, size_t maxsz);
+
+/* non-parser token methods */
+struct fy_atom *fy_token_atom(struct fy_token *fyt);
+
+static inline size_t fy_token_start_pos(struct fy_token *fyt)
+{
+	const struct fy_mark *start_mark;
+
+	if (!fyt)
+		return (size_t)-1;
+
+	start_mark = fy_token_start_mark(fyt);
+	return start_mark ? start_mark->input_pos : (size_t)-1;
+}
+
+static inline size_t fy_token_end_pos(struct fy_token *fyt)
+{
+	const struct fy_mark *end_mark;
+
+	if (!fyt)
+		return (size_t)-1;
+
+	end_mark = fy_token_end_mark(fyt);
+	return end_mark ? end_mark->input_pos : (size_t)-1;
+}
+
+static inline int fy_token_start_line(struct fy_token *fyt)
+{
+	const struct fy_mark *start_mark;
+
+	if (!fyt)
+		return -1;
+
+	start_mark = fy_token_start_mark(fyt);
+	return start_mark ? start_mark->line : -1;
+}
+
+static inline int fy_token_start_column(struct fy_token *fyt)
+{
+	const struct fy_mark *start_mark;
+
+	if (!fyt)
+		return -1;
+
+	start_mark = fy_token_start_mark(fyt);
+	return start_mark ? start_mark->column : -1;
+}
+
+static inline int fy_token_end_line(struct fy_token *fyt)
+{
+	const struct fy_mark *end_mark;
+
+	if (!fyt)
+		return -1;
+
+	end_mark = fy_token_end_mark(fyt);
+	return end_mark ? end_mark->line : -1;
+}
+
+static inline int fy_token_end_column(struct fy_token *fyt)
+{
+	const struct fy_mark *end_mark;
+
+	if (!fyt)
+		return -1;
+
+	end_mark = fy_token_end_mark(fyt);
+	return end_mark ? end_mark->column : -1;
+}
+
+static inline bool fy_token_is_multiline(struct fy_token *fyt)
+{
+	const struct fy_mark *start_mark, *end_mark;
+
+	if (!fyt)
+		return false;
+
+	start_mark = fy_token_start_mark(fyt);
+	end_mark = fy_token_end_mark(fyt);
+	return start_mark && end_mark ? end_mark->line > start_mark->line : false;
+}
+
+const char *fy_token_get_direct_output(struct fy_token *fyt, size_t *sizep);
+const char *fy_token_get_direct_simple_output(struct fy_token *fyt, size_t *sizep);
+
+static inline struct fy_input *fy_token_get_input(struct fy_token *fyt)
+{
+	return fyt ? fyt->handle.fyi : NULL;
+}
+
+static inline enum fy_atom_style fy_token_atom_style(struct fy_token *fyt)
+{
+	if (!fyt)
+		return FYAS_PLAIN;
+
+	if (fyt->type == FYTT_TAG)
+		return FYAS_URI;
+
+	return fyt->handle.style;
+}
+
+static inline bool fy_token_atom_json_mode(struct fy_token *fyt)
+{
+	if (!fyt)
+		return false;
+
+	return fy_atom_json_mode(&fyt->handle);
+}
+
+static inline enum fy_lb_mode fy_token_atom_lb_mode(struct fy_token *fyt)
+{
+	if (!fyt)
+		return fylb_cr_nl;
+
+	return fy_atom_lb_mode(&fyt->handle);
+}
+
+static inline enum fy_flow_ws_mode fy_token_atom_flow_ws_mode(struct fy_token *fyt)
+{
+	if (!fyt)
+		return fyfws_space_tab;
+
+	return fy_atom_flow_ws_mode(&fyt->handle);
+}
+
+static inline bool fy_token_is_lb(struct fy_token *fyt, int c)
+{
+	if (!fyt)
+		return false;
+
+	return fy_atom_is_lb(&fyt->handle, c);
+}
+
+static inline bool fy_token_is_flow_ws(struct fy_token *fyt, int c)
+{
+	if (!fyt)
+		return false;
+
+	return fy_atom_is_flow_ws(&fyt->handle, c);
+}
+
+const struct fy_token_analysis *fy_token_text_analyze(struct fy_token *fyt);
+
+unsigned int fy_analyze_scalar_content(const char *data, size_t size,
+		bool json_mode, enum fy_lb_mode lb_mode, enum fy_flow_ws_mode fws_mode);
+
+/* must be freed */
+char *fy_token_debug_text(struct fy_token *fyt);
+
+#ifdef _MSC_VER
+/* MSVC version using thread-local buffer */
+#define FY_TOKEN_DEBUG_TEXT_A_BUFSZ 4096
+static __declspec(thread) char fy_token_debug_text_a_buf[FY_TOKEN_DEBUG_TEXT_A_BUFSZ];
+static __inline const char *fy_token_debug_text_a_impl(struct fy_token *fyt)
+{
+	char *buf = fy_token_debug_text(fyt);
+	if (!buf) return "";
+	strncpy(fy_token_debug_text_a_buf, buf, FY_TOKEN_DEBUG_TEXT_A_BUFSZ - 1);
+	fy_token_debug_text_a_buf[FY_TOKEN_DEBUG_TEXT_A_BUFSZ - 1] = '\0';
+	free(buf);
+	return fy_token_debug_text_a_buf;
+}
+#define fy_token_debug_text_a(_fyt) fy_token_debug_text_a_impl(_fyt)
+#else
+#define fy_token_debug_text_a(_fyt) \
+	({ \
+		struct fy_token *__fyt = (_fyt); \
+		char *_buf, *_rbuf = ""; \
+		size_t _len; \
+		_buf = fy_token_debug_text(__fyt); \
+		if (_buf) { \
+			_len = strlen(_buf); \
+			_rbuf = alloca(_len + 1); \
+			memcpy(_rbuf, _buf, _len + 1); \
+			free(_buf); \
+		} \
+		_rbuf; \
+	})
+#endif
+
+int fy_token_memcmp(struct fy_token *fyt, const void *ptr, size_t len);
+int fy_token_strcmp(struct fy_token *fyt, const char *str);
+int fy_token_cmp(struct fy_token *fyt1, struct fy_token *fyt2);
+
+struct fy_token_iter {
+	struct fy_token *fyt;
+	struct fy_iter_chunk ic;	/* direct mode */
+	struct fy_atom_iter atom_iter;
+	int unget_c;
+};
+
+void fy_token_iter_start(struct fy_token *fyt, struct fy_token_iter *iter);
+void fy_token_iter_finish(struct fy_token_iter *iter);
+
+const char *fy_tag_token_get_directive_handle(struct fy_token *fyt, size_t *td_handle_sizep);
+const char *fy_tag_token_get_directive_prefix(struct fy_token *fyt, size_t *td_prefix_sizep);
+
+static inline bool fy_token_is_number(struct fy_token *fyt)
+{
+	struct fy_atom *atom;
+
+	if (!fyt || fyt->type != FYTT_SCALAR || fyt->scalar.style != FYSS_PLAIN)
+		return false;
+	atom = fy_token_atom(fyt);
+	if (!atom)
+		return false;
+	return fy_atom_is_number(atom);
+}
+
+struct fy_atom *fy_token_comment_handle(struct fy_token *fyt, enum fy_comment_placement placement, bool alloc);
+bool fy_token_has_any_comment(struct fy_token *fyt);
+
+const char *fy_token_get_scalar_path_key(struct fy_token *fyt, size_t *lenp);
+size_t fy_token_get_scalar_path_key_length(struct fy_token *fyt);
+const char *fy_token_get_scalar_path_key0(struct fy_token *fyt);
+
+struct fy_atom *fy_token_comment_handle(struct fy_token *fyt, enum fy_comment_placement placement, bool alloc);
+
+static inline FY_ALWAYS_INLINE enum fy_scalar_style
+fy_token_scalar_style_inline(struct fy_token *fyt)
+{
+	if (!fyt || fyt->type != FYTT_SCALAR)
+		return FYSS_PLAIN;
+
+	if (fyt->type == FYTT_SCALAR)
+		return fyt->scalar.style;
+
+	return FYSS_PLAIN;
+}
+
+static inline FY_ALWAYS_INLINE enum fy_token_type
+fy_token_get_type_inline(struct fy_token *fyt)
+{
+	return fyt ? fyt->type : FYTT_NONE;
+}
+
+/* needs fy_input_unref(handle->fyi) */
+struct fy_atom *
+fy_token_get_style_atom(struct fy_token *fyt, struct fy_atom *dst_handle);
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-types.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-types.c
@@ -1,0 +1,29 @@
+/*
+ * fy-types.c - types definition
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <limits.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+
+/* parse only types */
+FY_PARSE_TYPE_DEFINE_SIMPLE(indent);
+FY_PARSE_TYPE_DEFINE_SIMPLE(simple_key);
+FY_PARSE_TYPE_DEFINE_SIMPLE(parse_state_log);
+FY_PARSE_TYPE_DEFINE_SIMPLE(flow);
+FY_PARSE_TYPE_DEFINE_SIMPLE(streaming_alias);

--- a/numcosmo/external/libfyaml/src/lib/fy-types.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-types.h
@@ -1,0 +1,143 @@
+/*
+ * fy-types.h - common types builder
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_TYPES_H
+#define FY_TYPES_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <libfyaml.h>
+
+#include "fy-list.h"
+
+struct fy_parser;
+
+/* define type methods */
+#define FY_ALLOC_TYPE_DEFINE(_type) \
+\
+struct fy_ ## _type *fy_ ## _type ## _alloc_simple_internal( \
+		struct fy_ ## _type ## _list *_rl) \
+{ \
+	struct fy_ ## _type *_n; \
+	\
+	_n = fy_ ## _type ## _list_pop(_rl); \
+	if (_n) \
+		return _n; \
+	_n = malloc(sizeof(*_n)); \
+	if (_n) \
+		list_init(&_n->node); \
+	return _n; \
+} \
+\
+void fy_ ## _type ## _recycle_internal(struct fy_ ## _type ## _list *_rl, \
+		struct fy_ ## _type *_n) \
+{ \
+	if (_n) \
+		fy_ ## _type ## _list_push(_rl, _n); \
+} \
+\
+void fy_ ## _type ## _vacuum_internal(struct fy_ ## _type ## _list *_rl) \
+{ \
+	struct fy_ ## _type *_n; \
+	\
+	while ((_n = fy_ ## _type ## _list_pop(_rl)) != NULL) \
+		free(_n); \
+} \
+\
+struct __useless_struct_to_allow_semicolon
+
+/* declarations for alloc */
+
+#define FY_ALLOC_TYPE_ALLOC(_type) \
+struct fy_ ## _type *fy_ ## _type ## _alloc_simple_internal( \
+		struct fy_ ## _type ## _list *_rl); \
+void fy_ ## _type ## _recycle_internal(struct fy_ ## _type ## _list *_rl, \
+		struct fy_ ## _type *_n); \
+void fy_ ## _type ## _vacuum_internal(struct fy_ ## _type ## _list *_rl); \
+struct __useless_struct_to_allow_semicolon
+
+/* parser type methods */
+#define FY_PARSE_TYPE_DECL_ALLOC(_type) \
+\
+struct fy_ ## _type *fy_parse_ ## _type ## _alloc(struct fy_parser *fyp); \
+void fy_parse_ ## _type ## _vacuum(struct fy_parser *fyp); \
+void fy_parse_ ## _type ## _recycle(struct fy_parser *fyp, struct fy_ ## _type *_n); \
+void fy_parse_ ## _type ## _list_recycle_all(struct fy_parser *fyp, struct fy_ ## _type ## _list *_l); \
+\
+struct __useless_struct_to_allow_semicolon
+
+#define FY_PARSE_TYPE_DECL(_type) \
+FY_TYPE_FWD_DECL_LIST(_type); \
+FY_TYPE_DECL_LIST(_type); \
+FY_PARSE_TYPE_DECL_ALLOC(_type); \
+struct __useless_struct_to_allow_semicolon
+
+#define FY_PARSE_TYPE_DECL_AFTER_FWD(_type) \
+FY_TYPE_DECL_LIST(_type); \
+FY_PARSE_TYPE_DECL_ALLOC(_type); \
+struct __useless_struct_to_allow_semicolon
+
+/* define type methods */
+#define FY_PARSE_TYPE_DEFINE(_type) \
+\
+struct fy_ ## _type *fy_parse_ ## _type ## _alloc_simple(struct fy_parser *fyp) \
+{ \
+	return fy_ ## _type ## _alloc_simple_internal(&fyp->recycled_ ## _type); \
+} \
+\
+void fy_parse_ ## _type ## _vacuum(struct fy_parser *fyp) \
+{ \
+	fy_ ## _type ## _vacuum_internal(&fyp->recycled_ ## _type); \
+} \
+\
+void fy_parse_ ## _type ## _list_recycle_all(struct fy_parser *fyp, struct fy_ ## _type ## _list *_l) \
+{ \
+	struct fy_ ## _type *_n; \
+	\
+	while ((_n = fy_ ## _type ## _list_pop(_l)) != NULL) \
+		fy_parse_ ## _type ## _recycle(fyp, _n); \
+} \
+\
+void fy_parse_ ## _type ## _recycle_simple(struct fy_parser *fyp, struct fy_ ## _type *_n) \
+{ \
+	if (!fyp->suppress_recycling) \
+		fy_ ## _type ## _recycle_internal(&fyp->recycled_ ## _type, _n); \
+	else \
+		free(_n); \
+} \
+\
+struct __useless_struct_to_allow_semicolon
+
+#define FY_PARSE_TYPE_DEFINE_ALLOC_SIMPLE(_type) \
+struct fy_ ## _type *fy_parse_ ## _type ## _alloc(struct fy_parser *_fyp) \
+{ \
+	return fy_parse_ ## _type ## _alloc_simple(_fyp); \
+} \
+\
+void fy_parse_ ## _type ## _recycle(struct fy_parser *_fyp, struct fy_ ## _type *_n) \
+{ \
+	if (_n) \
+		fy_parse_ ## _type ## _recycle_simple(_fyp, _n); \
+} \
+\
+struct __useless_struct_to_allow_semicolon
+
+#define FY_PARSE_TYPE_DEFINE_SIMPLE(_type) \
+\
+FY_ALLOC_TYPE_DEFINE(_type); \
+FY_PARSE_TYPE_DEFINE(_type); \
+FY_PARSE_TYPE_DEFINE_ALLOC_SIMPLE(_type); \
+\
+struct __useless_struct_to_allow_semicolon
+
+#endif

--- a/numcosmo/external/libfyaml/src/lib/fy-walk.c
+++ b/numcosmo/external/libfyaml/src/lib/fy-walk.c
@@ -1,0 +1,5775 @@
+/*
+ * fy-walk.c - path walker
+ *
+ * Copyright (c) 2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
+#include <math.h>
+#include <limits.h>
+#include <float.h>
+
+#include <libfyaml.h>
+
+#include "fy-parse.h"
+#include "fy-doc.h"
+#include "fy-walk.h"
+
+#include "fy-utils.h"
+
+#undef DEBUG_EXPR
+// #define DEBUG_EXPR
+
+#define FY_PATH_EXEC_STEP_LIMIT		4096
+
+/* debugging for when expressions go crazy */
+#ifdef DEBUG_EXPR
+struct fy_walk_result *
+_fy_path_exec_walk_result_create(struct fy_path_exec *fypx,
+				const char *file, int line, const char *func,
+				enum fy_walk_result_type type, ...);
+#define fy_path_exec_walk_result_create(_fypx, _type, ...) \
+	_fy_path_exec_walk_result_create((_fypx), \
+			__FILE__, __LINE__, __func__, (_type) __VA_OPT__(,) __VA_ARGS__)
+
+void
+_fy_walk_result_free(struct fy_walk_result *fwr, const char *file, int line, const char *func);
+#define fy_walk_result_free(_fwr) _fy_walk_result_free((_fwr), __FILE__, __LINE__, __func__)
+
+void
+_fy_walk_result_clean(struct fy_walk_result *fwr, const char *file, int line, const char *func);
+#define fy_walk_result_clean(_fwr) _fy_walk_result_clean((_fwr), __FILE__, __LINE__, __func__)
+
+struct fy_walk_result *
+_fy_walk_result_clone(struct fy_walk_result *fwr, const char *file, int line, const char *func);
+#define fy_walk_result_clone(_fwr) _fy_walk_result_clone((_fwr), __FILE__, __LINE__, __func__)
+
+#endif
+
+const char *fy_walk_result_type_txt[FWRT_COUNT] = {
+	[fwrt_none]	= "none",
+	[fwrt_node_ref]	= "node-ref",
+	[fwrt_number]	= "number",
+	[fwrt_string]	= "string",
+	[fwrt_doc]	= "doc",
+	[fwrt_refs]	= "refs",
+};
+
+
+static struct fy_node *fy_node_alias_resolve_by_ypath_internal(struct fy_node *fyn, bool *errorp);
+
+void fy_walk_result_dump(struct fy_walk_result *fwr, struct fy_diag *diag, enum fy_error_type errlevel, int level,
+		const char *fmt, ...);
+
+void fy_walk_result_vdump(struct fy_walk_result *fwr, struct fy_diag *diag, enum fy_error_type errlevel, int level,
+		const char *fmt, va_list ap)
+{
+	struct fy_walk_result *fwr2;
+	char *banner;
+	char *texta = NULL;
+	const char *text = "";
+	size_t len;
+	bool save_on_error;
+	char buf[30];
+	int rc __FY_DEBUG_UNUSED__;
+
+	if (!diag)
+		return;
+
+	if (errlevel < diag->cfg.level)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = true;
+
+	if (fmt) {
+		banner = NULL;
+		rc = vasprintf(&banner, fmt, ap);
+		if (rc == -1 || !banner)
+			goto err_out;
+		fy_diag_diag(diag, errlevel, "%-*s%s", level*2, "", banner);
+		free(banner);
+		banner = NULL;
+	}
+	if (!fwr)
+		goto out;
+
+	switch (fwr->type) {
+	case fwrt_none:
+		text="";
+		break;
+	case fwrt_node_ref:
+		texta = fy_node_get_path(fwr->fyn);
+		if (!texta)
+			goto err_out;
+		text = texta;
+		break;
+	case fwrt_number:
+		snprintf(buf, sizeof(buf), "%f", fwr->number);
+		text = buf;
+		break;
+	case fwrt_string:
+		text = fwr->string;
+		break;
+	case fwrt_doc:
+		texta = fy_emit_document_to_string(fwr->fyd, FYECF_WIDTH_INF | FYECF_INDENT_DEFAULT | FYECF_MODE_FLOW_ONELINE);
+		if (!texta)
+			goto err_out;
+		text = texta;
+		break;
+	case fwrt_refs:
+		text="";
+		break;
+	}
+
+	len = strlen(text);
+
+	fy_diag_diag(diag, errlevel, "%-*s%s%s%.*s",
+			(level + 1) * 2, "",
+			fy_walk_result_type_txt[fwr->type],
+			len ? " " : "",
+			(int)len, text);
+
+	if (texta)
+		free(texta);
+	texta = NULL;
+
+	if (fwr->type == fwrt_refs) {
+		for (fwr2 = fy_walk_result_list_head(&fwr->refs); fwr2; fwr2 = fy_walk_result_next(&fwr->refs, fwr2))
+			fy_walk_result_dump(fwr2, diag, errlevel, level + 1, NULL);
+	}
+out:
+	diag->on_error = save_on_error;
+	return;
+err_out:
+	diag->on_error = true;
+	return;
+}
+
+void fy_walk_result_dump(struct fy_walk_result *fwr, struct fy_diag *diag, enum fy_error_type errlevel, int level,
+		const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fy_walk_result_vdump(fwr, diag, errlevel, level, fmt, ap);
+	va_end(ap);
+}
+
+/* NOTE that walk results do not take references and it is invalid to
+ * use _any_ call that modifies the document structure
+ */
+struct fy_walk_result *fy_walk_result_alloc_rl(struct fy_walk_result_list *fwrl)
+{
+	struct fy_walk_result *fwr = NULL;
+
+	if (fwrl)
+		fwr = fy_walk_result_list_pop(fwrl);
+
+	if (!fwr) {
+		fwr = malloc(sizeof(*fwr));
+		if (!fwr)
+			return NULL;
+		memset(fwr, 0, sizeof(*fwr));
+	} else
+		memset(&fwr->_clean, 0, sizeof(fwr->_clean));
+	fwr->type = fwrt_none;
+	return fwr;
+}
+
+struct fy_walk_result *fy_walk_result_clone_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result *fwr)
+{
+	struct fy_walk_result *fwrn = NULL, *fwrn2 = NULL, *fwrn3;
+
+	if (!fwr)
+		return NULL;
+
+	fwrn = fy_walk_result_alloc_rl(fwrl);
+	if (!fwrn)
+		return NULL;
+
+	fwrn->type = fwr->type;
+	switch (fwr->type) {
+	case fwrt_none:
+		break;
+	case fwrt_node_ref:
+		fwrn->fyn = fwr->fyn;
+		break;
+	case fwrt_number:
+		fwrn->number = fwr->number;
+		break;
+	case fwrt_string:
+		fwrn->string = strdup(fwr->string);
+		if (!fwrn->string)
+			goto err_out;
+		break;
+	case fwrt_doc:
+		fwrn->fyd = fy_document_clone(fwr->fyd);
+		if (!fwrn->fyd)
+			goto err_out;
+		break;
+	case fwrt_refs:
+
+		fy_walk_result_list_init(&fwrn->refs);
+
+		for (fwrn2 = fy_walk_result_list_head(&fwr->refs); fwrn2;
+			fwrn2 = fy_walk_result_next(&fwr->refs, fwrn2)) {
+
+			fwrn3 = fy_walk_result_clone_rl(fwrl, fwrn2);
+			if (!fwrn3)
+				goto err_out;
+
+			fy_walk_result_list_add_tail(&fwrn->refs, fwrn3);
+		}
+		break;
+	}
+	return fwrn;
+err_out:
+	if (fwrn)
+		fy_walk_result_free_rl(fwrl, fwrn);
+	return NULL;
+}
+
+#ifndef DEBUG_EXPR
+struct fy_walk_result *fy_walk_result_clone(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fwr)
+		return NULL;
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	return fy_walk_result_clone_rl(fwrl, fwr);
+}
+
+#else
+
+struct fy_walk_result *
+_fy_walk_result_clone(struct fy_walk_result *fwr, const char *file, int line, const char *func)
+{
+	struct fy_walk_result_list *fwrl;
+	struct fy_walk_result *fwrn;
+
+	if (!fwr)
+		return NULL;
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	fwrn = fy_walk_result_clone_rl(fwrl, fwr);
+
+	fprintf(stderr, "%s:%4d @%-48s %-32s fwr=%p (fypx=%p refs=%u)\n",
+			file, line, func, __func__, fwrn, fwrn->fypx, fwrn->fypx ? fwrn->fypx->refs : 0);
+
+	return fwrn;
+}
+
+#endif
+
+void fy_walk_result_clean_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result *fwr)
+{
+	struct fy_walk_result *fwrn;
+
+	if (!fwr)
+		return;
+
+	switch (fwr->type) {
+	case fwrt_none:
+		break;
+	case fwrt_node_ref:
+		fwr->fyn = NULL;
+		break;
+	case fwrt_number:
+		break;
+	case fwrt_string:
+		if (fwr->string)
+			free(fwr->string);
+		fwr->string = NULL;
+		break;
+	case fwrt_doc:
+		if (fwr->fyd)
+			fy_document_destroy(fwr->fyd);
+		fwr->fyd = NULL;
+		break;
+	case fwrt_refs:
+		while ((fwrn = fy_walk_result_list_pop(&fwr->refs)) != NULL)
+			fy_walk_result_free_rl(fwrl, fwrn);
+		break;
+	}
+
+	fwr->type = fwrt_none;
+	fwr->fypx = NULL;
+	memset(&fwr->_clean, 0, sizeof(fwr->_clean));
+}
+
+#ifndef DEBUG_EXPR
+void fy_walk_result_clean(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fwr)
+		return;
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	fy_walk_result_clean_rl(fwrl, fwr);
+}
+#else
+void _fy_walk_result_clean(struct fy_walk_result *fwr,
+			   const char *file, int line, const char *func)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fwr)
+		return;
+
+	fprintf(stderr, "%s:%4d @%-48s %-32s fwr=%p (fypx=%p refs=%u)\n",
+			file, line, func, __func__, fwr, fwr->fypx, fwr->fypx ? fwr->fypx->refs : 0);
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	fy_walk_result_clean_rl(fwrl, fwr);
+
+}
+#endif
+
+void fy_walk_result_free_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result *fwr)
+{
+	struct fy_path_exec *fypx;
+
+	if (!fwr)
+		return;
+
+	fypx = fwr->fypx;
+
+	fy_walk_result_clean_rl(fwrl, fwr);
+
+#ifndef DEBUG_EXPR
+	if (fwrl)
+		fy_walk_result_list_push(fwrl, fwr);
+	else
+#endif
+		free(fwr);
+
+	fy_path_exec_unref(fypx);	/* NULL is OK */
+}
+
+#ifndef DEBUG_EXPR
+void fy_walk_result_free(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fwr)
+		return;
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	fy_walk_result_free_rl(fwrl, fwr);
+}
+#else
+void _fy_walk_result_free(struct fy_walk_result *fwr, const char *file, int line, const char *func)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fwr)
+		return;
+
+	fprintf(stderr, "%s:%4d @%-48s %-32s fwr=%p (fypx=%p refs=%u)\n",
+			file, line, func, __func__, fwr, fwr->fypx, fwr->fypx ? fwr->fypx->refs : 0);
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	fy_walk_result_free_rl(fwrl, fwr);
+}
+#endif
+
+void fy_walk_result_list_free_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result_list *results)
+{
+	struct fy_walk_result *fwr;
+
+	while ((fwr = fy_walk_result_list_pop(results)) != NULL)
+		fy_walk_result_free_rl(fwrl, fwr);
+}
+
+struct fy_walk_result *fy_walk_result_vcreate_rl(struct fy_walk_result_list *fwrl, enum fy_walk_result_type type, va_list ap)
+{
+	struct fy_walk_result *fwr = NULL;
+
+	if ((unsigned int)type >= FWRT_COUNT)
+		goto err_out;
+
+	fwr = fy_walk_result_alloc_rl(fwrl);
+	if (!fwr)
+		goto err_out;
+
+	fwr->type = type;
+
+	switch (fwr->type) {
+	case fwrt_none:
+		break;
+	case fwrt_node_ref:
+		fwr->fyn = va_arg(ap, struct fy_node *);
+		break;
+	case fwrt_number:
+		fwr->number = va_arg(ap, double);
+		break;
+	case fwrt_string:
+		fwr->string = strdup(va_arg(ap, const char *));
+		if (!fwr->string)
+			goto err_out;
+		break;
+	case fwrt_doc:
+		fwr->fyd = va_arg(ap, struct fy_document *);
+		break;
+	case fwrt_refs:
+		fy_walk_result_list_init(&fwr->refs);
+		break;
+	}
+
+	return fwr;
+
+err_out:
+	fy_walk_result_free_rl(fwrl, fwr);
+
+	return NULL;
+}
+
+struct fy_walk_result *fy_walk_result_create_rl(struct fy_walk_result_list *fwrl, enum fy_walk_result_type type, ...)
+{
+	struct fy_walk_result *fwr;
+	va_list ap;
+
+	va_start(ap, type);
+	fwr = fy_walk_result_vcreate_rl(fwrl, type, ap);
+	va_end(ap);
+
+	return fwr;
+}
+
+void fy_walk_result_flatten_internal(struct fy_walk_result *fwr, struct fy_walk_result *fwrf)
+{
+	struct fy_walk_result *fwr2, *fwr2n;
+
+	if (!fwr || !fwrf || fwr->type != fwrt_refs)
+		return;
+
+	for (fwr2 = fy_walk_result_list_head(&fwr->refs); fwr2; fwr2 = fwr2n) {
+
+		fwr2n = fy_walk_result_next(&fwr->refs, fwr2);
+
+		if (fwr2->type != fwrt_refs) {
+			fy_walk_result_list_del(&fwr->refs, fwr2);
+			fy_walk_result_list_add_tail(&fwrf->refs, fwr2);
+			continue;
+		}
+		fy_walk_result_flatten_internal(fwr2, fwrf);
+	}
+}
+
+bool fy_walk_result_has_leaves_only(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result *fwrn;
+
+	if (!fwr || fwr->type != fwrt_refs)
+		return false;
+
+	if (fy_walk_result_list_empty(&fwr->refs))
+		return false;
+
+	for (fwrn = fy_walk_result_list_head(&fwr->refs); fwrn;
+			fwrn = fy_walk_result_next(&fwr->refs, fwrn)) {
+
+		if (fwrn->type == fwrt_refs)
+			return false;
+	}
+
+	return true;
+}
+
+struct fy_walk_result *
+fy_walk_result_flatten_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result *fwr)
+{
+	struct fy_walk_result *fwrf;
+
+	if (!fwr)
+		return NULL;
+
+	fwrf = fy_walk_result_create_rl(fwrl, fwrt_refs);
+	if (!fwrf)
+		goto err_out;
+
+	fy_walk_result_flatten_internal(fwr, fwrf);
+	fy_walk_result_free_rl(fwrl, fwr);
+	return fwrf;
+
+err_out:
+	return NULL;
+}
+
+struct fy_walk_result *
+fy_walk_result_flatten(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fwr)
+		return NULL;
+
+	fwrl = fy_path_exec_walk_result_rl(fwr->fypx);
+	return fy_walk_result_flatten_rl(fwrl, fwr);
+}
+
+static void
+fy_walk_result_refs_add_flattened(struct fy_walk_result *output, struct fy_walk_result *fwr)
+{
+	if (!output || output->type != fwrt_refs || !fwr)
+		return;
+
+	if (fwr->type != fwrt_refs) {
+		fy_walk_result_list_add_tail(&output->refs, fwr);
+		return;
+	}
+
+	fy_walk_result_flatten_internal(fwr, output);
+	fy_walk_result_free(fwr);
+}
+
+struct fy_node *
+fy_walk_result_node_iterate(struct fy_walk_result *fwr, void **prevp)
+{
+	struct fy_walk_result *fwrn;
+
+	if (!fwr || !prevp)
+		return NULL;
+
+	switch (fwr->type) {
+	case fwrt_node_ref:
+		if (!*prevp) {
+			*prevp = fwr;
+			return fwr->fyn;
+		}
+		*prevp = NULL;
+		return NULL;
+
+	case fwrt_refs:
+		if (!*prevp)
+			fwrn = fy_walk_result_list_head(&fwr->refs);
+		else
+			fwrn = fy_walk_result_next(&fwr->refs, *prevp);
+
+		/* skip over any non node refs */
+		while (fwrn && fwrn->type != fwrt_node_ref)
+			fwrn = fy_walk_result_next(&fwr->refs, fwrn);
+		*prevp = fwrn;
+		return fwrn ? fwrn->fyn : NULL;
+
+	default:
+		break;
+	}
+
+	return NULL;
+}
+
+const char *fy_path_expr_type_txt[FPET_COUNT] = {
+	[fpet_none]			= "none",
+	/* */
+	[fpet_root]			= "root",
+	[fpet_this]			= "this",
+	[fpet_parent]			= "parent",
+	[fpet_every_child]		= "every-child",
+	[fpet_every_child_r]		= "every-child-recursive",
+	[fpet_filter_collection]	= "filter-collection",
+	[fpet_filter_scalar]		= "filter-scalar",
+	[fpet_filter_sequence]		= "filter-sequence",
+	[fpet_filter_mapping]		= "filter-mapping",
+	[fpet_filter_unique]		= "filter-unique",
+	[fpet_seq_index]		= "seq-index",
+	[fpet_seq_slice]		= "seq-slice",
+	[fpet_alias]			= "alias",
+
+	[fpet_map_key]			= "map-key",
+
+	[fpet_multi]			= "multi",
+	[fpet_chain]			= "chain",
+	[fpet_logical_or]		= "logical-or",
+	[fpet_logical_and]		= "logical-and",
+	[fpet_select]			= "select",
+	[fpet_unselect]			= "unselect",
+
+	[fpet_eq]			= "equals",
+	[fpet_neq]			= "not-equals",
+	[fpet_lt]			= "less-than",
+	[fpet_gt]			= "greater-than",
+	[fpet_lte]			= "less-or-equal-than",
+	[fpet_gte]			= "greater-or-equal-than",
+
+	[fpet_scalar]			= "scalar",
+
+	[fpet_plus]			= "plus",
+	[fpet_minus]			= "minus",
+	[fpet_mult]			= "multiply",
+	[fpet_div]			= "divide",
+
+	[fpet_lparen]			= "left-parentheses",
+	[fpet_rparen]			= "right-parentheses",
+	[fpet_method]			= "method",
+
+	[fpet_scalar_expr]		= "scalar-expression",
+	[fpet_path_expr]		= "path-expression",
+	[fpet_arg_separator]		= "argument-separator",
+};
+
+struct fy_path_expr *fy_path_expr_alloc(void)
+{
+	struct fy_path_expr *expr = NULL;
+
+	expr = malloc(sizeof(*expr));
+	if (!expr)
+		return NULL;
+	memset(expr, 0, sizeof(*expr));
+	fy_path_expr_list_init(&expr->children);
+
+	return expr;
+}
+
+void fy_path_expr_free(struct fy_path_expr *expr)
+{
+	struct fy_path_expr *exprn;
+
+	if (!expr)
+		return;
+
+	while ((exprn = fy_path_expr_list_pop(&expr->children)) != NULL)
+		fy_path_expr_free(exprn);
+
+	fy_token_unref(expr->fyt);
+
+	free(expr);
+}
+
+struct fy_path_expr *fy_path_expr_alloc_recycle(struct fy_path_parser *fypp)
+{
+	struct fy_path_expr *expr = NULL;
+
+#ifndef DEBUG_EXPR
+	if (!fypp || fypp->suppress_recycling)
+		expr = fy_path_expr_alloc();
+
+	if (!expr) {
+		expr = fy_path_expr_list_pop(&fypp->expr_recycle);
+		if (expr) {
+			memset(expr, 0, sizeof(*expr));
+			fy_path_expr_list_init(&expr->children);
+		} else
+			expr = fy_path_expr_alloc();
+	}
+#else
+	expr = fy_path_expr_alloc();
+#endif
+
+	if (!expr)
+		return NULL;
+
+	expr->expr_mode = fypp->expr_mode;
+
+	return expr;
+}
+
+void fy_path_expr_free_recycle(struct fy_path_parser *fypp, struct fy_path_expr *expr)
+{
+#ifndef DEBUG_EXPR
+	struct fy_path_expr *exprn;
+
+	if (!fypp || fypp->suppress_recycling) {
+		fy_path_expr_free(expr);
+		return;
+	}
+
+	while ((exprn = fy_path_expr_list_pop(&expr->children)) != NULL)
+		fy_path_expr_free_recycle(fypp, exprn);
+
+	if (expr->fyt) {
+		fy_token_unref(expr->fyt);
+		expr->fyt = NULL;
+	}
+	fy_path_expr_list_add_tail(&fypp->expr_recycle, expr);
+#else
+	fy_path_expr_free(expr);
+#endif
+}
+
+void fy_expr_stack_setup(struct fy_expr_stack *stack)
+{
+	if (!stack)
+		return;
+
+	memset(stack, 0, sizeof(*stack));
+	stack->items = stack->items_static;
+	stack->alloc = ARRAY_SIZE(stack->items_static);
+}
+
+void fy_expr_stack_cleanup(struct fy_expr_stack *stack)
+{
+	if (!stack)
+		return;
+
+	while (stack->top > 0)
+		fy_path_expr_free(stack->items[--stack->top]);
+
+	if (stack->items != stack->items_static)
+		free(stack->items);
+	stack->items = stack->items_static;
+	stack->alloc = ARRAY_SIZE(stack->items_static);
+}
+
+void fy_expr_stack_dump(struct fy_diag *diag, struct fy_expr_stack *stack)
+{
+	struct fy_path_expr *expr;
+	unsigned int i;
+
+	if (!stack)
+		return;
+
+	if (!stack->top)
+		return;
+
+	i = stack->top;
+	do {
+		expr = stack->items[--i];
+		fy_path_expr_dump(expr, diag, FYET_NOTICE, 0, NULL);
+	} while (i > 0);
+}
+
+int fy_expr_stack_size(struct fy_expr_stack *stack)
+{
+	if (!stack || stack->top >= (unsigned int)INT_MAX)
+		return -1;
+	return (int)stack->top;
+}
+
+int fy_expr_stack_push(struct fy_expr_stack *stack, struct fy_path_expr *expr)
+{
+	struct fy_path_expr **items_new;
+	unsigned int alloc;
+	size_t size;
+
+	if (!stack || !expr || !stack->items || stack->alloc <= 0 || !expr->fyt)
+		goto err_out;
+
+	/* grow the stack if required */
+	if (stack->top >= stack->alloc) {
+		alloc = stack->alloc;
+		size = alloc * sizeof(*items_new);
+
+		if (stack->items == stack->items_static) {
+			items_new = malloc(size * 2);
+			if (items_new)
+				memcpy(items_new, stack->items_static, size);
+		} else
+			items_new = realloc(stack->items, size * 2);
+
+		if (!items_new)
+			return -1;
+
+		stack->alloc = alloc * 2;
+		stack->items = items_new;
+	}
+
+	stack->items[stack->top++] = expr;
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+struct fy_path_expr *fy_expr_stack_peek_at(struct fy_expr_stack *stack, unsigned int pos)
+{
+	if (!stack || stack->top <= pos)
+		return NULL;
+	return stack->items[stack->top - 1 - pos];
+}
+
+struct fy_path_expr *fy_expr_stack_peek(struct fy_expr_stack *stack)
+{
+	return fy_expr_stack_peek_at(stack, 0);
+}
+
+struct fy_path_expr *fy_expr_stack_pop(struct fy_expr_stack *stack)
+{
+	if (!stack || !stack->top)
+		return NULL;
+
+	return stack->items[--stack->top];
+}
+
+bool fy_token_type_can_be_path_expr(enum fy_token_type type)
+{
+	return type == FYTT_NONE ||
+	       type == FYTT_PE_LPAREN ||
+	       type == FYTT_PE_RPAREN ||
+	       type == FYTT_PE_EQEQ ||
+	       type == FYTT_PE_NOTEQ ||
+	       type == FYTT_PE_GT ||
+	       type == FYTT_PE_LT ||
+	       type == FYTT_PE_GTE ||
+	       type == FYTT_PE_LTE ||
+	       type == FYTT_PE_METHOD;
+}
+
+bool fy_token_type_can_be_before_negative_number(enum fy_token_type type)
+{
+	return type == FYTT_NONE ||
+	       type == FYTT_PE_LPAREN ||
+	       type == FYTT_PE_RPAREN ||
+	       type == FYTT_PE_EQEQ ||
+	       type == FYTT_PE_NOTEQ ||
+	       type == FYTT_PE_GT ||
+	       type == FYTT_PE_LT ||
+	       type == FYTT_PE_GTE ||
+	       type == FYTT_PE_LTE ||
+	       type == FYTT_SE_PLUS ||
+	       type == FYTT_SE_MINUS ||
+	       type == FYTT_SE_MULT ||
+	       type == FYTT_SE_DIV ||
+
+	       type == FYTT_SE_METHOD;
+}
+
+const char *fy_expr_mode_txt[FYEM_COUNT] = {
+	[fyem_none]	= "none",
+	[fyem_path]	= "path",
+	[fyem_scalar]	= "scalar",
+};
+
+static struct fy_diag *fy_path_parser_reader_get_diag(struct fy_reader *fyr)
+{
+	struct fy_path_parser *fypp = container_of(fyr, struct fy_path_parser, reader);
+	return fypp->cfg.diag;
+}
+
+static const struct fy_reader_ops fy_path_parser_reader_ops = {
+	.get_diag = fy_path_parser_reader_get_diag,
+};
+
+void fy_path_parser_setup(struct fy_path_parser *fypp, const struct fy_path_parse_cfg *pcfg)
+{
+	struct fy_diag_cfg dcfg;
+
+	if (!fypp)
+		return;
+
+	memset(fypp, 0, sizeof(*fypp));
+	if (pcfg)
+		fypp->cfg = *pcfg;
+	if (!fypp->cfg.diag) {
+		fy_diag_cfg_default(&dcfg);
+		fypp->cfg.diag = fy_diag_create(&dcfg);
+		fypp->owns_diag = true;
+	}
+	fy_reader_setup(&fypp->reader, &fy_path_parser_reader_ops);
+	fy_token_list_init(&fypp->queued_tokens);
+	fypp->last_queued_token_type = FYTT_NONE;
+
+	fy_expr_stack_setup(&fypp->operators);
+	fy_expr_stack_setup(&fypp->operands);
+
+	fy_path_expr_list_init(&fypp->expr_recycle);
+	fypp->suppress_recycling = (fypp->cfg.flags & FYPPCF_DISABLE_RECYCLING) || getenv("FY_VALGRIND");
+
+	fypp->expr_mode = fyem_path;
+	fypp->paren_nest_level = 0;
+}
+
+int fy_path_parser_reset(struct fy_path_parser *fypp)
+{
+	struct fy_path_expr *expr;
+
+	if (!fypp)
+		return -1;
+
+	fy_expr_stack_cleanup(&fypp->operands);
+	fy_expr_stack_cleanup(&fypp->operators);
+
+	fy_reader_cleanup(&fypp->reader);
+	fy_token_list_unref_all(&fypp->queued_tokens);
+
+	while ((expr = fy_path_expr_list_pop(&fypp->expr_recycle)) != NULL)
+		fy_path_expr_free(expr);
+
+	fypp->last_queued_token_type = FYTT_NONE;
+	fypp->stream_start_produced = false;
+	fypp->stream_end_produced = false;
+	fypp->stream_error = false;
+	fypp->token_activity_counter = 0;
+	fypp->paren_nest_level = 0;
+
+	return 0;
+}
+
+void fy_path_parser_cleanup(struct fy_path_parser *fypp)
+{
+	if (!fypp)
+		return;
+
+	fy_path_parser_reset(fypp);
+	if (fypp->owns_diag && fypp->cfg.diag)
+		fy_diag_unref(fypp->cfg.diag);
+	memset(fypp, 0, sizeof(*fypp));
+}
+
+int fy_path_parser_open(struct fy_path_parser *fypp,
+			struct fy_input *fyi, const struct fy_reader_input_cfg *icfg)
+{
+	int ret;
+
+	if (!fypp)
+		return -1;
+
+	ret = fy_reader_input_open(&fypp->reader, fyi, icfg);
+	if (ret)
+		return ret;
+
+	/* remove ref if there */
+	fy_input_unref(fypp->fyi);
+
+	/* take a reference to the input */
+	fypp->fyi = fy_input_ref(fyi);
+	return 0;
+}
+
+void fy_path_parser_close(struct fy_path_parser *fypp)
+{
+	if (!fypp)
+		return;
+
+	fy_input_unref(fypp->fyi);
+	fypp->fyi = NULL;
+
+	fy_reader_input_done(&fypp->reader);
+}
+
+struct fy_token *fy_path_token_vqueue(struct fy_path_parser *fypp, enum fy_token_type type, va_list ap)
+{
+	struct fy_token *fyt;
+
+	fyt = fy_token_list_vqueue(&fypp->queued_tokens, type, ap);
+	if (fyt) {
+		fypp->token_activity_counter++;
+		fypp->last_queued_token_type = type;
+	}
+	return fyt;
+}
+
+struct fy_token *fy_path_token_queue(struct fy_path_parser *fypp, enum fy_token_type type, ...)
+{
+	va_list ap;
+	struct fy_token *fyt;
+
+	va_start(ap, type);
+	fyt = fy_path_token_vqueue(fypp, type, ap);
+	va_end(ap);
+
+	return fyt;
+}
+
+int fy_path_fetch_seq_index_or_slice(struct fy_path_parser *fypp, int c)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt;
+	bool neg;
+	int i, j, val, nval, digits, indices[2];
+
+	fyr = &fypp->reader;
+
+	/* verify that the called context is correct */
+	if (!(fy_is_num(c) || (c == '-' && fy_is_num(fy_reader_peek_at(fyr, 1)))))
+		goto err_out;
+
+	i = 0;
+	indices[0] = indices[1] = -1;
+
+	j = 0;
+	while (j < 2) {
+
+		neg = false;
+		if (c == '-') {
+			neg = true;
+			i++;
+		}
+
+		digits = 0;
+		val = 0;
+		while (fy_is_num((c = fy_reader_peek_at(fyr, i)))) {
+			nval = (val * 10) | (c - '0');
+			FYR_PARSE_ERROR_CHECK(fyr, 0, i, FYEM_SCAN,
+					nval >= val && nval >= 0, err_out,
+					"illegal sequence index (overflow)");
+			val = nval;
+			i++;
+			digits++;
+		}
+		FYR_PARSE_ERROR_CHECK(fyr, 0, i, FYEM_SCAN,
+				(val == 0 && digits == 1) || (val > 0), err_out,
+				"bad number");
+		if (neg)
+			val = -val;
+
+		indices[j] = val;
+
+		/* continue only on slice : */
+		if (c == ':') {
+			c = fy_reader_peek_at(fyr, i + 1);
+			if (fy_is_num(c) || (c == '-' && fy_is_num(fy_reader_peek_at(fyr, i + 2)))) {
+				i++;
+				j++;
+				continue;
+			}
+		}
+
+		break;
+	}
+
+	if (j >= 1)
+		fyt = fy_path_token_queue(fypp, FYTT_PE_SEQ_SLICE, fy_reader_fill_atom_a(fyr, i), indices[0], indices[1]);
+	else
+		fyt = fy_path_token_queue(fypp, FYTT_PE_SEQ_INDEX, fy_reader_fill_atom_a(fyr, i), indices[0]);
+
+	fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+
+	return 0;
+
+err_out:
+	fypp->stream_error = true;
+	return -1;
+}
+
+int fy_path_fetch_plain_or_method(struct fy_path_parser *fypp, int c,
+				  enum fy_token_type fytt_plain,
+				  enum fy_token_type fytt_method)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt;
+	struct fy_atom *handlep;
+	int i;
+	enum fy_token_type type;
+
+	fyr = &fypp->reader;
+
+	if (!fy_is_first_alpha(c))
+		goto err_out;
+
+	type = fytt_plain;
+
+	i = 1;
+	while (fy_is_alnum(fy_reader_peek_at(fyr, i)))
+		i++;
+
+	if (fy_reader_peek_at(fyr, i) == '(')
+		type = fytt_method;
+
+	handlep = fy_reader_fill_atom_a(fyr, i);
+	if (type == FYTT_SCALAR) {
+		fyt = fy_path_token_queue(fypp, FYTT_SCALAR, handlep, FYSS_PLAIN, NULL);
+		fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+	} else {
+		fyt = fy_path_token_queue(fypp, type, handlep, NULL);
+		fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+	}
+
+	return 0;
+
+err_out:
+	fypp->stream_error = true;
+	return -1;
+}
+
+int fy_path_fetch_dot_method(struct fy_path_parser *fypp, int c, enum fy_token_type fytt)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt;
+	struct fy_atom *handlep;
+	int i;
+
+	fyr = &fypp->reader;
+
+	if (c != '.')
+		goto err_out;
+
+	fy_reader_advance(fyr, c);
+	c = fy_reader_peek(fyr);
+	if (!fy_is_first_alpha(c))
+		goto err_out;
+
+	/* verify that the called context is correct */
+	i = 1;
+	while (fy_is_alnum(fy_reader_peek_at(fyr, i)))
+		i++;
+
+	handlep = fy_reader_fill_atom_a(fyr, i);
+
+	fyt = fy_path_token_queue(fypp, fytt, handlep, NULL);
+	fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+
+	return 0;
+
+err_out:
+	fypp->stream_error = true;
+	return -1;
+}
+
+int fy_path_fetch_flow_document(struct fy_path_parser *fypp, int c, enum fy_token_type fytt)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt;
+	struct fy_document *fyd;
+	struct fy_atom handle;
+	struct fy_parser fyp_data, *fyp = &fyp_data;
+	struct fy_parse_cfg cfg_data, *cfg = NULL;
+	int rc;
+
+	fyr = &fypp->reader;
+
+	/* verify that the called context is correct */
+	if (!fy_is_path_flow_key_start(c))
+		goto err_out;
+
+	fy_reader_fill_atom_start(fyr, &handle);
+
+	cfg = &cfg_data;
+	memset(cfg, 0, sizeof(*cfg));
+	cfg->flags = FYPCF_DEFAULT_PARSE;
+	cfg->diag = fypp->cfg.diag;
+
+	rc = fy_parse_setup(fyp, cfg);
+	fyr_error_check(fyr, !rc, err_out, "fy_parse_setup() failed\n");
+
+	/* associate with reader and set flow mode */
+	fy_parser_set_reader(fyp, fyr);
+	fy_parser_set_flow_only_mode(fyp, true);
+
+	fyd = fy_parse_load_document(fyp);
+
+	/* cleanup the parser no matter what */
+	fy_parse_cleanup(fyp);
+
+	fyr_error_check(fyr, fyd, err_out, "fy_parse_load_document() failed\n");
+
+	fy_reader_fill_atom_end(fyr, &handle);
+
+	/* document is NULL, is a simple key */
+	fyt = fy_path_token_queue(fypp, fytt, &handle, fyd);
+	fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+
+	return 0;
+
+err_out:
+	fypp->stream_error = true;
+	return -1;
+}
+
+int fy_path_fetch_flow_map_key(struct fy_path_parser *fypp, int c)
+{
+	return fy_path_fetch_flow_document(fypp, c, FYTT_PE_MAP_KEY);
+}
+
+int fy_path_fetch_flow_scalar(struct fy_path_parser *fypp, int c)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt;
+	struct fy_atom handle;
+	bool is_single;
+	int rc = -1;
+
+	fyr = &fypp->reader;
+
+	/* verify that the called context is correct */
+	if (!fy_is_path_flow_scalar_start(c))
+		goto err_out;
+
+	is_single = c == '\'';
+
+	rc = fy_reader_fetch_flow_scalar_handle(fyr, c, 0, &handle, false);
+	if (rc)
+		goto err_out_rc;
+
+	/* document is NULL, is a simple key */
+	fyt = fy_path_token_queue(fypp, FYTT_SCALAR, &handle, is_single ? FYSS_SINGLE_QUOTED : FYSS_DOUBLE_QUOTED);
+	fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+
+	return 0;
+
+err_out:
+	rc = -1;
+err_out_rc:
+	fypp->stream_error = true;
+	return rc;
+}
+
+int fy_path_fetch_number(struct fy_path_parser *fypp, int c)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt;
+	int i, digits;
+
+	fyr = &fypp->reader;
+
+	/* verify that the called context is correct */
+	if (!(fy_is_num(c) || (c == '-' && fy_is_num(fy_reader_peek_at(fyr, 1)))))
+		goto err_out;
+
+	i = 0;
+	if (c == '-')
+		i++;
+
+	digits = 0;
+	while (fy_is_num((c = fy_reader_peek_at(fyr, i)))) {
+		i++;
+		digits++;
+	}
+	FYR_PARSE_ERROR_CHECK(fyr, 0, i, FYEM_SCAN,
+			digits > 0, err_out,
+			"bad number");
+
+	fyt = fy_path_token_queue(fypp, FYTT_SCALAR, fy_reader_fill_atom_a(fyr, i), FYSS_PLAIN);
+	fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+
+	return 0;
+
+err_out:
+	fypp->stream_error = true;
+	return -1;
+}
+
+int fy_path_fetch_tokens(struct fy_path_parser *fypp)
+{
+	enum fy_token_type type;
+	struct fy_token *fyt = NULL;
+	struct fy_reader *fyr;
+	int c, cn, rc, simple_token_count;
+
+	fyr = &fypp->reader;
+	if (!fypp->stream_start_produced) {
+
+		fyt = fy_path_token_queue(fypp, FYTT_STREAM_START, fy_reader_fill_atom_a(fyr, 0));
+		fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+		fyt = NULL;
+
+		fypp->stream_start_produced = true;
+		return 0;
+	}
+
+	/* XXX scan to next token? */
+
+	c = fy_reader_peek(fyr);
+
+	if (fy_is_z(c)) {
+
+		if (c >= 0)
+			fy_reader_advance(fyr, c);
+
+		/* produce stream end continuously */
+		fyt = fy_path_token_queue(fypp, FYTT_STREAM_END, fy_reader_fill_atom_a(fyr, 0));
+		fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+		fyt = NULL;
+
+		return 0;
+	}
+
+	fyt = NULL;
+	type = FYTT_NONE;
+	simple_token_count = 0;
+
+	/* first do the common tokens */
+	switch (c) {
+	case ',':
+		type = FYTT_PE_COMMA;
+		simple_token_count = 1;
+		break;
+
+	case '|':
+		if (fy_reader_peek_at(fyr, 1) == '|') {
+			type = FYTT_PE_BARBAR;
+			simple_token_count = 2;
+			break;
+		}
+		break;
+
+	case '&':
+		if (fy_reader_peek_at(fyr, 1) == '&') {
+			type = FYTT_PE_AMPAMP;
+			simple_token_count = 2;
+			break;
+		}
+		break;
+
+	case '(':
+		type = FYTT_PE_LPAREN;
+		simple_token_count = 1;
+		break;
+
+	case ')':
+		type = FYTT_PE_RPAREN;
+		simple_token_count = 1;
+		break;
+
+	case '=':
+		cn = fy_reader_peek_at(fyr, 1);
+		if (cn == '=') {
+			type = FYTT_PE_EQEQ;
+			simple_token_count = 2;
+			break;
+		}
+		break;
+
+	case '>':
+		cn = fy_reader_peek_at(fyr, 1);
+		if (cn == '=') {
+			type = FYTT_PE_GTE;
+			simple_token_count = 2;
+			break;
+		}
+		type = FYTT_PE_GT;
+		simple_token_count = 1;
+		break;
+
+	case '<':
+		cn = fy_reader_peek_at(fyr, 1);
+		if (cn == '=') {
+			type = FYTT_PE_LTE;
+			simple_token_count = 2;
+			break;
+		}
+		type = FYTT_PE_LT;
+		simple_token_count = 1;
+		break;
+
+	case '!':
+		cn = fy_reader_peek_at(fyr, 1);
+		if (cn == '=') {
+			type = FYTT_PE_NOTEQ;
+			simple_token_count = 2;
+			break;
+		}
+		if (cn == '/' || cn == '(' || fy_is_alnum(cn) || cn == '!') {
+			/* bang bang */
+			type = FYTT_PE_BANG;
+			simple_token_count = 1;
+		}
+		break;
+
+	case '@':
+		type = FYTT_PE_AT;
+		simple_token_count = 1;
+		break;
+
+	default:
+		break;
+	}
+
+	if (type != FYTT_NONE)
+		goto do_token;
+
+again:
+
+	switch (fypp->expr_mode) {
+	case fyem_none:
+		FY_IMPOSSIBLE_ABORT();
+
+	case fyem_path:
+
+		switch (c) {
+		case '/':
+			type = FYTT_PE_SLASH;
+			simple_token_count = 1;
+			break;
+
+		case '^':
+			type = FYTT_PE_ROOT;
+			simple_token_count = 1;
+			break;
+
+		case ':':
+			type = FYTT_PE_SIBLING;
+			simple_token_count = 1;
+			break;
+
+		case '$':
+			type = FYTT_PE_SCALAR_FILTER;
+			simple_token_count = 1;
+			break;
+
+		case '%':
+			type = FYTT_PE_COLLECTION_FILTER;
+			simple_token_count = 1;
+			break;
+
+		case '[':
+			if (fy_reader_peek_at(fyr, 1) == ']') {
+				type = FYTT_PE_SEQ_FILTER;
+				simple_token_count = 2;
+			}
+			break;
+
+		case '{':
+			if (fy_reader_peek_at(fyr, 1) == '}') {
+				type = FYTT_PE_MAP_FILTER;
+				simple_token_count = 2;
+			}
+			break;
+
+
+		case '.':
+			cn = fy_reader_peek_at(fyr, 1);
+			if (cn == '.') {
+				type = FYTT_PE_PARENT;
+				simple_token_count = 2;
+			} else if (!fy_is_first_alpha(cn)) {
+				type = FYTT_PE_THIS;
+				simple_token_count = 1;
+			}
+			break;
+
+		case '*':
+			if (fy_reader_peek_at(fyr, 1) == '*') {
+				type = FYTT_PE_EVERY_CHILD_R;
+				simple_token_count = 2;
+			} else if (!fy_is_first_alpha(fy_reader_peek_at(fyr, 1))) {
+				type = FYTT_PE_EVERY_CHILD;
+				simple_token_count = 1;
+			} else {
+				type = FYTT_PE_ALIAS;
+				simple_token_count = 2;
+				while (fy_is_alnum(fy_reader_peek_at(fyr, simple_token_count)))
+					simple_token_count++;
+			}
+			break;
+
+		case '!':
+			cn = fy_reader_peek_at(fyr, 1);
+			if (cn == '=') {
+				type = FYTT_PE_NOTEQ;
+				simple_token_count = 2;
+				break;
+			}
+			type = FYTT_PE_UNIQUE_FILTER;
+			simple_token_count = 1;
+			break;
+
+		default:
+			break;
+		}
+		break;
+
+	case fyem_scalar:
+
+
+		/* it is possible for the expression to be a path
+		 * we only detect a few cases (doing all too complex)
+		 * (/ , (./ , (*
+		 */
+		if (fy_token_type_can_be_path_expr(fypp->last_queued_token_type)) {
+			cn = fy_reader_peek_at(fyr, 1);
+			if (c == '/' ||
+			    (c == '.' && (cn == '/' || cn == ')' || cn == '>' || cn == '<' || cn == '!' || cn == '='))) {
+				fypp->expr_mode = fyem_path;
+#ifdef DEBUG_EXPR
+				fyr_notice(fyr, "switching to path expr\n");
+#endif
+				goto again;
+			}
+		}
+
+		switch (c) {
+		case '+':
+			type = FYTT_SE_PLUS;
+			simple_token_count = 1;
+			break;
+
+		case '-':
+			cn = fy_reader_peek_at(fyr, 1);
+			if (fy_is_num(cn) &&
+			    fy_token_type_can_be_before_negative_number(fypp->last_queued_token_type))
+				break;
+
+			type = FYTT_SE_MINUS;
+			simple_token_count = 1;
+			break;
+
+		case '*':
+			type = FYTT_SE_MULT;
+			simple_token_count = 1;
+			break;
+
+		case '/':
+			type = FYTT_SE_DIV;
+			simple_token_count = 1;
+			break;
+
+		default:
+			break;
+		}
+		break;
+	}
+
+do_token:
+	/* simple tokens */
+	if (simple_token_count > 0) {
+		fyt = fy_path_token_queue(fypp, type, fy_reader_fill_atom_a(fyr, simple_token_count));
+		fyr_error_check(fyr, fyt, err_out, "fy_path_token_queue() failed\n");
+		fyt = NULL;
+
+		return 0;
+	}
+
+	switch (fypp->expr_mode) {
+	case fyem_none:
+		FY_IMPOSSIBLE_ABORT();
+
+	case fyem_path:
+		if (fy_is_first_alpha(c))
+			return fy_path_fetch_plain_or_method(fypp, c, FYTT_PE_MAP_KEY, FYTT_PE_METHOD);
+
+		if (fy_is_path_flow_key_start(c))
+			return fy_path_fetch_flow_map_key(fypp, c);
+
+		if (fy_is_num(c) || (c == '-' && fy_is_num(fy_reader_peek_at(fyr, 1))))
+			return fy_path_fetch_seq_index_or_slice(fypp, c);
+
+		if (c == '.' && fy_is_first_alpha(fy_reader_peek_at(fyr, 1)))
+			return fy_path_fetch_dot_method(fypp, c, FYTT_PE_METHOD);
+
+		break;
+
+	case fyem_scalar:
+
+		if (fy_is_first_alpha(c))
+			return fy_path_fetch_plain_or_method(fypp, c, FYTT_SCALAR, FYTT_SE_METHOD);
+
+		if (fy_is_path_flow_scalar_start(c))
+			return fy_path_fetch_flow_scalar(fypp, c);
+
+		if (fy_is_num(c) || (c == '-' && fy_is_num(fy_reader_peek_at(fyr, 1))))
+			return fy_path_fetch_number(fypp, c);
+
+		// if (c == '.' && fy_is_first_alpha(fy_reader_peek_at(fyr, 1)))
+		//	return fy_path_fetch_dot_method(fypp, c, FYTT_SE_METHOD);
+
+		break;
+	}
+
+	FYR_PARSE_ERROR(fyr, 0, 1, FYEM_SCAN, "bad path expression starts here c=%d", c);
+
+err_out:
+	fypp->stream_error = true;
+	rc = -1;
+	return rc;
+}
+
+struct fy_token *fy_path_scan_peek(struct fy_path_parser *fypp, struct fy_token *fyt_prev)
+{
+	struct fy_token *fyt;
+	struct fy_reader *fyr;
+	int rc, last_token_activity_counter;
+
+	fyr = &fypp->reader;
+
+	/* nothing if stream end produced (and no stream end token in queue) */
+	if (!fyt_prev && fypp->stream_end_produced && fy_token_list_empty(&fypp->queued_tokens)) {
+
+		fyt = fy_token_list_head(&fypp->queued_tokens);
+		if (fyt && fyt->type == FYTT_STREAM_END)
+			return fyt;
+
+		return NULL;
+	}
+
+	for (;;) {
+		if (!fyt_prev)
+			fyt = fy_token_list_head(&fypp->queued_tokens);
+		else
+			fyt = fy_token_next(&fypp->queued_tokens, fyt_prev);
+		if (fyt)
+			break;
+
+		/* on stream error we're done */
+		if (fypp->stream_error)
+			return NULL;
+
+		/* keep track of token activity, if it didn't change
+		* after the fetch tokens call, the state machine is stuck
+		*/
+		last_token_activity_counter = fypp->token_activity_counter;
+
+		/* fetch more then */
+		rc = fy_path_fetch_tokens(fypp);
+		if (rc) {
+			fy_error(fypp->cfg.diag, "fy_path_fetch_tokens() failed\n");
+			goto err_out;
+		}
+		if (last_token_activity_counter == fypp->token_activity_counter) {
+			fy_error(fypp->cfg.diag, "out of tokens and failed to produce anymore");
+			goto err_out;
+		}
+	}
+
+	switch (fyt->type) {
+	case FYTT_STREAM_START:
+		fypp->stream_start_produced = true;
+		break;
+	case FYTT_STREAM_END:
+		fypp->stream_end_produced = true;
+
+		rc = fy_reader_input_done(fyr);
+		if (rc) {
+			fy_error(fypp->cfg.diag, "fy_parse_input_done() failed");
+			goto err_out;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return fyt;
+
+err_out:
+	fypp->stream_error = true;
+	return NULL;
+}
+
+struct fy_token *fy_path_scan_remove(struct fy_path_parser *fypp, struct fy_token *fyt)
+{
+	if (!fypp || !fyt)
+		return NULL;
+
+	fy_token_list_del(&fypp->queued_tokens, fyt);
+
+	return fyt;
+}
+
+struct fy_token *fy_path_scan_remove_peek(struct fy_path_parser *fypp, struct fy_token *fyt)
+{
+	fy_token_unref(fy_path_scan_remove(fypp, fyt));
+
+	return fy_path_scan_peek(fypp, NULL);
+}
+
+struct fy_token *fy_path_scan(struct fy_path_parser *fypp)
+{
+	return fy_path_scan_remove(fypp, fy_path_scan_peek(fypp, NULL));
+}
+
+void fy_path_expr_dump(struct fy_path_expr *expr, struct fy_diag *diag, enum fy_error_type errlevel, int level, const char *banner)
+{
+	struct fy_path_expr *expr2;
+	const char *style = "";
+	const char *text;
+	size_t len;
+	bool save_on_error;
+
+	if (errlevel < diag->cfg.level)
+		return;
+
+	save_on_error = diag->on_error;
+	diag->on_error = true;
+
+	if (banner)
+		fy_diag_diag(diag, errlevel, "%-*s%s", level*2, "", banner);
+
+	text = fy_token_get_text(expr->fyt, &len);
+
+	style = "";
+	if (expr->type == fpet_scalar) {
+		switch (fy_scalar_token_get_style(expr->fyt)) {
+		case FYSS_SINGLE_QUOTED:
+			style = "'";
+			break;
+		case FYSS_DOUBLE_QUOTED:
+			style = "\"";
+			break;
+		default:
+			style = "";
+			break;
+		}
+	}
+
+	fy_diag_diag(diag, errlevel, "> %-*s%s:%s %s%.*s%s",
+			level*2, "",
+			fy_path_expr_type_txt[expr->type],
+			fy_expr_mode_txt[expr->expr_mode],
+			style, (int)len, text, style);
+
+	for (expr2 = fy_path_expr_list_head(&expr->children); expr2; expr2 = fy_path_expr_next(&expr->children, expr2))
+		fy_path_expr_dump(expr2, diag, errlevel, level + 1, NULL);
+
+	diag->on_error = save_on_error;
+}
+
+static struct fy_node *
+fy_path_expr_to_node_internal(struct fy_document *fyd, struct fy_path_expr *expr)
+{
+	struct fy_path_expr *expr2;
+	const char *style = "";
+	const char *text;
+	size_t len;
+	struct fy_node *fyn = NULL, *fyn2 = NULL, *fyn_seq = NULL;
+	int rc;
+
+	text = fy_token_get_text(expr->fyt, &len);
+
+	/* by default use double quoted style */
+	style = "\"";
+	switch (expr->type) {
+	case fpet_scalar:
+		switch (fy_scalar_token_get_style(expr->fyt)) {
+		case FYSS_SINGLE_QUOTED:
+			style = "'";
+			break;
+		case FYSS_DOUBLE_QUOTED:
+			style = "\"";
+			break;
+		default:
+			style = "";
+			break;
+		}
+		break;
+
+	case fpet_map_key:
+		/* no styles for complex map keys */
+		if (expr->fyt->map_key.fyd)
+			style = "";
+		break;
+
+	default:
+		break;
+	}
+
+	/* list is empty this is a terminal */
+	if (fy_path_expr_list_empty(&expr->children) &&
+	    expr->type != fpet_method) {
+
+		fyn = fy_node_buildf(fyd, "%s: %s%.*s%s",
+			fy_path_expr_type_txt[expr->type],
+			style, (int)len, text, style);
+		if (!fyn)
+			return NULL;
+
+		return fyn;
+	}
+
+	fyn = fy_node_create_mapping(fyd);
+	if (!fyn)
+		goto err_out;
+
+	fyn_seq = fy_node_create_sequence(fyd);
+	if (!fyn_seq)
+		goto err_out;
+
+	for (expr2 = fy_path_expr_list_head(&expr->children); expr2; expr2 = fy_path_expr_next(&expr->children, expr2)) {
+		fyn2 = fy_path_expr_to_node_internal(fyd, expr2);
+		if (!fyn2)
+			goto err_out;
+		rc = fy_node_sequence_append(fyn_seq, fyn2);
+		if (rc)
+			goto err_out;
+		fyn2 = NULL;
+	}
+
+	if (expr->type != fpet_method) {
+		rc = fy_node_mapping_append(fyn,
+				fy_node_create_scalar(fyd, fy_path_expr_type_txt[expr->type], FY_NT),
+				fyn_seq);
+	} else {
+		rc = fy_node_mapping_append(fyn,
+				fy_node_create_scalarf(fyd, "%s()", expr->fym->name),
+				fyn_seq);
+	}
+	if (rc)
+		goto err_out;
+
+	return fyn;
+
+err_out:
+	fy_node_free(fyn_seq);
+	fy_node_free(fyn);
+	return NULL;
+}
+
+struct fy_document *fy_path_expr_to_document(struct fy_path_expr *expr)
+{
+	struct fy_document *fyd = NULL;
+
+	if (!expr)
+		return NULL;
+
+	fyd = fy_document_create(NULL);
+	if (!fyd)
+		return NULL;
+
+	fyd->root = fy_path_expr_to_node_internal(fyd, expr);
+	if (!fyd->root)
+		goto err_out;
+
+	return fyd;
+
+err_out:
+	fy_document_destroy(fyd);
+	return NULL;
+}
+
+enum fy_path_expr_type fy_map_token_to_path_expr_type(enum fy_token_type type, enum fy_expr_mode mode)
+{
+	switch (type) {
+	case FYTT_PE_ROOT:
+		return fpet_root;
+	case FYTT_PE_THIS:
+		return fpet_this;
+	case FYTT_PE_PARENT:
+	case FYTT_PE_SIBLING:	/* sibling maps to a chain of fpet_parent */
+		return fpet_parent;
+	case FYTT_PE_MAP_KEY:
+		return fpet_map_key;
+	case FYTT_PE_SEQ_INDEX:
+		return fpet_seq_index;
+	case FYTT_PE_SEQ_SLICE:
+		return fpet_seq_slice;
+	case FYTT_PE_EVERY_CHILD:
+		return fpet_every_child;
+	case FYTT_PE_EVERY_CHILD_R:
+		return fpet_every_child_r;
+	case FYTT_PE_ALIAS:
+		return fpet_alias;
+	case FYTT_PE_SCALAR_FILTER:
+		return fpet_filter_scalar;
+	case FYTT_PE_COLLECTION_FILTER:
+		return fpet_filter_collection;
+	case FYTT_PE_SEQ_FILTER:
+		return fpet_filter_sequence;
+	case FYTT_PE_MAP_FILTER:
+		return fpet_filter_mapping;
+	case FYTT_PE_UNIQUE_FILTER:
+		return fpet_filter_unique;
+	case FYTT_PE_COMMA:
+		return mode == fyem_path ? fpet_multi : fpet_arg_separator;
+	case FYTT_PE_SLASH:
+		return fpet_chain;
+	case FYTT_PE_BARBAR:
+		return fpet_logical_or;
+	case FYTT_PE_AMPAMP:
+		return fpet_logical_and;
+
+	case FYTT_PE_EQEQ:
+		return fpet_eq;
+	case FYTT_PE_NOTEQ:
+		return fpet_neq;
+	case FYTT_PE_LT:
+		return fpet_lt;
+	case FYTT_PE_GT:
+		return fpet_gt;
+	case FYTT_PE_LTE:
+		return fpet_lte;
+	case FYTT_PE_GTE:
+		return fpet_gte;
+
+	case FYTT_SCALAR:
+		return fpet_scalar;
+
+	case FYTT_SE_PLUS:
+		return fpet_plus;
+	case FYTT_SE_MINUS:
+		return fpet_minus;
+	case FYTT_SE_MULT:
+		return fpet_mult;
+	case FYTT_SE_DIV:
+		return fpet_div;
+
+	case FYTT_PE_LPAREN:
+		return fpet_lparen;
+	case FYTT_PE_RPAREN:
+		return fpet_rparen;
+
+	case FYTT_SE_METHOD:
+	case FYTT_PE_METHOD:
+		return fpet_method;
+
+	case FYTT_PE_BANG:
+		return fpet_unselect;
+
+	case FYTT_PE_AT:
+		return fpet_select;
+
+	default:
+		FY_IMPOSSIBLE_ABORT();
+	}
+	return fpet_none;
+}
+
+bool fy_token_type_is_operand(enum fy_token_type type)
+{
+	return type == FYTT_PE_ROOT ||
+	       type == FYTT_PE_THIS ||
+	       type == FYTT_PE_PARENT ||
+	       type == FYTT_PE_MAP_KEY ||
+	       type == FYTT_PE_SEQ_INDEX ||
+	       type == FYTT_PE_SEQ_SLICE ||
+	       type == FYTT_PE_EVERY_CHILD ||
+	       type == FYTT_PE_EVERY_CHILD_R ||
+	       type == FYTT_PE_ALIAS ||
+
+	       type == FYTT_SCALAR;
+}
+
+bool fy_token_type_is_operator(enum fy_token_type type)
+{
+	return type == FYTT_PE_SLASH ||
+	       type == FYTT_PE_SCALAR_FILTER ||
+	       type == FYTT_PE_COLLECTION_FILTER ||
+	       type == FYTT_PE_SEQ_FILTER ||
+	       type == FYTT_PE_MAP_FILTER ||
+	       type == FYTT_PE_UNIQUE_FILTER ||
+	       type == FYTT_PE_SIBLING ||
+	       type == FYTT_PE_COMMA ||
+	       type == FYTT_PE_BARBAR ||
+	       type == FYTT_PE_AMPAMP ||
+	       type == FYTT_PE_LPAREN ||
+	       type == FYTT_PE_RPAREN ||
+
+	       type == FYTT_PE_EQEQ ||
+	       type == FYTT_PE_NOTEQ ||
+	       type == FYTT_PE_LT ||
+	       type == FYTT_PE_GT ||
+	       type == FYTT_PE_LTE ||
+	       type == FYTT_PE_GTE ||
+
+	       type == FYTT_SE_PLUS ||
+	       type == FYTT_SE_MINUS ||
+	       type == FYTT_SE_MULT ||
+	       type == FYTT_SE_DIV ||
+
+	       type == FYTT_PE_BANG;
+}
+
+bool fy_token_type_is_operand_or_operator(enum fy_token_type type)
+{
+	return fy_token_type_is_operand(type) ||
+	       fy_token_type_is_operator(type);
+}
+
+int fy_path_expr_type_prec(enum fy_path_expr_type type)
+{
+	switch (type) {
+	default:
+		return -1;	/* terminals */
+	case fpet_filter_collection:
+	case fpet_filter_scalar:
+	case fpet_filter_sequence:
+	case fpet_filter_mapping:
+	case fpet_filter_unique:
+		return 5;
+	case fpet_logical_or:
+	case fpet_logical_and:
+		return 4;
+	case fpet_multi:
+		return 21;
+	case fpet_eq:
+	case fpet_neq:
+	case fpet_lt:
+	case fpet_gt:
+	case fpet_lte:
+	case fpet_gte:
+		return 7;
+	case fpet_mult:
+	case fpet_div:
+		return 9;
+	case fpet_plus:
+	case fpet_minus:
+		return 8;
+	case fpet_chain:
+		return 20;
+	case fpet_select:
+	case fpet_unselect:
+		return 10;	/* must be less than chain */
+	case fpet_lparen:
+	case fpet_rparen:
+	case fpet_method:
+		return 1000;
+	case fpet_arg_separator:
+		return 1;	/* lowest */
+	}
+	return -1;
+}
+
+static inline FY_UNUSED void
+dump_operand_stack(struct fy_path_parser *fypp)
+{
+	fy_expr_stack_dump(fypp->cfg.diag, &fypp->operands);
+}
+
+static inline int
+push_operand(struct fy_path_parser *fypp, struct fy_path_expr *expr)
+{
+	return fy_expr_stack_push(&fypp->operands, expr);
+}
+
+static inline FY_UNUSED struct fy_path_expr *
+peek_operand_at(struct fy_path_parser *fypp, unsigned int pos)
+{
+	return fy_expr_stack_peek_at(&fypp->operands, pos);
+}
+
+static inline FY_UNUSED struct fy_path_expr *
+peek_operand(struct fy_path_parser *fypp)
+{
+	return fy_expr_stack_peek(&fypp->operands);
+}
+
+static inline FY_UNUSED struct fy_path_expr *
+pop_operand(struct fy_path_parser *fypp)
+{
+	return fy_expr_stack_pop(&fypp->operands);
+}
+
+#define PREFIX	0
+#define INFIX	1
+#define POSTFIX	2
+
+int fy_token_type_operator_placement(enum fy_token_type type)
+{
+	switch (type) {
+	case FYTT_PE_SLASH:	/* SLASH is special at the start of the expression */
+	case FYTT_PE_COMMA:
+	case FYTT_PE_BARBAR:
+	case FYTT_PE_AMPAMP:
+	case FYTT_PE_EQEQ:
+	case FYTT_PE_NOTEQ:
+	case FYTT_PE_LT:
+	case FYTT_PE_GT:
+	case FYTT_PE_LTE:
+	case FYTT_PE_GTE:
+	case FYTT_SE_PLUS:
+	case FYTT_SE_MINUS:
+	case FYTT_SE_MULT:
+	case FYTT_SE_DIV:
+		return INFIX;
+	case FYTT_PE_SCALAR_FILTER:
+	case FYTT_PE_COLLECTION_FILTER:
+	case FYTT_PE_SEQ_FILTER:
+	case FYTT_PE_MAP_FILTER:
+	case FYTT_PE_UNIQUE_FILTER:
+		return POSTFIX;
+	case FYTT_PE_SIBLING:
+	case FYTT_PE_BANG:
+		return PREFIX;
+	default:
+		break;
+	}
+	return -1;
+}
+
+int fy_path_expr_type_assoc(enum fy_path_expr_type type)
+{
+	switch (type) {
+	case fpet_root:
+	case fpet_select:
+	case fpet_unselect:
+		return PREFIX;
+
+	case fpet_this:
+	case fpet_parent:
+	case fpet_every_child:
+	case fpet_every_child_r:
+	case fpet_filter_collection:
+	case fpet_filter_scalar:
+	case fpet_filter_sequence:
+	case fpet_filter_mapping:
+	case fpet_filter_unique:
+	case fpet_seq_index:
+	case fpet_map_key:
+	case fpet_seq_slice:
+	case fpet_alias:
+		return POSTFIX;
+
+	case fpet_logical_or:
+	case fpet_logical_and:
+	case fpet_eq:
+	case fpet_neq:
+	case fpet_lt:
+	case fpet_gt:
+	case fpet_lte:
+	case fpet_gte:
+	case fpet_plus:
+	case fpet_minus:
+	case fpet_mult:
+	case fpet_div:
+	case fpet_arg_separator:	/* argument separator (comma in scalar mode) */
+		return INFIX;
+
+	case fpet_scalar:
+	case fpet_lparen:
+	case fpet_rparen:
+	case fpet_method:
+	case fpet_scalar_expr:
+	case fpet_path_expr:
+	default:
+		break;
+	}
+	return -1;
+}
+
+const struct fy_mark *fy_path_expr_start_mark(struct fy_path_expr *expr)
+{
+	if (!expr)
+		return NULL;
+
+	return fy_token_start_mark(expr->fyt);
+}
+
+const struct fy_mark *fy_path_expr_end_mark(struct fy_path_expr *expr)
+{
+	if (!expr)
+		return NULL;
+
+	return fy_token_end_mark(expr->fyt);
+}
+
+struct fy_token *
+expr_to_token_mark(struct fy_path_expr *expr, struct fy_input *fyi)
+{
+	const struct fy_mark *ms, *me;
+	struct fy_atom handle;
+
+	if (!expr || !fyi)
+		return NULL;
+
+	ms = fy_path_expr_start_mark(expr);
+	if (!ms)
+		goto err_out;
+	me = fy_path_expr_end_mark(expr);
+	if (!me)
+		goto err_out;
+
+	memset(&handle, 0, sizeof(handle));
+	handle.start_mark = *ms;
+	handle.end_mark = *me;
+	handle.fyi = fyi;
+	handle.style = FYAS_PLAIN;
+	handle.chomp = FYAC_CLIP;
+
+	return fy_token_create(FYTT_INPUT_MARKER, &handle);
+err_out:
+	return NULL;
+}
+
+struct fy_token *
+expr_lr_to_token_mark(struct fy_path_expr *exprl, struct fy_path_expr *exprr, struct fy_input *fyi)
+{
+	const struct fy_mark *ms, *me;
+	struct fy_atom handle;
+
+	if (!exprl || !exprr || !fyi)
+		return NULL;
+
+	ms = fy_path_expr_start_mark(exprl);
+	if (!ms)
+		goto err_out;
+	me = fy_path_expr_end_mark(exprr);
+	if (!me)
+		goto err_out;
+
+	memset(&handle, 0, sizeof(handle));
+	handle.start_mark = *ms;
+	handle.end_mark = *me;
+	handle.fyi = fyi;
+	handle.style = FYAS_PLAIN;
+	handle.chomp = FYAC_CLIP;
+
+	return fy_token_create(FYTT_INPUT_MARKER, &handle);
+err_out:
+	return NULL;
+}
+
+int
+fy_path_expr_order(struct fy_path_expr *expr1, struct fy_path_expr *expr2)
+{
+	const struct fy_mark *m1 = NULL, *m2 = NULL;
+
+	if (expr1)
+		m1 = fy_path_expr_start_mark(expr1);
+
+	if (expr2)
+		m2 = fy_path_expr_start_mark(expr2);
+
+	if (m1 == m2)
+		return 0;
+
+	if (!m1)
+		return -1;
+
+	if (!m2)
+		return 1;
+
+	return m1->input_pos == m2->input_pos ? 0 :
+	       m1->input_pos  < m2->input_pos ? -1 : 1;
+}
+
+int push_operand_lr(struct fy_path_parser *fypp,
+		    enum fy_path_expr_type type,
+		    struct fy_path_expr *exprl, struct fy_path_expr *exprr,
+		    bool optimize)
+{
+	struct fy_reader *fyr;
+	struct fy_path_expr *expr = NULL, *exprt;
+	const struct fy_mark *ms = NULL, *me = NULL, *mtmp;
+	struct fy_atom handle;
+	int ret;
+
+	optimize = false;
+	if (!exprl && !exprr)
+		goto err_out;
+
+	fyr = &fypp->reader;
+
+#if 0
+	fyr_notice(fyr, ">>> %s <%s> l=<%s> r=<%s>\n", __func__,
+			fy_path_expr_type_txt[type],
+			exprl ?fy_path_expr_type_txt[exprl->type] : "NULL",
+			exprr ?fy_path_expr_type_txt[exprr->type] : "NULL");
+#endif
+
+	expr = fy_path_expr_alloc_recycle(fypp);
+	fyr_error_check(fyr, expr, err_out,
+			"fy_path_expr_alloc_recycle() failed\n");
+
+	expr->type = type;
+	expr->fyt = NULL;
+
+	ms = fy_token_start_mark(exprl ? exprl->fyt : exprr->fyt);
+	if (!ms)
+		goto err_out;
+
+	me = fy_token_end_mark(exprr ? exprr->fyt : exprl->fyt);
+	if (!me)
+		goto err_out;
+
+	/* yes, it might be switched */
+	if (ms->input_pos > me->input_pos) {
+		mtmp = ms;
+		ms = me;
+		me = mtmp;
+	}
+
+	memset(&handle, 0, sizeof(handle));
+	handle.start_mark = *ms;
+	handle.end_mark = *me;
+	handle.fyi = fypp->fyi;
+	handle.style = FYAS_PLAIN;
+	handle.chomp = FYAC_CLIP;
+
+	if (exprl) {
+		if (type == exprl->type && fy_path_expr_type_is_mergeable(type)) {
+			while ((exprt = fy_path_expr_list_pop(&exprl->children)) != NULL) {
+				fy_path_expr_list_add_tail(&expr->children, exprt);
+				exprt->parent = expr;
+			}
+			fy_path_expr_free_recycle(fypp, exprl);
+		} else {
+			fy_path_expr_list_add_tail(&expr->children, exprl);
+			exprl->parent = expr;
+		}
+		exprl = NULL;
+	}
+
+	if (exprr) {
+		if (type == exprr->type && fy_path_expr_type_is_mergeable(type)) {
+			while ((exprt = fy_path_expr_list_pop(&exprr->children)) != NULL) {
+				fy_path_expr_list_add_tail(&expr->children, exprt);
+				exprt->parent = expr;
+			}
+			fy_path_expr_free_recycle(fypp, exprr);
+		} else {
+			fy_path_expr_list_add_tail(&expr->children, exprr);
+			exprr->parent = expr;
+		}
+		exprr = NULL;
+	}
+
+	expr->fyt = fy_token_create(FYTT_INPUT_MARKER, &handle);
+	fyr_error_check(fyr, expr->fyt, err_out,
+			"expr_to_token_mark() failed\n");
+
+	ret = push_operand(fypp, expr);
+	fyr_error_check(fyr, !ret, err_out,
+			"push_operand() failed\n");
+
+#ifdef DEBUG_EXPR
+	FYR_TOKEN_DIAG(fyr, expr->fyt,
+		FYDF_NOTICE, FYEM_PARSE, "pushed operand lr");
+#endif
+
+	return 0;
+err_out:
+	fy_path_expr_free(expr);
+	fy_path_expr_free(exprl);
+	fy_path_expr_free(exprr);
+	return -1;
+}
+
+enum fy_method_idx {
+	fymi_test,
+	fymi_sum,
+	fymi_this,
+	fymi_parent,
+	fymi_root,
+	fymi_any,
+	fymi_all,
+	fymi_select,
+	fymi_key,
+	fymi_value,
+	fymi_index,
+	fymi_null,
+};
+
+static struct fy_walk_result *
+common_builtin_ref_exec(const struct fy_method *fym,
+	struct fy_path_exec *fypx, int level,
+	struct fy_path_expr *expr,
+	struct fy_walk_result *input,
+	struct fy_walk_result **args, int nargs,
+	bool *errorp);
+
+static struct fy_walk_result *
+common_builtin_collection_exec(const struct fy_method *fym,
+	struct fy_path_exec *fypx, int level,
+	struct fy_path_expr *expr,
+	struct fy_walk_result *input,
+	struct fy_walk_result **args, int nargs,
+	bool *errorp);
+
+
+static struct fy_walk_result *
+test_exec(const struct fy_method *fym,
+	  struct fy_path_exec *fypx, int level,
+	  struct fy_path_expr *expr,
+	  struct fy_walk_result *input,
+	  struct fy_walk_result **args, int nargs,
+	  bool *errorp);
+
+static struct fy_walk_result *
+sum_exec(const struct fy_method *fym,
+	 struct fy_path_exec *fypx, int level,
+	 struct fy_path_expr *expr,
+	 struct fy_walk_result *input,
+	 struct fy_walk_result **args, int nargs,
+	 bool *errorp);
+
+static const struct fy_method fy_methods[] = {
+	[fymi_test] = {
+		.name	= "test",
+		.len    = 4,
+		.mode	= fyem_scalar,
+		.nargs	= 1,
+		.exec	= test_exec,
+	},
+	[fymi_sum] = {
+		.name	= "sum",
+		.len    = 3,
+		.mode	= fyem_scalar,
+		.nargs	= 2,
+		.exec	= sum_exec,
+	},
+	[fymi_this] = {
+		.name	= "this",
+		.len    = 4,
+		.mode	= fyem_path,
+		.nargs	= 0,
+		.exec	= common_builtin_ref_exec,
+	},
+	[fymi_parent] = {
+		.name	= "parent",
+		.len    = 6,
+		.mode	= fyem_path,
+		.nargs	= 0,
+		.exec	= common_builtin_ref_exec,
+	},
+	[fymi_root] = {
+		.name	= "root",
+		.len    = 4,
+		.mode	= fyem_path,
+		.nargs	= 0,
+		.exec	= common_builtin_ref_exec,
+	},
+	[fymi_any] = {
+		.name	= "any",
+		.len    = 3,
+		.mode	= fyem_path,
+		.nargs	= 1,
+		.exec	= common_builtin_collection_exec,
+	},
+	[fymi_all] = {
+		.name	= "all",
+		.len    = 3,
+		.mode	= fyem_path,
+		.nargs	= 1,
+		.exec	= common_builtin_collection_exec,
+	},
+	[fymi_select] = {
+		.name	= "select",
+		.len    = 6,
+		.mode	= fyem_path,
+		.nargs	= 1,
+		.exec	= common_builtin_collection_exec,
+	},
+	[fymi_key] = {
+		.name	= "key",
+		.len    = 3,
+		.mode	= fyem_path,
+		.nargs	= 1,
+		.exec	= common_builtin_ref_exec,
+	},
+	[fymi_value] = {
+		.name	= "value",
+		.len    = 5,
+		.mode	= fyem_path,
+		.nargs	= 1,
+		.exec	= common_builtin_ref_exec,
+	},
+	[fymi_index] = {
+		.name	= "index",
+		.len    = 5,
+		.mode	= fyem_path,
+		.nargs	= 1,
+		.exec	= common_builtin_ref_exec,
+	},
+	[fymi_null] = {
+		.name	= "null",
+		.len    = 4,
+		.mode	= fyem_path,
+		.nargs	= 0,
+		.exec	= common_builtin_ref_exec,
+	},
+};
+
+static inline int fy_method_to_builtin_idx(const struct fy_method *fym)
+{
+	if (!fym || fym < fy_methods || fym >= &fy_methods[ARRAY_SIZE(fy_methods)])
+		return -1;
+	return (int)(fym - fy_methods);
+}
+
+static struct fy_walk_result *
+common_builtin_ref_exec(const struct fy_method *fym,
+	    struct fy_path_exec *fypx, int level,
+            struct fy_path_expr *expr,
+	    struct fy_walk_result *input,
+	    struct fy_walk_result **args, int nargs,
+	    bool *errorp)
+{
+	enum fy_method_idx midx;
+	struct fy_walk_result *output = NULL;
+	struct fy_walk_result *fwr, *fwrn;
+	struct fy_node *fyn, *fynt;
+	bool error;
+	int i;
+
+	if (errorp)
+		*errorp = false;
+
+	if (!fypx || !input)
+		goto err_out;
+
+	i = fy_method_to_builtin_idx(fym);
+	if (i < 0)
+		goto err_out;
+	midx = (enum fy_method_idx)i;
+
+	switch (midx) {
+	case fymi_key:
+	case fymi_value:
+		if (!args || nargs != 1 || !args[0] || args[0]->type != fwrt_string)
+			goto err_out;
+		break;
+	case fymi_index:
+		if (!args || nargs != 1 || !args[0] || args[0]->type != fwrt_number)
+			goto err_out;
+		break;
+	case fymi_root:
+	case fymi_parent:
+	case fymi_this:
+	case fymi_null:
+		if (nargs != 0)
+			goto err_out;
+		break;
+	default:
+		goto err_out;
+	}
+
+	output = fy_path_exec_walk_result_create(fypx, fwrt_refs);
+	if (!output)
+		goto err_out;
+
+	for (fwr = fy_walk_result_iter_start(input); fwr;
+			fwr = fy_walk_result_iter_next(input, fwr)) {
+
+		if (fwr->type != fwrt_node_ref || !fwr->fyn)
+			continue;
+
+		fynt = fwr->fyn;
+
+		switch (midx) {
+		case fymi_key:
+		case fymi_value:
+		case fymi_index:
+		case fymi_this:
+		case fymi_null:
+			/* dereference alias */
+			if (fy_node_is_alias(fynt)) {
+				fynt = fy_node_alias_resolve_by_ypath_internal(fynt, &error);
+				if (error)
+					goto err_out;
+			}
+			break;
+		default:
+			break;
+		}
+
+		fyn = NULL;
+		switch (midx) {
+		case fymi_key:
+			if (!fy_node_is_mapping(fynt))
+				break;
+			fyn = fy_node_mapping_lookup_key_by_string(fynt, args[0]->string, FY_NT);
+			break;
+
+		case fymi_value:
+			if (!fy_node_is_mapping(fynt))
+				break;
+			fyn = fy_node_mapping_lookup_by_string(fynt, args[0]->string, FY_NT);
+			break;
+
+		case fymi_index:
+			if (!fy_node_is_sequence(fynt))
+				break;
+			fyn = fy_node_sequence_get_by_index(fynt, (int)args[0]->number);
+			break;
+
+		case fymi_root:
+			fyn = fy_document_root(fy_node_document(fynt));
+			break;
+
+		case fymi_parent:
+			fyn = fy_node_get_parent(fynt);
+			break;
+
+		case fymi_null:
+			if (!fy_node_is_mapping(fynt))
+				break;
+			fyn = fy_node_mapping_lookup_value_by_null_key(fynt);
+			break;
+
+		case fymi_this:
+			fyn = fynt;
+			break;
+
+		default:
+			break;
+		}
+
+		if (!fyn)
+			continue;
+
+		fwrn = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fyn);
+		if (!fwrn)
+			goto err_out;
+		fy_walk_result_list_add_tail(&output->refs, fwrn);
+	}
+
+	/* output convert zero to NULL, singular to node_ref */
+	if (output && output->type == fwrt_refs) {
+		if (fy_walk_result_list_empty(&output->refs)) {
+			fy_walk_result_free(output);
+			output = NULL;
+		} else if (fy_walk_result_list_is_singular(&output->refs)) {
+			fwr = fy_walk_result_list_pop(&output->refs);
+			if (!fwr)
+				goto err_out;
+			fy_walk_result_free(output);
+			output = fwr;
+		}
+	}
+
+out:
+	fy_walk_result_free(input);
+	input = NULL;
+	if (args) {
+		for (i = 0; i < nargs; i++)
+			fy_walk_result_free(args[i]);
+	}
+	return output;
+err_out:
+	if (errorp)
+		*errorp = true;
+	fy_walk_result_free(output);
+	output = NULL;
+	goto out;
+}
+
+static struct fy_walk_result *
+common_builtin_collection_exec(const struct fy_method *fym,
+	 struct fy_path_exec *fypx, int level,
+	 struct fy_path_expr *expr,
+	 struct fy_walk_result *input,
+	 struct fy_walk_result **args, int nargs,
+	 bool *errorp)
+{
+	enum fy_method_idx midx;
+	struct fy_walk_result *output = NULL;
+	struct fy_walk_result *fwr, *fwrn, *fwrt;
+	struct fy_path_expr *expr_arg;
+	bool match, done;
+	int input_count, match_count;
+	bool error;
+	int i;
+
+	if (errorp)
+		*errorp = false;
+
+	if (!fypx || !input)
+		goto err_out;
+
+	i = fy_method_to_builtin_idx(fym);
+	if (i < 0)
+		goto err_out;
+	midx = (enum fy_method_idx)i;
+
+	switch (midx) {
+	case fymi_any:
+	case fymi_all:
+	case fymi_select:
+		if (!args || nargs != 1 || !args[0])
+			goto err_out;
+		break;
+	default:
+		goto err_out;
+	}
+
+	expr_arg = fy_path_expr_list_head(&expr->children);
+	if (!expr_arg)
+		goto err_out;
+
+	/* only handle inputs of node and refs */
+	if (input->type != fwrt_node_ref && input->type != fwrt_refs)
+		goto err_out;
+
+	output = NULL;
+
+	switch (midx) {
+	case fymi_select:
+		output = fy_path_exec_walk_result_create(fypx, fwrt_refs);
+		if (!output)
+			goto err_out;
+		break;
+	default:
+		break;
+	}
+
+
+	done = false;
+	match_count = input_count = 0;
+	for (fwr = fy_walk_result_iter_start(input); fwr && !done; fwr = fy_walk_result_iter_next(input, fwr)) {
+
+		input_count++;
+
+		fwrt = fy_walk_result_clone(fwr);
+		if (!fwrt)
+			goto err_out;
+
+		fwrn = fy_path_expr_execute(fypx, level + 1, expr_arg, fwrt, expr->type, &error);
+		fwrt = NULL;
+		if (error)
+			goto err_out;
+
+		match = fwrn != NULL;
+		if (match)
+			match_count++;
+
+		switch (midx) {
+		case fymi_any:
+			/* on any match, we're done */
+			if (match)
+				done = true;
+			break;
+
+		case fymi_all:
+			/* on any non match, we're done */
+			if (!match)
+				done = true;
+			break;
+
+		case fymi_select:
+			/* select only works on node refs */
+			if (fwr->type != fwrt_node_ref)
+				break;
+			if (match) {
+				fwrt = fy_walk_result_clone(fwr);
+				if (!fwrt)
+					goto err_out;
+				fy_walk_result_list_add_tail(&output->refs, fwrt);
+			}
+			break;
+
+		default:
+			break;
+		}
+
+		fy_walk_result_free(fwrn);
+		fwrn = NULL;
+	}
+
+	switch (midx) {
+	case fymi_any:
+		if (input_count > 0 && match_count <= input_count) {
+			output = input;
+			input = NULL;
+		}
+		break;
+	case fymi_all:
+		if (input_count > 0 && match_count == input_count) {
+			output = input;
+			input = NULL;
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	/* output convert zero to NULL, singular to node_ref */
+	if (output && output->type == fwrt_refs) {
+		if (fy_walk_result_list_empty(&output->refs)) {
+			fy_walk_result_free(output);
+			output = NULL;
+		} else if (fy_walk_result_list_is_singular(&output->refs)) {
+			fwr = fy_walk_result_list_pop(&output->refs);
+			if (!fwr)
+				goto err_out;
+			fy_walk_result_free(output);
+			output = fwr;
+		}
+	}
+
+out:
+	fy_walk_result_free(input);
+	if (args) {
+		for (i = 0; i < nargs; i++)
+			fy_walk_result_free(args[i]);
+	}
+
+	return output;
+
+err_out:
+	if (errorp)
+		*errorp = true;
+	fy_walk_result_free(output);
+	output = NULL;
+	goto out;
+}
+
+static struct fy_walk_result *
+test_exec(const struct fy_method *fym,
+	  struct fy_path_exec *fypx, int level,
+	  struct fy_path_expr *expr,
+	  struct fy_walk_result *input,
+	  struct fy_walk_result **args, int nargs,
+	  bool *errorp)
+{
+	int i;
+	struct fy_walk_result *output = NULL;
+
+	if (!fypx || !args || nargs != 1)
+		goto out;
+
+	/* require a single number argument */
+	if (!args[0] || args[0]->type != fwrt_number)
+		goto out;
+
+	/* reuse argument */
+	output = args[0];
+	args[0] = NULL;
+
+	/* add 1 to the number */
+	output->number += 1;
+
+out:
+	fy_walk_result_free(input);
+	if (args) {
+		for (i = 0; i < nargs; i++)
+			fy_walk_result_free(args[i]);
+	}
+	return output;
+}
+
+static struct fy_walk_result *
+sum_exec(const struct fy_method *fym,
+	 struct fy_path_exec *fypx, int level,
+         struct fy_path_expr *expr,
+	 struct fy_walk_result *input,
+	 struct fy_walk_result **args, int nargs,
+	 bool *errorp)
+{
+	int i;
+	struct fy_walk_result *output = NULL;
+
+	if (!fypx || !args || nargs != 2)
+		goto out;
+
+	/* require two number argument */
+	if (!args[0] || args[0]->type != fwrt_number ||
+	    !args[1] || args[1]->type != fwrt_number)
+		goto out;
+
+	/* reuse argument */
+	output = args[0];
+	args[0] = NULL;
+
+	/* add 1 to the number */
+	output->number += args[1]->number;
+
+out:
+	fy_walk_result_free(input);
+	if (args) {
+		for (i = 0; i < nargs; i++)
+			fy_walk_result_free(args[i]);
+	}
+	return output;
+}
+
+int evaluate_method(struct fy_path_parser *fypp, struct fy_path_expr *exprm,
+		    struct fy_path_expr *exprl, struct fy_path_expr *exprr)
+{
+	struct fy_reader *fyr;
+	struct fy_path_expr *exprt;
+	struct fy_token *fyt;
+	const char *text;
+	size_t len;
+	const struct fy_method *fym;
+	unsigned int i, count;
+	int ret;
+
+	fyr = &fypp->reader;
+
+#ifdef DEBUG_EXPR
+	FYR_TOKEN_DIAG(fyr, exprm->fyt,
+		FYDF_NOTICE, FYEM_PARSE, "evaluating method");
+#endif
+
+	text = fy_token_get_text(exprm->fyt, &len);
+	fyr_error_check(fyr, text, err_out,
+			"fy_token_get_text() failed\n");
+
+	for (i = 0, fym = fy_methods; i < ARRAY_SIZE(fy_methods); i++, fym++) {
+		if (fym->len == len && !memcmp(text, fym->name, len))
+			break;
+	}
+
+	FYR_TOKEN_ERROR_CHECK(fyr, exprm->fyt, FYEM_PARSE,
+			i < ARRAY_SIZE(fy_methods), err_out,
+			"invalid method %.*s\n", (int)len, text);
+
+	/* reuse exprm */
+	count = 0;
+	while ((exprt = fy_expr_stack_peek(&fypp->operands)) != NULL &&
+		fy_path_expr_order(exprm, exprt) < 0) {
+
+		exprt = fy_expr_stack_pop(&fypp->operands);
+		if (!exprt)
+			goto err_out;
+
+#ifdef DEBUG_EXPR
+		FYR_TOKEN_DIAG(fyr, exprt->fyt,
+			FYDF_NOTICE, FYEM_PARSE, "poped argument %d", count);
+#endif
+
+		/* add in reverse order */
+		fy_path_expr_list_add(&exprm->children, exprt);
+		exprt->parent = exprm;
+		count++;
+
+	}
+
+	if (exprr) {
+		fyt = expr_lr_to_token_mark(exprm, exprr, fypp->fyi);
+		fyr_error_check(fyr, fyt, err_out,
+				"expr_lr_to_token_mark() failed\n");
+
+		fy_token_unref(exprm->fyt);
+		exprm->fyt = fyt;
+	}
+
+	FYR_TOKEN_ERROR_CHECK(fyr, exprm->fyt, FYEM_PARSE,
+			fym->nargs == count, err_out,
+			"too %s argument for method %s, expected %d, got %d\n",
+			fym->nargs < count ? "many" : "few",
+			fym->name, fym->nargs, count);
+
+	exprm->fym = fym;
+
+	if (exprl)
+		fy_path_expr_free_recycle(fypp, exprl);
+	if (exprr)
+		fy_path_expr_free_recycle(fypp, exprr);
+
+	/* and push as an operand */
+	ret = push_operand(fypp, exprm);
+	fyr_error_check(fyr, !ret, err_out,
+			"push_operand() failed\n");
+
+#ifdef DEBUG_EXPR
+	FYR_TOKEN_DIAG(fyr, exprm->fyt,
+		FYDF_NOTICE, FYEM_PARSE, "pushed operand evaluate_method");
+#endif
+	return 0;
+
+err_out:
+	/* we don't need the parentheses operators */
+	fy_path_expr_free_recycle(fypp, exprm);
+	if (exprl)
+		fy_path_expr_free_recycle(fypp, exprl);
+	if (exprr)
+		fy_path_expr_free_recycle(fypp, exprr);
+
+	return -1;
+}
+
+int evaluate_new(struct fy_path_parser *fypp)
+{
+	struct fy_reader *fyr;
+	struct fy_path_expr *expr = NULL, *expr_peek, *exprt;
+	struct fy_path_expr *exprl = NULL, *exprr = NULL, *chain = NULL, *exprm = NULL;
+	struct fy_path_expr *parent = NULL;
+	struct fy_token *fyt;
+	enum fy_path_expr_type type, etype;
+	int ret;
+
+	fyr = &fypp->reader;
+
+	expr = fy_expr_stack_pop(&fypp->operators);
+	fyr_error_check(fyr, expr && expr->fyt, err_out,
+			"pop_operator() failed to find token operator to evaluate\n");
+
+#ifdef DEBUG_EXPR
+	FYR_TOKEN_DIAG(fyr, expr->fyt,
+		FYDF_NOTICE, FYEM_PARSE, "poped operator expression");
+	fy_path_expr_dump(expr, fypp->cfg.diag, FYET_NOTICE, 0, "poped expr: ");
+#endif
+
+	exprl = NULL;
+	exprr = NULL;
+	type = expr->type;
+	switch (type) {
+
+	case fpet_chain:
+
+		/* dump_operand_stack(fypp); */
+		/* dump_operator_stack(fypp); */
+
+		/* peek the next operator */
+		expr_peek = fy_expr_stack_peek(&fypp->operators);
+
+		/* pop the top in either case */
+		exprr = fy_expr_stack_pop(&fypp->operands);
+		if (!exprr) {
+			// fyr_notice(fyr, "ROOT value (with no arguments)\n");
+
+			/* conver to root and push to operands */
+			expr->type = fpet_root;
+
+			ret = push_operand(fypp, expr);
+			fyr_error_check(fyr, !ret, err_out,
+					"push_operand() failed\n");
+			return 0;
+		}
+
+#ifdef DEBUG_EXPR
+		FYR_TOKEN_DIAG(fyr, exprr->fyt,
+			FYDF_NOTICE, FYEM_PARSE, "exprr");
+#endif
+
+		/* expression is to the left, that means it's a root chain */
+		if (fy_path_expr_order(expr, exprr) < 0 &&
+		    (!(exprl = fy_expr_stack_peek(&fypp->operands)) ||
+		     (expr_peek && fy_path_expr_order(exprl, expr_peek) <= 0))) {
+
+			// fyr_notice(fyr, "ROOT operator (with arguments)\n");
+
+			exprl = fy_path_expr_alloc_recycle(fypp);
+			fyr_error_check(fyr, exprl, err_out,
+					"fy_path_expr_alloc_recycle() failed\n");
+			exprl->type = fpet_root;
+
+			/* move token to the root */
+			exprl->fyt = expr->fyt;
+			expr->fyt = NULL;
+
+		} else if (!(exprl = fy_expr_stack_pop(&fypp->operands))) {
+
+			// fyr_notice(fyr, "COLLECTION operator\n");
+
+			exprl = exprr;
+
+			exprr = fy_path_expr_alloc_recycle(fypp);
+			fyr_error_check(fyr, exprr, err_out,
+					"fy_path_expr_alloc_recycle() failed\n");
+			exprr->type = fpet_filter_collection;
+
+			/* move token to the filter collection */
+			exprr->fyt = expr->fyt;
+			expr->fyt = NULL;
+
+		} else {
+			if (!(exprr && exprl))
+				goto err_out;
+
+			// fyr_notice(fyr, "CHAIN operator\n");
+		}
+
+		/* we don't need the chain operator now */
+		fy_path_expr_free_recycle(fypp, expr);
+		expr = NULL;
+
+		ret = push_operand_lr(fypp, fpet_chain, exprl, exprr, true);
+		fyr_error_check(fyr, !ret, err_out,
+				"push_operand_lr() failed\n");
+		return 0;
+
+	case fpet_multi:
+	case fpet_logical_or:
+	case fpet_logical_and:
+
+	case fpet_eq:
+	case fpet_neq:
+	case fpet_lt:
+	case fpet_gt:
+	case fpet_lte:
+	case fpet_gte:
+
+	case fpet_plus:
+	case fpet_minus:
+	case fpet_mult:
+	case fpet_div:
+
+		exprl = NULL;
+		exprr = NULL;
+		exprt = fy_expr_stack_peek(&fypp->operators);
+
+		// fyr_error(fyr, "mode=%s top-mode=%s\n",
+		//		fy_expr_mode_txt[fypp->expr_mode],
+		//		exprt ? fy_expr_mode_txt[exprt->expr_mode] : "");
+
+#if 0
+		exprr = fy_expr_stack_peek(&fypp->operands);
+		if (exprr && exprt && fy_path_expr_order(exprr, exprt) <= 0)
+			exprr = NULL;
+		else
+#endif
+			exprr = fy_expr_stack_pop(&fypp->operands);
+		fyr_error_check(fyr, exprr, err_out,
+				"fy_expr_stack_pop() failed for exprr\n");
+
+#if 0
+		exprl = fy_expr_stack_peek_at(&fypp->operands, 1);
+		if (exprl && exprt && fy_path_expr_order(exprl, exprt) <= 0)
+			exprl = NULL;
+		else
+#endif
+			exprl = fy_expr_stack_pop(&fypp->operands);
+		fyr_error_check(fyr, exprl, err_out,
+				"fy_expr_stack_pop() failed for exprl\n");
+
+		/* we don't need the operator now */
+		fy_path_expr_free_recycle(fypp, expr);
+		expr = NULL;
+
+		ret = push_operand_lr(fypp, type, exprl, exprr, true);
+		fyr_error_check(fyr, !ret, err_out,
+				"push_operand_lr() failed\n");
+
+		break;
+
+	case fpet_filter_collection:
+	case fpet_filter_scalar:
+	case fpet_filter_sequence:
+	case fpet_filter_mapping:
+	case fpet_filter_unique:
+
+		exprl = fy_expr_stack_pop(&fypp->operands);
+		FYR_TOKEN_ERROR_CHECK(fyr, expr->fyt, FYEM_PARSE,
+				exprl, err_out,
+				"filter operator without argument");
+
+		exprr = fy_path_expr_alloc_recycle(fypp);
+		fyr_error_check(fyr, exprr, err_out,
+				"fy_path_expr_alloc_recycle() failed\n");
+		exprr->type = type;
+
+		/* move token to the filter collection */
+		exprr->fyt = expr->fyt;
+		expr->fyt = NULL;
+
+		/* we don't need the operator now */
+		fy_path_expr_free_recycle(fypp, expr);
+		expr = NULL;
+
+		/* push as a chain */
+		ret = push_operand_lr(fypp, fpet_chain, exprl, exprr, true);
+		fyr_error_check(fyr, !ret, err_out,
+				"push_operand_lr() failed\n");
+
+		break;
+
+	case fpet_lparen:
+#ifdef DEBUG_EXPR
+		FYR_TOKEN_DIAG(fyr, expr->fyt,
+			FYDF_NOTICE, FYEM_PARSE, "(");
+#endif
+
+		return 0;
+
+	case fpet_arg_separator:
+
+		/* separator is right hand side of the expression now */
+		exprr = expr;
+		expr = NULL;
+
+		/* evaluate until we hit a match to the rparen */
+		exprl = fy_expr_stack_peek(&fypp->operators);
+		if (!exprl)
+			goto err_out;
+
+		if (!fy_path_expr_type_is_lparen(exprl->type)) {
+			exprl = NULL;
+			ret = evaluate_new(fypp);
+			if (ret)
+				goto err_out;
+		}
+		exprl = NULL;
+
+		fy_path_expr_free_recycle(fypp, exprr);
+		exprr = NULL;
+
+		break;
+
+	case fpet_rparen:
+
+		/* rparen is right hand side of the expression now */
+		exprr = expr;
+		expr = NULL;
+
+		/* evaluate until we hit a match to the rparen */
+		while ((exprl = fy_expr_stack_peek(&fypp->operators)) != NULL) {
+
+			if (fy_path_expr_type_is_lparen(exprl->type))
+				break;
+
+			exprl = NULL;
+			ret = evaluate_new(fypp);
+			if (ret)
+				goto err_out;
+		}
+
+		FYR_TOKEN_ERROR_CHECK(fyr, exprr->fyt, FYEM_PARSE,
+				exprl, err_out,
+				"missing matching left parentheses");
+
+		exprl = fy_expr_stack_pop(&fypp->operators);
+		if (!exprl)
+			goto err_out;
+
+		exprt = fy_expr_stack_peek(&fypp->operands);
+
+		etype = exprl->expr_mode == fyem_scalar ? fpet_scalar_expr : fpet_path_expr;
+
+		/* already is an expression, reuse */
+		if (exprt && exprt->type == etype) {
+
+			fyt = expr_lr_to_token_mark(exprl, exprr, fypp->fyi);
+			fyr_error_check(fyr, fyt, err_out,
+					"expr_lr_to_token_mark() failed\n");
+			fy_token_unref(exprt->fyt);
+			exprt->fyt = fyt;
+			exprt->expr_mode = exprl->expr_mode;
+
+			/* we don't need the parentheses operators */
+			fy_path_expr_free_recycle(fypp, exprl);
+			exprl = NULL;
+			fy_path_expr_free_recycle(fypp, exprr);
+			exprr = NULL;
+
+			return 0;
+		}
+
+		/* if it's method, evaluate */
+		exprm = fy_expr_stack_peek(&fypp->operators);
+		if (exprm && exprm->type == fpet_method) {
+
+			exprm = fy_expr_stack_pop(&fypp->operators);
+			if (!exprm)
+				goto err_out;
+
+			return evaluate_method(fypp, exprm, exprl, exprr);
+		}
+
+		expr = fy_path_expr_alloc_recycle(fypp);
+		fyr_error_check(fyr, expr, err_out,
+				"fy_path_expr_alloc_recycle() failed\n");
+		expr->type = etype;
+		expr->expr_mode = exprl->expr_mode;
+
+		expr->fyt = expr_lr_to_token_mark(exprl, exprr, fypp->fyi);
+
+		exprt = fy_expr_stack_pop(&fypp->operands);
+		if (!exprt)
+			goto err_out;
+
+		FYR_TOKEN_ERROR_CHECK(fyr, exprr->fyt, FYEM_PARSE,
+				exprt, err_out,
+				"empty expression in parentheses");
+
+		fy_path_expr_list_add_tail(&expr->children, exprt);
+		exprt->parent = expr;
+
+		/* pop all operands that after exprl */
+		while ((exprt = fy_expr_stack_peek(&fypp->operands)) != NULL &&
+			fy_path_expr_order(exprt, exprl) >= 0) {
+#ifdef DEBUG_EXPR
+			FYR_TOKEN_DIAG(fyr, exprt->fyt,
+				FYDF_NOTICE, FYEM_PARSE, "discarding argument");
+#endif
+			fy_path_expr_free_recycle(fypp, fy_expr_stack_pop(&fypp->operands));
+		}
+
+		if (exprl->expr_mode != fyem_none) {
+			fypp->expr_mode = exprl->expr_mode;
+#ifdef DEBUG_EXPR
+			fyr_notice(fyr, "poping expr_mode %s\n", fy_expr_mode_txt[fypp->expr_mode]);
+#endif
+		}
+
+		/* we don't need the parentheses operators */
+		fy_path_expr_free_recycle(fypp, exprl);
+		exprl = NULL;
+		fy_path_expr_free_recycle(fypp, exprr);
+		exprr = NULL;
+
+		ret = push_operand(fypp, expr);
+		fyr_error_check(fyr, !ret, err_out,
+				"push_operand() failed\n");
+
+#ifdef DEBUG_EXPR
+		FYR_TOKEN_DIAG(fyr, expr->fyt,
+			FYDF_NOTICE, FYEM_PARSE, "pushed operand evaluate_new");
+#endif
+		return 0;
+
+	case fpet_method:
+		return evaluate_method(fypp, expr, NULL, NULL);
+
+	case fpet_select:
+	case fpet_unselect:
+
+		/* we don't need the not operator now */
+		fy_path_expr_free_recycle(fypp, expr);
+		expr = NULL;
+
+		exprl = fy_expr_stack_pop(&fypp->operands);
+		fyr_error_check(fyr, exprl, err_out,
+				"fy_expr_stack_pop() failed for exprl\n");
+		exprr = NULL;
+
+		ret = push_operand_lr(fypp, type, exprl, exprr, true);
+		fyr_error_check(fyr, !ret, err_out,
+				"push_operand_lr() failed\n");
+
+		return 0;
+
+		/* shoud never */
+	case fpet_scalar_expr:
+	case fpet_path_expr:
+		FY_IMPOSSIBLE_ABORT();
+
+	default:
+		fyr_error(fyr, "Unknown expression %s\n", fy_path_expr_type_txt[expr->type]);
+		goto err_out;
+	}
+
+	return 0;
+
+err_out:
+
+#ifdef DEBUG_EXPR
+	if (expr)
+		fy_path_expr_dump(expr, fypp->cfg.diag, FYET_NOTICE, 0, "expr:");
+	if (exprl)
+		fy_path_expr_dump(exprl, fypp->cfg.diag, FYET_NOTICE, 0, "exprl:");
+	if (exprr)
+		fy_path_expr_dump(exprr, fypp->cfg.diag, FYET_NOTICE, 0, "exprr:");
+	if (chain)
+		fy_path_expr_dump(chain, fypp->cfg.diag, FYET_NOTICE, 0, "chain:");
+	if (parent)
+		fy_path_expr_dump(parent, fypp->cfg.diag, FYET_NOTICE, 0, "parent:");
+
+	fy_notice(fypp->cfg.diag, "operator stack\n");
+	fy_expr_stack_dump(fypp->cfg.diag, &fypp->operators);
+	fy_notice(fypp->cfg.diag, "operand stack\n");
+	fy_expr_stack_dump(fypp->cfg.diag, &fypp->operands);
+#endif
+
+	fy_path_expr_free(expr);
+	fy_path_expr_free(exprl);
+	fy_path_expr_free(exprr);
+	fy_path_expr_free(chain);
+	fy_path_expr_free(parent);
+
+	return -1;
+}
+
+int fy_path_check_expression_alias(struct fy_path_parser *fypp, struct fy_path_expr *expr)
+{
+	struct fy_reader *fyr;
+	struct fy_path_expr *exprn;
+	int rc;
+
+	if (!expr)
+		return 0;
+
+	fyr = &fypp->reader;
+
+	/* an alias with a parent.. must be the first one */
+	if (expr->type == fpet_alias && expr->parent) {
+
+		exprn = fy_path_expr_list_head(&expr->parent->children);
+
+		/* an alias may only be the first of a path expression */
+		FYR_TOKEN_ERROR_CHECK(fyr, expr->fyt, FYEM_PARSE,
+				expr == exprn, err_out,
+				"alias is not first in the path expresion");
+	}
+
+	for (exprn = fy_path_expr_list_head(&expr->children); exprn;
+		exprn = fy_path_expr_next(&expr->children, exprn)) {
+
+		rc = fy_path_check_expression_alias(fypp, exprn);
+		if (rc)
+			return rc;
+	}
+
+	return 0;
+
+err_out:
+	return -1;
+}
+
+/* check expression for validity */
+int fy_path_check_expression(struct fy_path_parser *fypp, struct fy_path_expr *expr)
+{
+	int rc;
+
+	rc = fy_path_check_expression_alias(fypp, expr);
+	if (rc)
+		return rc;
+
+	return 0;
+}
+
+struct fy_path_expr *
+fy_path_parse_expression(struct fy_path_parser *fypp)
+{
+	struct fy_reader *fyr;
+	struct fy_token *fyt = NULL;
+	enum fy_token_type fytt;
+	struct fy_path_expr *expr = NULL, *expr_top, *exprt;
+	enum fy_expr_mode old_scan_mode, prev_scan_mode;
+	int ret, rc;
+
+	/* the parser must be in the correct state */
+	if (!fypp || fy_expr_stack_size(&fypp->operators) > 0 || fy_expr_stack_size(&fypp->operands) > 0)
+		return NULL;
+
+	fyr = &fypp->reader;
+
+	/* find stream start */
+	fyt = fy_path_scan_peek(fypp, NULL);
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_PARSE,
+			fyt && fyt->type == FYTT_STREAM_START, err_out,
+			"no tokens available or start without stream start");
+
+	/* remove stream start */
+	fy_token_unref(fy_path_scan_remove(fypp, fyt));
+	fyt = NULL;
+
+	prev_scan_mode = fypp->expr_mode;
+
+	while ((fyt = fy_path_scan_peek(fypp, NULL)) != NULL) {
+
+		if (fyt->type == FYTT_STREAM_END)
+			break;
+
+#ifdef DEBUG_EXPR
+		FYR_TOKEN_DIAG(fyr, fyt, FYET_NOTICE, FYEM_PARSE, "next token %s", fy_token_debug_text_a(fyt));
+#endif
+		fytt = fyt->type;
+
+		/* create an expression in either operator/operand case */
+		expr = fy_path_expr_alloc_recycle(fypp);
+		fyr_error_check(fyr, expr, err_out,
+				"fy_path_expr_alloc_recycle() failed\n");
+
+		expr->fyt = fy_path_scan_remove(fypp, fyt);
+		/* this it the first attempt, it might not be the final one */
+		expr->type = fy_map_token_to_path_expr_type(fyt->type, fypp->expr_mode);
+		fyt = NULL;
+
+#ifdef DEBUG_EXPR
+		fy_path_expr_dump(expr, fypp->cfg.diag, FYET_NOTICE, 0, "-> expr");
+#endif
+
+		if (prev_scan_mode != fypp->expr_mode) {
+#ifdef DEBUG_EXPR
+			fyr_warning(fyr, "switched expr_mode %s -> %s\n",
+					fy_expr_mode_txt[prev_scan_mode],
+					fy_expr_mode_txt[fypp->expr_mode]);
+#endif
+			expr_top = fy_expr_stack_peek(&fypp->operators);
+
+#ifdef DEBUG_EXPR
+			if (expr_top)
+				fy_path_expr_dump(expr_top, fypp->cfg.diag, FYET_NOTICE, 0, NULL);
+#endif
+
+			if (expr_top && fy_path_expr_type_is_lparen(expr_top->type) &&
+					expr_top->expr_mode != fypp->expr_mode) {
+#ifdef DEBUG_EXPR
+				fyr_warning(fyr, "switched top lparen expr_mode %s -> %s\n",
+						fy_expr_mode_txt[expr_top->expr_mode],
+						fy_expr_mode_txt[fypp->expr_mode]);
+				expr_top->expr_mode = fypp->expr_mode;
+#endif
+			}
+		}
+
+		prev_scan_mode = fypp->expr_mode;
+
+		/* if it's an operand convert it to expression and push */
+		if (fy_token_type_is_operand(fytt)) {
+
+			ret = fy_expr_stack_push(&fypp->operands, expr);
+			fyr_error_check(fyr, !ret, err_out, "push_operand() failed\n");
+			expr = NULL;
+
+			continue;
+		}
+
+		/* specials for SLASH */
+
+		if (expr->fyt->type == FYTT_PE_SLASH) {
+
+			/* try to get next token */
+			fyt = fy_path_scan_peek(fypp, NULL);
+			if (!fyt) {
+				if (!fypp->stream_error) {
+					(void)fy_path_fetch_tokens(fypp);
+					fyt = fy_path_scan_peek(fypp, NULL);
+				}
+			}
+
+			/* last token, it means it's a collection filter (or a root) */
+			if (!fyt || fyt->type == FYTT_STREAM_END || fyt->type == FYTT_PE_RPAREN) {
+
+				exprt = fy_expr_stack_peek(&fypp->operands);
+
+				/* if no argument exists it's a root */
+				if (!exprt) {
+					expr->type = fpet_root;
+
+					ret = fy_expr_stack_push(&fypp->operands, expr);
+					fyr_error_check(fyr, !ret, err_out, "push_operand() failed\n");
+					expr = NULL;
+					continue;
+				}
+
+				expr->type = fpet_filter_collection;
+			}
+		}
+
+#ifdef DEBUG_EXPR
+		fy_notice(fypp->cfg.diag, "operator stack (before)\n");
+		fy_expr_stack_dump(fypp->cfg.diag, &fypp->operators);
+		fy_notice(fypp->cfg.diag, "operator stack (before) ends\n");
+		fy_notice(fypp->cfg.diag, "operand stack (before)\n");
+		fy_expr_stack_dump(fypp->cfg.diag, &fypp->operands);
+		fy_notice(fypp->cfg.diag, "operand stack (before) ends\n");
+#endif
+
+		old_scan_mode = fypp->expr_mode;
+
+		FYR_TOKEN_ERROR_CHECK(fyr, expr->fyt, FYEM_PARSE,
+				expr->type != fpet_select && expr->type != fpet_unselect, err_out,
+				"select/unselect set operators are not supported anymore");
+
+		/* for rparen, need to push before */
+		if (expr->type == fpet_rparen) {
+
+			FYR_TOKEN_ERROR_CHECK(fyr, expr->fyt, FYEM_PARSE,
+					fypp->paren_nest_level > 0, err_out,
+					"Mismatched right parentheses");
+
+			fypp->paren_nest_level--;
+
+			ret = fy_expr_stack_push(&fypp->operators, expr);
+			fyr_error_check(fyr, !ret, err_out, "push_operator() failed\n");
+			expr = NULL;
+
+			ret = evaluate_new(fypp);
+			/* evaluate will print diagnostic on error */
+			if (ret < 0)
+				goto err_out;
+
+		} else if (fy_path_expr_type_is_lparen(expr->type)) {
+
+			expr->expr_mode = fypp->expr_mode;
+			fypp->expr_mode = fyem_scalar;
+
+			fypp->paren_nest_level++;
+
+			/* push the operator */
+			ret = fy_expr_stack_push(&fypp->operators, expr);
+			fyr_error_check(fyr, !ret, err_out, "push_operator() failed\n");
+			expr = NULL;
+
+#ifdef DEBUG_EXPR
+			if (old_scan_mode != fypp->expr_mode)
+				fyr_notice(fyr, "expr_mode %s -> %s\n",
+						fy_expr_mode_txt[old_scan_mode],
+						fy_expr_mode_txt[fypp->expr_mode]);
+#endif
+		} else {
+			switch (fypp->expr_mode) {
+			case fyem_none:
+				FY_IMPOSSIBLE_ABORT();
+
+			case fyem_path:
+				if (fy_path_expr_type_is_conditional(expr->type)) {
+					/* switch to scalar mode */
+					fypp->expr_mode = fyem_scalar;
+					break;
+				}
+				break;
+			case fyem_scalar:
+				if (expr->type == fpet_root) {
+					fypp->expr_mode = fyem_path;
+					break;
+				}
+
+				/* div out of parentheses, it's a chain */
+				if (expr->type == fpet_div && fypp->paren_nest_level == 0) {
+					expr->type = fpet_chain;
+					fypp->expr_mode = fyem_path;
+
+					/* mode change means evaluate */
+					ret = evaluate_new(fypp);
+					/* evaluate will print diagnostic on error */
+					if (ret < 0)
+						goto err_out;
+
+					break;
+				}
+				break;
+
+			}
+
+			if (old_scan_mode != fypp->expr_mode) {
+#ifdef DEBUG_EXPR
+				fyr_notice(fyr, "expr_mode %s -> %s\n",
+						fy_expr_mode_txt[old_scan_mode],
+						fy_expr_mode_txt[fypp->expr_mode]);
+#endif
+			}
+
+			ret = -1;
+			for (;;) {
+				expr_top = fy_expr_stack_peek(&fypp->operators);
+				if (!expr_top)
+					break;
+
+				if (fy_path_expr_type_prec(expr->type) > fy_path_expr_type_prec(expr_top->type))
+					break;
+
+				if (fy_path_expr_type_is_lparen(expr_top->type))
+					break;
+
+				/* XXX same priority and prefix operator (have no arguments yet) */
+				if (fy_path_expr_type_prec(expr->type) == fy_path_expr_type_prec(expr_top->type)) {
+					if (fy_path_expr_type_assoc(expr_top->type) == PREFIX)
+						break;
+				}
+
+				ret = evaluate_new(fypp);
+				/* evaluate will print diagnostic on error */
+				if (ret < 0)
+					goto err_out;
+			}
+
+			/* push the operator */
+			ret = fy_expr_stack_push(&fypp->operators, expr);
+			fyr_error_check(fyr, !ret, err_out, "push_operator() failed\n");
+			expr = NULL;
+		}
+
+#ifdef DEBUG_EXPR
+		fy_notice(fypp->cfg.diag, "operator stack (after)\n");
+		fy_expr_stack_dump(fypp->cfg.diag, &fypp->operators);
+		fy_notice(fypp->cfg.diag, "operator stack (after) ends\n");
+		fy_notice(fypp->cfg.diag, "operand stack (after)\n");
+		fy_expr_stack_dump(fypp->cfg.diag, &fypp->operands);
+		fy_notice(fypp->cfg.diag, "operand stack (after) ends\n");
+#endif
+
+		prev_scan_mode = fypp->expr_mode;
+	}
+
+	if (fypp->stream_error)
+		goto err_out;
+
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_PARSE,
+			fypp->stream_error || (fyt && fyt->type == FYTT_STREAM_END), err_out,
+			"stream ended without STREAM_END");
+
+	/* remove stream end */
+	fy_token_unref(fy_path_scan_remove(fypp, fyt));
+	fyt = NULL;
+
+#if 0
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_PARSE,
+			fypp->paren_nest_level == 0, err_out,
+			"Missing right parenthesis");
+#endif
+
+	/* drain */
+	while ((expr_top = fy_expr_stack_peek(&fypp->operators)) != NULL &&
+		!fy_path_expr_type_is_lparen(expr_top->type)) {
+
+		ret = evaluate_new(fypp);
+		/* evaluate will print diagnostic on error */
+		if (ret < 0)
+			goto err_out;
+
+	}
+
+#ifdef DEBUG_EXPR
+	expr_top = fy_expr_stack_peek(&fypp->operators);
+	if (expr_top)
+		fy_path_expr_dump(expr_top, fypp->cfg.diag, FYET_NOTICE, 0, "operator top left");
+#endif
+
+	expr = fy_expr_stack_pop(&fypp->operands);
+
+	FYR_PARSE_ERROR_CHECK(fyr, 0, 1, FYEM_PARSE,
+			expr != NULL, err_out,
+			"No operands left on operand stack");
+
+	if (fy_expr_stack_size(&fypp->operands) != 0) {
+		FYR_TOKEN_ERROR(fyr, expr->fyt, FYEM_PARSE,
+				"Operand stack contains more than 1 value at end");
+		fy_path_expr_free(expr);
+		expr = NULL;
+		goto err_out;
+	}
+
+	/* check the expression for validity */
+	rc = fy_path_check_expression(fypp, expr);
+	if (rc) {
+		fy_path_expr_free(expr);
+		expr = NULL;
+	}
+
+	return expr;
+
+err_out:
+	if (expr)
+		fy_path_expr_free(expr);
+#ifdef DEBUG_EXPR
+	fy_notice(fypp->cfg.diag, "operator stack (error)\n");
+	fy_expr_stack_dump(fypp->cfg.diag, &fypp->operators);
+	fy_notice(fypp->cfg.diag, "operand stack (error)\n");
+	fy_expr_stack_dump(fypp->cfg.diag, &fypp->operands);
+#endif
+	fypp->stream_error = true;
+	return NULL;
+}
+
+static struct fy_node *
+fy_path_expr_execute_single_result(struct fy_diag *diag, struct fy_path_expr *expr, struct fy_node *fyn, bool *errorp)
+{
+	struct fy_token *fyt;
+	struct fy_anchor *fya;
+	const char *text;
+	size_t len;
+	bool error;
+
+	if (errorp)
+		*errorp = false;
+
+	if (!expr)
+		goto err_out;
+
+	switch (expr->type) {
+	case fpet_root:
+		return fyn->fyd->root;
+
+	case fpet_this:
+		if (fy_node_is_alias(fyn)) {
+			fyn = fy_node_alias_resolve_by_ypath_internal(fyn, &error);
+			if (error)
+				goto err_out;
+		}
+
+		return fyn;
+
+	case fpet_parent:
+		return fy_node_get_parent(fyn);
+
+	case fpet_alias:
+		fyt = expr->fyt;
+		if (!fyt || fyt->type != FYTT_PE_ALIAS)
+			goto err_out;
+
+		text = fy_token_get_text(fyt, &len);
+		if (!text || len < 1)
+			goto err_out;
+
+		if (*text == '*') {
+			text++;
+			len--;
+		}
+		fya = fy_document_lookup_anchor(fyn->fyd, text, len);
+		if (!fya)
+			goto err_out;
+
+		return fya->fyn;
+
+	case fpet_seq_index:
+		fyt = expr->fyt;
+		if (!fyt || fyt->type != FYTT_PE_SEQ_INDEX)
+			goto err_out;
+
+		if (fy_node_is_alias(fyn)) {
+			fyn = fy_node_alias_resolve_by_ypath_internal(fyn, &error);
+			if (error)
+				goto err_out;
+		}
+
+		/* only on sequence */
+		if (!fy_node_is_sequence(fyn))
+			break;
+
+		return fy_node_sequence_get_by_index(fyn, fyt->seq_index.index);
+
+	case fpet_map_key:
+		fyt = expr->fyt;
+		if (!fyt || fyt->type != FYTT_PE_MAP_KEY)
+			goto err_out;
+
+		if (fy_node_is_alias(fyn)) {
+			fyn = fy_node_alias_resolve_by_ypath_internal(fyn, &error);
+			if (error)
+				goto err_out;
+		}
+
+		if (!fy_node_is_mapping(fyn))
+			break;
+
+		if (!fyt->map_key.fyd) {
+			/* simple key */
+			text = fy_token_get_text(fyt, &len);
+			if (!text || len < 1)
+				break;
+			return fy_node_mapping_lookup_value_by_simple_key(fyn, text, len);
+		}
+
+		return fy_node_mapping_lookup_value_by_key(fyn, fyt->map_key.fyd->root);
+
+	case fpet_filter_scalar:
+		if (!(fy_node_is_scalar(fyn) || fy_node_is_alias(fyn)))
+			break;
+		return fyn;
+
+	case fpet_filter_collection:
+
+		if (fy_node_is_alias(fyn)) {
+			fyn = fy_node_alias_resolve_by_ypath_internal(fyn, &error);
+			if (error)
+				goto err_out;
+		}
+
+		if (!(fy_node_is_mapping(fyn) || fy_node_is_sequence(fyn)))
+			break;
+		return fyn;
+
+	case fpet_filter_sequence:
+
+		if (fy_node_is_alias(fyn)) {
+			fyn = fy_node_alias_resolve_by_ypath_internal(fyn, &error);
+			if (error)
+				goto err_out;
+		}
+
+		if (!fy_node_is_sequence(fyn))
+			break;
+		return fyn;
+
+	case fpet_filter_mapping:
+
+		if (fy_node_is_alias(fyn)) {
+			fyn = fy_node_alias_resolve_by_ypath_internal(fyn, &error);
+			if (error)
+				goto err_out;
+		}
+
+		if (!fy_node_is_mapping(fyn))
+			break;
+		return fyn;
+
+	default:
+		break;
+	}
+
+	return NULL;
+
+err_out:
+	if (errorp)
+		*errorp = true;
+	return NULL;
+}
+
+static double
+token_number(struct fy_token *fyt)
+{
+	const char *value;
+
+	if (!fyt || fyt->type != FYTT_SCALAR || (value = fy_token_get_text0(fyt)) == NULL)
+		return NAN;
+	return strtod(value, NULL);
+}
+
+void fy_path_exec_cleanup(struct fy_path_exec *fypx)
+{
+	if (!fypx)
+		return;
+
+	fy_walk_result_free(fypx->result);
+	fypx->result = NULL;
+	fypx->fyn_start = NULL;
+}
+
+/* publicly exported methods */
+struct fy_path_parser *fy_path_parser_create(const struct fy_path_parse_cfg *pcfg)
+{
+	struct fy_path_parser *fypp;
+
+	fypp = malloc(sizeof(*fypp));
+	if (!fypp)
+		return NULL;
+	fy_path_parser_setup(fypp, pcfg);
+	return fypp;
+}
+
+void fy_path_parser_destroy(struct fy_path_parser *fypp)
+{
+	if (!fypp)
+		return;
+	fy_path_parser_cleanup(fypp);
+	free(fypp);
+}
+
+struct fy_path_expr *
+fy_path_parse_expr_from_string(struct fy_path_parser *fypp,
+			       const char *str, size_t len)
+{
+	struct fy_path_expr *expr = NULL;
+	struct fy_input *fyi = NULL;
+	int rc;
+
+	if (!fypp || !str || !len)
+		return NULL;
+
+	fy_path_parser_reset(fypp);
+
+	fyi = fy_input_from_data(str, len, NULL, false);
+	if (!fyi) {
+		fy_error(fypp->cfg.diag, "failed to create ypath input from %.*s\n",
+				(int)len, str);
+		goto err_out;
+	}
+
+	rc = fy_path_parser_open(fypp, fyi, NULL);
+	if (rc) {
+		fy_error(fypp->cfg.diag, "failed to open path parser input from %.*s\n",
+				(int)len, str);
+		goto err_out;
+	}
+
+	expr = fy_path_parse_expression(fypp);
+	if (!expr) {
+		fy_error(fypp->cfg.diag, "failed to parse path expression %.*s\n",
+				(int)len, str);
+		goto err_out;
+	}
+
+	fy_path_parser_close(fypp);
+
+	fy_input_unref(fyi);
+
+	return expr;
+
+err_out:
+	fy_path_expr_free(expr);
+	fy_path_parser_close(fypp);
+	fy_input_unref(fyi);
+	return NULL;
+}
+
+struct fy_path_expr *
+fy_path_expr_build_from_string(const struct fy_path_parse_cfg *pcfg,
+			       const char *str, size_t len)
+{
+	struct fy_path_parser fypp_data, *fypp = &fypp_data;
+	struct fy_path_expr *expr = NULL;
+
+	if (!str)
+		return NULL;
+
+	fy_path_parser_setup(fypp, pcfg);
+	expr = fy_path_parse_expr_from_string(fypp, str, len);
+	fy_path_parser_cleanup(fypp);
+
+	return expr;
+}
+
+struct fy_path_exec *fy_path_exec_create(const struct fy_path_exec_cfg *xcfg)
+{
+	struct fy_path_exec *fypx;
+
+	fypx = malloc(sizeof(*fypx));
+	if (!fypx)
+		return NULL;
+
+	memset(fypx, 0, sizeof(*fypx));
+	if (xcfg)
+		fypx->cfg = *xcfg;
+	fypx->fwr_recycle = NULL;	/* initially no recycling list */
+	fypx->refs = 1;
+
+	fypx->supress_recycling = !!(fypx->cfg.flags & FYPXCF_DISABLE_RECYCLING) ||
+		                  (getenv("FY_VALGRIND") &&
+				   !getenv("FY_VALGRIND_RECYCLING"));
+	return fypx;
+}
+
+struct fy_path_exec *fy_path_exec_create_on_document(struct fy_document *fyd)
+{
+	struct fy_path_exec_cfg xcfg_local, *xcfg = &xcfg_local;
+	struct fy_path_exec *fypx;
+
+	memset(xcfg, 0, sizeof(*xcfg));
+	xcfg->diag = fyd ? fyd->diag : NULL;
+
+	xcfg->flags = (fyd->parse_cfg.flags & FYPCF_DISABLE_RECYCLING) ?
+			FYPXCF_DISABLE_RECYCLING : 0;
+
+	fypx = fy_path_exec_create(xcfg);
+	if (!fypx)
+		return NULL;
+	return fypx;
+}
+
+void fy_path_exec_destroy(struct fy_path_exec *fypx)
+{
+	if (!fypx)
+		return;
+	fy_path_exec_cleanup(fypx);
+	free(fypx);
+}
+
+int fy_path_exec_reset(struct fy_path_exec *fypx)
+{
+	if (!fypx)
+		return -1;
+	fy_path_exec_cleanup(fypx);
+	return 0;
+}
+
+struct fy_walk_result *fy_walk_result_simplify(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result *fwr2;
+
+	/* no fwr */
+	if (!fwr)
+		return NULL;
+
+	/* non recursive */
+	if (fwr->type != fwrt_refs)
+		return fwr;
+
+	/* refs, if empty, return NULL */
+	if (fy_walk_result_list_empty(&fwr->refs)) {
+		fy_walk_result_free(fwr);
+		return NULL;
+	}
+
+	/* single element, switch it out */
+	if (fy_walk_result_list_is_singular(&fwr->refs)) {
+		fwr2 = fy_walk_result_list_pop(&fwr->refs);
+		if (!fwr2)
+			goto err_out;
+
+		fy_walk_result_free(fwr);
+		fwr = fwr2;
+	}
+
+	return fwr;
+err_out:
+	fy_walk_result_free(fwr);
+	return NULL;
+}
+
+int fy_walk_result_all_children_recursive_internal(struct fy_path_exec *fypx, struct fy_node *fyn,
+		struct fy_walk_result *output)
+{
+	struct fy_node *fyni;
+	struct fy_walk_result *fwr;
+	void *prevp;
+	int ret;
+
+	if (!fyn)
+		return 0;
+
+	if (!output || output->type != fwrt_refs)
+		goto err_out;
+
+	/* this node */
+	fwr = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fyn);
+	if (!fwr)
+		goto err_out;
+	fy_walk_result_list_add_tail(&output->refs, fwr);
+	fwr = NULL;
+
+	if (fy_node_is_scalar(fyn))
+		return 0;
+
+	prevp = NULL;
+	while ((fyni = fy_node_collection_iterate(fyn, &prevp)) != NULL) {
+		ret = fy_walk_result_all_children_recursive_internal(fypx, fyni, output);
+		if (ret)
+			goto err_out;
+	}
+
+	return 0;
+err_out:
+	return -1;
+}
+
+bool
+fy_walk_result_compare_simple(struct fy_path_exec *fypx, enum fy_path_expr_type type,
+			      struct fy_walk_result *fwrl, struct fy_walk_result *fwrr,
+			      bool *errorp)
+{
+	struct fy_token *fyt;
+	struct fy_walk_result *fwrt;
+	const char *str;
+	bool match, ret, error;
+
+	if (errorp)
+		*errorp = false;
+
+	/* both NULL */
+	if (!fwrl && !fwrr) {
+		switch (type) {
+		case fpet_eq:
+			return true;
+		default:
+			break;
+		}
+		return false;
+	}
+
+	/* any NULL */
+	if (!fwrl || !fwrr) {
+		switch (type) {
+		case fpet_neq:
+			return true;
+		default:
+			break;
+		}
+		return false;
+	}
+
+	/* both are non NULL */
+
+	/* none should be multiple */
+	if (fwrl->type == fwrt_refs || fwrr->type == fwrt_refs)
+		goto err_out;
+
+	/* both are the same type */
+	if (fwrl->type == fwrr->type) {
+
+		switch (fwrl->type) {
+		case fwrt_none:
+			goto err_out;
+
+		case fwrt_node_ref:
+			switch (type) {
+			case fpet_eq:
+				/* simple and fast direct node comparison */
+				if (fwrl->fyn == fwrr->fyn)
+					return true;
+				return fy_node_compare(fwrl->fyn, fwrr->fyn);
+			case fpet_neq:
+				/* simple and fast direct node comparison */
+				if (fwrl->fyn != fwrr->fyn)
+					return true;
+				return !fy_node_compare(fwrl->fyn, fwrr->fyn);
+			default:
+				goto err_out;
+			}
+			break;
+
+		case fwrt_refs:
+			goto err_out;
+
+		case fwrt_doc:
+			switch (type) {
+			case fpet_eq:
+			case fpet_neq:
+				match = false;
+				if (fwrl->fyd == fwrr->fyd)
+					match = true;
+				else if (!fwrl->fyd || !fwrr->fyd)
+					match = false;
+				else
+					match = fy_node_compare(fwrl->fyd->root, fwrr->fyd->root);
+				if (type == fpet_neq)
+					match = !match;
+				return match;
+			default:
+				goto err_out;
+			}
+			break;
+
+		case fwrt_number:
+			switch (type) {
+			case fpet_eq:
+				return fwrl->number == fwrr->number;
+			case fpet_neq:
+				return fwrl->number != fwrr->number;
+			case fpet_lt:
+				return fwrl->number < fwrr->number;
+			case fpet_gt:
+				return fwrl->number > fwrr->number;
+			case fpet_lte:
+				return fwrl->number <= fwrr->number;
+			case fpet_gte:
+				return fwrl->number >= fwrr->number;
+			default:
+				goto err_out;
+			}
+			break;
+
+		case fwrt_string:
+			switch (type) {
+			case fpet_eq:
+				return strcmp(fwrl->string, fwrr->string) == 0;
+			case fpet_neq:
+				return strcmp(fwrl->string, fwrr->string) != 0;
+			case fpet_lt:
+				return strcmp(fwrl->string, fwrr->string) < 0;
+			case fpet_gt:
+				return strcmp(fwrl->string, fwrr->string) > 0;
+			case fpet_lte:
+				return strcmp(fwrl->string, fwrr->string) <= 0;
+			case fpet_gte:
+				return strcmp(fwrl->string, fwrr->string) >= 0;
+			default:
+				goto err_out;
+			}
+			break;
+		}
+		return false;
+	}
+
+	/* only handle the node refs at the left */
+	if (fwrr->type == fwrt_node_ref) {
+		switch (type) {
+		case fpet_lt:
+			type = fpet_gte;
+			break;
+		case fpet_gt:
+			type = fpet_lte;
+			break;
+		case fpet_lte:
+			type = fpet_gt;
+			break;
+		case fpet_gte:
+			type = fpet_lt;
+			break;
+		default:
+			goto err_out;
+		}
+
+		/* swap left with right */
+		ret = fy_walk_result_compare_simple(fypx, type, fwrr, fwrl, &error);
+		if (error)
+			goto err_out;
+		return ret;
+	}
+
+	switch (fwrl->type) {
+	case fwrt_node_ref:
+
+		/* non scalar mode, only returns true for non-eq */
+		if (!fy_node_is_scalar(fwrl->fyn)) {
+			/* XXX case of rhs being a document not handled */
+			return type == fpet_neq;
+		}
+
+		fyt = fy_node_get_scalar_token(fwrl->fyn);
+		if (!fyt)
+			goto err_out;
+
+		str = fy_token_get_text0(fyt);
+		if (!str)
+			goto err_out;
+
+		fwrt = NULL;
+		/* node ref against */
+		switch (fwrr->type) {
+		case fwrt_string:
+			/* create a new temporary walk result */
+			fwrt = fy_path_exec_walk_result_create(fypx, fwrt_string, str);
+			if (!fwrt)
+				goto err_out;
+
+			break;
+
+		case fwrt_number:
+			/* if it's not a number return true only for non-eq */
+			if (!fy_token_is_number(fyt))
+				return type == fpet_neq;
+
+			/* create a new temporary walk result */
+			fwrt = fy_path_exec_walk_result_create(fypx, fwrt_number, strtod(str, NULL));
+			if (!fwrt)
+				goto err_out;
+			break;
+
+		default:
+			break;
+		}
+
+		if (!fwrt)
+			return false;
+
+		match = fy_walk_result_compare_simple(fypx, type, fwrt, fwrr, &error);
+		if (error)
+			goto err_out;
+
+		/* free the temporary result */
+		fy_walk_result_free(fwrt);
+		fwrt = NULL;
+
+		return match;
+
+	default:
+		break;
+	}
+
+	return false;
+
+err_out:
+	if (errorp)
+		*errorp = true;
+	return false;
+}
+
+struct fy_walk_result *
+fy_walk_result_arithmetic_simple(struct fy_path_exec *fypx,
+				 struct fy_path_expr *expr,
+				 struct fy_path_expr *exprl, struct fy_walk_result *fwrl,
+				 struct fy_path_expr *exprr, struct fy_walk_result *fwrr,
+				 bool *errorp)
+{
+	struct fy_diag *diag;
+	struct fy_walk_result *output = NULL;
+	char *str;
+	size_t len, len1, len2;
+
+	if (errorp)
+		*errorp = false;
+
+	if (!fwrl || !fwrr)
+		goto err_out;
+
+	diag = fypx->cfg.diag;
+
+	/* node refs are not handled yet */
+	if (fwrl->type == fwrt_node_ref || fwrr->type == fwrt_node_ref)
+		goto out;
+
+	/* same type */
+	if (fwrl->type == fwrr->type) {
+
+		switch (fwrl->type) {
+
+		case fwrt_string:
+			/* for strings, only concatenation */
+			if (expr->type != fpet_plus)
+				break;
+			len1 = strlen(fwrl->string);
+			len2 = strlen(fwrr->string);
+			len = len1 + len2;
+			str = malloc(len + 1);
+			if (!str)
+				goto err_out;
+			memcpy(str, fwrl->string, len1);
+			memcpy(str + len1, fwrr->string, len2);
+			str[len] = '\0';
+
+			free(fwrl->string);
+			fwrl->string = str;
+
+			/* reuse */
+			output = fwrl;
+			fwrl = NULL;
+
+			break;
+
+		case fwrt_number:
+			/* reuse fwrl */
+			output = fwrl;
+			switch (expr->type) {
+			case fpet_plus:
+				output->number = fwrl->number + fwrr->number;
+				break;
+			case fpet_minus:
+				output->number = fwrl->number - fwrr->number;
+				break;
+			case fpet_mult:
+				output->number = fwrl->number * fwrr->number;
+				break;
+			case fpet_div:
+				output->number = fwrr->number ? (fwrl->number / fwrr->number) : INFINITY;
+				break;
+			default:
+				FY_IMPOSSIBLE_ABORT();
+			}
+			fwrl = NULL;
+			break;
+
+		default:
+			fy_error(diag, "fwrl->type=%s\n", fy_walk_result_type_txt[fwrl->type]);
+			FY_IMPOSSIBLE_ABORT();
+		}
+	}
+
+out:
+	fy_walk_result_free(fwrl);
+	fy_walk_result_free(fwrr);
+	return output;
+
+err_out:
+	fy_walk_result_free(output);
+	output = NULL;
+	if (errorp)
+		*errorp = true;
+	goto out;
+}
+
+struct fy_walk_result *
+fy_walk_result_conditional_simple(struct fy_path_exec *fypx,
+				  struct fy_path_expr *expr,
+				  struct fy_path_expr *exprl, struct fy_walk_result *fwrl,
+				  struct fy_path_expr *exprr, struct fy_walk_result *fwrr,
+				  bool *errorp)
+{
+	bool match, error;
+
+	if (errorp)
+		*errorp = false;
+
+	match = fy_walk_result_compare_simple(fypx, expr->type, fwrl, fwrr, &error);
+	if (error)
+		goto err_out;
+
+	/* path expr, return left hand side result if match */
+
+	fy_walk_result_free(fwrr);
+	fwrr = NULL;
+
+	if (!match) {
+		fy_walk_result_free(fwrl);
+		fwrl = NULL;
+	}
+
+	return fwrl;
+
+err_out:
+	fy_walk_result_free(fwrl);
+	fy_walk_result_free(fwrr);
+	if (errorp)
+		*errorp = true;
+	return NULL;
+}
+
+struct fy_walk_result *
+fy_walk_result_lhs_rhs(struct fy_path_exec *fypx,
+		       struct fy_path_expr *expr,
+		       struct fy_path_expr *exprl, struct fy_walk_result *fwrl,
+		       struct fy_path_expr *exprr, struct fy_walk_result *fwrr,
+		       bool *errorp)
+{
+	struct fy_walk_result *output = NULL, *fwr = NULL, *fwrrt = NULL, *fwrlt = NULL, *fwrlc = NULL, *fwrrc = NULL;
+	struct fy_walk_result *outputl = NULL, *outputr = NULL;
+	bool error;
+
+	if (errorp)
+		*errorp = false;
+
+	if (!expr || !exprl || !exprr)
+		goto err_out;
+
+	/* only supports those */
+	if (!fy_path_expr_type_is_conditional(expr->type) &&
+	    !fy_path_expr_type_is_arithmetic(expr->type))
+		goto out;
+
+	/* both NULL */
+	if (!fwrl && !fwrr)
+		goto out;
+
+	/* any NULL */
+	if (!fwrl || !fwrr) {
+		if (expr->type == fpet_neq) {
+			output = fwrl;
+			fwrl = NULL;
+		}
+		goto out;
+	}
+
+	output = fy_path_exec_walk_result_create(fypx, fwrt_refs);
+	if (!output)
+		goto err_out;
+
+	for (fwrlt = fy_walk_result_iter_start(fwrl); fwrlt;
+			fwrlt = fy_walk_result_iter_next(fwrl, fwrlt)) {
+
+		/* for recursive ones */
+		if (fwrlt->type == fwrt_refs) {
+
+			fwrlc = fy_walk_result_clone(fwrlt);
+			if (!fwrlc)
+				goto err_out;
+			fwrrc = fy_walk_result_clone(fwrr);
+			if (!fwrrc)
+				goto err_out;
+
+			outputl = fy_walk_result_lhs_rhs(fypx, expr, exprl, fwrlc, exprr, fwrrc, &error);
+			fwrlc = NULL;
+			fwrrc = NULL;
+			if (error)
+				goto err_out;
+
+			if (outputl)
+				fy_walk_result_refs_add_flattened(output, outputl);
+			else {
+				fy_walk_result_free(outputl);
+				outputl = NULL;
+			}
+			continue;
+		}
+
+		/* non-recursive case */
+		for (fwrrt = fy_walk_result_iter_start(fwrr); fwrrt;
+				fwrrt = fy_walk_result_iter_next(fwrr, fwrrt)) {
+
+			/* for recursive ones */
+			if (fwrrt->type == fwrt_refs) {
+
+				fwrlc = fy_walk_result_clone(fwrlt);
+				if (!fwrlc)
+					goto err_out;
+				fwrrc = fy_walk_result_clone(fwrrt);
+				if (!fwrrc)
+					goto err_out;
+
+				outputr = fy_walk_result_lhs_rhs(fypx, expr, exprl, fwrlc, exprr, fwrrc, &error);
+				fwrlc = NULL;
+				fwrrc = NULL;
+				if (error)
+					goto err_out;
+
+				if (outputr)
+					fy_walk_result_refs_add_flattened(output, outputr);
+				else {
+					fy_walk_result_free(outputr);
+					outputr = NULL;
+				}
+				continue;
+			}
+
+
+			fwrlc = fy_walk_result_clone(fwrlt);
+			if (!fwrlc)
+				goto err_out;
+			fwrrc = fy_walk_result_clone(fwrrt);
+			if (!fwrrc)
+				goto err_out;
+
+			fwr = NULL;
+			if (fy_path_expr_type_is_conditional(expr->type)) {
+				fwr = fy_walk_result_conditional_simple(fypx, expr, exprl, fwrlc, exprr, fwrrc, &error);
+				fwrlc = NULL;
+				fwrrc = NULL;
+				if (error)
+					goto err_out;
+			} else if (fy_path_expr_type_is_arithmetic(expr->type)) {
+				fwr = fy_walk_result_arithmetic_simple(fypx, expr, exprl, fwrlc, exprr, fwrrc, &error);
+				fwrlc = NULL;
+				fwrrc = NULL;
+				if (error)
+					goto err_out;
+			} else
+				FY_IMPOSSIBLE_ABORT();
+
+			if (fwr)
+				fy_walk_result_refs_add_flattened(output, fwr);
+		}
+	}
+
+out:
+	fy_walk_result_free(fwrlc);
+	fy_walk_result_free(fwrrc);
+	fy_walk_result_free(fwrl);
+	fy_walk_result_free(fwrr);
+
+	return fy_walk_result_simplify(output);
+err_out:
+	fy_walk_result_free(output);
+	output = NULL;
+	goto out;
+}
+
+struct fy_path_expr *
+fy_scalar_walk_result_to_expr(struct fy_path_exec *fypx, struct fy_walk_result *fwr,
+		enum fy_path_expr_type ptype, bool *errorp)
+{
+	struct fy_input *fyit = NULL;
+	struct fy_path_expr *exprt = NULL;
+	struct fy_atom handle;
+	bool collection_addressing;
+	char *buf;
+	int rc __FY_DEBUG_UNUSED__;
+
+	if (errorp)
+		*errorp = false;
+
+	if (!fwr)
+		goto err_out;
+
+	collection_addressing = ptype == fpet_chain || ptype == fpet_multi;
+
+	switch (fwr->type) {
+	case fwrt_string:
+		fyit = fy_input_from_malloc_data(fwr->string, FY_NT, &handle, true);
+		if (!fyit)
+			goto err_out;
+
+		fwr->string = NULL;
+		fy_walk_result_free(fwr);
+		fwr = NULL;
+
+		exprt = fy_path_expr_alloc();
+		if (!exprt)
+			goto err_out;
+		if (collection_addressing) {
+			exprt->type = fpet_map_key;
+			exprt->fyt = fy_token_create(FYTT_PE_MAP_KEY, &handle, NULL);
+			if (!exprt->fyt)
+				goto err_out;
+		} else {
+			exprt->type = fpet_scalar;
+			exprt->fyt = fy_token_create(FYTT_SCALAR, &handle, FYSS_PLAIN, NULL);
+			if (!exprt->fyt)
+				goto err_out;
+		}
+		break;
+
+	case fwrt_number:
+		if (!isfinite(fwr->number))
+			goto err_out;
+
+		rc = asprintf(&buf, "%.*g", DBL_DECIMAL_DIG, fwr->number);
+		if (rc == -1)
+			goto err_out;
+
+		fyit = fy_input_from_malloc_data(buf, FY_NT, &handle, true);
+		if (!fyit)
+			goto err_out;
+
+		exprt = fy_path_expr_alloc();
+		if (!exprt)
+			goto err_out;
+		if (collection_addressing) {
+			if (trunc(fwr->number) != fwr->number ||
+			    fwr->number < INT_MIN || fwr->number > INT_MAX)
+				goto err_out;
+			exprt->type = fpet_seq_index;
+			exprt->fyt = fy_token_create(FYTT_PE_SEQ_INDEX, &handle, (int)fwr->number);
+			if (!exprt->fyt)
+				goto err_out;
+		} else {
+			exprt->type = fpet_scalar;
+			exprt->fyt = fy_token_create(FYTT_SCALAR, &handle, FYSS_PLAIN, NULL);
+			if (!exprt->fyt)
+				goto err_out;
+		}
+
+		break;
+
+	default:
+		break;
+	}
+
+out:
+	fy_walk_result_free(fwr);
+	fy_input_unref(fyit);
+
+	return exprt;
+err_out:
+	fy_path_expr_free(exprt);
+	exprt = NULL;
+	if (errorp)
+		*errorp = true;
+	goto out;
+}
+
+struct fy_walk_result *
+fy_path_expr_execute(struct fy_path_exec *fypx, int level, struct fy_path_expr *expr,
+		     struct fy_walk_result *input, enum fy_path_expr_type ptype,
+		     bool *errorp)
+{
+	struct fy_path_exec *fypxt;
+	struct fy_diag *diag;
+	struct fy_walk_result *fwr = NULL, *fwrn = NULL, *fwrt = NULL, *fwrtn = NULL;
+	struct fy_walk_result *output = NULL, *input1 = NULL, *output1 = NULL, *input2 = NULL, *output2 = NULL;
+	struct fy_path_expr *exprn, *exprl, *exprr;
+	struct fy_node *fyn, *fynn, *fyni;
+	struct fy_token *fyt;
+	int start, end, count, i;
+	bool match;
+	struct fy_path_expr *exprt;
+	unsigned int nargs;
+	struct fy_walk_result **fwr_args;
+	void *prevp;
+	bool error;
+	int rc __FY_DEBUG_UNUSED__;
+
+	if (errorp)
+		*errorp = false;
+
+	/* error */
+	if (!fypx || !expr)
+		goto out;
+
+	diag = fypx->cfg.diag;
+	if (++fypx->exec_steps > FY_PATH_EXEC_STEP_LIMIT) {
+		fy_error(diag, "ypath execution step limit exceeded");
+		goto err_out;
+	}
+
+#ifdef DEBUG_EXPR
+	if (input)
+		fy_walk_result_dump(input, diag, FYET_NOTICE, level, "input %s\n", fy_path_expr_type_txt[expr->type]);
+#endif
+
+	/* recursive */
+	if (input && input->type == fwrt_refs && !fy_path_expr_type_handles_refs(expr->type)) {
+
+		output = fy_path_exec_walk_result_create(fypx, fwrt_refs);
+		if (!output)
+			goto err_out;
+
+		while ((fwr = fy_walk_result_list_pop(&input->refs)) != NULL) {
+
+			fwrn = fy_path_expr_execute(fypx, level + 1, expr, fwr, ptype, &error);
+			fwr = NULL;
+			if (error)
+				goto err_out;
+			if (fwrn)
+				fy_walk_result_refs_add_flattened(output, fwrn);
+			}
+		fy_walk_result_free(input);
+		input = NULL;
+		goto out;
+	}
+
+
+	/* single result case is common enough to optimize */
+	if (fy_path_expr_type_is_single_result(expr->type)) {
+
+		if (input && input->type == fwrt_node_ref) {
+
+			fynn = fy_path_expr_execute_single_result(diag, expr, input->fyn, &error);
+			if (error)
+				goto err_out;
+			if (!fynn)
+				goto out;
+
+			fypxt = input->fypx;
+			input->fypx = NULL;
+			fy_walk_result_clean(input);
+			output = input;
+			input = NULL;
+
+			output->type = fwrt_node_ref;
+			output->fyn = fynn;
+			output->fypx = fypxt;
+		}
+
+		goto out;
+	}
+
+	/* handle the remaining multi result cases */
+	switch (expr->type) {
+
+	case fpet_chain:
+
+		if (!input)
+			goto out;
+
+		/* iterate over each chain item */
+		output = input;
+		input = NULL;
+		for (exprn = fy_path_expr_list_head(&expr->children); exprn;
+			exprn = fy_path_expr_next(&expr->children, exprn)) {
+
+			output = fy_path_expr_execute(fypx, level + 1, exprn, output, expr->type, &error);
+			if (error)
+				goto err_out;
+			if (!output)
+				break;
+		}
+
+		break;
+
+	case fpet_multi:
+
+		if (!input)
+			goto out;
+
+		/* allocate a refs output result */
+		output = fy_path_exec_walk_result_create(fypx, fwrt_refs);
+		if (!output)
+			goto err_out;
+
+		/* iterate over each multi item */
+		for (exprn = fy_path_expr_list_head(&expr->children); exprn;
+			exprn = fy_path_expr_next(&expr->children, exprn)) {
+
+			input2 = fy_walk_result_clone(input);
+			if (!input2)
+				goto err_out;
+
+			output2 = fy_path_expr_execute(fypx, level + 1, exprn, input2, expr->type, &error);
+			input2 = NULL;
+			if (error)
+				goto err_out;
+			if (!output2)
+				continue;
+
+			fy_walk_result_refs_add_flattened(output, output2);
+			output2 = NULL;
+		}
+		fy_walk_result_free(input);
+		input = NULL;
+		break;
+
+	case fpet_every_child:
+
+		if (!input)
+			goto out;
+
+		/* only valid for node ref */
+		if (input->type != fwrt_node_ref)
+			break;
+
+		fyn = input->fyn;
+
+		/* every scalar/alias is a single result (although it should not happen) */
+		if (fy_node_is_scalar(fyn) || fy_node_is_alias(fyn)) {
+			output = input;
+			input = NULL;
+			break;
+
+		}
+
+		/* re-use input for output root */
+		fypxt = input->fypx;
+		input->fypx = NULL;
+		fy_walk_result_clean(input);
+		output = input;
+		input = NULL;
+
+		output->type = fwrt_refs;
+		fy_walk_result_list_init(&output->refs);
+		output->fypx = fypxt;
+
+		prevp = NULL;
+		while ((fyni = fy_node_collection_iterate(fyn, &prevp)) != NULL) {
+			fwr = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fyni);
+			if (!fwr)
+				goto err_out;
+			fy_walk_result_list_add_tail(&output->refs, fwr);
+		}
+
+		break;
+
+	case fpet_every_child_r:
+
+		if (!input)
+			goto out;
+
+		/* only valid for node ref */
+		if (input->type != fwrt_node_ref)
+			break;
+
+		fyn = input->fyn;
+
+		/* re-use input for output root */
+		fypxt = input->fypx;
+		input->fypx = NULL;
+		fy_walk_result_clean(input);
+		output = input;
+		input = NULL;
+
+		output->type = fwrt_refs;
+		fy_walk_result_list_init(&output->refs);
+		output->fypx = fypxt;
+
+		rc = fy_walk_result_all_children_recursive_internal(fypx, fyn, output);
+		if (rc)
+			goto err_out;
+		break;
+
+	case fpet_seq_slice:
+
+		if (!input)
+			goto out;
+
+		/* only valid for node ref on a sequence */
+		if (input->type != fwrt_node_ref || !fy_node_is_sequence(input->fyn))
+			break;
+		fyn = input->fyn;
+
+		fyt = expr->fyt;
+		if (!fyt || fyt->type != FYTT_PE_SEQ_SLICE)
+			goto err_out;
+
+		start = fyt->seq_slice.start_index;
+		end = fyt->seq_slice.end_index;
+		count = fy_node_sequence_item_count(fyn);
+
+		/* don't handle negative slices yet */
+		if (start < 0 || end < 1 || start >= end)
+			break;
+
+		if (count < end)
+			end = count;
+
+		/* re-use input for output root */
+		fypxt = input->fypx;
+		input->fypx = NULL;
+		fy_walk_result_clean(input);
+		output = input;
+		input = NULL;
+
+		output->type = fwrt_refs;
+		fy_walk_result_list_init(&output->refs);
+		output->fypx = fypxt;
+
+		for (i = start; i < end; i++) {
+
+			fynn = fy_node_sequence_get_by_index(fyn, i);
+			if (!fynn)
+				continue;
+
+			fwr = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fynn);
+			if (!fwr)
+				goto err_out;
+
+			fy_walk_result_list_add_tail(&output->refs, fwr);
+		}
+
+		break;
+
+	case fpet_eq:
+	case fpet_neq:
+	case fpet_lt:
+	case fpet_gt:
+	case fpet_lte:
+	case fpet_gte:
+	case fpet_plus:
+	case fpet_minus:
+	case fpet_mult:
+	case fpet_div:
+
+		exprl = fy_path_expr_lhs(expr);
+		if (!exprl)
+			goto err_out;
+		exprr = fy_path_expr_rhs(expr);
+		if (!exprr)
+			goto err_out;
+
+		if (input) {
+			input1 = fy_walk_result_clone(input);
+			if (!input1)
+				goto err_out;
+
+			input2 = input;
+			input = NULL;
+
+		} else {
+			input1 = NULL;
+			input2 = NULL;
+		}
+
+		/* execute LHS and RHS */
+		output1 = fy_path_expr_execute(fypx, level + 1, exprl, input1, expr->type, &error);
+		input1 = NULL;
+		if (error)
+			goto err_out;
+
+		output2 = fy_path_expr_execute(fypx, level + 1, exprr, input2, expr->type, &error);
+		input2 = NULL;
+		if (error)
+			goto err_out;
+
+		output = fy_walk_result_lhs_rhs(fypx, expr, exprl, output1, exprr, output2, &error);
+		output1 = NULL;
+		output2 = NULL;
+		if (error)
+			goto err_out;
+		break;
+
+	case fpet_scalar:
+
+		/* duck typing! */
+		if (fy_token_is_number(expr->fyt)) {
+			output = fy_path_exec_walk_result_create(fypx, fwrt_number, token_number(expr->fyt));
+			if (!output)
+				goto err_out;
+		} else {
+			output = fy_path_exec_walk_result_create(fypx, fwrt_string, fy_token_get_text0(expr->fyt));
+			if (!output)
+				goto err_out;
+		}
+
+		fy_walk_result_free(input);
+		input = NULL;
+
+		break;
+
+	case fpet_logical_or:
+
+		/* return the first that is not NULL */
+		for (exprn = fy_path_expr_list_head(&expr->children); exprn;
+			exprn = fy_path_expr_next(&expr->children, exprn)) {
+
+			if (input) {
+				input1 = fy_walk_result_clone(input);
+				if (!input1)
+					goto err_out;
+			} else
+				input1 = NULL;
+
+			output = fy_path_expr_execute(fypx, level + 1, exprn, input1, expr->type, &error);
+			input1 = NULL;
+			if (error)
+				goto err_out;
+
+			if (output)
+				break;
+		}
+		break;
+
+	case fpet_logical_and:
+		output = NULL;
+
+		/* return the last that was not NULL */
+		for (exprn = fy_path_expr_list_head(&expr->children); exprn;
+			exprn = fy_path_expr_next(&expr->children, exprn)) {
+
+			if (input) {
+				input1 = fy_walk_result_clone(input);
+				if (!input1)
+					goto err_out;
+			} else
+				input1 = NULL;
+
+			output1 = fy_path_expr_execute(fypx, level + 1, exprn, input1, expr->type, &error);
+			input1 = NULL;
+			if (error)
+				goto err_out;
+
+			if (output1) {
+				fy_walk_result_free(output);
+				output = output1;
+				output1 = NULL;
+			} else
+				break;
+		}
+		break;
+
+	case fpet_filter_unique:
+
+		if (!input)
+			goto out;
+
+		/* for non refs, return input */
+		if (input->type != fwrt_refs) {
+			output = input;
+			input = NULL;
+			break;
+		}
+
+		/* nothing in there? */
+		if (fy_walk_result_list_empty(&input->refs)) {
+			output = NULL;
+			break;
+		}
+
+		/* remove duplicates filter */
+		for (fwr = fy_walk_result_list_head(&input->refs); fwr;
+				fwr = fy_walk_result_next(&input->refs, fwr)) {
+
+			/* do not check recursively */
+			if (fwr->type == fwrt_refs) {
+				continue;
+			}
+
+			/* check the entries from this point forward */
+			for (fwrt = fy_walk_result_next(&input->refs, fwr); fwrt; fwrt = fwrtn) {
+
+				fwrtn = fy_walk_result_next(&input->refs, fwrt);
+
+				/* do not check recursively (or the same result) */
+				if (fwrt->type == fwrt_refs)
+					continue;
+
+				if (fwrt == fwr)
+					goto err_out;
+
+				match = fy_walk_result_compare_simple(fypx, fpet_eq, fwr, fwrt, &error);
+				if (error)
+					goto err_out;
+
+				if (match) {
+					fy_walk_result_list_del(&input->refs, fwrt);
+					fy_walk_result_free(fwrt);
+				}
+			}
+		}
+		output = input;
+		input = NULL;
+
+		break;
+
+	case fpet_scalar_expr:
+
+		exprl = fy_path_expr_list_head(&expr->children);
+		if (!exprl)
+			goto out;
+
+		output = fy_path_expr_execute(fypx, level + 1, exprl, NULL, ptype, &error);
+		if (error)
+			goto err_out;
+
+		if (!output)
+			goto out;
+
+		exprt = fy_scalar_walk_result_to_expr(fypx, output, ptype, &error);
+		output = NULL;	/* consumed by fy_scalar_walk_result_to_expr() */
+		if (error) {
+			fy_path_expr_free(exprt);
+			exprt = NULL;
+			goto err_out;
+		}
+
+		if (!exprt)
+			break;
+
+		output = fy_path_expr_execute(fypx, level + 1, exprt, input, ptype, &error);
+		input = NULL;
+		fy_path_expr_free(exprt);
+		exprt = NULL;
+
+		if (error)
+			goto err_out;
+
+		break;
+
+	case fpet_path_expr:
+		exprl = fy_path_expr_list_head(&expr->children);
+		if (!exprl)
+			goto out;
+
+		output = fy_path_expr_execute(fypx, level + 1, exprl, input, ptype, &error);
+		input = NULL;
+		if (error)
+			goto err_out;
+		input = NULL;
+		break;
+
+	case fpet_method:
+
+		if (!expr->fym)
+			goto err_out;
+
+		/* execute the arguments */
+		nargs = expr->fym->nargs;
+		if (nargs > 0) {
+			fwr_args = alloca(sizeof(*fwr_args) * nargs);
+			memset(fwr_args, 0, sizeof(*fwr_args) * nargs);
+			for (i = 0, exprt = fy_path_expr_list_head(&expr->children); exprt;
+					exprt = fy_path_expr_next(&expr->children, exprt), i++) {
+
+				if (input) {
+					input1 = fy_walk_result_clone(input);
+					if (!input1)
+						goto err_out;
+				} else
+					input1 = NULL;
+
+				fwr_args[i] = fy_path_expr_execute(fypx, level + 1, exprt, input1,
+							expr->type, &error);
+				input1 = NULL;
+				if (error)
+					goto err_out;
+			}
+		} else
+			fwr_args = NULL;
+
+		output = expr->fym->exec(expr->fym, fypx, level + 1, expr, input, fwr_args, nargs, &error);
+		input = NULL;
+		if (error)
+			goto err_out;
+
+		break;
+
+	case fpet_select:
+	case fpet_unselect:
+
+		/* the select and unselect ops were buggy so they are removed */
+		goto err_out;
+
+	default:
+		fy_error(diag, "%s\n", fy_path_expr_type_txt[expr->type]);
+		FY_IMPOSSIBLE_ABORT();
+	}
+
+out:
+	fy_walk_result_free(output1);
+	fy_walk_result_free(output2);
+	fy_walk_result_free(input1);
+	fy_walk_result_free(input2);
+	fy_walk_result_free(input);
+	output = fy_walk_result_simplify(output);
+
+#ifdef DEBUG_EXPR
+	if (output)
+		fy_walk_result_dump(output, diag, FYET_NOTICE, level, "output %s\n", fy_path_expr_type_txt[expr->type]);
+#endif
+	return output;
+
+err_out:
+	if (errorp)
+		*errorp = true;
+	fy_walk_result_free(output);
+	output = NULL;
+	goto out;
+}
+
+static int fy_path_exec_execute_internal(struct fy_path_exec *fypx,
+		struct fy_path_expr *expr, struct fy_node *fyn_start)
+{
+	struct fy_walk_result *fwr;
+	bool error;
+
+	if (!fypx || !expr || !fyn_start)
+		return -1;
+
+	fy_walk_result_free(fypx->result);
+	fypx->result = NULL;
+	fypx->exec_steps = 0;
+
+	fwr = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fyn_start);
+	if (!fwr)
+		goto err_out;
+
+	error = true;
+	fwr = fy_path_expr_execute(fypx, 0, expr, fwr, fpet_none, &error);
+	if (error)
+		goto err_out;
+
+	if (!fwr)
+		return 0;
+
+	/* flatten results */
+	if (fwr->type == fwrt_refs) {
+		fwr = fy_walk_result_flatten(fwr);
+		if (!fwr)
+			return -1;
+	}
+	fypx->result = fwr;
+
+	return 0;
+err_out:
+	fy_walk_result_free(fwr);
+	return -1;
+}
+
+int fy_path_exec_execute(struct fy_path_exec *fypx, struct fy_path_expr *expr, struct fy_node *fyn_start)
+{
+	if (!fypx || !expr || !fyn_start)
+		return -1;
+
+	fypx->fyn_start = fyn_start;
+	return fy_path_exec_execute_internal(fypx, expr, fypx->fyn_start);
+}
+
+struct fy_node *
+fy_path_exec_results_iterate(struct fy_path_exec *fypx, void **prevp)
+{
+	struct fy_walk_result *fwr;
+
+	if (!fypx || !prevp)
+		return NULL;
+
+	if (!fypx->result)
+		return NULL;
+
+	if (fypx->result->type != fwrt_refs) {
+		fwr = fypx->result;
+
+		if (fwr->type != fwrt_node_ref)
+			return NULL;
+
+		if (!*prevp) {
+			*prevp = fwr;
+			return fwr->fyn;
+		}
+		*prevp = NULL;
+		return NULL;
+	}
+
+	/* loop over non node refs for now */
+	do {
+		if (!*prevp)
+			fwr = fy_walk_result_list_head(&fypx->result->refs);
+		else
+			fwr = fy_walk_result_next(&fypx->result->refs, *prevp);
+		*prevp = fwr;
+	} while (fwr && fwr->type != fwrt_node_ref);
+
+	return fwr ? fwr->fyn : NULL;
+}
+
+struct fy_walk_result *
+fy_path_exec_take_results(struct fy_path_exec *fypx)
+{
+	struct fy_walk_result *fwr;
+
+	if (!fypx || !fypx->result)
+		return NULL;
+	fwr = fypx->result;
+	fypx->result = NULL;
+	return fwr;
+}
+
+struct fy_walk_result *
+fy_path_exec_walk_result_vcreate(struct fy_path_exec *fypx, enum fy_walk_result_type type, va_list ap)
+{
+	struct fy_walk_result_list *fwrl;
+
+	if (!fypx)
+		return NULL;
+
+	fwrl = fy_path_exec_walk_result_rl(fypx);
+	return fy_walk_result_vcreate_rl(fwrl, type, ap);
+}
+
+#ifndef DEBUG_EXPR
+struct fy_walk_result *
+fy_path_exec_walk_result_create(struct fy_path_exec *fypx, enum fy_walk_result_type type, ...)
+{
+	struct fy_walk_result_list *fwrl;
+	struct fy_walk_result *fwr;
+	va_list ap;
+
+	if (!fypx)
+		return NULL;
+
+	fwrl = fy_path_exec_walk_result_rl(fypx);
+
+	va_start(ap, type);
+	fwr = fy_walk_result_vcreate_rl(fwrl, type, ap);
+	va_end(ap);
+
+	if (!fwr)
+		return NULL;
+
+	fwr->fypx = fy_path_exec_ref(fypx);
+
+	return fwr;
+}
+#else
+struct fy_walk_result *
+_fy_path_exec_walk_result_create(struct fy_path_exec *fypx,
+				const char *file, int line, const char *func,
+				enum fy_walk_result_type type, ...)
+{
+	struct fy_walk_result_list *fwrl;
+	struct fy_walk_result *fwr;
+	va_list ap;
+
+	if (!fypx)
+		return NULL;
+
+	fwrl = fy_path_exec_walk_result_rl(fypx);
+
+	va_start(ap, type);
+	fwr = fy_walk_result_vcreate_rl(fwrl, type, ap);
+	va_end(ap);
+
+	if (!fwr)
+		return NULL;
+
+	fwr->fypx = fy_path_exec_ref(fypx);
+
+	fprintf(stderr, "%s:%4d @%-48s %-32s fwr=%p (fypx=%p refs=%u)\n",
+			file, line, func, __func__, fwr, fwr->fypx, fwr->fypx ? fwr->fypx->refs : 0);
+
+	return fwr;
+}
+#endif
+
+void
+fy_path_exec_walk_result_free(struct fy_path_exec *fypx, struct fy_walk_result *fwr)
+{
+	struct fy_walk_result_list *fwrl;
+
+	fwrl = fypx ? fy_path_exec_walk_result_rl(fypx) : NULL;
+	fy_walk_result_free_rl(fwrl, fwr);
+}
+
+int fy_document_setup_path_expr_data(struct fy_document *fyd)
+{
+	struct fy_path_parse_cfg pcfg_local, *pcfg = &pcfg_local;
+	struct fy_path_expr_document_data *pxdd;
+
+	if (!fyd || fyd->pxdd)
+		return 0;
+
+	pxdd = malloc(sizeof(*pxdd));
+	if (!pxdd)
+		goto err_no_mem;
+
+	memset(pxdd, 0, sizeof(*pxdd));
+
+	fy_walk_result_list_init(&pxdd->fwr_recycle);
+
+	memset(pcfg, 0, sizeof(*pcfg));
+	pcfg->diag = fyd->diag;
+	pxdd->fypp = fy_path_parser_create(pcfg);
+	if (!pxdd->fypp)
+		goto err_no_fypp;
+
+	fyd->pxdd = pxdd;
+
+	return 0;
+
+err_no_fypp:
+	free(pxdd);
+err_no_mem:
+	return -1;
+}
+
+void fy_document_cleanup_path_expr_data(struct fy_document *fyd)
+{
+	struct fy_path_expr_document_data *pxdd;
+	struct fy_walk_result *fwr;
+
+	if (!fyd || !fyd->pxdd)
+		return;
+
+	pxdd = fyd->pxdd;
+
+	fy_path_parser_destroy(pxdd->fypp);
+
+	while ((fwr = fy_walk_result_list_pop(&pxdd->fwr_recycle)) != NULL)
+		free(fwr);
+
+	free(fyd->pxdd);
+	fyd->pxdd = NULL;
+}
+
+int fy_node_setup_path_expr_data(struct fy_node *fyn)
+{
+	struct fy_path_expr_document_data *pxdd;
+	struct fy_path_expr_node_data *pxnd;
+	const char *text;
+	size_t len;
+	char *alloc = NULL;
+	int rc;
+
+	if (!fyn || fyn->pxnd)
+		return 0;
+
+	/* only on alias nodes */
+	if (!fy_node_is_alias(fyn))
+		return 0;
+
+	/* a document must exist */
+	if (!fyn->fyd)
+		return -1;
+
+	if (!fyn->fyd->pxdd) {
+		rc = fy_document_setup_path_expr_data(fyn->fyd);
+		if (rc)
+			return rc;
+	}
+	pxdd = fyn->fyd->pxdd;
+	if (!pxdd)
+		goto err_out;
+
+	pxnd = malloc(sizeof(*pxnd));
+	if (!pxnd)
+		goto err_no_mem;
+	memset(pxnd, 0, sizeof(*pxnd));
+
+	text = fy_token_get_text(fyn->scalar, &len);
+	if (!text)
+		goto err_no_text;
+
+	if (!fy_is_first_alpha(*text)) {
+		pxnd->fyi = fy_input_from_data(text, len, NULL, false);
+		if (!pxnd->fyi)
+			goto err_no_input;
+	} else {
+		alloc = malloc(len + 2);
+		if (!alloc)
+			goto err_no_input;
+		alloc[0] = '*';
+		memcpy(alloc + 1, text, len);
+		alloc[len + 1] = '\0';
+
+		pxnd->fyi = fy_input_from_malloc_data(alloc, len + 1, NULL, false);
+		if (!pxnd->fyi)
+			goto err_no_input;
+		alloc = NULL;
+	}
+
+	fy_path_parser_reset(pxdd->fypp);
+
+	rc = fy_path_parser_open(pxdd->fypp, pxnd->fyi, NULL);
+	if (rc)
+		goto err_no_open;
+
+	pxnd->expr = fy_path_parse_expression(pxdd->fypp);
+	if (!pxnd->expr)
+		goto err_parse;
+
+	fy_path_parser_close(pxdd->fypp);
+
+	fyn->pxnd = pxnd;
+
+	return 0;
+err_parse:
+	fy_path_parser_close(pxdd->fypp);
+err_no_open:
+	fy_input_unref(pxnd->fyi);
+err_no_input:
+	if (alloc)
+		free(alloc);
+err_no_text:
+	free(pxnd);
+err_no_mem:
+err_out:
+	return -1;
+}
+
+void fy_node_cleanup_path_expr_data(struct fy_node *fyn)
+{
+	struct fy_path_expr_node_data *pxnd;
+
+	if (!fyn || !fyn->pxnd)
+		return;
+
+	pxnd = fyn->pxnd;
+
+	if (pxnd->expr)
+		fy_path_expr_free(pxnd->expr);
+
+	if (pxnd->fyi)
+		fy_input_unref(pxnd->fyi);
+
+	free(pxnd);
+	fyn->pxnd = NULL;
+}
+
+struct fy_walk_result *
+fy_node_alias_resolve_by_ypath_result(struct fy_node *fyn)
+{
+	struct fy_document *fyd;
+	struct fy_path_expr_document_data *pxdd = NULL;
+	struct fy_path_expr_node_data *pxnd = NULL;
+	struct fy_walk_result *fwr;
+	struct fy_anchor *fya;
+	struct fy_path_exec *fypx = NULL;
+	int rc;
+
+	if (!fyn || !fy_node_is_alias(fyn))
+		return NULL;
+
+	fyd = fyn->fyd;
+	if (!fyd)
+		return NULL;
+
+	/* simple */
+	fya = fy_document_lookup_anchor_by_token(fyd, fyn->scalar);
+	if (fya) {
+
+		fwr = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fya->fyn);
+		fyd_error_check(fyd, fwr, err_out,
+				"fy_walk_result_alloc_rl() failed");
+
+		return fwr;
+	}
+
+	/* ok, complex, setup the node data */
+	rc = fy_node_setup_path_expr_data(fyn);
+	fyd_error_check(fyd, !rc, err_out,
+			"fy_node_setup_path_expr_data() failed");
+
+	pxnd = fyn->pxnd;
+	if (!pxnd)
+		goto err_out;
+
+	pxdd = fyd->pxdd;
+	if (!pxdd)
+		goto err_out;
+
+	if (pxnd->traversals++ > 0) {
+		FYD_NODE_ERROR(fyd, fyn, FYEM_DOC,
+				"recursive reference detected at %s\n",
+				fy_node_get_path_alloca(fyn));
+		pxnd->traversals--;
+		return NULL;
+	}
+
+	fypx = fy_path_exec_create_on_document(fyd);
+	fyd_error_check(fyd, !rc, err_out,
+			"fy_path_exec_create_on_document() failed");
+
+	fy_path_exec_set_result_recycle_list(fypx, &pxdd->fwr_recycle);
+
+	/* execute, starting at this */
+	rc = fy_path_exec_execute(fypx, pxnd->expr, fyn);
+	if (rc)
+		goto err_out;
+
+	fwr = fy_path_exec_take_results(fypx);
+
+	fy_path_exec_unref(fypx);
+
+	pxnd->traversals--;
+
+	if (!fwr)
+		return NULL;
+
+	return fwr;
+
+err_out:
+	if (pxnd)
+		pxnd->traversals--;
+	fy_path_exec_unref(fypx);	/* NULL OK */
+	return NULL;
+}
+
+static struct fy_node *
+fy_node_alias_resolve_by_ypath_internal(struct fy_node *fyn, bool *errorp)
+{
+	struct fy_anchor *fya;
+	struct fy_walk_result *fwr;
+	void *iterp;
+
+	if (!fyn || !fy_node_is_alias(fyn))
+		goto err_out;
+
+	/* simple and common enough to do it now */
+	fya = fy_document_lookup_anchor_by_token(fyn->fyd, fyn->scalar);
+	if (fya) {
+		if (errorp)
+			*errorp = false;
+		return fya->fyn;
+	}
+
+	fwr = fy_node_alias_resolve_by_ypath_result(fyn);
+	if (!fwr)
+		goto err_out;
+
+	iterp = NULL;
+	fyn = fy_walk_result_node_iterate(fwr, &iterp);
+
+	fy_walk_result_free(fwr);
+
+	if (errorp)
+		*errorp = false;
+
+	return fyn;
+err_out:
+	if (errorp)
+		*errorp = true;
+	return NULL;
+}
+
+struct fy_node *fy_node_alias_resolve_by_ypath(struct fy_node *fyn)
+{
+	return fy_node_alias_resolve_by_ypath_internal(fyn, NULL);
+}
+
+struct fy_walk_result *
+fy_node_by_ypath_result(struct fy_node *fyn, const char *path, size_t len)
+{
+	struct fy_path_expr_document_data *pxdd;
+	struct fy_document *fyd;
+	struct fy_walk_result *fwr;
+	struct fy_anchor *fya;
+	struct fy_input *fyi = NULL;
+	struct fy_path_expr *expr;
+	struct fy_path_exec *fypx = NULL;
+	int rc;
+
+	if (!fyn || !path || !len)
+		return NULL;
+
+	fyd = fyn->fyd;
+	if (!fyd)
+		return NULL;
+
+	if (len == FY_NT)
+		len = strlen(path);
+
+	/* simple */
+	fya = fy_document_lookup_anchor(fyn->fyd, path, len);
+	if (fya) {
+		fwr = fy_path_exec_walk_result_create(fypx, fwrt_node_ref, fya->fyn);
+		fyd_error_check(fyd, fwr, err_out,
+				"fy_walk_result_alloc_rl() failed");
+		return fwr;
+	}
+
+	/* ok, complex, setup the document data */
+	rc = fy_document_setup_path_expr_data(fyd);
+	fyd_error_check(fyd, !rc, err_setup,
+			"fy_node_setup_path_expr_data() failed");
+
+	pxdd = fyd->pxdd;
+	if (!pxdd)
+		goto err_out;
+
+	fyi = fy_input_from_data(path, len, NULL, false);
+	fyd_error_check(fyd, fyi, err_no_input,
+			"fy_input_from_data() failed");
+
+	fy_path_parser_reset(pxdd->fypp);
+
+	rc = fy_path_parser_open(pxdd->fypp, fyi, NULL);
+	fyd_error_check(fyd, !rc, err_no_open,
+			"fy_path_parser_open() failed");
+
+	expr = fy_path_parse_expression(pxdd->fypp);
+	fyd_error_check(fyd, expr, err_parse,
+			"fy_path_parse_expression() failed");
+
+	fy_path_parser_close(pxdd->fypp);
+
+	fypx = fy_path_exec_create_on_document(fyd);
+	fyd_error_check(fyd, !rc, err_no_fypx,
+			"fy_path_exec_create_on_document() failed");
+
+	/* execute, starting at this */
+	rc = fy_path_exec_execute(fypx, expr, fyn);
+	fyd_error_check(fyd, !rc, err_exec,
+			"fy_path_parse_expression() failed");
+
+	fwr = fy_path_exec_take_results(fypx);
+
+	fy_path_exec_unref(fypx);
+
+	fy_path_expr_free(expr);
+	fy_input_unref(fyi);
+
+	return fwr;
+
+err_exec:
+	fy_path_expr_free(expr);
+err_no_fypx:
+	fy_path_exec_unref(fypx);
+err_parse:
+	fy_path_parser_close(pxdd->fypp);
+
+err_no_open:
+	fy_input_unref(fyi);
+
+err_no_input:
+err_setup:
+err_out:
+	return NULL;
+}
+
+struct fy_node *fy_node_by_ypath(struct fy_node *fyn, const char *path, size_t len)
+{
+	struct fy_walk_result *fwr;
+	struct fy_anchor *fya;
+	void *iterp;
+
+	if (!fyn || !path || !len)
+		return NULL;
+
+	/* simple */
+	fya = fy_document_lookup_anchor(fyn->fyd, path, len);
+	if (fya)
+		return fya->fyn;
+
+	fwr = fy_node_by_ypath_result(fyn, path, len);
+	if (!fwr)
+		return NULL;
+
+	iterp = NULL;
+	fyn = fy_walk_result_node_iterate(fwr, &iterp);
+
+	fy_walk_result_free(fwr);
+
+	return fyn;
+}

--- a/numcosmo/external/libfyaml/src/lib/fy-walk.h
+++ b/numcosmo/external/libfyaml/src/lib/fy-walk.h
@@ -1,0 +1,448 @@
+/*
+ * fy-walk.h - walker  internal header file
+ *
+ * Copyright (c) 2021 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_WALK_H
+#define FY_WALK_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <assert.h>
+
+#include <libfyaml.h>
+
+#include "fy-ctype.h"
+#include "fy-utf8.h"
+#include "fy-list.h"
+#include "fy-typelist.h"
+#include "fy-types.h"
+#include "fy-diag.h"
+#include "fy-dump.h"
+#include "fy-docstate.h"
+#include "fy-accel.h"
+#include "fy-token.h"
+#include "fy-input.h"
+
+struct fy_document;
+
+enum fy_walk_result_type {
+	fwrt_none,
+	fwrt_node_ref,
+	fwrt_number,
+	fwrt_string,
+	fwrt_doc,
+	fwrt_refs,
+};
+
+#define FWRT_COUNT (fwrt_refs + 1)
+extern const char *fy_walk_result_type_txt[FWRT_COUNT];
+
+struct fy_path_exec;
+
+FY_TYPE_FWD_DECL_LIST(walk_result);
+struct fy_walk_result {
+	struct list_head node;
+	struct fy_path_exec *fypx;
+	enum fy_walk_result_type type;
+	union {
+		uintptr_t _clean[2];
+		struct fy_node *fyn;
+		double number;
+		char *string;
+		struct fy_walk_result_list refs;
+		struct fy_document *fyd;
+	};
+};
+FY_TYPE_DECL_LIST(walk_result);
+
+struct fy_walk_result *fy_walk_result_alloc_rl(struct fy_walk_result_list *fwrl);
+void fy_walk_result_free_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result *fwr);
+void fy_walk_result_list_free_rl(struct fy_walk_result_list *fwrl, struct fy_walk_result_list *results);
+
+void fy_walk_result_free(struct fy_walk_result *fwr);
+
+struct fy_walk_result *fy_walk_result_vcreate_rl(struct fy_walk_result_list *fwrl, enum fy_walk_result_type type, va_list ap);
+struct fy_walk_result *fy_walk_result_create_rl(struct fy_walk_result_list *fwrl, enum fy_walk_result_type type, ...);
+
+static inline struct fy_walk_result *
+fy_walk_result_iter_start(struct fy_walk_result *fwr)
+{
+	struct fy_walk_result *fwri;
+
+	if (!fwr)
+		return NULL;
+	if (fwr->type != fwrt_refs)
+		return fwr;
+	fwri = fy_walk_result_list_head(&fwr->refs);
+	if (!fwri)
+		return NULL;
+	return fwri;
+}
+
+static inline struct fy_walk_result *
+fy_walk_result_iter_next(struct fy_walk_result *fwr, struct fy_walk_result *fwri)
+{
+	if (!fwr || !fwri || fwr->type != fwrt_refs)
+		return NULL;
+	fwri = fy_walk_result_next(&fwr->refs, fwri);
+	if (!fwri)
+		return NULL;
+	return fwri;
+}
+
+struct fy_node *
+fy_walk_result_node_iterate(struct fy_walk_result *fwr, void **prevp);
+
+enum fy_path_expr_type {
+	fpet_none,
+	/* ypath */
+	fpet_root,		/* /^ or / at the beginning of the expr */
+	fpet_this,		/* /. */
+	fpet_parent,		/* /.. */
+	fpet_every_child,	// /* every immediate child
+	fpet_every_child_r,	// /** every recursive child
+	fpet_filter_collection,	/* match only collection (at the end only) */
+	fpet_filter_scalar,	/* match only scalars (leaves) */
+	fpet_filter_sequence,	/* match only sequences */
+	fpet_filter_mapping,	/* match only mappings */
+	fpet_filter_unique,	/* removes duplicates */
+	fpet_seq_index,
+	fpet_map_key,		/* complex map key (quoted, flow seq or map) */
+	fpet_seq_slice,
+	fpet_alias,
+
+	fpet_multi,		/* merge results of children */
+	fpet_chain,		/* children move in sequence */
+	fpet_logical_or,	/* first non null result set */
+	fpet_logical_and,	/* the last non null result set */
+
+	fpet_select,		/* set selection */
+	fpet_unselect,		/* negation of set selection */
+
+	fpet_eq,		/* equal expression */
+	fpet_neq,		/* not equal */
+	fpet_lt,		/* less than */
+	fpet_gt,		/* greater than */
+	fpet_lte,		/* less or equal than */
+	fpet_gte,		/* greater or equal than */
+
+	fpet_scalar,		/* scalar */
+
+	fpet_plus,		/* add */
+	fpet_minus,		/* subtract */
+	fpet_mult,		/* multiply */
+	fpet_div,		/* divide */
+
+	fpet_lparen,		/* left paren (they do not appear in final expression) */
+	fpet_rparen,		/* right parent */
+	fpet_method,		/* method (or parentheses) */
+
+	fpet_scalar_expr,	/* non-eval phase scalar expression  */
+	fpet_path_expr,		/* non-eval phase path expression */
+	fpet_arg_separator,	/* argument separator (comma in scalar mode) */
+};
+
+#define FPET_COUNT (fpet_arg_separator + 1)
+
+extern const char *path_expr_type_txt[FPET_COUNT];
+
+static inline bool fy_path_expr_type_is_valid(enum fy_path_expr_type type)
+{
+	return type >= fpet_root && type < FPET_COUNT;
+}
+
+/* XXX do neg and reg check */
+static inline bool fy_path_expr_type_is_single_result(enum fy_path_expr_type type)
+{
+	return type == fpet_root ||
+	       type == fpet_this ||
+	       type == fpet_parent ||
+	       type == fpet_map_key ||
+	       type == fpet_seq_index ||
+	       type == fpet_alias ||
+	       type == fpet_filter_collection ||
+	       type == fpet_filter_scalar ||
+	       type == fpet_filter_sequence ||
+	       type == fpet_filter_mapping;
+}
+
+static inline bool fy_path_expr_type_is_parent(enum fy_path_expr_type type)
+{
+	return type == fpet_multi ||
+	       type == fpet_chain ||
+	       type == fpet_logical_or ||
+	       type == fpet_logical_and ||
+	       type == fpet_eq ||
+	       type == fpet_method ||
+	       type == fpet_scalar_expr ||
+	       type == fpet_path_expr;
+}
+
+static inline bool fy_path_expr_type_is_mergeable(enum fy_path_expr_type type)
+{
+	return type == fpet_multi ||
+	       type == fpet_chain ||
+	       type == fpet_logical_or ||
+	       type == fpet_logical_and;
+}
+
+/* type handles refs by itself */
+static inline bool fy_path_expr_type_handles_refs(enum fy_path_expr_type type)
+{
+	return type == fpet_filter_unique ||
+	       type == fpet_method;
+}
+
+static inline bool fy_path_expr_type_is_parent_lhs_rhs(enum fy_path_expr_type type)
+{
+	return type == fpet_eq ||
+	       type == fpet_neq ||
+	       type == fpet_lt ||
+	       type == fpet_gt ||
+	       type == fpet_lte ||
+	       type == fpet_gte ||
+
+	       type == fpet_plus ||
+	       type == fpet_minus ||
+	       type == fpet_mult ||
+	       type == fpet_div;
+}
+
+static inline bool
+fy_path_expr_type_is_conditional(enum fy_path_expr_type type)
+{
+	return type == fpet_eq ||
+	       type == fpet_neq ||
+	       type == fpet_lt ||
+	       type == fpet_gt ||
+	       type == fpet_lte ||
+	       type == fpet_gte;
+}
+
+static inline bool
+fy_path_expr_type_is_arithmetic(enum fy_path_expr_type type)
+{
+	return type == fpet_plus ||
+	       type == fpet_minus ||
+	       type == fpet_mult ||
+	       type == fpet_div;
+}
+
+static inline bool
+fy_path_expr_type_is_lparen(enum fy_path_expr_type type)
+{
+	return type == fpet_lparen /* ||
+	       type == fpet_method */ ;
+}
+
+enum fy_expr_mode {
+	fyem_none,	/* invalid mode */
+	fyem_path,	/* expression is path */
+	fyem_scalar,	/* expression is scalar */
+};
+
+#define FYEM_COUNT (fyem_scalar + 1)
+
+extern const char *fy_expr_mode_txt[FYEM_COUNT];
+
+struct fy_path_expr;
+
+struct fy_method {
+	const char *name;
+	size_t len;
+	enum fy_expr_mode mode;
+	unsigned int nargs;
+	struct fy_walk_result *(*exec)(const struct fy_method *fym,
+		struct fy_path_exec *fypx, int level,
+		struct fy_path_expr *expr,
+		struct fy_walk_result *input,
+		struct fy_walk_result **args, int nargs,
+		bool *errorp);
+};
+
+FY_TYPE_FWD_DECL_LIST(path_expr);
+struct fy_path_expr {
+	struct list_head node;
+	struct fy_path_expr *parent;
+	enum fy_path_expr_type type;
+	struct fy_token *fyt;
+	struct fy_path_expr_list children;
+	enum fy_expr_mode expr_mode;	/* for parens */
+	const struct fy_method *fym;
+};
+FY_TYPE_DECL_LIST(path_expr);
+
+static inline struct fy_path_expr *
+fy_path_expr_lhs(struct fy_path_expr *expr)
+{
+	if (!expr || !fy_path_expr_type_is_parent_lhs_rhs(expr->type))
+		return NULL;
+	return fy_path_expr_list_head(&expr->children);
+}
+
+static inline struct fy_path_expr *
+fy_path_expr_rhs(struct fy_path_expr *expr)
+{
+	if (!expr || !fy_path_expr_type_is_parent_lhs_rhs(expr->type))
+		return NULL;
+	return fy_path_expr_list_tail(&expr->children);
+}
+
+const struct fy_mark *fy_path_expr_start_mark(struct fy_path_expr *expr);
+const struct fy_mark *fy_path_expr_end_mark(struct fy_path_expr *expr);
+
+struct fy_expr_stack {
+	unsigned int top;
+	unsigned int alloc;
+	struct fy_path_expr **items;
+	struct fy_path_expr *items_static[32];
+};
+
+void fy_expr_stack_setup(struct fy_expr_stack *stack);
+void fy_expr_stack_cleanup(struct fy_expr_stack *stack);
+void fy_expr_stack_dump(struct fy_diag *diag, struct fy_expr_stack *stack);
+int fy_expr_stack_push(struct fy_expr_stack *stack, struct fy_path_expr *expr);
+struct fy_path_expr *fy_expr_stack_peek_at(struct fy_expr_stack *stack, unsigned int pos);
+struct fy_path_expr *fy_expr_stack_peek(struct fy_expr_stack *stack);
+struct fy_path_expr *fy_expr_stack_pop(struct fy_expr_stack *stack);
+
+struct fy_path_parser {
+	struct fy_path_parse_cfg cfg;
+	struct fy_reader reader;
+	struct fy_token_list queued_tokens;
+	enum fy_token_type last_queued_token_type;
+	bool stream_start_produced;
+	bool stream_end_produced;
+	bool stream_error;
+	bool owns_diag;
+	int token_activity_counter;
+
+	struct fy_input *fyi;
+	struct fy_expr_stack operators;
+	struct fy_expr_stack operands;
+
+	/* to avoid allocating */
+	struct fy_path_expr_list expr_recycle;
+	bool suppress_recycling;
+
+	enum fy_expr_mode expr_mode;
+	int paren_nest_level;
+
+};
+
+struct fy_path_expr *fy_path_expr_alloc(void);
+/* fy_path_expr_free is declared in libfyaml.h */
+// void fy_path_expr_free(struct fy_path_expr *expr);
+
+void fy_path_parser_setup(struct fy_path_parser *fypp, const struct fy_path_parse_cfg *pcfg);
+void fy_path_parser_cleanup(struct fy_path_parser *fypp);
+int fy_path_parser_open(struct fy_path_parser *fypp,
+			struct fy_input *fyi, const struct fy_reader_input_cfg *icfg);
+void fy_path_parser_close(struct fy_path_parser *fypp);
+
+struct fy_token *fy_path_scan(struct fy_path_parser *fypp);
+
+struct fy_path_expr *fy_path_parse_expression(struct fy_path_parser *fypp);
+
+void fy_path_expr_dump(struct fy_path_expr *expr, struct fy_diag *diag, enum fy_error_type errlevel, int level, const char *banner);
+
+struct fy_path_exec {
+	struct fy_path_exec_cfg cfg;
+	struct fy_node *fyn_start;
+	struct fy_walk_result *result;
+	struct fy_walk_result_list *fwr_recycle;
+	size_t exec_steps;
+	int refs;
+	bool supress_recycling;
+};
+
+struct fy_path_exec *fy_path_exec_create(const struct fy_path_exec_cfg *xcfg);
+struct fy_path_exec *fy_path_exec_create_on_document(struct fy_document *fyd);
+void fy_path_exec_destroy(struct fy_path_exec *fypx);
+void fy_path_exec_cleanup(struct fy_path_exec *fypx);
+
+static inline struct fy_path_exec *
+fy_path_exec_ref(struct fy_path_exec *fypx)
+{
+	/* take care of overflow */
+	if (!fypx)
+		return NULL;
+	assert(fypx->refs + 1 > 0);
+	fypx->refs++;
+
+	return fypx;
+}
+
+static inline void
+fy_path_exec_unref(struct fy_path_exec *fypx)
+{
+	if (!fypx)
+		return;
+
+	assert(fypx->refs > 0);
+
+	if (--fypx->refs == 0)
+		fy_path_exec_destroy(fypx);
+}
+
+struct fy_walk_result *
+fy_path_expr_execute(struct fy_path_exec *fypx, int level, struct fy_path_expr *expr,
+		     struct fy_walk_result *input, enum fy_path_expr_type ptype,
+		     bool *errorp);
+
+static inline struct fy_walk_result_list *
+fy_path_exec_walk_result_rl(struct fy_path_exec *fypx)
+{
+	return fypx && !fypx->supress_recycling ? fypx->fwr_recycle : NULL;
+}
+
+static inline void
+fy_path_exec_set_result_recycle_list(struct fy_path_exec *fypx,
+				     struct fy_walk_result_list *fwrl)
+{
+	if (!fypx)
+		return;
+	fypx->fwr_recycle = fwrl;
+}
+
+struct fy_walk_result *
+fy_path_exec_walk_result_create(struct fy_path_exec *fypx, enum fy_walk_result_type type, ...);
+
+void
+fy_path_exec_walk_result_free(struct fy_path_exec *fypx, struct fy_walk_result *fwr);
+
+struct fy_path_expr_document_data {
+	struct fy_path_parser *fypp;
+	struct fy_walk_result_list fwr_recycle;
+};
+
+struct fy_path_expr_node_data {
+	struct fy_input *fyi;
+	struct fy_path_expr *expr;
+	struct fy_node *fyn_target;
+	int traversals;
+};
+
+int fy_document_setup_path_expr_data(struct fy_document *fyd);
+void fy_document_cleanup_path_expr_data(struct fy_document *fyd);
+int fy_node_setup_path_expr_data(struct fy_node *fyn);
+void fy_node_cleanup_path_expr_data(struct fy_node *fyn);
+
+struct fy_walk_result *
+fy_node_alias_resolve_by_ypath_result(struct fy_node *fyn);
+struct fy_node *fy_node_alias_resolve_by_ypath(struct fy_node *fyn);
+
+struct fy_walk_result *
+fy_node_by_ypath_result(struct fy_node *fyn, const char *path, size_t len);
+struct fy_node *fy_node_by_ypath(struct fy_node *fyn, const char *path, size_t len);
+
+#endif

--- a/numcosmo/external/libfyaml/src/thread/fy-thread.c
+++ b/numcosmo/external/libfyaml/src/thread/fy-thread.c
@@ -1,0 +1,1331 @@
+/*
+ * fy-thread.c - Lighting fast thread pool implementation
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdio.h>
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+
+#ifndef _WIN32
+#include <pthread.h>
+#include <unistd.h>
+#endif
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <linux/futex.h>
+#endif
+
+#include "fy-win32.h"
+#include "fy-diag.h"
+#include "fy-utils.h"
+#include "fy-thread.h"
+
+#undef WORK_SHUTDOWN
+#define WORK_SHUTDOWN 	((struct fy_thread_work *)(void *)-1)
+
+/* Platform-specific thread-local storage access */
+#ifdef _WIN32
+#define fy_thread_getspecific(key) TlsGetValue(key)
+#else
+#define fy_thread_getspecific(key) pthread_getspecific(key)
+#endif
+
+#ifdef FY_THREAD_DEBUG
+#define TDBG(_fmt, ...) \
+	do { fprintf(stderr, (_fmt) __VA_OPT__(,) __VA_ARGS__); } while(0)
+#else
+#define TDBG(_fmt, ...) \
+	do { /* nothing */ } while(0)
+#endif
+
+#ifdef _WIN32
+static DWORD WINAPI fy_worker_thread_standard(void *arg);
+static DWORD WINAPI fy_worker_thread_steal(void *arg);
+#else
+static void *fy_worker_thread_standard(void *arg);
+static void *fy_worker_thread_steal(void *arg);
+#endif
+
+static void fy_thread_work_join_standard(struct fy_thread_pool *tp, struct fy_thread_work *works, size_t work_count, fy_work_check_fn check_fn);
+static void fy_thread_work_join_steal(struct fy_thread_pool *tp, struct fy_thread_work *works, size_t work_count, fy_work_check_fn check_fn);
+static void fy_thread_work_join_steal_2(struct fy_thread_pool *tp, struct fy_thread_work works[2], fy_work_check_fn check_fn);
+
+#if defined(_WIN32)
+
+/* Windows implementation using Events and Critical Sections */
+
+static inline void fy_thread_init_sync(struct fy_thread *t)
+{
+	t->submit_event = CreateEvent(NULL, FALSE, FALSE, NULL);
+	t->done_event = CreateEvent(NULL, FALSE, FALSE, NULL);
+	InitializeCriticalSection(&t->lock);
+	InitializeCriticalSection(&t->wait_lock);
+}
+
+static inline struct fy_thread_work *fy_worker_wait_for_work(struct fy_thread *t)
+{
+	struct fy_thread_work *work;
+
+	while ((work = fy_atomic_load(&t->work)) == NULL)
+		WaitForSingleObject(t->submit_event, INFINITE);
+
+	return work;
+}
+
+static inline void fy_worker_signal_work_done(struct fy_thread *t, struct fy_thread_work *work)
+{
+	struct fy_thread_work *exp_work;
+
+	EnterCriticalSection(&t->wait_lock);
+
+	exp_work = work;
+	if (!fy_atomic_compare_exchange_strong(&t->work, &exp_work, NULL))
+		assert(exp_work == WORK_SHUTDOWN);
+	SetEvent(t->done_event);
+	LeaveCriticalSection(&t->wait_lock);
+}
+
+static inline int fy_thread_submit_work_internal(struct fy_thread *t, struct fy_thread_work *work)
+{
+	struct fy_thread_work *exp_work;
+	int ret;
+
+	assert(t);
+	assert(work);
+
+	EnterCriticalSection(&t->lock);
+	exp_work = NULL;
+	if (!fy_atomic_compare_exchange_strong(&t->work, &exp_work, work)) {
+		assert(exp_work == WORK_SHUTDOWN);
+		ret = -1;
+	} else {
+		SetEvent(t->submit_event);
+		ret = 0;
+	}
+	LeaveCriticalSection(&t->lock);
+
+	return ret;
+}
+
+static inline int fy_thread_wait_work_internal(struct fy_thread *t)
+{
+	const struct fy_thread_work *work;
+
+	EnterCriticalSection(&t->wait_lock);
+	while ((work = fy_atomic_load(&t->work)) != NULL) {
+		LeaveCriticalSection(&t->wait_lock);
+		WaitForSingleObject(t->done_event, INFINITE);
+		EnterCriticalSection(&t->wait_lock);
+	}
+	LeaveCriticalSection(&t->wait_lock);
+
+	return 0;
+}
+
+void fy_worker_thread_shutdown(struct fy_thread *t)
+{
+	EnterCriticalSection(&t->lock);
+	fy_atomic_store(&t->work, WORK_SHUTDOWN);
+	SetEvent(t->submit_event);
+	LeaveCriticalSection(&t->lock);
+
+	WaitForSingleObject(t->tid, INFINITE);
+	CloseHandle(t->tid);
+	CloseHandle(t->submit_event);
+	CloseHandle(t->done_event);
+	DeleteCriticalSection(&t->lock);
+	DeleteCriticalSection(&t->wait_lock);
+}
+
+#elif defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+
+/* linux pedal to the metal implementation */
+static inline int futex(FY_ATOMIC(uint32_t) *uaddr, int futex_op, uint32_t val, const struct timespec *timeout, uint32_t *uaddr2, uint32_t val3)
+{
+	return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3);
+}
+
+static inline int fwait(FY_ATOMIC(uint32_t) *futexp)
+{
+	long s;
+	uint32_t one = 1;
+
+	while (!fy_atomic_compare_exchange_strong(futexp, &one, 0)) {
+		s = futex(futexp, FUTEX_WAIT_PRIVATE, 0, NULL, NULL, 0);
+		if (s == -1 && errno != EAGAIN)
+			return -1;
+	}
+	return 0;
+}
+
+static inline int fpost(FY_ATOMIC(uint32_t) *futexp)
+{
+	long s;
+	uint32_t zero = 0;
+
+	if (fy_atomic_compare_exchange_strong(futexp, &zero, 1)) {
+		s = futex(futexp, FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+		if (s == -1)
+			return -1;
+	}
+	return 0;
+}
+
+static inline void fy_thread_init_sync(struct fy_thread *t)
+{
+	/* nothing more needed for futexes */
+	fy_atomic_store(&t->submit, 0);
+	fy_atomic_store(&t->done, 0);
+}
+
+static inline struct fy_thread_work *fy_worker_wait_for_work(struct fy_thread *t)
+{
+	struct fy_thread_work *w;
+	int rc __FY_DEBUG_UNUSED__;
+
+	while ((w = fy_atomic_load(&t->work)) == NULL) {
+		rc = fwait(&t->submit);
+		assert(!rc);
+	}
+	return w;
+}
+
+static inline void fy_worker_signal_work_done(struct fy_thread *t, struct fy_thread_work *work)
+{
+	struct fy_thread_work *exp_work;
+	bool ok __FY_DEBUG_UNUSED__;
+	int rc __FY_DEBUG_UNUSED__;
+
+	/* note that the work won't be replaced if it's a shutdown */
+	exp_work = work;
+	ok = fy_atomic_compare_exchange_strong(&t->work, &exp_work, NULL);
+	assert(ok);
+
+	rc = fpost(&t->done);
+	assert(!rc);
+}
+
+static inline int fy_thread_submit_work_internal(struct fy_thread *t, struct fy_thread_work *work)
+{
+	struct fy_thread_work *exp_work;
+	int rc __FY_DEBUG_UNUSED__;
+
+	/* atomically update the work */
+	exp_work = NULL;
+	if (!fy_atomic_compare_exchange_strong(&t->work, &exp_work, work))
+		return -1;
+
+	rc = fpost(&t->submit);
+	assert(!rc);
+
+	return 0;
+}
+
+static inline int fy_thread_wait_work_internal(struct fy_thread *t)
+{
+	const struct fy_thread_work *work;
+
+	while ((work = fy_atomic_load(&t->work)) != NULL)
+		fwait(&t->done);
+
+	fy_atomic_store(&t->done, 0);
+
+	return 0;
+}
+
+void fy_worker_thread_shutdown(struct fy_thread *t)
+{
+	int rc __FY_DEBUG_UNUSED__;
+
+	fy_atomic_store(&t->work, WORK_SHUTDOWN);
+	rc = fpost(&t->submit);
+	assert(!rc);
+
+	rc = pthread_join(t->tid, NULL);
+	assert(!rc);
+
+	if (!(t->tp->cfg.flags & FYTPCF_STEAL_MODE))
+		fy_atomic_store(&t->work, NULL);
+}
+
+#else
+
+/* portable pthread implementation */
+
+static inline void fy_thread_init_sync(struct fy_thread *t)
+{
+	pthread_mutex_init(&t->lock, NULL);
+	pthread_cond_init(&t->cond, NULL);
+
+	pthread_mutex_init(&t->wait_lock, NULL);
+	pthread_cond_init(&t->wait_cond, NULL);
+}
+
+static inline struct fy_thread_work *fy_worker_wait_for_work(struct fy_thread *t)
+{
+	struct fy_thread_work *work;
+
+	pthread_mutex_lock(&t->lock);
+	while ((work = fy_atomic_load(&t->work)) == NULL)
+		pthread_cond_wait(&t->cond, &t->lock);
+	pthread_mutex_unlock(&t->lock);
+
+	return work;
+}
+
+static inline void fy_worker_signal_work_done(struct fy_thread *t, struct fy_thread_work *work)
+{
+	struct fy_thread_work *exp_work;
+
+	/* clear the work, so that the user knows we're done */
+	pthread_mutex_lock(&t->wait_lock);
+
+	/* note that the work won't be replaced if it's a shutdown */
+	exp_work = work;
+	if (!fy_atomic_compare_exchange_strong(&t->work, &exp_work, NULL))
+		assert(exp_work == WORK_SHUTDOWN);
+	pthread_cond_signal(&t->wait_cond);
+	pthread_mutex_unlock(&t->wait_lock);
+}
+
+static inline int fy_thread_submit_work_internal(struct fy_thread *t, struct fy_thread_work *work)
+{
+	struct fy_thread_work *exp_work;
+	int ret;
+
+	/* atomically update the work */
+
+	assert(t);
+	assert(work);
+
+	pthread_mutex_lock(&t->lock);
+	exp_work = NULL;
+	if (!fy_atomic_compare_exchange_strong(&t->work, &exp_work, work)) {
+		assert(exp_work == WORK_SHUTDOWN);
+		ret = -1;
+	} else {
+		pthread_cond_signal(&t->cond);
+		ret = 0;
+	}
+	pthread_mutex_unlock(&t->lock);
+
+	return ret;
+}
+
+static inline int fy_thread_wait_work_internal(struct fy_thread *t)
+{
+	const struct fy_thread_work *work;
+
+	pthread_mutex_lock(&t->wait_lock);
+	while ((work = fy_atomic_load(&t->work)) != NULL)
+		pthread_cond_wait(&t->wait_cond, &t->wait_lock);
+	pthread_mutex_unlock(&t->wait_lock);
+
+	return 0;
+}
+
+void fy_worker_thread_shutdown(struct fy_thread *t)
+{
+	pthread_mutex_lock(&t->lock);
+	fy_atomic_store(&t->work, WORK_SHUTDOWN);
+	pthread_cond_signal(&t->cond);
+	pthread_mutex_unlock(&t->lock);
+	pthread_join(t->tid, NULL);
+}
+
+#endif
+
+static inline struct fy_thread *fy_thread_reserve_internal(struct fy_thread_pool *tp)
+{
+	struct fy_thread *t;
+	unsigned int slot;
+	FY_ATOMIC(uint64_t) *free;
+	uint64_t exp, v;
+	unsigned int i, num_threads_words;
+
+	t = NULL;
+
+	num_threads_words = FY_BIT64_COUNT(tp->num_threads);
+	for (i = 0, free = tp->freep; i < num_threads_words; i++, free++) {
+		v = fy_atomic_load(free);
+		while (v) {
+			slot = FY_BIT64_LOWEST(v);
+			assert(v & FY_BIT64(slot));
+			exp = v;		/* expecting the previous value */
+			v &= ~FY_BIT64(slot);	/* clear this bit */
+			if (fy_atomic_compare_exchange_strong(free, &exp, v)) {
+				slot += i * 64;
+				t = tp->threads + slot;
+				assert(slot == t->id);
+				return t;
+			}
+			v = exp;
+		}
+	}
+
+	return NULL;
+}
+
+static inline void fy_thread_unreserve_internal(struct fy_thread *t)
+{
+	struct fy_thread_pool *tp;
+	FY_ATOMIC(uint64_t) *free;
+
+	tp = t->tp;
+	free = tp->freep + (unsigned int)(t->id / 64);
+	fy_atomic_fetch_or(free, FY_BIT64(t->id & 63));
+}
+
+static inline bool fy_thread_is_reserved_internal(struct fy_thread *t)
+{
+	struct fy_thread_pool *tp = t->tp;
+	FY_ATOMIC(uint64_t) *free;
+
+	free = tp->freep + (unsigned int)(t->id / 64);
+	return !(fy_atomic_load(free) & FY_BIT64(t->id & 63));
+}
+
+static inline bool fy_thread_pool_are_all_reserved_internal(struct fy_thread_pool *tp)
+{
+	FY_ATOMIC(uint64_t) *free;
+	uint64_t v, m;
+	unsigned int i, num_threads_words;
+
+	num_threads_words = FY_BIT64_COUNT(tp->num_threads);
+	for (i = 0, free = tp->freep; i < num_threads_words - 1; i++, free++) {
+		v = fy_atomic_load(free);
+		if (v != 0)
+			return false;
+	}
+	v = fy_atomic_load(free);
+	m = (tp->num_threads & 63) ? FY_BIT64(tp->num_threads & 63) - 1 : (uint64_t)-1;
+	return (v & m) == 0;
+}
+
+static inline bool fy_thread_pool_is_any_reserved_internal(struct fy_thread_pool *tp)
+{
+	FY_ATOMIC(uint64_t) *free;
+	uint64_t v, m;
+	unsigned int i, num_threads_words;
+
+	num_threads_words = FY_BIT64_COUNT(tp->num_threads);
+	for (i = 0, free = tp->freep; i < num_threads_words - 1; i++, free++) {
+		v = fy_atomic_load(free);
+		if (v != (uint64_t)-1)
+			return true;
+	}
+	v = fy_atomic_load(free);
+	m = (tp->num_threads & 63) ? FY_BIT64(tp->num_threads & 63) - 1 : (uint64_t)-1;
+	return (v & m) != m;
+}
+
+struct fy_thread *fy_thread_reserve(struct fy_thread_pool *tp)
+{
+	if (!tp)
+		return NULL;
+
+	/* only valid for non-work stealing thread pools */
+	if (tp->cfg.flags & FYTPCF_STEAL_MODE)
+		return NULL;
+
+	return fy_thread_reserve_internal(tp);
+}
+
+void fy_thread_unreserve(struct fy_thread *t)
+{
+	struct fy_thread_pool *tp;
+
+	if (!t)
+		return;
+
+	tp = t->tp;
+	assert(tp);
+
+	/* only valid for non-work stealing thread pools */
+	if (tp->cfg.flags & FYTPCF_STEAL_MODE)
+		return;
+
+	fy_thread_unreserve_internal(t);
+}
+
+bool fy_thread_is_reserved(struct fy_thread *t)
+{
+	if (!t)
+		return false;
+
+	return fy_thread_is_reserved_internal(t);
+}
+
+bool fy_thread_pool_are_all_reserved(struct fy_thread_pool *tp)
+{
+	return fy_thread_pool_are_all_reserved_internal(tp);
+}
+
+bool fy_thread_pool_is_any_reserved(struct fy_thread_pool *tp)
+{
+	return fy_thread_pool_is_any_reserved_internal(tp);
+}
+
+int fy_thread_submit_work(struct fy_thread *t, struct fy_thread_work *work)
+{
+	if (!t || !work)
+		return -1;
+
+	if (t->tp->cfg.flags & FYTPCF_STEAL_MODE)
+		return -1;
+
+	return fy_thread_submit_work_internal(t, work);
+}
+
+int fy_thread_wait_work(struct fy_thread *t)
+{
+	if (!t)
+		return -1;
+
+	if (t->tp->cfg.flags & FYTPCF_STEAL_MODE)
+		return -1;
+
+	return fy_thread_wait_work_internal(t);
+}
+
+void fy_thread_pool_cleanup(struct fy_thread_pool *tp)
+{
+	struct fy_thread *t;
+	unsigned int i;
+
+	if (!tp)
+		return;
+
+	if (tp->threads) {
+		/* get out of steal mode */
+		for (i = 0, t = tp->threads; i < tp->num_threads; i++, t++) {
+			fy_worker_thread_shutdown(t);
+		}
+
+		fy_cacheline_free(tp->threads);
+	}
+
+#ifdef _WIN32
+	if (tp->key != TLS_OUT_OF_INDEXES)
+		TlsFree(tp->key);
+#endif
+
+	memset(tp, 0, sizeof(*tp));
+}
+
+int fy_thread_pool_setup(struct fy_thread_pool *tp, const struct fy_thread_pool_cfg *cfg)
+{
+	struct fy_thread *t;
+	unsigned int i, num_threads, num_threads_words;
+	size_t size, free_offset, loot_offset, thread_bitmask_size;
+#ifdef _WIN32
+	LPTHREAD_START_ROUTINE start_routine;
+#else
+	void *(*start_routine)(void *);
+	int rc __FY_DEBUG_UNUSED__;
+#endif
+	long scval;
+
+	assert(tp);
+
+	memset(tp, 0, sizeof(*tp));
+
+	if (!cfg) {
+		tp->cfg.flags = 0;
+		tp->cfg.num_threads = 0;
+	} else
+		tp->cfg = *cfg;
+
+	if (!tp->cfg.num_threads) {
+		scval = sysconf(_SC_NPROCESSORS_ONLN);
+		assert(scval > 0);
+		num_threads = (unsigned int)scval;
+	} else
+		num_threads = tp->cfg.num_threads;
+
+	tp->num_threads = num_threads;
+
+	num_threads_words = FY_BIT64_COUNT(tp->num_threads);
+	thread_bitmask_size = FY_BIT64_SIZE(tp->num_threads);
+
+	/* the size of the threads, aligned to a cache line */
+	size = FY_CACHELINE_SIZE_ALIGN(sizeof(*tp->threads) * tp->num_threads);
+
+	/* the free bitmask array offset */
+	free_offset = size;
+	size = FY_CACHELINE_SIZE_ALIGN(size + thread_bitmask_size);
+
+	/* the loot bitmask array offset, aligned to a 64 byte cacheline */
+	loot_offset = size;
+	size = FY_CACHELINE_SIZE_ALIGN(size + thread_bitmask_size);
+
+	/* allocate everything in one go */
+	tp->threads = fy_cacheline_alloc(size);
+	if (!tp->threads)
+		goto err_out;
+
+	memset(tp->threads, 0, size);
+
+#ifdef _WIN32
+	tp->key = TlsAlloc();
+	assert(tp->key != TLS_OUT_OF_INDEXES);
+#else
+	rc = pthread_key_create(&tp->key, NULL);
+	assert(!rc);
+#endif
+
+	tp->freep = (_Atomic(uint64_t) *)((char *)tp->threads + free_offset);
+	tp->lootp = (_Atomic(uint64_t) *)((char *)tp->threads + loot_offset);
+
+	/* prime the thread free */
+	for (i = 0; i < num_threads_words - 1; i++)
+		tp->freep[i] = (uint64_t)-1;
+	tp->freep[i] = (tp->num_threads & 63) ? FY_BIT64(tp->num_threads & 63) - 1 : (uint64_t)-1;
+
+	/* the lootp's are zero */
+
+	for (i = 0, t = tp->threads; i < tp->num_threads; i++, t++) {
+
+		t->tp = tp;
+		t->id = i;
+
+		fy_thread_init_sync(t);
+	}
+
+	start_routine = !(tp->cfg.flags & FYTPCF_STEAL_MODE) ?
+				fy_worker_thread_standard :
+				fy_worker_thread_steal;
+
+	for (i = 0, t = tp->threads; i < tp->num_threads; i++, t++) {
+#ifdef _WIN32
+		t->tid = CreateThread(NULL, 0, start_routine, t, 0, NULL);
+		if (t->tid == NULL)
+			goto err_out;
+#else
+		rc = pthread_create(&t->tid, NULL, start_routine, t);
+		if (rc)
+			goto err_out;
+#endif
+	}
+
+	return 0;
+
+err_out:
+	fy_thread_pool_cleanup(tp);
+	return -1;
+}
+
+struct fy_thread_pool *fy_thread_pool_create(const struct fy_thread_pool_cfg *cfg)
+{
+	struct fy_thread_pool *tp;
+	int rc;
+
+	tp = malloc(sizeof(*tp));
+	if (!tp)
+		return NULL;
+
+	rc = fy_thread_pool_setup(tp, cfg);
+	if (rc) {
+		free(tp);
+		return NULL;
+	}
+
+	return tp;
+}
+
+void fy_thread_pool_destroy(struct fy_thread_pool *tp)
+{
+	if (!tp)
+		return;
+
+	fy_thread_pool_cleanup(tp);
+	free(tp);
+}
+
+int fy_thread_pool_get_num_threads(struct fy_thread_pool *tp)
+{
+	if (!tp)
+		return -1;
+
+	return (int)tp->num_threads;
+}
+
+const struct fy_thread_pool_cfg *fy_thread_pool_get_cfg(struct fy_thread_pool *tp)
+{
+	if (!tp)
+		return NULL;
+	return &tp->cfg;
+}
+
+void fy_thread_work_join(struct fy_thread_pool *tp, struct fy_thread_work *works, size_t work_count, fy_work_check_fn check_fn)
+{
+	if (!(tp->cfg.flags & FYTPCF_STEAL_MODE))
+		fy_thread_work_join_standard(tp, works, work_count, check_fn);
+	else if (work_count == 2)
+		fy_thread_work_join_steal_2(tp, works, check_fn);
+	else
+		fy_thread_work_join_steal(tp, works, work_count, check_fn);
+}
+
+void fy_thread_args_join(struct fy_thread_pool *tp, fy_work_exec_fn fn, fy_work_check_fn check_fn, void **args, size_t count)
+{
+	struct fy_thread_work *works;
+	size_t i;
+
+	if (!count)
+		return;
+
+	works = alloca(sizeof(*works) * count);
+	memset(works, 0, sizeof(*works) * count);
+	for (i = 0; i < count; i++) {
+		works[i].fn = fn;
+		works[i].arg = args ? args[i] : NULL;
+	}
+
+	fy_thread_work_join(tp, works, count, check_fn);
+}
+
+void fy_thread_arg_array_join(struct fy_thread_pool *tp, fy_work_exec_fn fn, fy_work_check_fn check_fn, void *args, size_t argsize, size_t count)
+{
+	struct fy_thread_work *works;
+	size_t i;
+
+	if (!count)
+		return;
+
+	works = alloca(sizeof(*works) * count);
+	memset(works, 0, sizeof(*works) * count);
+	for (i = 0; i < count; i++) {
+		works[i].fn = fn;
+		works[i].arg = args;
+		args = (char *)args + argsize;
+	}
+
+	fy_thread_work_join(tp, works, count, check_fn);
+}
+
+void fy_thread_arg_join(struct fy_thread_pool *tp, fy_work_exec_fn fn, fy_work_check_fn check_fn, void *arg, size_t count)
+{
+	struct fy_thread_work *works;
+	size_t i;
+
+	if (!count)
+		return;
+
+	works = alloca(sizeof(*works) * count);
+	memset(works, 0, sizeof(*works) * count);
+	for (i = 0; i < count; i++) {
+		works[i].fn = fn;
+		works[i].arg = arg;
+	}
+
+	fy_thread_work_join(tp, works, count, check_fn);
+}
+
+/*
+ * the standard (non-stealing implementation)
+ */
+#ifdef _WIN32
+static DWORD WINAPI fy_worker_thread_standard(void *arg)
+#else
+static void *fy_worker_thread_standard(void *arg)
+#endif
+{
+	struct fy_thread *t = arg;
+	struct fy_thread_pool *tp;
+	struct fy_thread_work *work;
+
+	tp = t->tp;
+
+	/* store per thread info */
+#ifdef _WIN32
+	TlsSetValue(tp->key, t);
+#else
+	pthread_setspecific(tp->key, t);
+#endif
+
+	while ((work = fy_worker_wait_for_work(t)) != WORK_SHUTDOWN) {
+		work->fn(work->arg);
+		fy_worker_signal_work_done(t, work);
+	}
+
+#ifdef _WIN32
+	return 0;
+#else
+	return NULL;
+#endif
+}
+
+static void fy_thread_work_join_standard(struct fy_thread_pool *tp, struct fy_thread_work *works, size_t work_count, fy_work_check_fn check_fn)
+{
+	struct fy_thread_work **direct_work, **thread_work, *w;
+	struct fy_thread **threads, *t;
+	size_t i, direct_work_count, thread_work_count;
+	int rc;
+
+	/* just a single (or no) work, or no threads? execute directly */
+	if (work_count <= 1 || !tp || !tp->num_threads) {
+		for (i = 0, w = works; i < work_count; i++, w++)
+			w->fn(w->arg);
+		return;
+	}
+
+	/* allocate the keeper of direct work */
+	direct_work = alloca(work_count * sizeof(*direct_work));
+	direct_work_count = 0;
+
+	threads = alloca(work_count * sizeof(*threads));
+	thread_work = alloca(work_count * sizeof(*thread_work));
+	thread_work_count = 0;
+
+	for (i = 0, w = works; i < work_count; i++, w++) {
+
+		t = NULL;
+		if (!check_fn || check_fn(w->arg))
+			t = fy_thread_reserve_internal(tp);
+
+		if (t) {
+			threads[thread_work_count] = t;
+			thread_work[thread_work_count++] = w;
+		} else
+			direct_work[direct_work_count++] = w;
+	}
+
+	/* if we don't have any direct_work, steal the last threaded work as direct */
+	if (!direct_work_count) {
+		assert(thread_work_count > 0);
+		t = threads[thread_work_count - 1];
+		w = thread_work[thread_work_count - 1];
+		thread_work_count--;
+
+		/* unreserve this */
+		fy_thread_unreserve_internal(t);
+		direct_work[direct_work_count++] = w;
+	}
+
+	/* submit the threaded work */
+	for (i = 0; i < thread_work_count; i++) {
+		t = threads[i];
+		w = thread_work[i];
+		rc = fy_thread_submit_work_internal(t, w);
+		if (rc) {
+			/* unable to submit? remove work, and move to direct */
+			threads[i] = NULL;
+			thread_work[i] = NULL;
+			fy_thread_unreserve_internal(t);
+			direct_work[direct_work_count++] = w;
+		}
+	}
+
+	/* now perform the direct work while the threaded work is being performed in parallel */
+	for (i = 0; i < direct_work_count; i++) {
+		w = direct_work[i];
+		w->fn(w->arg);
+	}
+
+	/* finally wait for all threaded work to complete */
+	for (i = 0; i < thread_work_count; i++) {
+		t = threads[i];
+		assert(t);
+		fy_thread_wait_work_internal(t);
+		fy_thread_unreserve_internal(t);
+	}
+}
+
+/*
+ * the stealing implementation
+ */
+static inline struct fy_work_pool *fy_work_pool_init(struct fy_work_pool *wp, size_t work_count)
+{
+#if !(defined(__linux__) && !defined(FY_THREAD_PORTABLE)) && !defined(_WIN32)
+	int rc __FY_DEBUG_UNUSED__;
+#endif
+
+	if (!wp)
+		return NULL;
+
+	fy_atomic_store(&wp->work_left, work_count);
+#if defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+	fy_atomic_store(&wp->done, !work_count);
+#elif defined(__APPLE__)
+	wp->sem = dispatch_semaphore_create(!work_count);
+        assert(wp->sem != NULL);
+	(void)rc;
+#elif defined(_WIN32)
+	wp->sem = CreateSemaphore(NULL, !work_count, LONG_MAX, NULL);
+	assert(wp->sem != NULL);
+#else
+	rc = sem_init(&wp->sem, 0, !work_count);
+	assert(!rc);
+#endif
+	return wp;
+}
+
+static inline void fy_work_pool_cleanup(struct fy_work_pool *wp)
+{
+#if !(defined(__linux__) && !defined(FY_THREAD_PORTABLE)) && !defined(_WIN32)
+	int rc __FY_DEBUG_UNUSED__;
+#endif
+
+	if (!wp)
+		return;
+
+#if defined(_WIN32)
+	CloseHandle(wp->sem);
+#elif defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+	/* nothing */
+#elif defined(__APPLE__)
+	/* nothing */
+	(void)rc;
+#else
+	rc = sem_destroy(&wp->sem);
+	assert(!rc);
+#endif
+}
+
+static inline bool fy_work_pool_signal(struct fy_work_pool *wp)
+{
+	size_t prev_work_left;
+#if !defined(_WIN32)
+	int rc __FY_DEBUG_UNUSED__;
+#endif
+
+	if (!wp)
+		return false;
+
+	prev_work_left = fy_atomic_fetch_sub(&wp->work_left, 1);
+	if (prev_work_left == 1) {
+#if defined(_WIN32)
+		ReleaseSemaphore(wp->sem, 1, NULL);
+#elif defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+		rc = fpost(&wp->done);
+		assert(!rc);
+#elif defined(__APPLE__)
+		dispatch_semaphore_signal(wp->sem);
+		(void)rc;
+#else
+		rc = sem_post(&wp->sem);
+		assert(!rc);
+#endif
+		return true;
+	}
+	return false;
+}
+
+static inline void fy_work_pool_wait(struct fy_work_pool *wp)
+{
+#if !defined(_WIN32)
+	int rc __FY_DEBUG_UNUSED__;
+#else
+	DWORD rc __FY_DEBUG_UNUSED__;
+#endif
+
+	if (!wp)
+		return;
+
+	/* if there's any work left, wait for it */
+	while (fy_atomic_load(&wp->work_left) > 0) {
+#if defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+		rc = fwait(&wp->done);
+		assert(!rc || (rc == -1 && errno == EAGAIN));
+#elif defined(__APPLE__)
+		dispatch_semaphore_wait(wp->sem, DISPATCH_TIME_FOREVER);
+		rc = 0;
+#elif defined(_WIN32)
+		rc = WaitForSingleObject(wp->sem, INFINITE);
+		assert(rc == WAIT_OBJECT_0);
+#else
+		rc = sem_wait(&wp->sem);
+		assert(!rc || (rc == -1 && errno == EAGAIN));
+#endif
+	}
+}
+
+static inline void fy_worker_thread_steal_execute(struct fy_thread *t, struct fy_thread_work *w)
+{
+	struct fy_work_pool *wp;
+	bool signalled __FY_DEBUG_UNUSED__;
+
+	TDBG("%s: T#%u worker executing W:%p\n", __func__, t->id, w);
+	wp = w->wp;
+	assert(wp);
+	w->fn(w->arg);
+	TDBG("%s: T#%u worker executed W:%p\n", __func__, t->id, w);
+
+	signalled = fy_work_pool_signal(wp);
+	(void)signalled;
+	TDBG("%s: T#%u W:%p WP:%p signalled=%s\n", __func__,
+			t->id, w, wp, signalled ? "true" : "false");
+}
+
+static inline struct fy_thread_work *fy_worker_thread_steal_work(struct fy_thread_pool *tp, struct fy_thread *t_thief)
+{
+	struct fy_thread *t;
+	unsigned int slot;
+	FY_ATOMIC(uint64_t) *loot;
+	uint64_t exp, v;
+	unsigned int i, num_threads_words;
+	struct fy_thread_work *w, *w_exp;
+
+	/* the threads that have work to steal, have the loot bit set */
+	t = NULL;
+
+	num_threads_words = FY_BIT64_COUNT(tp->num_threads);
+	for (i = 0, loot = tp->lootp; i < num_threads_words; i++, loot++) {
+		v = fy_atomic_load(loot);
+		while (v) {
+			slot = FY_BIT64_LOWEST(v);
+			assert(v & FY_BIT64(slot));
+			exp = v;		/* expecting the previous value */
+			v &= ~FY_BIT64(slot);	/* clear this bit */
+
+			if (fy_atomic_compare_exchange_strong(loot, &exp, v)) {
+				slot += i * 64;
+				t = tp->threads + slot;
+				if ((w = fy_atomic_load(&t->next_work)) != NULL) {
+					w_exp = w;
+					if (fy_atomic_compare_exchange_strong(&t->next_work, &w_exp, NULL))
+						return w;
+				}
+			}
+			v = exp;
+		}
+	}
+
+	return NULL;
+}
+
+#ifdef _WIN32
+static DWORD WINAPI fy_worker_thread_steal(void *arg)
+#else
+static void *fy_worker_thread_steal(void *arg)
+#endif
+{
+	struct fy_thread *t = arg;
+	struct fy_thread_pool *tp;
+	struct fy_thread_work *w, *w_exp, *w_stolen, *w_last;
+
+	tp = t->tp;
+
+	/* store per thread info */
+#ifdef _WIN32
+	TlsSetValue(tp->key, t);
+#else
+	pthread_setspecific(tp->key, t);
+#endif
+
+	TDBG("%s: T#%u in steal mode\n", __func__, t->id);
+
+	while ((w = fy_worker_wait_for_work(t)) != WORK_SHUTDOWN) {
+
+		assert(fy_thread_is_reserved_internal(t));
+
+		for (;;) {
+			fy_worker_thread_steal_execute(t, w);
+			w_last = w;
+			w_stolen = fy_worker_thread_steal_work(tp, t);
+			w = NULL;
+			if (!w_stolen)
+				break;
+
+			TDBG("%s: T#%u stole W:%p\n", __func__, t->id, w_stolen);
+			w_exp = w_last;
+			if (!fy_atomic_compare_exchange_strong(&t->work, &w_exp, w_stolen)) {
+				assert(w_exp != WORK_SHUTDOWN);
+				TDBG("%s: T#%u t->work:%p w:%p w_stolen:%p\n", __func__, t->id, fy_atomic_load(&t->work), w, w_stolen);
+				FY_IMPOSSIBLE_ABORT();
+			}
+			w = w_stolen;
+		}
+
+		/* unreserve first */
+		fy_thread_unreserve_internal(t);
+
+		w_exp = w_last;
+		if (!fy_atomic_compare_exchange_strong(&t->work, &w_exp, NULL))
+			break;
+	}
+	TDBG("%s: T#%u leaving steal mode\n", __func__, t->id);
+
+#ifdef _WIN32
+	return 0;
+#else
+	return NULL;
+#endif
+}
+
+static void fy_thread_work_join_steal(struct fy_thread_pool *tp, struct fy_thread_work *works, size_t work_count, fy_work_check_fn check_fn)
+{
+	struct fy_work_pool wp_local, *wp;
+	struct fy_thread_work *dw, *expw;
+	struct fy_thread *t, *tw;
+	bool has_loot, resolved_t;
+	int rc __FY_DEBUG_UNUSED__;
+	int tid __FY_DEBUG_UNUSED__;
+
+	t = NULL;
+	resolved_t = false;
+	tid = -1;
+	(void)tid;
+	(void)rc;
+
+#ifdef FY_THREAD_DEBUG
+#ifdef _WIN32
+	t = TlsGetValue(tp->key);
+#else
+	t = fy_thread_getspecific(tp->key);
+#endif
+	tid = t ? (int)t->id : -1;
+	resolved_t = true;
+#else
+	t = NULL;
+	tid = -1;
+	resolved_t = false;
+#endif
+
+	dw = NULL;
+	wp = NULL;
+
+	while (work_count > 0) {
+		if (!dw) {
+			dw = works++;
+			work_count--;
+
+			TDBG("%s: T#%d sdir W:%p\n", __func__, tid, dw);
+
+			continue;
+		}
+
+		has_loot = false;
+		if (work_count > 0 && (!check_fn || check_fn(works->arg))) {
+			while (work_count > 0 && (tw = fy_thread_reserve_internal(tp)) != NULL) {
+
+				assert(!works->wp);
+
+				if (!wp)
+					wp = fy_work_pool_init(&wp_local, work_count + !!dw);
+
+				works->wp = wp;
+				expw = NULL;
+
+				rc = fy_thread_submit_work_internal(tw, works);
+				assert(!rc);
+
+				TDBG("%s: T#%d post W:%p to T#%u\n", __func__, tid, works, tw->id);
+
+				works++;
+				work_count--;
+			}
+
+			if (work_count > 0) {
+
+				if (!resolved_t) {
+					t = fy_thread_getspecific(tp->key);
+					tid = t ? (int)t->id : -1;
+					resolved_t = true;
+				}
+
+				if (t && fy_atomic_load(&t->next_work) == NULL) {
+					TDBG("%s: T#%d could not post, available to steal W:%p\n", __func__, tid, works);
+					assert(works->wp == NULL);
+
+					if (!wp)
+						wp = fy_work_pool_init(&wp_local, work_count + !!dw);
+
+					works->wp = wp;
+
+					expw = NULL;
+					if (!fy_atomic_compare_exchange_strong(&t->next_work, &expw, works)) {
+						TDBG("%s: T#%d could not update next_work: W:%p\n", __func__, tid, works);
+						abort();
+					}
+
+					/* set the has loot bit */
+					fy_atomic_fetch_or(tp->lootp + (unsigned int)(t->id / 64), FY_BIT64(t->id & 63));
+
+					has_loot = true;
+				}
+			}
+		}
+
+		if (dw) {
+			TDBG("%s: T#%d exec W:%p\n", __func__, tid, dw);
+
+			/* execute the direct work */
+			dw->fn(dw->arg);
+			dw = NULL;
+
+			fy_work_pool_signal(wp);
+		}
+
+		if (has_loot) {
+			assert(t);
+			expw = works;
+
+			/* clear the has loot bit unconditionally */
+			fy_atomic_fetch_and(tp->lootp + (unsigned int)(t->id / 64), ~FY_BIT64(t->id & 63));
+
+			if (!fy_atomic_compare_exchange_strong(&t->next_work, &expw, NULL)) {
+				TDBG("%s: T#%d had W:%p stolen, good\n", __func__, tid, works);
+				work_count--;
+				works++;
+			} else {
+				TDBG("%s: T#%d had W:%p not stolen, bad\n", __func__, tid, works);
+			}
+		}
+	}
+
+	/* last out and direct work */
+	if (dw) {
+		TDBG("%s: T#%d executing final direct W:%p\n", __func__, tid, dw);
+
+		dw->fn(dw->arg);
+		dw = NULL;
+
+		fy_work_pool_signal(wp);
+	}
+
+	TDBG("%s: T#%d wait WP:%p\n", __func__, tid, wp);
+
+	fy_work_pool_wait(wp);
+	fy_work_pool_cleanup(wp);
+
+	TDBG("%s: T#%d done WP:%p\n", __func__, tid, wp);
+}
+
+static void fy_thread_work_join_steal_2(struct fy_thread_pool *tp, struct fy_thread_work works[2], fy_work_check_fn check_fn)
+{
+	struct fy_work_pool wp_local, *wp;
+	struct fy_thread_work *expw;
+	struct fy_thread *t, *tw;
+	bool has_loot, pushed, resolved_t;
+	int rc __FY_DEBUG_UNUSED__;
+	int tid __FY_DEBUG_UNUSED__;
+
+	t = NULL;
+	resolved_t = false;
+	tid = -1;
+
+	(void)tid;
+
+#ifdef FY_THREAD_DEBUG
+#ifdef _WIN32
+	t = TlsGetValue(tp->key);
+#else
+	t = fy_thread_getspecific(tp->key);
+#endif
+	tid = t ? (int)t->id : -1;
+	resolved_t = true;
+#else
+	t = NULL;
+	tid = -1;
+	resolved_t = false;
+#endif
+
+	wp = NULL;
+
+	pushed = false;
+	has_loot = false;
+	if (!check_fn || check_fn(works->arg)) {
+		if ((tw = fy_thread_reserve_internal(tp)) != NULL) {
+
+			assert(!works[1].wp);
+
+			if (!wp)
+				wp = fy_work_pool_init(&wp_local, 1);
+
+			works[1].wp = wp;
+			expw = NULL;
+
+			rc = fy_thread_submit_work_internal(tw, &works[1]);
+			assert(!rc);
+
+			TDBG("%s: T#%d post W:%p to T#%u\n", __func__, tid, &works[1], tw->id);
+
+			pushed = true;
+
+		} else {
+			if (!resolved_t) {
+				t = fy_thread_getspecific(tp->key);
+				tid = t ? (int)t->id : -1;
+				resolved_t = true;
+			}
+
+			if (t && fy_atomic_load(&t->next_work) == NULL) {
+				TDBG("%s: T#%d could not post, available to steal W:%p\n", __func__, tid, &works[1]);
+				assert(works[1].wp == NULL);
+
+				if (!wp)
+					wp = fy_work_pool_init(&wp_local, 1);
+
+				works[1].wp = wp;
+
+				expw = NULL;
+				if (!fy_atomic_compare_exchange_strong(&t->next_work, &expw, &works[1])) {
+					TDBG("%s: T#%d could not update next_work: W:%p\n", __func__, tid, &works[1]);
+					abort();
+				}
+
+				/* set the has loot bit */
+				fy_atomic_fetch_or(tp->lootp + (unsigned int)(t->id / 64), FY_BIT64(t->id & 63));
+
+				has_loot = true;
+			}
+		}
+	}
+
+	TDBG("%s: T#%d exec W:%p (left)\n", __func__, tid, &works[0]);
+
+	/* execute the direct work */
+	works[0].fn(works[0].arg);
+
+	if (has_loot) {
+		assert(t);
+		expw = &works[1];
+
+		/* clear the has loot bit unconditionally */
+		fy_atomic_fetch_and(tp->lootp + (unsigned int)(t->id / 64), ~FY_BIT64(t->id & 63));
+
+		if (!fy_atomic_compare_exchange_strong(&t->next_work, &expw, NULL)) {
+			TDBG("%s: T#%d had W:%p stolen\n", __func__, tid, &works[1]);
+		} else {
+			TDBG("%s: T#%d had W:%p not stolen\n", __func__, tid, &works[1]);
+
+			TDBG("%s: T#%d exec W:%p (right)\n", __func__, tid, &works[1]);
+			/* execute the direct work */
+			works[1].fn(works[1].arg);
+			fy_work_pool_signal(wp);
+		}
+
+	} else if (!pushed) {
+
+		TDBG("%s: T#%d exec W:%p (right)\n", __func__, tid, &works[1]);
+		/* execute the direct work */
+		works[1].fn(works[1].arg);
+		fy_work_pool_signal(wp);
+	}
+
+	TDBG("%s: T#%d wait WP:%p\n", __func__, tid, wp);
+
+	fy_work_pool_wait(wp);
+	fy_work_pool_cleanup(wp);
+
+	TDBG("%s: T#%d done WP:%p\n", __func__, tid, wp);
+}

--- a/numcosmo/external/libfyaml/src/thread/fy-thread.h
+++ b/numcosmo/external/libfyaml/src/thread/fy-thread.h
@@ -1,0 +1,94 @@
+/*
+ * fy-thread.h - Lighting fast thread pool implementation
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_THREAD_H
+#define FY_THREAD_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifndef _WIN32
+#include <pthread.h>
+#ifndef __APPLE__
+#include <semaphore.h>
+#else
+#include <dispatch/dispatch.h>
+#endif
+#endif
+
+#include "fy-win32.h"
+#include "fy-bit64.h"
+#include "fy-align.h"
+#include "fy-atomics.h"
+
+#include <libfyaml.h>
+
+// #define FY_THREAD_DEBUG		/* define to enable debugging information to stderr */
+// #define FY_THREAD_PORTABLE	/* define to use the portable implementation even on linux */
+
+struct fy_work_pool {
+	FY_ATOMIC(size_t) work_left;
+#if defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+	FY_ATOMIC(uint32_t) done;
+#elif defined(__APPLE__)
+	dispatch_semaphore_t sem;
+#elif defined(_WIN32)
+	HANDLE sem;
+#else
+	sem_t sem;
+#endif
+};
+
+struct fy_thread {
+	struct fy_thread_pool *tp;
+	unsigned int id;
+	FY_ATOMIC(struct fy_thread_work *)work;
+	FY_ATOMIC(struct fy_thread_work *)next_work;
+#ifndef _WIN32
+	pthread_t tid;
+#else
+	HANDLE tid;
+#endif
+#if defined(__linux__) && !defined(FY_THREAD_PORTABLE)
+	FY_ATOMIC(uint32_t) submit;
+	FY_ATOMIC(uint32_t) done;
+#elif defined(_WIN32)
+	HANDLE submit_event;
+	HANDLE done_event;
+	CRITICAL_SECTION lock;
+	CRITICAL_SECTION wait_lock;
+#else
+	pthread_mutex_t lock;
+	pthread_cond_t cond;
+	pthread_mutex_t wait_lock;
+	pthread_cond_t wait_cond;
+#endif
+};
+
+struct fy_thread_pool {
+	struct fy_thread_pool_cfg cfg;
+	unsigned int num_threads;
+	struct fy_thread *threads;
+	FY_ATOMIC(uint64_t) *freep;
+	FY_ATOMIC(uint64_t) *lootp;
+#if !defined(_WIN32)
+	pthread_key_t key;
+#else	// _WIN32
+	DWORD key;
+#endif
+};
+
+/* those are internal only */
+int fy_thread_pool_setup(struct fy_thread_pool *tp, const struct fy_thread_pool_cfg *cfg);
+void fy_thread_pool_cleanup(struct fy_thread_pool *tp);
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-align.h
+++ b/numcosmo/external/libfyaml/src/util/fy-align.h
@@ -1,0 +1,4 @@
+#ifndef FY_ALIGN_H
+#define FY_ALIGN_H
+#include <libfyaml/libfyaml-align.h>
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-atomics.h
+++ b/numcosmo/external/libfyaml/src/util/fy-atomics.h
@@ -1,0 +1,4 @@
+#ifndef FY_ATOMIC_H
+#define FY_ATOMIC_H
+#include <libfyaml/libfyaml-atomics.h>
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-bit64.h
+++ b/numcosmo/external/libfyaml/src/util/fy-bit64.h
@@ -1,0 +1,193 @@
+/*
+ * fy-bit64.h - various bit64 methods
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef FY_BIT64_H
+#define FY_BIT64_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+
+#define FY_BIT64(x) ((uint64_t)1 << (x))
+#define FY_BIT64_COUNT(_x) (((_x) + 63) / 64)
+#define FY_BIT64_SIZE(_x) ((size_t)((((_x) + 63) / 64) * sizeof(uint64_t)))
+
+#if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+
+#define FY_BIT64_LOWEST(_x) ((unsigned int)__builtin_ctzll((uint64_t)(_x)))
+#define FY_BIT64_HIGHEST(_x) ((unsigned int)__builtin_clzll((uint64_t)(_x)))
+#define FY_BIT64_POPCNT(_x) ((unsigned int)__builtin_popcountl((uint64_t)(_x)))
+#define FY_BIT64_FFS(_x) ((unsigned int)__builtin_ffsll((uint64_t)(_x)))
+
+static inline unsigned int fy_bit64_lowest(uint64_t x)
+{
+	return FY_BIT64_LOWEST(x);
+}
+
+static inline unsigned int fy_bit64_highest(uint64_t x)
+{
+	return FY_BIT64_HIGHEST(x);
+}
+
+static inline unsigned int fy_bit64_popcnt(uint64_t x)
+{
+	return FY_BIT64_POPCNT(x);
+}
+
+static inline unsigned int fy_bit64_ffs(uint64_t x)
+{
+	return FY_BIT64_FFS(x);
+}
+
+#elif defined(_MSC_VER)	/* MSVC implementation */
+
+#include <intrin.h>
+
+#if defined(_M_X64) || defined(_M_AMD64) || defined(_M_ARM64)
+/* 64-bit MSVC - use native 64-bit intrinsics */
+
+static inline unsigned int fy_bit64_lowest(uint64_t x)
+{
+	unsigned long index;
+	if (_BitScanForward64(&index, x))
+		return (unsigned int)index;
+	return 64;
+}
+
+static inline unsigned int fy_bit64_highest(uint64_t x)
+{
+	unsigned long index;
+	if (_BitScanReverse64(&index, x))
+		return 63 - (unsigned int)index;
+	return 64;
+}
+
+static inline unsigned int fy_bit64_popcnt(uint64_t x)
+{
+	return (unsigned int)__popcnt64(x);
+}
+
+static inline unsigned int fy_bit64_ffs(uint64_t x)
+{
+	unsigned long index;
+	if (x == 0)
+		return 0;
+	_BitScanForward64(&index, x);
+	return (unsigned int)index + 1;
+}
+
+#else
+/* 32-bit MSVC - use 32-bit intrinsics on halves */
+
+static inline unsigned int fy_bit64_lowest(uint64_t x)
+{
+	unsigned long index;
+	uint32_t lo = (uint32_t)x;
+	uint32_t hi = (uint32_t)(x >> 32);
+
+	if (lo && _BitScanForward(&index, lo))
+		return (unsigned int)index;
+	if (hi && _BitScanForward(&index, hi))
+		return (unsigned int)index + 32;
+	return 64;
+}
+
+static inline unsigned int fy_bit64_highest(uint64_t x)
+{
+	unsigned long index;
+	uint32_t lo = (uint32_t)x;
+	uint32_t hi = (uint32_t)(x >> 32);
+
+	if (hi && _BitScanReverse(&index, hi))
+		return 63 - ((unsigned int)index + 32);
+	if (lo && _BitScanReverse(&index, lo))
+		return 63 - (unsigned int)index;
+	return 64;
+}
+
+static inline unsigned int fy_bit64_popcnt(uint64_t x)
+{
+	uint32_t lo = (uint32_t)x;
+	uint32_t hi = (uint32_t)(x >> 32);
+	return (unsigned int)(__popcnt(lo) + __popcnt(hi));
+}
+
+static inline unsigned int fy_bit64_ffs(uint64_t x)
+{
+	unsigned long index;
+	uint32_t lo = (uint32_t)x;
+	uint32_t hi = (uint32_t)(x >> 32);
+
+	if (x == 0)
+		return 0;
+	if (lo && _BitScanForward(&index, lo))
+		return (unsigned int)index + 1;
+	if (hi && _BitScanForward(&index, hi))
+		return (unsigned int)index + 33;
+	return 0;
+}
+
+#endif /* 64-bit vs 32-bit MSVC */
+
+#define FY_BIT64_LOWEST(_x) fy_bit64_lowest(_x)
+#define FY_BIT64_HIGHEST(_x) fy_bit64_highest(_x)
+#define FY_BIT64_POPCNT(_x) fy_bit64_popcnt(_x)
+#define FY_BIT64_FFS(_x) fy_bit64_ffs(_x)
+
+#else	/* portable implementation */
+
+static inline unsigned int fy_bit64_lowest(uint64_t x)
+{
+	unsigned int c = 0;
+
+	if (!(x & 0x00000000ffffffffULL)) { x >>= 32; c += 32; }
+	if (!(x & 0x000000000000ffffULL)) { x >>= 16; c += 16; }
+	if (!(x & 0x00000000000000ffULL)) { x >>=  8; c +=  8; }
+	if (!(x & 0x000000000000000fULL)) { x >>=  4; c +=  4; }
+	if (!(x & 0x0000000000000003ULL)) { x >>=  2; c +=  2; }
+	if (!(x & 0x0000000000000001ULL)) {           c +=  1; }
+	return c;
+}
+
+static inline unsigned int fy_bit64_highest(uint64_t x)
+{
+	unsigned int c = 0;
+
+	if (x & 0xffffffff00000000ULL) { x >>= 32; c += 32; }
+	if (x & 0x00000000ffff0000ULL) { x >>= 16; c += 16; }
+	if (x & 0x000000000000ff00ULL) { x >>=  8; c +=  8; }
+	if (x & 0x00000000000000f0ULL) { x >>=  4; c +=  4; }
+	if (x & 0x000000000000000cULL) { x >>=  2; c +=  2; }
+	if (x & 0x0000000000000002ULL) {           c +=  1; }
+	return c;
+}
+
+static inline unsigned int fy_bit64_popcnt(uint64_t x)
+{
+	unsigned int count;
+
+	for (count = 0; x; x &= x - 1)
+		count++;
+	return count;
+}
+
+static inline unsigned int fy_bit64_ffs(uint64_t x)
+{
+	return x ? (fy_bit64_lowest(x) + 1) : 0;
+}
+
+#define FY_BIT64_LOWEST(_x) fy_bit64_lowest(_x)
+#define FY_BIT64_HIGHEST(_x) fy_bit64_highest(_x)
+#define FY_BIT64_POPCNT(_x) fy_bit64_popcnt(_x)
+#define FY_BIT64_FFS(_x) fy_bit64_ffs(_x)
+
+#endif
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-blob.c
+++ b/numcosmo/external/libfyaml/src/util/fy-blob.c
@@ -1,0 +1,147 @@
+/*
+ * fy-blob.c - binary blob handling
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/stat.h>
+#endif
+
+#include "fy-win32.h"
+#include "fy-blob.h"
+
+/* define optimized methods for probing */
+BR_DEFINE_WX(br_probe_w,  8, false, false);
+BR_DEFINE_WX(br_probe_w, 16, false, false);
+BR_DEFINE_WX(br_probe_w, 32, false, false);
+BR_DEFINE_WX(br_probe_w, 64, false, false);
+
+/* define optimized methods for writing */
+BR_DEFINE_WX(br_native_w,  8, false, true);
+BR_DEFINE_WX(br_native_w, 16, false, true);
+BR_DEFINE_WX(br_native_w, 32, false, true);
+BR_DEFINE_WX(br_native_w, 64, false, true);
+
+BR_DEFINE_WX(br_bswap_w,  8, true, true);
+BR_DEFINE_WX(br_bswap_w, 16, true, true);
+BR_DEFINE_WX(br_bswap_w, 32, true, true);
+BR_DEFINE_WX(br_bswap_w, 64, true, true);
+
+void *fy_blob_read(const char *file, size_t *sizep)
+{
+	struct stat sb;
+	void *blob = NULL;
+	uint8_t *p;
+	size_t size, left;
+	ssize_t rdn;
+	int fd = -1, rc;
+
+	if (!file || !sizep)
+		goto err_out;
+
+	fd = open(file, O_RDONLY);
+	if (fd < 0)
+		goto err_out;
+
+	rc = fstat(fd, &sb);
+	if (rc < 0)
+		goto err_out;
+
+	size = sb.st_size;
+	blob = malloc(size);
+	if (!blob)
+		goto err_out;
+
+	p = blob;
+	left = size;
+	while (left > 0) {
+		do {
+			rdn = read(fd, p, left);
+		} while (rdn == -1 && errno == EAGAIN);
+		if (rdn < 0)
+			goto err_out;
+		p += rdn;
+		left -= rdn;
+	}
+	close(fd);
+
+	*sizep = size;
+	return blob;
+
+err_out:
+	if (blob)
+		free(blob);
+	if (fd >= 0)
+		close(fd);
+	return NULL;
+}
+
+int fy_blob_write(const char *file, const void *blob, size_t size)
+{
+	int fd = -1;
+	const uint8_t *p;
+	size_t left;
+	ssize_t wrn;
+
+	if (!file || !blob)
+		return -1;
+
+	fd = open(file, O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IRGRP | S_IROTH);
+	if (fd < 0)
+		goto err_out;
+
+	p = blob;
+	left = size;
+	while (left > 0) {
+		do {
+			wrn = write(fd, p, left);
+		} while (wrn == -1 && errno == EAGAIN);
+		if (wrn < 0)
+			goto err_out;
+		p += wrn;
+		left -= wrn;
+	}
+	close(fd);
+
+	return 0;
+
+err_out:
+	if (fd >= 0)
+		close(fd);
+	return -1;
+}
+
+size_t br_wstr(struct blob_region *br, bool dedup, const char *str)
+{
+	const char *p, *e, *pt;
+	size_t tlen, len;
+
+	len = strlen(str);
+
+	/* search in the string table for duplicates */
+	if (dedup && br->wstart) {
+		p = (const char *)br->wstart;
+		e = p + br->curr;
+		while (p < e) {
+			tlen = strlen(p);
+			if (tlen >= len) {
+				pt = p + (tlen - len);
+				if (!memcmp(pt, str, len))
+					return (size_t)(pt - (const char *)br->wstart);
+			}
+			p += tlen + 1;
+		}
+	}
+	return br_write(br, str, len + 1);
+}

--- a/numcosmo/external/libfyaml/src/util/fy-blob.h
+++ b/numcosmo/external/libfyaml/src/util/fy-blob.h
@@ -1,0 +1,430 @@
+/*
+ * fy-blob.h - binary blob handling support
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_BLOB_H
+#define FY_BLOB_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+#include <stdint.h>
+#ifdef HAVE_BYTESWAP_H
+#include <byteswap.h>
+#else
+#ifdef HAVE___BUILTIN_BSWAP16
+#define bswap_16(value) __builtin_bswap16(value)
+#else
+#define bswap_16(value) ((((value)&0xff) << 8) | ((value) >> 8))
+#endif
+
+#ifdef HAVE___BUILTIN_BSWAP32
+#define bswap_32(value) __builtin_bswap32(value)
+#else
+#define bswap_32(value)                                                                            \
+  (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) |                                        \
+   (uint32_t)bswap_16((uint16_t)((value) >> 16)))
+#endif
+
+#ifdef HAVE___BUILTIN_BSWAP64
+#define bswap_64(value) __builtin_bswap64(value)
+#else
+#define bswap_64(value)                                                                            \
+  (((uint64_t)bswap_32((uint32_t)((value)&0xffffffff)) << 32) |                                    \
+   (uint64_t)bswap_32((uint32_t)((value) >> 32)))
+#endif
+#endif
+
+#include <stdbool.h>
+#include <time.h>
+
+#include "fy-utils.h"
+#include "fy-endian.h"
+
+/* special unaligned types for pointer accesses */
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+typedef union { uint64_t v; } __attribute__((__packed__)) br_64;
+typedef union { uint32_t v; } __attribute__((__packed__)) br_32;
+typedef union { uint16_t v; } __attribute__((__packed__)) br_16;
+typedef union { uint8_t v; } br_8;
+#elif defined(_MSC_VER)
+#pragma pack(push, 1)
+typedef union { uint64_t v; } br_64;
+typedef union { uint32_t v; } br_32;
+typedef union { uint16_t v; } br_16;
+typedef union { uint8_t v; } br_8;
+#pragma pack(pop)
+#else
+#error Unsupported compiler
+#endif
+
+enum blob_id_size {
+	BID_U8,
+	BID_U16,
+	BID_U32,
+	BID_U64,
+};
+
+static inline enum blob_id_size
+blob_count_to_id_size(uintmax_t count)
+{
+	if (count <= (1LLU << 8))
+		return BID_U8;
+	if (count <= (1LLU << 16))
+		return BID_U16;
+	if (count <= (1LLU << 32))
+		return BID_U32;
+	return BID_U64;
+}
+
+static inline unsigned int
+blob_id_size_to_byte_size(enum blob_id_size size)
+{
+	return 1U << size;
+}
+
+static inline unsigned int
+blob_id_size_to_bit_size(enum blob_id_size size)
+{
+	return blob_id_size_to_byte_size(size) * 8;
+}
+
+enum blob_endian_type {
+	BET_NATIVE_ENDIAN,
+	BET_LITTLE_ENDIAN,
+	BET_BIG_ENDIAN
+};
+
+struct blob_region {
+	union {
+		uint8_t *wstart;
+		const uint8_t *rstart;
+	};
+	size_t size;
+	enum blob_endian_type endian;
+	bool bswap;
+	size_t curr;
+};
+
+#define BR_DEFINE_WX(_pfx, _bits, _bswap, _write) \
+size_t _pfx ## _bits (struct blob_region *br, uint ## _bits ## _t v) \
+{ \
+	size_t pos; \
+\
+	if (_write) { \
+		if (_bswap) \
+			v = bswap_ ## _bits (v); \
+		((br_ ## _bits *)(br->wstart + br->curr))->v = v; \
+	} \
+	pos = br->curr; \
+	br->curr += sizeof(v); \
+	return pos; \
+} \
+struct __useless_struct_to_allow_semicolon
+
+#define BR_DEFINE_RX(_pfx, _bits, _bswap) \
+uint ## _bits ## _t _pfx ## _bits (struct blob_region *br) \
+{ \
+	uint ## _bits ## _t v; \
+\
+	v = ((const br_ ## _bits *)(br->rstart + br->curr))->v; \
+	if (_bswap) \
+		v = bswap_ ## _bits (v); \
+	br->curr += sizeof(v); \
+	return v; \
+} \
+struct __useless_struct_to_allow_semicolon
+
+static inline void br_setup_common(struct blob_region *br, size_t size, enum blob_endian_type endian)
+{
+	memset(br, 0, sizeof(*br));
+	br->size = size;
+	br->endian = endian;
+
+	switch (br->endian) {
+	case BET_NATIVE_ENDIAN:
+		/* native endian never needs swap */
+		br->bswap = false;
+		break;
+
+	case BET_LITTLE_ENDIAN:
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		br->bswap = false;
+#else
+		br->bswap = true;
+#endif
+		break;
+
+	case BET_BIG_ENDIAN:
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		br->bswap = true;
+#else
+		br->bswap = false;
+#endif
+		break;
+	}
+
+	br->curr = 0;
+}
+
+static inline void br_wsetup(struct blob_region *br, void *data, size_t size, enum blob_endian_type endian)
+{
+	/* write with null data means probe */
+	br_setup_common(br, size, endian);
+	br->wstart = data;
+}
+
+static inline void br_rsetup(struct blob_region *br, const void *data, size_t size, enum blob_endian_type endian)
+{
+	/* read makes no sense without data */
+	br_setup_common(br, size, endian);
+	br->rstart = data;
+}
+
+static inline void br_reset(struct blob_region *br)
+{
+	br->curr = 0;
+}
+
+static inline size_t br_curr(struct blob_region *br)
+{
+	return br->curr;
+}
+
+static inline size_t br_write(struct blob_region *br, const void *data, size_t size)
+{
+	size_t pos;
+
+	if (br->wstart)
+		memcpy(br->wstart + br->curr, data, size);
+	pos = br->curr;
+	br->curr += size;
+	return pos;
+}
+
+static inline size_t br_w0(struct blob_region *br, size_t size)
+{
+	size_t pos;
+
+	if (br->wstart)
+		memset(br->wstart + br->curr, 0, size);
+	pos = br->curr;
+	br->curr += size;
+	return pos;
+}
+
+static inline size_t br_wskip(struct blob_region *br, size_t size)
+{
+	return br_w0(br, size);
+}
+
+static inline size_t br_wskip_to(struct blob_region *br, size_t offset)
+{
+	return br_w0(br, offset - br->curr);
+}
+
+static inline BR_DEFINE_WX(br_w,  8, br->bswap, br->wstart != NULL);
+static inline BR_DEFINE_WX(br_w, 16, br->bswap, br->wstart != NULL);
+static inline BR_DEFINE_WX(br_w, 32, br->bswap, br->wstart != NULL);
+static inline BR_DEFINE_WX(br_w, 64, br->bswap, br->wstart != NULL);
+
+typedef size_t (*br_wid_func)(struct blob_region *br, int id);
+
+static inline size_t br_wid8(struct blob_region *br, int id)
+{
+	return br_w8(br, (uint8_t)id);
+}
+
+static inline size_t br_wid16(struct blob_region *br, int id)
+{
+	return br_w16(br, (uint16_t)id);
+}
+
+static inline size_t br_wid32(struct blob_region *br, int id)
+{
+	return br_w32(br, (uint32_t)id);
+}
+
+static inline size_t br_wid64(struct blob_region *br, int id)
+{
+	return br_w64(br, (uint64_t)id);
+}
+
+static inline br_wid_func br_wid_get_func(enum blob_id_size id_size)
+{
+	switch (id_size) {
+	case BID_U8:
+		return br_wid8;
+
+	case BID_U16:
+		return br_wid16;
+
+	case BID_U32:
+		return br_wid32;
+
+	case BID_U64:
+		return br_wid64;
+	}
+	return NULL;
+}
+
+/* write a string with optional dedup */
+size_t br_wstr(struct blob_region *br, bool dedup, const char *str);
+
+static inline size_t br_wX(struct blob_region *br, enum blob_id_size x_size, uint64_t x)
+{
+	switch (x_size) {
+	case BID_U8:
+		return br_w8(br, (uint8_t)x);
+
+	case BID_U16:
+		return br_w16(br, (uint16_t)x);
+
+	case BID_U32:
+		return br_w32(br, (uint32_t)x);
+
+	case BID_U64:
+		return br_w64(br, x);
+	}
+	return (size_t)-1;
+}
+
+static inline size_t br_wid(struct blob_region *br, enum blob_id_size id_size, int id)
+{
+	switch (id_size) {
+	case BID_U8:
+		return br_wid8(br, id);
+
+	case BID_U16:
+		return br_wid16(br, id);
+
+	case BID_U32:
+		return br_wid32(br, id);
+
+	case BID_U64:
+		return br_wid64(br, id);
+	}
+	return br->curr;
+}
+
+static inline size_t br_read(struct blob_region *br, void *data, size_t size)
+{
+	size_t pos;
+
+	memcpy(data, br->rstart + br->curr, size);
+	pos = br->curr;
+	br->curr += size;
+	return pos;
+}
+
+static inline void br_rskip(struct blob_region *br, size_t size)
+{
+	br->curr += size;
+}
+
+static inline void br_rskip_to(struct blob_region *br, size_t offset)
+{
+	br->curr = offset;
+}
+
+static inline BR_DEFINE_RX(br_r,  8, br->bswap);
+static inline BR_DEFINE_RX(br_r, 16, br->bswap);
+static inline BR_DEFINE_RX(br_r, 32, br->bswap);
+static inline BR_DEFINE_RX(br_r, 64, br->bswap);
+
+typedef int (*br_rid_func)(struct blob_region *br);
+
+static inline int br_rid8(struct blob_region *br)
+{
+	return (int)br_r8(br);
+}
+
+static inline int br_rid16(struct blob_region *br)
+{
+	return (int)br_r16(br);
+}
+
+static inline int br_rid32(struct blob_region *br)
+{
+	return (int)br_r32(br);
+}
+
+static inline int br_rid64(struct blob_region *br)
+{
+	return (int)br_r64(br);
+}
+
+static inline br_rid_func br_rid_get_func(enum blob_id_size id_size)
+{
+	switch (id_size) {
+	case BID_U8:
+		return br_rid8;
+
+	case BID_U16:
+		return br_rid16;
+
+	case BID_U32:
+		return br_rid32;
+
+	case BID_U64:
+		return br_rid64;
+	}
+	return NULL;
+}
+
+static inline uint64_t br_rX(struct blob_region *br, enum blob_id_size x_size)
+{
+	switch (x_size) {
+	case BID_U8:
+		return br_r8(br);
+
+	case BID_U16:
+		return br_r16(br);
+
+	case BID_U32:
+		return br_r32(br);
+
+	case BID_U64:
+		return br_r64(br);
+	}
+	FY_IMPOSSIBLE_ABORT();
+}
+
+static inline int br_rid(struct blob_region *br, enum blob_id_size id_size)
+{
+	int id;
+
+	switch (id_size) {
+	case BID_U8:
+		id = br_rid8(br);
+		break;
+
+	case BID_U16:
+		id = br_rid16(br);
+		break;
+
+	case BID_U32:
+		id = br_rid32(br);
+		break;
+
+	case BID_U64:
+		id = br_rid64(br);
+		break;
+
+	default:
+		id = -1;
+		FY_IMPOSSIBLE_ABORT();
+	}
+	return id;
+}
+
+void *fy_blob_read(const char *file, size_t *sizep);
+int fy_blob_write(const char *file, const void *blob, size_t size);
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-ctype.c
+++ b/numcosmo/external/libfyaml/src/util/fy-ctype.c
@@ -1,0 +1,67 @@
+/*
+ * fy-ctype.c - ctype utilities
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "fy-ctype.h"
+
+const char *fy_uri_esc(const char *s, size_t len, uint8_t *code, int *code_len)
+{
+	const char *e = s + len;
+	int j, k, width;
+	uint8_t octet;
+	char c;
+
+	width = 0;
+	k = 0;
+	do {
+		/* check for enough space for %XX */
+		if ((e - s) < 3)
+			return NULL;
+
+		/* if more than one run, expect '%' */
+		if (s[0] != '%')
+			return NULL;
+
+		octet = 0;
+		for (j = 0; j < 2; j++) {
+			c = s[1 + j];
+			octet <<= 4;
+			if (c >= '0' && c <= '9')
+				octet |= c - '0';
+			else if (c >= 'a' && c <= 'f')
+				octet |= 10 + c - 'a';
+			else
+				octet |= 10 + c - 'A';
+		}
+		if (!width) {
+			width = fy_utf8_width_by_first_octet(octet);
+			if (!width)
+				return NULL;
+			k = 0;
+		}
+		if (k >= *code_len)
+			return NULL;
+
+		code[k++] = octet;
+
+		/* skip over the 3 character escape */
+		s += 3;
+
+	} while (--width > 0);
+
+	*code_len = k;
+
+	return s;
+}
+

--- a/numcosmo/external/libfyaml/src/util/fy-ctype.h
+++ b/numcosmo/external/libfyaml/src/util/fy-ctype.h
@@ -1,0 +1,365 @@
+/*
+ * fy-ctype.h - ctype like macros header
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_CTYPE_H
+#define FY_CTYPE_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "fy-utf8.h"
+
+enum fy_lb_mode {
+	fylb_cr_nl,			/* only \r, \n (json + >= yaml1.2 */
+	fylb_cr_nl_N_L_P,		/* NEL/LS/PS (yaml1.1) */
+};
+
+enum fy_flow_ws_mode {
+	fyfws_space_tab,		/* space + TAB (yaml) */
+	fyfws_space,			/* only space (json) */
+};
+
+static inline bool fy_is_first_alpha(const int c)
+{
+	return (c >= 'a' && c <= 'z') ||
+	       (c >= 'A' && c <= 'Z') ||
+	       c == '_';
+}
+
+static inline bool fy_is_alpha(const int c)
+{
+	return fy_is_first_alpha(c) || c == '-';
+}
+
+static inline bool fy_is_num(const int c)
+{
+	return c >= '0' && c <= '9';
+}
+
+static inline bool fy_is_digit(const int c)
+{
+	return c >= '0' && c <= '9';
+}
+
+static inline bool fy_is_xdigit(const int c)
+{
+	return fy_is_digit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+static inline bool fy_is_first_alnum(const int c)
+{
+	return fy_is_first_alpha(c);
+}
+
+static inline bool fy_is_alnum(const int c)
+{
+	return fy_is_alpha(c) || fy_is_num(c);
+}
+
+static inline bool fy_is_space(const int c)
+{
+	return fy_utf8_is_space(c);
+}
+
+static inline bool fy_is_tab(const int c)
+{
+	return fy_utf8_is_tab(c);
+}
+
+static inline bool fy_is_ws(const int c)
+{
+	return fy_utf8_is_ws(c);
+}
+
+static inline bool fy_is_hex(const int c)
+{
+	return fy_utf8_is_hex(c);
+}
+
+static inline bool fy_is_flow_indicator(const int c)
+{
+	return fy_utf8_is_flow_indicator(c);
+}
+
+static inline bool fy_is_lb_r_n(const int c)
+{
+	return fy_utf8_is_lb(c);
+}
+
+static inline bool fy_is_blank(const int c)
+{
+	return fy_utf8_is_ws(c);
+}
+
+static inline bool fy_is_blank_lb_r_n(const int c)
+{
+	return fy_utf8_is_ws_lb(c);
+}
+
+static inline bool fy_is_uri(const int c)
+{
+	return fy_is_alnum(c) || fy_utf8_strchr(";/?:@&=+$,.!~*\'()[]%", c);
+}
+
+static inline bool fy_is_lb_NEL(const int c)
+{
+	return c == 0x85;
+}
+
+static inline bool fy_is_lb_LS_PS(const int c)
+{
+	return c == 0x2028 || c == 0x2029;
+}
+
+static inline bool fy_is_unicode_lb(const int c)
+{
+	/* note that YAML1.1 supports NEL #x85, LS #x2028 and PS #x2029 as linebreaks */
+	/* YAML1.2 and higher does not */
+	return fy_is_lb_NEL(c) || fy_is_lb_LS_PS(c);
+}
+
+static inline bool fy_is_any_lb(const int c)
+{
+	return fy_is_lb_r_n(c) || fy_is_unicode_lb(c);
+}
+
+static inline bool fy_is_z(const int c)
+{
+	return c <= 0;
+}
+
+#define FY_UTF8_BOM	0xfeff
+
+static inline bool fy_is_print(const int c)
+{
+	return c == '\n' || c == '\r' ||
+	       (c >= 0x0020 && c <= 0x007e) ||
+	       (c >= 0x00a0 && c <= 0xd7ff) ||
+	       (c >= 0xe000 && c <= 0xfffd && c != FY_UTF8_BOM);
+}
+
+static inline bool fy_is_printq(const int c)
+{
+	return c != '\t' && c != 0xa0 && !fy_is_any_lb(c) && fy_is_print(c);
+}
+
+static inline bool fy_is_nb_char(const int c)
+{
+	return (c >= 0x0020 && c <= 0x007e) ||
+	       (c >= 0x00a0 && c <= 0xd7ff) ||
+	       (c >= 0xe000 && c <= 0xfffd && c != FY_UTF8_BOM);
+}
+
+static inline bool fy_is_ns_char(const int c)
+{
+	return fy_is_nb_char(c) && !fy_is_ws(c);
+}
+
+static inline bool fy_is_start_indicator(const int c)
+{
+	return !!fy_utf8_strchr(",[]{}#&*!|>'\"%%@`", c);
+}
+
+static inline bool fy_is_indicator_before_space(const int c)
+{
+	return !!fy_utf8_strchr("-:?`", c);
+}
+
+static inline bool fy_is_path_flow_scalar_start(const int c)
+{
+	return c == '\'' || c == '"';
+}
+
+static inline bool fy_is_path_flow_key_start(const int c)
+{
+	return c == '"' || c == '\'' || c == '{' || c == '[';
+}
+
+static inline bool fy_is_path_flow_key_end(const int c)
+{
+	return c == '"' || c == '\'' || c == '}' || c == ']';
+}
+
+static inline bool fy_is_unicode_control(const int c)
+{
+        return (c >= 0 && c <= 0x1f) || (c >= 0x80 && c <= 0x9f);
+}
+
+static inline bool fy_is_unicode_space(const int c)
+{
+        return c == 0x20 || c == 0xa0 ||
+               (c >= 0x2000 && c <= 0x200a) ||
+               c == 0x202f || c == 0x205f || c == 0x3000;
+}
+
+static inline bool fy_is_json_unescaped(const int c)
+{
+	return c >= 0x20 && c <= 0x110000 && c != '"' && c != '\\';
+}
+
+static inline bool fy_is_json_unescaped_range_only(const int c)
+{
+	return c >= 0x20 && c <= 0x110000;
+}
+
+static inline bool fy_is_lb_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	if (fy_is_lb_r_n(c))
+		return true;
+	return lb_mode == fylb_cr_nl_N_L_P && fy_is_unicode_lb(c);
+}
+
+static inline bool fy_is_generic_lb_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	if (fy_is_lb_r_n(c))
+		return true;
+	return lb_mode == fylb_cr_nl_N_L_P && fy_is_lb_NEL(c);
+}
+
+static inline bool fy_is_blank_lb_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	if (fy_is_blank_lb_r_n(c))
+		return true;
+	return lb_mode == fylb_cr_nl_N_L_P && fy_is_unicode_lb(c);
+}
+
+static inline bool fy_is_lbz_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	return fy_is_lb_m(c, lb_mode) || fy_is_z(c);
+}
+
+static inline bool fy_is_generic_lbz_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	return fy_is_generic_lb_m(c, lb_mode) || fy_is_z(c);
+}
+
+static inline bool fy_is_blankz_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	return fy_is_ws(c) || fy_is_lbz_m(c, lb_mode);
+}
+
+static inline bool fy_is_generic_blankz_m(const int c, const enum fy_lb_mode lb_mode)
+{
+	return fy_is_ws(c) || fy_is_generic_lbz_m(c, lb_mode);
+}
+
+static inline bool fy_is_flow_ws_m(const int c, const enum fy_flow_ws_mode fws_mode)
+{
+	return fy_is_space(c) || (fws_mode == fyfws_space_tab && fy_is_tab(c));
+}
+
+#define FY_CTYPE_AT_BUILDER(_kind) \
+static inline const void * \
+fy_find_ ## _kind (const void *s, size_t len) \
+{ \
+	const char *sc = (const char *)s; \
+	const char *e = sc + len; \
+	int c, w; \
+	for (; sc < e && (c = fy_utf8_get(sc, (size_t)(e - sc), &w)) >= 0; sc += w) { \
+		assert(w); \
+		if (fy_is_ ## _kind (c)) \
+			return sc; \
+	} \
+	return NULL; \
+} \
+static inline const void * \
+fy_find_non_ ## _kind (const void *s, size_t len) \
+{ \
+	const char *sc = (const char *)s; \
+	const char *e = sc + len; \
+	int c, w; \
+	for (; sc < e && (c = fy_utf8_get(sc, (size_t)(e - sc), &w)) >= 0; sc += w) { \
+		assert(w); \
+		if (!(fy_is_ ## _kind (c))) \
+			return sc; \
+		assert(w); \
+	} \
+	return NULL; \
+} \
+struct useless_struct_for_semicolon
+
+FY_CTYPE_AT_BUILDER(first_alpha);
+FY_CTYPE_AT_BUILDER(alpha);
+FY_CTYPE_AT_BUILDER(num);
+FY_CTYPE_AT_BUILDER(digit);
+FY_CTYPE_AT_BUILDER(xdigit);
+FY_CTYPE_AT_BUILDER(first_alnum);
+FY_CTYPE_AT_BUILDER(alnum);
+FY_CTYPE_AT_BUILDER(space);
+FY_CTYPE_AT_BUILDER(tab);
+FY_CTYPE_AT_BUILDER(ws);
+FY_CTYPE_AT_BUILDER(hex);
+FY_CTYPE_AT_BUILDER(uri);
+FY_CTYPE_AT_BUILDER(z);
+FY_CTYPE_AT_BUILDER(any_lb);
+FY_CTYPE_AT_BUILDER(blank);
+FY_CTYPE_AT_BUILDER(print);
+FY_CTYPE_AT_BUILDER(printq);
+FY_CTYPE_AT_BUILDER(nb_char);
+FY_CTYPE_AT_BUILDER(ns_char);
+FY_CTYPE_AT_BUILDER(start_indicator);
+FY_CTYPE_AT_BUILDER(indicator_before_space);
+FY_CTYPE_AT_BUILDER(flow_indicator);
+FY_CTYPE_AT_BUILDER(path_flow_key_start);
+FY_CTYPE_AT_BUILDER(path_flow_key_end);
+FY_CTYPE_AT_BUILDER(unicode_control);
+FY_CTYPE_AT_BUILDER(unicode_space);
+FY_CTYPE_AT_BUILDER(json_unescaped);
+
+/*
+ * Very special linebreak/ws methods
+ * Things get interesting due to \r\n and
+ * unicode linebreaks/spaces
+ */
+
+/* skip for a _single_ linebreak */
+static inline const void *fy_skip_lb(const void *ptr, size_t left)
+{
+	int c, width;
+
+	/* get the utf8 character at this point */
+	c = fy_utf8_get(ptr, left, &width);
+	if (c < 0 || !fy_is_any_lb(c))
+		return NULL;
+
+	/* MS-DOS: check if next character is '\n' */
+	if (c == '\r' && left > (size_t)width && *(char *)ptr == '\n')
+		width++;
+
+	return (const char *)ptr + width;
+}
+
+/* given a pointer to a chunk of memory, return pointer to first
+ * ws character after the last non-ws character, or the end
+ * of the chunk
+ */
+static inline const void *fy_last_non_ws(const void *ptr, size_t left)
+{
+	const char *s, *e;
+	int c;
+
+	s = ptr;
+	e = s + left;
+	while (e > s) {
+		c = e[-1];
+		if (c != ' ' && c != '\t')
+			return e;
+		e--;
+
+	}
+	return NULL;
+}
+
+const char *fy_uri_esc(const char *s, size_t len, uint8_t *code, int *code_len);
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-endian.h
+++ b/numcosmo/external/libfyaml/src/util/fy-endian.h
@@ -1,0 +1,4 @@
+#ifndef FY_ENDIAN_H
+#define FY_ENDIAN_H
+#include <libfyaml/libfyaml-endian.h>
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-id.h
+++ b/numcosmo/external/libfyaml/src/util/fy-id.h
@@ -1,0 +1,239 @@
+/*
+ * fy-id.h - small ID allocator
+ *
+ * Copyright (c) 2023 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_ID_H
+#define FY_ID_H
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <stdint.h>
+
+#include "fy-bit64.h"
+#include "fy-atomics.h"
+
+typedef uint64_t fy_id_bits_non_atomic;
+typedef FY_ATOMIC(fy_id_bits_non_atomic) fy_id_bits;
+
+#define FY_ID_BITS_SZ		((size_t)(sizeof(fy_id_bits)))
+#define FY_ID_BITS_BITS 	(FY_ID_BITS_SZ * 8)	/* yes, every character is 8 bits in 2023 */
+#define FY_ID_BITS_MASK		((uint64_t)(FY_ID_BITS_BITS - 1))
+
+#define FY_ID_BITS_ARRAY_COUNT_BITS(_bits) \
+	(((_bits) + FY_ID_BITS_MASK) & ~FY_ID_BITS_MASK)
+
+#define FY_ID_BITS_ARRAY_COUNT(_bits) \
+	(FY_ID_BITS_ARRAY_COUNT_BITS(_bits) / FY_ID_BITS_BITS)
+
+#define FY_ID_OFFSET(_id)	((_id) / FY_ID_BITS_BITS)
+#define FY_ID_BIT_MASK(_id)	((uint64_t)1 << ((_id) & FY_ID_BITS_MASK))
+
+static inline int fy_id_ffs(const fy_id_bits_non_atomic id_bit)
+{
+	if (!id_bit)
+		return -1;
+	return FY_BIT64_FFS(id_bit) - 1;
+}
+
+static inline int fy_id_popcount(const fy_id_bits_non_atomic id_bit)
+{
+	return FY_BIT64_POPCNT(id_bit);
+}
+
+static inline void fy_id_reset(fy_id_bits *bits, const size_t count)
+{
+	size_t i;
+
+	for (i = 0; i < count; i++, bits++)
+		fy_atomic_store(bits, 0);
+}
+
+static inline int fy_id_alloc(fy_id_bits *bits, const size_t count)
+{
+	size_t i;
+	int pos;
+	fy_id_bits_non_atomic v, new_v;
+
+	for (i = 0; i < count; i++, bits++) {
+		for (;;) {
+			v = fy_atomic_load(bits);
+			pos = fy_id_ffs(~v);
+			if (pos < 0)
+				break;
+			new_v = v | FY_ID_BIT_MASK(pos);
+			if (fy_atomic_compare_exchange_strong(bits, &v, new_v))
+				return ((int)i * FY_ID_BITS_BITS) + pos;
+		}
+	}
+	return -1;
+}
+
+static inline int fy_id_alloc_fixed(fy_id_bits *bits, const size_t count, const int id)
+{
+	size_t offset;
+	fy_id_bits_non_atomic m, v, new_v;
+
+	offset = FY_ID_OFFSET(id);
+	if (offset >= count)
+		return -1;
+	bits += offset;
+
+	m = FY_ID_BIT_MASK(id);
+	v = fy_atomic_load(bits);
+	if (v & m)
+		return -1;
+	new_v = v | m;
+	if (!fy_atomic_compare_exchange_strong(bits, &v, new_v))
+		return -1;
+
+	return id;
+}
+
+static inline bool fy_id_is_used(fy_id_bits *bits, const size_t count, const int id)
+{
+	fy_id_bits_non_atomic v;
+	size_t offset;
+
+	offset = FY_ID_OFFSET(id);
+	if (offset >= count)
+		return false;
+	bits += offset;
+	v = fy_atomic_load(bits);
+	return !!(v & FY_ID_BIT_MASK(id));
+}
+
+static inline bool fy_id_is_free(fy_id_bits *bits, const size_t count, const int id)
+{
+	fy_id_bits_non_atomic v;
+	size_t offset;
+
+	offset = FY_ID_OFFSET(id);
+	if (offset >= count)
+		return false;
+	bits += offset;
+	v = fy_atomic_load(bits);
+	return !(v & FY_ID_BIT_MASK(id));
+}
+
+static inline void fy_id_free(fy_id_bits *bits, const size_t count, int id)
+{
+	size_t offset;
+
+	offset = FY_ID_OFFSET(id);
+	if (offset >= count)
+		return;
+	bits += offset;
+	fy_atomic_fetch_and(bits, ~FY_ID_BIT_MASK(id));	/* no need to check, if bit is free, it is still free */
+}
+
+static inline void fy_id_set_used(fy_id_bits *bits, const size_t count, const int id)
+{
+	size_t offset;
+
+	offset = FY_ID_OFFSET(id);
+	if (offset >= count)
+		return;
+	bits += offset;
+	fy_atomic_fetch_or(bits, FY_ID_BIT_MASK(id));
+}
+
+static inline void fy_id_set_free(fy_id_bits *bits, const size_t count, const int id)
+{
+	size_t offset;
+
+	offset = FY_ID_OFFSET(id);
+	if (offset >= count)
+		return;
+	bits += offset;
+	fy_atomic_fetch_and(bits, ~FY_ID_BIT_MASK(id));
+}
+
+static inline size_t fy_id_count_used(fy_id_bits *bits, const size_t count)
+{
+	fy_id_bits v;
+	size_t i, popcount;
+
+	popcount = 0;
+	for (i = 0; i < count; i++, bits++) {
+		v = fy_atomic_load(bits);
+		popcount += fy_id_popcount(v);
+	}
+	return popcount;
+}
+
+static inline size_t fy_id_count_free(fy_id_bits *bits, const size_t count)
+{
+	return count - fy_id_count_used(bits, count);
+}
+
+struct fy_id_iter {
+	const fy_id_bits *s;
+	fy_id_bits m;
+};
+
+static inline void fy_id_iter_begin(const fy_id_bits *bits, const size_t count, struct fy_id_iter *iterp)
+{
+	iterp->s = bits;
+	iterp->m = ~(fy_id_bits_non_atomic)0;
+}
+
+static inline int fy_id_iter_next(const fy_id_bits *bits, const size_t count, struct fy_id_iter *iterp)
+{
+	const fy_id_bits *s, *e;
+	fy_id_bits_non_atomic v, m;
+	int pos;
+
+	s = iterp->s;
+	if (!s)
+		return -1;
+
+	m = iterp->m;
+	e = bits + count;
+
+	if (s >= e)
+		return -1;
+
+	/* scan until we find a set bit or hit the end */
+	pos = -1;
+	while (s < e) {
+		v = fy_atomic_load(s);
+		pos = fy_id_ffs(v & m);
+		if (pos >= 0)
+			break;
+		s++;
+		m = ~(fy_id_bits_non_atomic)0;
+	}
+
+	/* not found */
+	if (pos < 0) {
+		iterp->s = NULL;
+		iterp->m = 0;
+		return -1;
+	}
+
+	/* remove this bit from the mask */
+	m &= ~((fy_id_bits_non_atomic)1 << pos);
+
+	/* advance by the number of fy_id_bits we scanned */
+	pos += (int)(s - bits) * FY_ID_BITS_BITS;
+
+	/* if we run out of mask, advance */
+	if (!m) {
+		s++;
+		m = ~(fy_id_bits_non_atomic)0;
+	}
+	iterp->s = s;
+	iterp->m = m;
+	return pos;
+}
+
+static inline void fy_id_iter_end(const fy_id_bits *bits, const size_t count, const struct fy_id_iter *iterp)
+{
+	/* nothing */
+}
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-list.h
+++ b/numcosmo/external/libfyaml/src/util/fy-list.h
@@ -1,0 +1,92 @@
+/*
+ * fy-list.h - Circular doubly-linked list implementation
+ *
+ * Copyright (c) 2025 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_LIST_H
+#define FY_LIST_H
+
+struct list_head {
+	struct list_head *next;
+	struct list_head *prev;
+};
+
+static inline void list_init(struct list_head *list)
+{
+	list->next = list->prev = list;
+}
+
+static inline void list_add(struct list_head *new_item, struct list_head *head)
+{
+	struct list_head *prev = head;
+	struct list_head *next = head->next;
+
+	next->prev = new_item;
+	new_item->next = next;
+	new_item->prev = prev;
+	prev->next = new_item;
+}
+
+static inline void list_add_tail(struct list_head *new_item, struct list_head *head)
+{
+	struct list_head *prev = head->prev;
+	struct list_head *next = head;
+
+	next->prev = new_item;
+	new_item->next = next;
+	new_item->prev = prev;
+	prev->next = new_item;
+}
+
+static inline void list_del(struct list_head *entry)
+{
+	struct list_head *prev = entry->prev;
+	struct list_head *next = entry->next;
+
+	next->prev = prev;
+	prev->next = next;
+}
+
+static inline int list_empty(const struct list_head *head)
+{
+	return head->next == head;
+}
+
+static inline int list_is_singular(const struct list_head *head)
+{
+	return !list_empty(head) && head->next == head->prev;
+}
+
+static inline void list_splice(const struct list_head *list,
+			       struct list_head *head)
+{
+	struct list_head *first = list->next;
+	struct list_head *last = list->prev;
+	struct list_head *prev = head;
+	struct list_head *next = head->next;
+
+	if (list_empty(list))
+		return;
+
+	first->prev = prev;
+	prev->next = first;
+
+	last->next = next;
+	next->prev = last;
+}
+
+#undef list_entry
+#define list_entry(ptr, type, member) \
+	container_of(ptr, type, member)
+
+#undef list_first_entry
+#define list_first_entry(ptr, type, member) \
+	list_entry((ptr)->next, type, member)
+
+#undef list_last_entry
+#define list_last_entry(ptr, type, member) \
+	list_entry((ptr)->prev, type, member)
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-typelist.h
+++ b/numcosmo/external/libfyaml/src/util/fy-typelist.h
@@ -1,0 +1,159 @@
+/*
+ * fy-typelist.h - typed list method builders
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_TYPELIST_H
+#define FY_TYPELIST_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "fy-list.h"
+
+/* declare type methods */
+
+#define FY_TYPE_FWD_DECL_LIST(_type) \
+/* type safe list wrapper */ \
+struct fy_ ## _type ## _list { struct list_head _lh; }; \
+\
+struct __useless_struct_to_allow_semicolon
+
+#define FY_TYPE_DECL_LIST(_type) \
+static inline void fy_ ## _type ## _list_init(struct fy_ ## _type ## _list *_l) \
+{ \
+	list_init(&_l->_lh); \
+} \
+static inline void fy_ ## _type ## _list_add(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _n) \
+		list_add(&_n->node, &_l->_lh); \
+} \
+static inline void fy_ ## _type ## _list_add_tail(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _n) \
+		list_add_tail(&_n->node, &_l->_lh); \
+} \
+static inline void fy_ ## _type ## _list_push(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _n) \
+		fy_ ## _type ## _list_add(_l, _n); \
+} \
+static inline void fy_ ## _type ## _list_push_tail(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _n) \
+		fy_ ## _type ## _list_add_tail(_l, _n); \
+} \
+static inline bool fy_ ## _type ## _list_empty(struct fy_ ## _type ## _list *_l) \
+{ \
+	return _l ? list_empty(&_l->_lh) : true; \
+} \
+static inline bool fy_ ## _type ## _list_is_singular(struct fy_ ## _type ## _list *_l) \
+{ \
+	return _l ? list_is_singular(&_l->_lh) : true; \
+} \
+static inline void fy_ ## _type ## _list_del(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _n) \
+		list_del(&_n->node); \
+} \
+static inline void fy_ ## _type ## _list_insert_after(struct fy_ ## _type ## _list *_l, \
+		struct fy_ ## _type *_p, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _p && _n) \
+		list_add(&_n->node, &_p->node); \
+} \
+static inline void fy_ ## _type ## _list_insert_before(struct fy_ ## _type ## _list *_l, \
+		struct fy_ ## _type *_p, struct fy_ ## _type *_n) \
+{ \
+	if (_l && _p && _n) \
+		list_add_tail(&_n->node, &_p->node); \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _list_head(struct fy_ ## _type ## _list *_l) \
+{ \
+	return !fy_ ## _type ## _list_empty(_l) ? list_first_entry(&_l->_lh, struct fy_ ## _type, node) : NULL; \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _list_tail(struct fy_ ## _type ## _list *_l) \
+{ \
+	return !fy_ ## _type ## _list_empty(_l) ? list_last_entry(&_l->_lh, struct fy_ ## _type, node) : NULL; \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _list_first(struct fy_ ## _type ## _list *_l) \
+{ \
+	return fy_ ## _type ## _list_head(_l); \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _list_last(struct fy_ ## _type ## _list *_l) \
+{ \
+	return fy_ ## _type ## _list_tail(_l); \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _list_pop(struct fy_ ## _type ## _list *_l) \
+{ \
+	struct fy_ ## _type *_n; \
+	\
+	_n = fy_ ## _type ## _list_head(_l); \
+	if (!_n) \
+		return NULL; \
+	fy_ ## _type ## _list_del(_l, _n); \
+	return _n; \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _list_pop_tail(struct fy_ ## _type ## _list *_l) \
+{ \
+	struct fy_ ## _type *_n; \
+	\
+	_n = fy_ ## _type ## _list_tail(_l); \
+	if (!_n) \
+		return NULL; \
+	fy_ ## _type ## _list_del(_l, _n); \
+	return _n; \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _next(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (!_n || !_l || _n->node.next == &_l->_lh) \
+		return NULL; \
+	return list_entry(_n->node.next, struct fy_ ## _type, node); \
+} \
+static inline struct fy_ ## _type *fy_ ## _type ## _prev(struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n) \
+{ \
+	if (!_n || !_l || _n->node.prev == &_l->_lh) \
+		return NULL; \
+	return list_entry(_n->node.prev, struct fy_ ## _type, node); \
+} \
+static inline void fy_ ## _type ## _lists_splice( \
+		struct fy_ ## _type ## _list *_l, \
+		struct fy_ ## _type ## _list *_lfrom) \
+{ \
+	/* check arguments for sanity and lists are not empty */ \
+	if (!_l || !_lfrom || \
+	    fy_ ## _type ## _list_empty(_lfrom)) \
+		return; \
+	list_splice(&_lfrom->_lh, &_l->_lh); \
+} \
+static inline void fy_ ## _type ## _list_splice_after( \
+		struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n, \
+		struct fy_ ## _type ## _list *_lfrom) \
+{ \
+	/* check arguments for sanity and lists are not empty */ \
+	if (!_l || !_n || !_lfrom || \
+	    fy_ ## _type ## _list_empty(_lfrom)) \
+		return; \
+	list_splice(&_lfrom->_lh, &_n->node); \
+} \
+static inline void fy_ ## _type ## _list_splice_before( \
+		struct fy_ ## _type ## _list *_l, struct fy_ ## _type *_n, \
+		struct fy_ ## _type ## _list *_lfrom) \
+{ \
+	/* check arguments for sanity and lists are not empty */ \
+	if (!_l || !_n || !_lfrom || \
+	    fy_ ## _type ## _list_empty(_lfrom)) \
+		return; \
+	list_splice(&_lfrom->_lh, _n->node.prev); \
+} \
+struct __useless_struct_to_allow_semicolon
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-utf8.c
+++ b/numcosmo/external/libfyaml/src/util/fy-utf8.c
@@ -1,0 +1,1059 @@
+/*
+ * fy-utf8.c - utf8 handling methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "fy-utf8.h"
+
+/* to avoid dragging in libfyaml.h */
+#ifndef FY_BIT
+#define FY_BIT(x) (1U << (x))
+#endif
+
+const int8_t fy_utf8_width_table[32] = {
+	1, 1, 1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1, 1, 1,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	2, 2, 2, 2, 3, 3, 4, 0,
+};
+
+int fy_utf8_get_generic(const void *ptr, size_t left, int *widthp)
+{
+	const uint8_t *p = ptr;
+	int i, width, value;
+
+	if (left < 1)
+		return FYUG_EOF;
+
+	/* this is the slow path */
+	width = fy_utf8_width_by_first_octet(p[0]);
+	if (!width)
+		return FYUG_INV;
+	if ((size_t)width > left)
+		return FYUG_PARTIAL;
+
+	/* initial value */
+	value = *p++ & (0xff >> width);
+	for (i = 1; i < width; i++) {
+		if ((*p & 0xc0) != 0x80)
+			return FYUG_INV;
+		value = (value << 6) | (*p++ & 0x3f);
+	}
+
+	if (!fy_utf8_is_valid(value))
+		return FYUG_INV;
+
+	*widthp = width;
+
+	return value;
+}
+
+int fy_utf8_get_right_generic(const void *ptr, size_t left, int *widthp)
+{
+	const uint8_t *s, *e;
+	uint8_t v;
+
+	s = ptr;
+	e =  s + left;
+
+	if (left < 1)
+		return FYUG_EOF;
+
+	/* single byte sequence */
+	v = e[-1];
+	if ((v & 0x80) == 0) {
+		if (widthp)
+			*widthp = 1;
+		return (int)v & 0x7f;
+	}
+
+	/* the last byte must be & 0xc0 == 0x80 */
+	if ((v & 0xc0) != 0x80)
+		return FYUG_INV;
+
+	/* at least two byte sequence */
+	if (left < 2)
+		return FYUG_EOF;
+
+	v = e[-2];
+	/* the first byte of the sequence (must be a two byte sequence) */
+	if ((v & 0xc0) != 0x80) {
+		/* two byte start is 110x_xxxx */
+		if ((v & 0xe0) != 0xc0)
+			return FYUG_INV;
+		return fy_utf8_get(e - 2, 2, widthp);
+	}
+
+	/* at least three byte sequence */
+	if (left < 3)
+		return FYUG_EOF;
+
+	v = e[-3];
+	/* the first byte of the sequence (must be a three byte sequence) */
+	if ((v & 0xc0) != 0x80) {
+		/* three byte start is 1110_xxxx */
+		if ((v & 0xf0) != 0xe0)
+			return FYUG_INV;
+		return fy_utf8_get(e - 3, 3, widthp);
+	}
+
+	/* at least four byte sequence */
+	if (left < 4)
+		return FYUG_EOF;
+
+	v = e[-4];
+
+	/* the first byte of the sequence (must be a four byte sequence) */
+	/* four byte start is 1111_0xxx */
+	if ((v & 0xf8) != 0xf0) {
+		return FYUG_INV;
+	}
+	return fy_utf8_get(e - 4, 4, widthp);
+}
+
+struct fy_utf8_fmt_esc_map {
+	const int *ch;
+	const int *map;
+};
+
+static const struct fy_utf8_fmt_esc_map esc_all = {
+	.ch  = (const int []){ '\\', '\0', '\b', '\r', '\t', '\f', '\n', '\v', '\a', '\x1b', 0x85, 0xa0, 0x2028, 0x2029, -1 },
+	.map = (const int []){ '\\',  '0',  'b',  'r',  't',  'f',  'n',  'v',  'a',  'e',  'N',  '_',    'L',    'P',  0 }
+};
+
+static inline int esc_map(const struct fy_utf8_fmt_esc_map *esc_map, int c)
+{
+	const int *ch;
+	int cc;
+
+	ch = esc_map->ch;
+	while ((cc = *ch++) >= 0) {
+		if (cc == c)
+			return esc_map->map[(ch - esc_map->ch) - 1];
+	}
+	return -1;
+}
+
+static inline int fy_utf8_esc_map(int c, enum fy_utf8_escape esc)
+{
+	if (esc == fyue_none)
+		return -1;
+	if (esc == fyue_singlequote && c == '\'')
+		return '\'';
+	if (fy_utf8_escape_is_any_doublequote(esc) && c == '"')
+		return '"';
+	return esc_map(&esc_all, c);
+}
+
+size_t fy_utf8_format_text_length(const char *buf, size_t len,
+			          enum fy_utf8_escape esc)
+{
+	int c, w;
+	ssize_t l;
+	const char *s, *e;
+
+	s = buf;
+	e = buf + len;
+	l = 0;
+	while (s < e) {
+		c = fy_utf8_get(s, e - s, &w);
+		if (!w || c < 0)
+			break;
+		s += w;
+		if (fy_utf8_esc_map(c, esc))
+			w = 2;
+		l += w;
+	}
+	return l + 1;
+}
+
+char *fy_utf8_format_text(const char *buf, size_t len,
+			  char *out, size_t maxsz,
+			  enum fy_utf8_escape esc)
+{
+	int c, w, cc;
+	const char *s, *e;
+	char *os, *oe;
+
+	s = buf;
+	e = buf + len;
+	os = out;
+	oe = out + maxsz - 1;
+	while (s < e) {
+		c = fy_utf8_get(s, e - s, &w);
+		if (!w || c < 0)
+			break;
+		s += w;
+
+		if ((cc = fy_utf8_esc_map(c, esc)) > 0) {
+			if (os + 2 > oe)
+				break;
+			*os++ = '\\';
+			*os++ = cc;
+			continue;
+		}
+
+		if (os + w > oe)
+			break;
+
+		os = fy_utf8_put_unchecked(os, c);
+	}
+	*os++ = '\0';
+	return out;
+}
+
+char *fy_utf8_format(int c, char *buf, enum fy_utf8_escape esc)
+{
+	int cc;
+	char *s;
+
+	if (!fy_utf8_is_valid(c)) {
+		*buf = '\0';
+		return buf;
+	}
+
+	s = buf;
+	if ((cc = fy_utf8_esc_map(c, esc)) > 0) {
+		*s++ = '\\';
+		*s++ = cc;
+	} else
+		s = fy_utf8_put_unchecked(s, c);
+	*s = '\0';
+	return buf;
+}
+
+char *fy_utf8_format_text_alloc(const char *buf, size_t len, enum fy_utf8_escape esc)
+{
+	size_t outsz;
+	char *out;
+
+	outsz = fy_utf8_format_text_length(buf, len, esc);
+	if ((ssize_t)outsz < 0)
+		return NULL;
+	out = malloc(outsz);
+	if (!out)
+		return NULL;
+	fy_utf8_format_text(buf, len, out, outsz, esc);
+
+	return out;
+}
+
+const void *fy_utf8_memchr_generic(const void *s, int c, size_t n)
+{
+	int cc, w;
+	const char *sc, *e;
+
+	sc = (const char *)s;
+	e = sc + n;
+	while (sc < e && (cc = fy_utf8_get(sc, e - sc, &w)) >= 0) {
+		if (c == cc)
+			return sc;
+		sc += w;
+	}
+
+	return NULL;
+}
+
+/* parse an escape and return utf8 value */
+int fy_utf8_parse_escape(const char **strp, size_t len, enum fy_utf8_escape esc)
+{
+	const char *s, *e;
+	char c;
+	int i, value, code_length, cc, w;
+	unsigned int hi_surrogate, lo_surrogate;
+
+	/* why do you bother us? */
+	if (esc == fyue_none)
+		return -1;
+
+	if (!strp || !*strp || len < 2)
+		return -1;
+
+	value = -1;
+
+	s = *strp;
+	e = s + len;
+
+	c = *s++;
+
+	if (esc == fyue_singlequote) {
+		if (c != '\'')
+			goto out;
+		c = *s++;
+		if (c != '\'')
+			goto out;
+
+		value = '\'';
+		goto out;
+	}
+
+	/* get '\\' */
+	if (c != '\\')
+		goto out;
+
+	c = *s++;
+
+	/* common YAML & JSON escapes */
+	switch (c) {
+	case 'b':
+		value = '\b';
+		break;
+	case 'f':
+		value = '\f';
+		break;
+	case 'n':
+		value = '\n';
+		break;
+	case 'r':
+		value = '\r';
+		break;
+	case 't':
+		value = '\t';
+		break;
+	case '"':
+		value = '"';
+		break;
+	case '/':
+		value = '/';
+		break;
+	case '\\':
+		value = '\\';
+		break;
+	default:
+		break;
+	}
+
+	if (value >= 0)
+		goto out;
+
+	if (esc == fyue_doublequote || esc == fyue_doublequote_yaml_1_1) {
+		switch (c) {
+		case '0':
+			value = '\0';
+			break;
+		case 'a':
+			value = '\a';
+			break;
+		case '\t':
+			value = '\t';
+			break;
+		case 'v':
+			value = '\v';
+			break;
+		case 'e':
+			value = '\x1b';
+			break;
+		case ' ':
+			value = ' ';
+			break;
+		case 'N':
+			value = 0x85;	/* NEL */
+			break;
+		case '_':
+			value = 0xa0;
+			break;
+		case 'L':
+			value = 0x2028;	/* LS */
+			break;
+		case 'P':	/* PS 0x2029 */
+			value = 0x2029; /* PS */
+			break;
+		default:
+			/* weird unicode escapes */
+			if ((uint8_t)c >= 0x80) {
+				/* in non yaml-1.1 mode we don't allow this craziness */
+				if (esc == fyue_doublequote)
+					goto out;
+
+				cc = fy_utf8_get(s - 1, e - (s - 1), &w);
+				switch (cc) {
+				case 0x2028:
+				case 0x2029:
+				case 0x85:
+				case 0xa0:
+					value = cc;
+					break;
+				default:
+					break;
+				}
+			}
+			break;
+		}
+		if (value >= 0)
+			goto out;
+	}
+
+	/* finally try the unicode escapes */
+	code_length = 0;
+
+	if (esc == fyue_doublequote || esc == fyue_doublequote_yaml_1_1) {
+		switch (c) {
+		case 'x':
+			code_length = 2;
+			break;
+		case 'u':
+			code_length = 4;
+			break;
+		case 'U':
+			code_length = 8;
+			break;
+		default:
+			return -1;
+		}
+	} else if (esc == fyue_doublequote_json && c == 'u')
+		code_length = 4;
+
+	if (!code_length || code_length > (e - s))
+		goto out;
+
+	value = 0;
+	for (i = 0; i < code_length; i++) {
+		c = *s++;
+		value <<= 4;
+		if (c >= '0' && c <= '9')
+			value |= c - '0';
+		else if (c >= 'a' && c <= 'f')
+			value |= 10 + c - 'a';
+		else if (c >= 'A' && c <= 'F')
+			value |= 10 + c - 'A';
+		else
+			goto out;
+	}
+
+	/* hi/lo surrogate pair */
+	if (code_length == 4 && value >= 0xd800 && value <= 0xdbff &&
+		(e - s) >= 6 && s[0] == '\\' && s[1] == 'u') {
+		hi_surrogate = value;
+
+		s += 2;
+
+		value = 0;
+		for (i = 0; i < code_length; i++) {
+			c = *s++;
+			value <<= 4;
+			if (c >= '0' && c <= '9')
+				value |= c - '0';
+			else if (c >= 'a' && c <= 'f')
+				value |= 10 + c - 'a';
+			else if (c >= 'A' && c <= 'F')
+				value |= 10 + c - 'A';
+			else
+				return -1;
+		}
+		lo_surrogate = value;
+		value = 0x10000 + (hi_surrogate - 0xd800) * 0x400 + (lo_surrogate - 0xdc00);
+	}
+
+out:
+	*strp = s;
+
+	return value;
+}
+
+const uint8_t fy_utf8_low_ascii_flags[256] = {
+	[0x00] = 0,					// NUL '\0' (null character)
+	[0x01] = 0, 					// SOH (start of heading)
+	[0x02] = 0,					// STX (start of text)
+	[0x03] = 0,					// ETX (end of text)
+	[0x04] = 0,					// EOT (end of transmission)
+	[0x05] = 0,					// ENQ (enquiry)
+	[0x06] = 0,					// ACK (acknowledge)
+	[0x07] = 0,					// BEL '\a' (bell)
+	[0x08] = 0,					// BS  '\b' (backspace)
+	[0x09] = F_WS,					// HT  '\t' (horizontal tab)
+	[0x0A] = F_LB,					// LF  '\n' (new line)
+	[0x0B] = 0,					// VT  '\v' (vertical tab)
+	[0x0C] = 0,					// FF  '\f' (form feed)
+	[0x0D] = F_LB,					// CR  '\r' (carriage ret)
+	[0x0E] = 0,					// SO  (shift out)
+	[0x0F] = 0,					// SI  (shift in)
+	[0x10] = 0,					// DLE (data link escape)
+	[0x11] = 0,					// DC1 (device control 1)
+	[0x12] = 0,					// DC2 (device control 2)
+	[0x13] = 0,					// DC3 (device control 3)
+	[0x14] = 0,					// DC4 (device control 4)
+	[0x15] = 0,					// NAK (negative ack.)
+	[0x16] = 0,					// SYN (synchronous idle)
+	[0x17] = 0,					// ETB (end of trans. blk)
+	[0x18] = 0,					// CAN (cancel)
+	[0x19] = 0,					// EM  (end of medium)
+	[0x1A] = 0,					// SUB (substitute)
+	[0x1B] = 0,					// ESC (escape)
+	[0x1C] = 0,					// FS  (file separator)
+	[0x1D] = 0,					// GS  (group separator)
+	[0x1E] = 0,					// RS  (record separator)
+	[0x1F] = 0,					// US  (unit separator)
+	[' ']  = F_DIRECT_PRINT | F_WS,
+	['!']  = F_DIRECT_PRINT,
+	['"']  = F_DIRECT_PRINT,
+	['#']  = F_DIRECT_PRINT,
+	['$']  = F_DIRECT_PRINT,
+	['%']  = F_DIRECT_PRINT,
+	['&']  = F_DIRECT_PRINT,
+	['\''] = F_DIRECT_PRINT,
+	['(']  = F_DIRECT_PRINT,
+	[')']  = F_DIRECT_PRINT,
+	['*']  = F_DIRECT_PRINT,
+	['+']  = F_DIRECT_PRINT,
+	[',']  = F_DIRECT_PRINT | F_FLOW_INDICATOR,
+	['-']  = F_DIRECT_PRINT,
+	['.']  = F_DIRECT_PRINT,
+	['/']  = F_DIRECT_PRINT,
+	['0']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['1']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['2']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['3']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['4']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['5']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['6']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['7']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['8']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	['9']  = F_DIRECT_PRINT | F_DIGIT | F_XDIGIT | F_SIMPLE_SCALAR,
+	[':']  = F_DIRECT_PRINT,
+	[';']  = F_DIRECT_PRINT,
+	['<']  = F_DIRECT_PRINT,
+	['=']  = F_DIRECT_PRINT,
+	['>']  = F_DIRECT_PRINT,
+	['?']  = F_DIRECT_PRINT,
+	['@']  = F_DIRECT_PRINT,
+	['A']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['B']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['C']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['D']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['E']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['F']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['G']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['H']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['I']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['J']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['K']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['L']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['M']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['N']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['O']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['P']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['Q']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['R']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['S']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['T']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['U']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['V']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['W']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['X']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['Y']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['Z']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['[']  = F_DIRECT_PRINT | F_FLOW_INDICATOR,
+	['\\'] = F_DIRECT_PRINT,  				// '\\'
+	[']']  = F_DIRECT_PRINT | F_FLOW_INDICATOR,
+	['^']  = F_DIRECT_PRINT,
+	['_']  = F_DIRECT_PRINT                       | F_SIMPLE_SCALAR,
+	['`']  = F_DIRECT_PRINT,
+	['a']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['b']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['c']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['d']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['e']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['f']  = F_DIRECT_PRINT | F_LETTER | F_XDIGIT | F_SIMPLE_SCALAR,
+	['g']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['h']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['i']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['j']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['k']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['l']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['m']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['n']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['o']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['p']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['q']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['r']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['s']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['t']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['u']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['v']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['w']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['x']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['y']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['z']  = F_DIRECT_PRINT | F_LETTER            | F_SIMPLE_SCALAR,
+	['{']  = F_DIRECT_PRINT | F_FLOW_INDICATOR,
+	['|']  = F_DIRECT_PRINT,
+	['}']  = F_DIRECT_PRINT | F_FLOW_INDICATOR,
+	['~']  = F_DIRECT_PRINT,
+	[0x7F] = 0,					// DEL
+	/* the rest are zero */
+};
+
+void *fy_utf8_split_posix(const char *str, int *argcp, const char * const *argvp[])
+{
+	enum split_state {
+		SS_WS,			/* at whitespace */
+		SS_WS_BS,		/* backslash at whitespace */
+		SS_UQ,			/* at unquoted */
+		SS_UQ_BS,		/* backslash at unquoted */
+		SS_SQ,			/* at single quote */
+		SS_SQ_BS,		/* backslash at single quote */
+		SS_DQ,			/* at double quote */
+		SS_DQ_BS,		/* backslash at double quote */
+		SS_DQ_BS_OCT1,		/* in \nnn octal escape digit 1 */
+		SS_DQ_BS_OCT2,		/* in \nnn octal escape digit 2 */
+		SS_DQ_BS_HEX0,		/* in \xNN hex escape digit 0 */
+		SS_DQ_BS_HEX1,		/* in \xNN hex escape digit 1 */
+		SS_DQ_BS_HEX2,		/* in \xNN hex escape digit 2 */
+		SS_DQ_BS_C,		/* in \cN control character escape */
+		SS_WS_BS_ERR_EOL,	/* EOL while waiting for char after \ */
+		SS_UQ_BS_ERR_EOL,	/* EOL while waiting for char after \ */
+		SS_SQ_BS_ERR_EOL,	/* EOL while waiting for char after \ */
+		SS_DQ_BS_ERR_EOL,	/* EOL while waiting for char after \ */
+		SS_DQ_BS_ERR_BAD,	/* bad escape */
+		SS_SQ_NC_ERR,		/* no closing single quote */
+		SS_DQ_NC_ERR,		/* no closing double quote */
+		SS_DQ_BS_ERR_OCT_BAD,	/* bad octal escape */
+		SS_DQ_BS_ERR_HEX_BAD,	/* bad hex escape */
+		SS_DQ_BS_ERR_C_BAD,	/* bad control char */
+		SS_DONE			/* final state */
+	};
+	const char *s, *e;
+	enum split_state ss;
+	int c, w, val, tmp, outc, i;
+	size_t arg_alloc = strlen(str) + 1, tmplen;
+	char *arg = NULL, *args, *arge, *tmparg;
+	int argv_alloc = 64, argv_count = 0;
+	char **argv = NULL, **tmpargv;
+	void *mem;
+
+	if (!str || !argcp || !argvp)
+		return NULL;
+
+	/* the temporary is guaranteed to fit one split */
+	arg = alloca(arg_alloc);
+	args = arg;
+	arge = arg + arg_alloc - 1;
+
+	argv = alloca(sizeof(*argv) * argv_alloc);
+
+	e = str + strlen(str);
+
+#undef OUTC
+#define OUTC(_c) \
+	do { \
+		assert(args < arge); \
+		args = fy_utf8_put(args, arge - args, (_c)); \
+		assert(args); \
+	} while(0)
+
+#undef NEW_ARGV
+#define NEW_ARGV() \
+	do { \
+		if (args > arg) { \
+			if (argv_count + 1 >= argv_alloc) { \
+				argv_alloc *= 2; \
+				tmpargv = alloca((sizeof(*tmpargv) * argv_alloc)); \
+				memcpy(tmpargv, argv, argv_count * sizeof(*tmpargv)); \
+			} \
+			tmplen = args - arg; \
+			tmparg = alloca(tmplen + 1); \
+			memcpy(tmparg, arg, tmplen); \
+			tmparg[tmplen] = '\0'; \
+			argv[argv_count] = tmparg; \
+			argv[++argv_count] = NULL; \
+		} \
+		args = arg; \
+	} while(0)
+
+#define GOTO(_ss) \
+	do { \
+		ss = (_ss); \
+	} while(0)
+
+
+	ss = SS_WS;
+	s = str;
+	val = 0;
+	while (!(ss >= SS_WS_BS_ERR_EOL && ss <= SS_DONE)) {
+		c = fy_utf8_get(s, e - s, &w);
+		switch (ss) {
+		case SS_WS:
+			if (c < 0) {
+				NEW_ARGV();
+				GOTO(SS_DONE);
+				break;
+			}
+			switch (c) {
+			case ' ':
+			case '\t':
+				break;	/* no change */
+			case '\\':
+				GOTO(SS_WS_BS);
+				break;
+			case '"':
+				GOTO(SS_DQ);	/* start double quoted */
+				NEW_ARGV();
+				break;
+			case '\'':
+				GOTO(SS_SQ);	/* start single quoted */
+				NEW_ARGV();
+				break;
+			default:
+				GOTO(SS_UQ);	/* start unquoted */
+				NEW_ARGV();
+				OUTC(c);
+				break;
+			}
+			break;
+
+		case SS_WS_BS:
+			if (c < 0) {
+				GOTO(SS_WS_BS_ERR_EOL);
+				break;
+			}
+			if (c == '\n') {	/* backslash newline, continuation */
+				GOTO(SS_WS);
+				break;
+			}
+			GOTO(SS_UQ);
+			NEW_ARGV();
+			OUTC(c);
+			break;
+
+		case SS_UQ:
+			if (c <= 0) {
+				NEW_ARGV();
+				GOTO(SS_DONE);
+				break;
+			}
+
+			switch (c) {
+			case ' ':
+			case '\t':
+				GOTO(SS_WS);
+				NEW_ARGV();
+				break;	/* no change */
+			case '\\':
+				GOTO(SS_UQ_BS);
+				break;
+			case '"':
+				GOTO(SS_DQ);	/* double quoted */
+				break;
+			case '\'':
+				GOTO(SS_SQ);	/* single quoted */
+				break;
+			default:
+				OUTC(c);
+				break;
+			}
+			break;
+
+		case SS_UQ_BS:
+			if (c < 0) {
+				GOTO(SS_UQ_BS_ERR_EOL);
+				break;
+			}
+			if (c == '\n') {	/* backslash new line only */
+				GOTO(SS_UQ);
+				break;
+			}
+			GOTO(SS_UQ);
+			OUTC(c);
+			break;
+
+		case SS_SQ:
+			if (c < 0) {
+				GOTO(SS_SQ_NC_ERR);	/* no closing ' */
+				break;
+			}
+			switch (c) {
+			case '\'':		/* end of quote, back to unquoted */
+				GOTO(SS_UQ);
+				break;
+			case '\\':
+				OUTC(c);
+				GOTO(SS_SQ_BS);	/* backslash */
+				break;
+			default:
+				OUTC(c);
+				break;
+			}
+			break;
+
+		case SS_SQ_BS:
+			if (c < 0) {
+				GOTO(SS_SQ_BS_ERR_EOL);
+				break;
+			}
+			if (c == '\n') {	/* backslash new line only */
+				GOTO(SS_SQ);	/* back to single quoted */
+				break;
+			}
+			GOTO(SS_UQ);		/* always back to */
+			OUTC(c);
+			break;
+
+		case SS_DQ:
+			if (c < 0) {
+				GOTO(SS_DQ_NC_ERR);	/* no closing ' */
+				break;
+			}
+			switch (c) {
+			case '"':		/* end of quote, back to unquoted */
+				GOTO(SS_UQ);
+				break;
+			case '\\':
+				GOTO(SS_DQ_BS);	/* backslash */
+				break;
+			default:
+				OUTC(c);
+				break;
+			}
+			break;
+
+		case SS_DQ_BS:
+			if (c < 0) {
+				GOTO(SS_DQ_BS_ERR_EOL);
+				break;
+			}
+			outc = -1;
+			switch (c) {
+			case 'a':
+				outc = '\a';
+				break;
+			case 'b':
+				outc = '\b';
+				break;
+			case 'e':
+				outc = '\x1b';	/* escape */
+				break;
+			case 'n':
+				outc = '\n';
+				break;
+			case 'r':
+				outc = '\r';
+				break;
+			case 't':
+				outc = '\t';
+				break;
+			case 'v':
+				outc = '\v';
+				break;
+			case '\\':
+				outc = '\\';
+				break;
+			case '\'':
+				outc = '\'';
+				break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+				val = c - '0';
+				GOTO(SS_DQ_BS_OCT1);
+				break;
+			case 'x':
+				val = 0;
+				GOTO(SS_DQ_BS_HEX0);
+				break;
+			case 'c':
+				val = 0;
+				GOTO(SS_DQ_BS_C);
+				break;
+			default:
+				GOTO(SS_DQ_BS_ERR_BAD);	/* unknown escape */
+				break;
+			}
+			if (outc > 0) {
+				OUTC(outc);
+				GOTO(SS_DQ);
+			}
+			break;
+
+		case SS_DQ_BS_OCT1:
+		case SS_DQ_BS_OCT2:
+			if (c < 0) {
+				OUTC(val);
+				NEW_ARGV();
+				GOTO(SS_DONE);
+				break;
+			}
+			if (!(c >= '0' && c <= '7')) {
+				OUTC(val);
+				GOTO(SS_DQ);
+				w = 0;	/* redo, same */
+				break;
+			}
+			val *= 8;
+			val += c - '0';
+			if (ss == SS_DQ_BS_OCT2) {
+				OUTC(val);
+				GOTO(SS_DQ);
+			} else
+				GOTO(SS_DQ_BS_OCT2);
+			break;
+
+		case SS_DQ_BS_HEX0:
+		case SS_DQ_BS_HEX1:
+		case SS_DQ_BS_HEX2:
+			tmp = -1;
+			if (c >= '0' && c <= '9')
+				tmp = c - '0';
+			else if (c >= 'a' && c <= 'f')
+				tmp = 10 + c - 'a';
+			else if (c >= 'A' && c <= 'F')
+				tmp = 10 + c - 'A';
+
+			switch (ss) {
+			case SS_DQ_BS_HEX0:
+				if (tmp < 0) {
+					fprintf(stderr, "tmp=%d c=%c\n", tmp, c);
+					GOTO(SS_DQ_BS_ERR_HEX_BAD);
+					break;
+				}
+				val = tmp;
+				GOTO(SS_DQ_BS_HEX1);
+				break;
+
+			case SS_DQ_BS_HEX1:
+			case SS_DQ_BS_HEX2:
+				if (tmp < 0) {
+					GOTO(SS_DQ);
+					OUTC(val);
+					w = 0;	/* redo */
+					break;
+				}
+				val *= 16;
+				val += tmp;
+				if (ss == SS_DQ_BS_HEX1)
+					GOTO(SS_DQ_BS_HEX2);
+				else {
+					OUTC(val);
+					GOTO(SS_DQ);
+				}
+				break;
+
+			default:
+				FY_IMPOSSIBLE_ABORT();
+			}
+			break;
+
+		case SS_DQ_BS_C:
+			outc = -1;
+			if (c >= 'a' && c <= 'z')
+				outc = c - 'a' + 1;
+			else if (c >= 'A' && c <= 'Z')
+				outc = c - 'Z' + 1;
+			if (outc > 0x20) {
+				outc = -1;
+				GOTO(SS_DQ_BS_ERR_C_BAD);
+			} else
+				GOTO(SS_DQ);
+			if (outc > 0)
+				OUTC(outc);
+			break;
+		default:
+			FY_IMPOSSIBLE_ABORT();
+		}
+		s += w;
+	}
+
+	/* someething went wrong */
+	if (ss != SS_DONE)
+		return NULL;
+
+	tmplen = (argv_count + 1) * sizeof(*argv);
+	for (i = 0; i < argv_count; i++)
+		tmplen += strlen(argv[i]) + 1;
+
+	mem = malloc(tmplen);
+	if (!mem)
+		return NULL;
+
+	tmpargv = mem;
+	tmparg = (char *)mem + (argv_count + 1) * sizeof(*tmpargv);
+	for (i = 0; i < argv_count; i++) {
+		tmpargv[i] = tmparg;
+		strcpy(tmparg, argv[i]);
+		tmparg = tmparg + strlen(argv[i]) + 1;
+	}
+	tmpargv[i] = NULL;
+
+	*argcp = i;
+	*argvp = mem;
+
+	return mem;
+}
+
+int fy_utf8_get_generic_s(const void *ptr, const void *ptr_end, int *widthp)
+{
+	const uint8_t *p = ptr;
+	int i, width, value;
+
+	if (ptr >= ptr_end)
+		return FYUG_EOF;
+
+	/* this is the slow path */
+	width = fy_utf8_width_by_first_octet(p[0]);
+	if (!width)
+		return FYUG_INV;
+	if ((const char *)ptr + width > (const char *)ptr_end)
+		return FYUG_PARTIAL;
+
+	/* initial value */
+	value = *p++ & (0xff >> width);
+	for (i = 1; i < width; i++) {
+		if ((*p & 0xc0) != 0x80)
+			return FYUG_INV;
+		value = (value << 6) | (*p++ & 0x3f);
+	}
+
+	/* check for validity */
+	if ((width == 4 && value < 0x10000) ||
+	    (width == 3 && value <   0x800) ||
+	    (width == 2 && value <    0x80) ||
+	    (value >= 0xd800 && value <= 0xdfff) || value >= 0x110000)
+		return FYUG_INV;
+
+	*widthp = width;
+
+	return value;
+}
+
+int fy_utf8_get_generic_s_nocheck(const void *ptr, int *widthp)
+{
+	const uint8_t *p = ptr;
+	int i, width, value;
+
+	/* this is the slow path */
+	width = fy_utf8_width_by_first_octet(p[0]);
+	if (!width)
+		return FYUG_INV;
+
+	/* initial value */
+	value = *p++ & (0xff >> width);
+	for (i = 1; i < width; i++) {
+		if ((*p & 0xc0) != 0x80)
+			return FYUG_INV;
+		value = (value << 6) | (*p++ & 0x3f);
+	}
+
+	/* check for validity */
+	if ((width == 4 && value < 0x10000) ||
+	    (width == 3 && value <   0x800) ||
+	    (width == 2 && value <    0x80) ||
+	    (value >= 0xd800 && value <= 0xdfff) || value >= 0x110000)
+		return FYUG_INV;
+
+	*widthp = width;
+
+	return value;
+}

--- a/numcosmo/external/libfyaml/src/util/fy-utf8.h
+++ b/numcosmo/external/libfyaml/src/util/fy-utf8.h
@@ -1,0 +1,665 @@
+/*
+ * fy-utf8.h - UTF-8 methods
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef FY_UTF8_H
+#define FY_UTF8_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
+#include "fy-win32.h"
+#include "fy-utils.h"
+
+#define FY_UTF8_MIN_WIDTH 1
+#define FY_UTF8_MAX_WIDTH 4
+
+extern const int8_t fy_utf8_width_table[32];
+
+static inline int
+fy_utf8_width_by_first_octet_no_table(const uint8_t c)
+{
+	return (c & 0x80) == 0x00 ? 1 :
+	       (c & 0xe0) == 0xc0 ? 2 :
+	       (c & 0xf0) == 0xe0 ? 3 :
+	       (c & 0xf8) == 0xf0 ? 4 : 0;
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_width_by_first_octet(uint8_t c)
+{
+	return fy_utf8_width_table[c >> 3];
+}
+
+/* assumes valid utf8 character */
+static inline size_t
+fy_utf8_width(const int c)
+{
+	return 1 + (c >= 0x80) + (c >= 0x800) + (c >= 0x10000);
+}
+
+static inline bool
+fy_utf8_is_valid(const int c)
+{
+	return c >= 0 && !((c >= 0xd800 && c <= 0xdfff) || c >= 0x110000);
+}
+
+/* generic utf8 decoder (not inlined) */
+int fy_utf8_get_generic(const void *ptr, size_t left, int *widthp);
+
+/* -1 for end of input, -2 for invalid character, -3 for partial */
+#define FYUG_EOF	-1
+#define FYUG_INV	-2
+#define FYUG_PARTIAL	-3
+
+#define FY_UTF8_64_C(_x)	((int)(int32_t)(_x))
+#define FY_UTF8_64_W(_x)	(((int)((_x) >> 32)))
+
+#define FY_UTF8_64_MAKE(_w, _c)	((int64_t)(((int64_t)((_w)) << 32) | (int64_t)(_c)))
+
+static inline FY_ALWAYS_INLINE int64_t
+fy_utf8_get_branch_64(const void *ptr, size_t left)
+{
+	const uint8_t *s = ptr;
+	unsigned int a, b, c, d;
+	uint32_t code;
+
+	if (!left)
+		return FYUG_EOF;
+
+	a = s[0];
+	if (a < 0x80) 				// 1 byte: 0xxxxxxx
+		return FY_UTF8_64_MAKE(1, a);
+
+	if (left < 2)
+		return FYUG_PARTIAL;
+
+	b = s[1];
+	if ((a & 0xe0) == 0xc0) {		// 2 bytes: 110xxxxx 10xxxxxx
+		if ((b & 0xc0) != 0x80)
+			return FYUG_INV;
+
+		code = (int)(((a & 0x1f) << 6) | (b & 0x3f));
+		if (code < 0x80)
+			return FYUG_INV;	// overlong
+
+		return FY_UTF8_64_MAKE(2, code);
+	}
+
+	if (left < 3)
+		return FYUG_PARTIAL;
+
+	c = s[2];
+	if ((a & 0xf0) == 0xe0) {		// 3 bytes: 1110xxxx 10xxxxxx 10xxxxxx
+
+		if ((b & 0xc0) != 0x80 || (c & 0xc0) != 0x80)
+			return FYUG_INV;
+
+		code = (int)(((a & 0x0f) << 12) | ((b & 0x3f) << 6) | (c & 0x3f));
+		if (code < 0x800 || (code >= 0xd800 && code <= 0xdfff))
+			return FYUG_INV;	// overlong or surrogate
+
+		return FY_UTF8_64_MAKE(3, code);
+	}
+
+	if (left < 4)
+		return FYUG_PARTIAL;
+
+	d = s[3];
+	if ((a & 0xf8) == 0xf0) {		// 4 bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+
+		if ((b & 0xc0) != 0x80 || (c & 0xc0) != 0x80 || (d & 0xc0) != 0x80)
+			return FYUG_INV;
+
+		code = ((a & 0x07) << 18) | ((b & 0x3f) << 12) |
+		       ((c & 0x3f) <<  6)  | (d & 0x3f);
+
+		if (code < 0x10000 || code > 0x10ffff)
+			return FYUG_INV;	// overlong or out of range
+
+		return FY_UTF8_64_MAKE(4, code);
+	}
+
+	return FYUG_INV;
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_get_branch(const void *ptr, size_t left, int *widthp)
+{
+	const uint8_t *s = ptr;
+	unsigned int a, b, c, d;
+	int code;
+
+	if (!left)
+		goto err_eof;
+
+	a = s[0];
+	if (a < 0x80) {				// 1 byte: 0xxxxxxx
+		code = (int)a;
+		*widthp = 1;
+		return code;
+	}
+
+	if (left < 2)
+		goto err_partial;
+
+	b = s[1];
+	if ((a & 0xe0) == 0xc0) {		// 2 bytes: 110xxxxx 10xxxxxx
+		if ((b & 0xc0) != 0x80)
+			goto err_inv;
+
+		code = (int)(((a & 0x1f) << 6) | (b & 0x3f));
+		if (code < 0x80)
+			goto err_inv;		// overlong
+
+		*widthp = 2;
+		return code;
+	}
+
+	if (left < 3)
+		goto err_partial;
+
+	c = s[2];
+	if ((a & 0xf0) == 0xe0) {		// 3 bytes: 1110xxxx 10xxxxxx 10xxxxxx
+
+		if ((b & 0xc0) != 0x80 || (c & 0xc0) != 0x80)
+			goto err_inv;
+
+		code = (int)(((a & 0x0f) << 12) | ((b & 0x3f) << 6) | (c & 0x3f));
+		if (code < 0x800 || (code >= 0xd800 && code <= 0xdfff))
+			goto err_inv;		// overlong or surrogate
+
+		*widthp = 3;
+		return code;
+	}
+
+	if (left < 4)
+		goto err_partial;
+
+	d = s[3];
+	if ((a & 0xf8) == 0xf0) {		// 4 bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+
+		if ((b & 0xc0) != 0x80 || (c & 0xc0) != 0x80 || (d & 0xc0) != 0x80)
+			goto err_inv;
+
+		code = ((a & 0x07) << 18) | ((b & 0x3f) << 12) |
+		       ((c & 0x3f) <<  6)  | (d & 0x3f);
+
+		if (code < 0x10000 || code > 0x10ffff)
+			goto err_inv;		// overlong or out of range
+
+		*widthp = 4;
+		return code;
+	}
+
+err_inv:
+	*widthp = 0;
+	return FYUG_INV;
+
+err_partial:
+	*widthp = 0;
+	return FYUG_PARTIAL;
+
+err_eof:
+	*widthp = 0;
+	return FYUG_EOF;
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_get_table(const void *ptr, size_t left, int *widthp)
+{
+	const uint8_t *s = ptr;
+	unsigned int a, b, c, d;
+	int code, w;
+
+	if (!left)
+		goto err_eof;
+
+	w = fy_utf8_width_by_first_octet(s[0]);
+	if ((size_t)w > left)
+		goto err_partial;
+
+	*widthp = w;
+
+	switch (w) {
+	case 1:
+		a = s[0];
+		code = (int)a;
+		return code;
+	case 2:
+		a = s[0];
+		b = s[1];
+		if ((b & 0xc0) != 0x80)
+			goto err_inv;
+
+		code = (int)(((a & 0x1f) << 6) | (b & 0x3f));
+		if (code < 0x80)
+			goto err_inv;		// overlong
+
+		return code;
+	case 3:
+		a = s[0];
+		b = s[1];
+		c = s[2];
+
+		if (((b | c) & 0xc0) != 0x80)
+			goto err_inv;
+
+		code = (int)(((a & 0x0f) << 12) | ((b & 0x3f) << 6) | (c & 0x3f));
+		if (code < 0x800 || (code >= 0xd800 && code <= 0xdfff))
+			goto err_inv;		// overlong or surrogate
+
+		return code;
+	case 4:
+		a = s[0];
+		b = s[1];
+		c = s[2];
+		d = s[3];
+
+		if (((b | c | d) & 0xc0) != 0x80)
+			goto err_inv;
+
+		code = ((a & 0x07) << 18) | ((b & 0x3f) << 12) |
+		       ((c & 0x3f) <<  6) | (d & 0x3f);
+
+		if (code < 0x10000 || code > 0x10ffff)
+			goto err_inv;		// overlong or out of range
+
+		return code;
+
+	default:
+		break;
+	}
+
+err_inv:
+	*widthp = 0;
+	return FYUG_INV;
+
+err_partial:
+	*widthp = 0;
+	return FYUG_PARTIAL;
+
+err_eof:
+	*widthp = 0;
+	return FYUG_EOF;
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_get(const void *ptr, size_t left, int *widthp)
+{
+	return fy_utf8_get_branch(ptr, left, widthp);
+}
+
+static inline FY_ALWAYS_INLINE int64_t
+fy_utf8_get_64(const void *ptr, size_t left)
+{
+	return fy_utf8_get_branch_64(ptr, left);
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_get_no_width(const void *ptr, size_t left)
+{
+	int w;
+
+	return fy_utf8_get(ptr, left, &w);
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_get_end(const void *ptr, const void *ptr_end, int *widthp)
+{
+	return fy_utf8_get(ptr, (size_t)((const char *)ptr_end - (const char *)ptr), widthp);
+}
+
+static inline FY_ALWAYS_INLINE int
+fy_utf8_get_end_no_width(const void *ptr, const void *ptr_end)
+{
+	int w;
+
+	return fy_utf8_get(ptr, (size_t)((const char *)ptr_end - (const char *)ptr), &w);
+}
+
+int fy_utf8_get_right_generic(const void *ptr, size_t left, int *widthp);
+
+static inline int fy_utf8_get_right(const void *ptr, size_t left, int *widthp)
+{
+	const uint8_t *p = (const uint8_t *)ptr + left;
+
+	/* single byte (hot path) */
+	if (left > 0 && !(p[-1] & 0x80)) {
+		if (widthp)
+			*widthp = 1;
+		return p[-1] & 0x7f;
+	}
+	return fy_utf8_get_right_generic(ptr, left, widthp);
+}
+
+
+/* for when you _know_ that there's enough room and c is valid */
+static inline void *fy_utf8_put_unchecked(void *ptr, int c)
+{
+	uint8_t *s = ptr;
+
+	assert(c >= 0);
+	if (c < 0x80)
+		*s++ = c;
+	else if (c < 0x800) {
+		*s++ = (c >> 6) | 0xc0;
+		*s++ = (c & 0x3f) | 0x80;
+	} else if (c < 0x10000) {
+		*s++ = (c >> 12) | 0xe0;
+		*s++ = ((c >> 6) & 0x3f) | 0x80;
+		*s++ = (c & 0x3f) | 0x80;
+	} else {
+		*s++ = (c >> 18) | 0xf0;
+		*s++ = ((c >> 12) & 0x3f) | 0x80;
+		*s++ = ((c >> 6) & 0x3f) | 0x80;
+		*s++ = (c & 0x3f) | 0x80;
+	}
+	return s;
+}
+
+static inline void *fy_utf8_put(void *ptr, size_t left, int c)
+{
+	if (!fy_utf8_is_valid(c) || fy_utf8_width(c) > left)
+		return NULL;
+
+	return fy_utf8_put_unchecked(ptr, c);
+}
+
+/* buffer must contain at least 5 characters */
+#define FY_UTF8_FORMAT_BUFMIN	5
+enum fy_utf8_escape {
+	fyue_none,
+	fyue_singlequote,
+	fyue_doublequote,
+	fyue_doublequote_json,
+	fyue_doublequote_yaml_1_1,
+};
+
+static inline bool fy_utf8_escape_is_any_doublequote(const enum fy_utf8_escape esc)
+{
+	return esc >= fyue_doublequote && esc <= fyue_doublequote_yaml_1_1;
+}
+
+char *fy_utf8_format(int c, char *buf, const enum fy_utf8_escape esc);
+
+#ifdef _MSC_VER
+/* MSVC doesn't support GCC statement expressions - use static buffers */
+static __declspec(thread) char fy_utf8_format_a_buf[FY_UTF8_FORMAT_BUFMIN];
+static __declspec(thread) char fy_utf8_format_text_a_buf[4096];
+
+#define fy_utf8_format_a(_c, _esc) \
+	strcpy(alloca(FY_UTF8_FORMAT_BUFMIN + 1), \
+		fy_utf8_format((_c), fy_utf8_format_a_buf, (_esc)))
+
+#define fy_utf8_format_text_a(_buf, _len, _esc) \
+	strcpy(alloca(sizeof(fy_utf8_format_text_a_buf) + 1), \
+		fy_utf8_format_text((_buf), (_len), \
+			fy_utf8_format_text_a_buf, sizeof(fy_utf8_format_text_a_buf) - 1, (_esc)))
+#else
+/* GCC/Clang version with statement expressions */
+#define fy_utf8_format_a(_c, _esc) \
+	({ \
+	 	char *_buf = alloca(FY_UTF8_FORMAT_BUFMIN); \
+	 	fy_utf8_format((_c), _buf, _esc); \
+	})
+#endif
+
+size_t fy_utf8_format_text_length(const char *buf, size_t len,
+			          enum fy_utf8_escape esc);
+char *fy_utf8_format_text(const char *buf, size_t len,
+			  char *out, size_t maxsz,
+			  enum fy_utf8_escape esc);
+
+#ifndef _MSC_VER
+#define fy_utf8_format_text_a(_buf, _len, _esc) \
+	({ \
+		const char *__buf = (_buf); \
+		size_t __len = (_len); \
+		enum fy_utf8_escape __esc = (_esc); \
+		size_t _outsz = fy_utf8_format_text_length(__buf, __len, __esc); \
+		char *_out = alloca(_outsz + 1); \
+		fy_utf8_format_text(__buf, __len, _out, _outsz, __esc); \
+	})
+#endif
+
+char *fy_utf8_format_text_alloc(const char *buf, size_t len, const enum fy_utf8_escape esc);
+
+const void *fy_utf8_memchr_generic(const void *s, int c, size_t n);
+
+static inline const void *fy_utf8_memchr(const void *s, int c, size_t n)
+{
+	if (c < 0 || !n)
+		return NULL;
+	if (c < 0x80)
+		return memchr(s, c, n);
+	return fy_utf8_memchr_generic(s, c, n);
+}
+
+static inline const void *fy_utf8_strchr(const void *s, int c)
+{
+	if (c < 0)
+		return NULL;
+	if (c < 0x80)
+		return strchr(s, c);
+	return fy_utf8_memchr_generic(s, c, strlen(s));
+}
+
+static inline int fy_utf8_count(const void *ptr, size_t len)
+{
+	const uint8_t *s = (const uint8_t *)ptr, *e = (const uint8_t *)ptr + len;
+	int w, count;
+
+	count = 0;
+	while (s < e) {
+		w = fy_utf8_width_by_first_octet(*s);
+
+		/* malformed? */
+		if (!w || s + w > e)
+			break;
+		s += w;
+
+		count++;
+	}
+
+	return count;
+}
+
+int fy_utf8_parse_escape(const char **strp, size_t len, const enum fy_utf8_escape esc);
+
+#define F_NONE			0
+#define F_SIMPLE_SCALAR		FY_BIT(0)	/* part of simple scalar 0-9a-zA-Z_ */
+#define F_DIRECT_PRINT		FY_BIT(1)	/* 0x20..0x7e */
+#define F_LB			FY_BIT(2)	/* is a linebreak */
+#define F_WS			FY_BIT(3)	/* is a whitespace */
+#define F_LETTER		FY_BIT(4)	/* is a letter a..z A..Z */
+#define F_DIGIT			FY_BIT(5)	/* is a digit 0..9 */
+#define F_XDIGIT		FY_BIT(6)	/* is a hex digit 0..9 a-f A-F */
+#define F_FLOW_INDICATOR	FY_BIT(7)	/* is ,[]{} */
+
+extern const uint8_t fy_utf8_low_ascii_flags[256];
+
+void *fy_utf8_split_posix(const char *str, int *argcp, const char * const *argvp[]);
+
+int fy_utf8_get_generic_s(const void *ptr, const void *ptr_end, int *widthp);
+int fy_utf8_get_generic_s_nocheck(const void *ptr, int *widthp);
+
+static inline int fy_utf8_get_s(const void *ptr, const void *ptr_end, int *widthp)
+{
+	const uint8_t *p = ptr;
+
+	/* single byte (hot path) */
+	if (ptr >= ptr_end) {
+		*widthp = 0;
+		return FYUG_EOF;
+	}
+
+	if (!(p[0] & 0x80)) {
+		*widthp = 1;
+		return p[0];
+	}
+	return fy_utf8_get_generic_s(ptr, ptr_end, widthp);
+}
+
+static inline int fy_utf8_get_s_nocheck(const void *ptr, int *widthp)
+{
+	const uint8_t *p = ptr;
+
+	if (!(p[0] & 0x80)) {
+		*widthp = 1;
+		return p[0];
+	}
+	return fy_utf8_get_generic_s_nocheck(ptr, widthp);
+}
+
+/* for most 64 bit arches this will fit in a single register */
+struct fy_utf8_result {
+	int c;
+	int w;
+};
+
+/* probably the most performant version */
+static inline struct fy_utf8_result fy_utf8_get_s_res(const void *ptr, const void *ptr_end)
+{
+	const uint8_t *p = ptr;
+	int c, width;
+
+	/* single byte (hot path) */
+	if (ptr >= ptr_end)
+		return (struct fy_utf8_result){ FYUG_EOF, 0 };
+
+	if (!(p[0] & 0x80))
+		return (struct fy_utf8_result){ p[0], 1 };
+
+	c = fy_utf8_get_generic_s(ptr, ptr_end, &width);
+	if (c < 0)
+		return (struct fy_utf8_result){ c, 0 };
+	return (struct fy_utf8_result){ c, width };
+}
+
+static inline bool fy_utf8_is_space(const int c)
+{
+	return c == ' ';
+}
+
+static inline bool fy_utf8_is_tab(const int c)
+{
+	return c == '\t';
+}
+
+static inline bool fy_utf8_is_simple_scalar_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_SIMPLE_SCALAR;
+}
+
+static inline bool
+fy_utf8_is_printable_ascii_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_DIRECT_PRINT;
+}
+
+static inline bool fy_utf8_is_lb_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_LB;
+}
+
+static inline bool fy_utf8_is_ws_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_WS;
+}
+
+static inline bool fy_utf8_is_ws_lb_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & (F_WS | F_LB);
+}
+
+static inline bool fy_utf8_is_letter_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_LETTER;
+}
+
+static inline bool fy_utf8_is_digit_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_DIGIT;
+}
+
+static inline bool fy_utf8_is_hex_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_XDIGIT;
+}
+
+static inline bool fy_utf8_is_flow_indicator_no_check(const int c)
+{
+	return fy_utf8_low_ascii_flags[(uint8_t)c] & F_FLOW_INDICATOR;
+}
+
+static inline bool fy_utf8_is_low_ascii(const int c)
+{
+	return (unsigned int)c < 128;
+}
+
+static inline bool fy_utf8_is_simple_scalar(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_simple_scalar_no_check(c);
+}
+
+static inline bool
+fy_utf8_is_printable_ascii_x(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_printable_ascii_no_check(c);
+}
+
+static inline bool
+fy_utf8_is_printable_ascii(const int c)
+{
+	return c >= 0x20 && c <= 0x7e;
+}
+
+static inline bool fy_utf8_is_lb(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_lb_no_check(c);
+}
+
+static inline bool fy_utf8_is_ws(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_ws_no_check(c);
+}
+
+static inline bool fy_utf8_is_ws_lb(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_ws_lb_no_check(c);
+}
+
+static inline bool fy_utf8_is_letter(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_letter_no_check(c);
+}
+
+static inline bool fy_utf8_is_digit(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_digit_no_check(c);
+}
+
+static inline bool fy_utf8_is_hex(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_hex_no_check(c);
+}
+
+static inline bool fy_utf8_is_flow_indicator(const int c)
+{
+	return fy_utf8_is_low_ascii(c) && fy_utf8_is_flow_indicator_no_check(c);
+}
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-utils.c
+++ b/numcosmo/external/libfyaml/src/util/fy-utils.c
@@ -1,0 +1,1008 @@
+/*
+ * fy-utils.c - Generic utilities for functionality that's missing
+ *              from platforms.
+ *
+ * For now only used to implement memstream for Apple platforms.
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+
+#ifndef _WIN32
+#include <termios.h>
+#include <unistd.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#endif
+
+#include "fy-win32.h"
+#include "fy-utf8.h"
+#include "fy-ctype.h"
+#include "fy-utils.h"
+
+#include "xxhash.h"
+
+#if defined(__APPLE__) && (_POSIX_C_SOURCE < 200809L)
+
+/*
+ * adapted from http://piumarta.com/software/memstream/
+ *
+ * Under the MIT license.
+ */
+
+/*
+ * ----------------------------------------------------------------------------
+ *
+ * OPEN_MEMSTREAM(3)      BSD and Linux Library Functions     OPEN_MEMSTREAM(3)
+ *
+ * SYNOPSIS
+ *     #include "memstream.h"
+ *
+ *     FILE *open_memstream(char **bufp, size_t *sizep);
+ *
+ * DESCRIPTION
+ *     The open_memstream()  function opens a  stream for writing to  a buffer.
+ *     The   buffer  is   dynamically  allocated   (as  with   malloc(3)),  and
+ *     automatically grows  as required.  After closing the  stream, the caller
+ *     should free(3) this buffer.
+ *
+ *     When  the  stream is  closed  (fclose(3))  or  flushed (fflush(3)),  the
+ *     locations  pointed  to  by  bufp  and  sizep  are  updated  to  contain,
+ *     respectively,  a pointer  to  the buffer  and  the current  size of  the
+ *     buffer.  These values  remain valid only as long  as the caller performs
+ *     no further output  on the stream.  If further  output is performed, then
+ *     the  stream  must  again  be  flushed  before  trying  to  access  these
+ *     variables.
+ *
+ *     A null byte  is maintained at the  end of the buffer.  This  byte is not
+ *     included in the size value stored at sizep.
+ *
+ *     The stream's  file position can  be changed with fseek(3)  or fseeko(3).
+ *     Moving the file position past the  end of the data already written fills
+ *     the intervening space with zeros.
+ *
+ * RETURN VALUE
+ *     Upon  successful  completion open_memstream()  returns  a FILE  pointer.
+ *     Otherwise, NULL is returned and errno is set to indicate the error.
+ *
+ * CONFORMING TO
+ *     POSIX.1-2008
+ *
+ * ----------------------------------------------------------------------------
+ */
+
+#ifndef min
+#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
+#endif
+
+struct memstream {
+	size_t position;
+	size_t size;
+	size_t capacity;
+	char *contents;
+	char **ptr;
+	size_t *sizeloc;
+};
+
+static int memstream_grow(struct memstream *ms, size_t minsize)
+{
+	size_t newcap;
+	char *newcontents;
+
+	newcap = ms->capacity * 2;
+	while (newcap <= minsize + 1)
+		newcap *= 2;
+	newcontents = realloc(ms->contents, newcap);
+	if (!newcontents)
+		return -1;
+	ms->contents = newcontents;
+	memset(ms->contents + ms->capacity, 0, newcap - ms->capacity);
+	ms->capacity = newcap;
+	*ms->ptr = ms->contents;
+	return 0;
+}
+
+static int memstream_read(void *cookie, char *buf, int count)
+{
+	struct memstream *ms = cookie;
+	size_t n;
+
+	n = min(ms->size - ms->position, (size_t)count);
+	if (n < 1)
+		return 0;
+	memcpy(buf, ms->contents, n);
+	ms->position += n;
+	return n;
+}
+
+static int memstream_write(void *cookie, const char *buf, int count)
+{
+	struct memstream *ms = cookie;
+
+	if (ms->capacity <= ms->position + (size_t)count &&
+	    memstream_grow(ms, ms->position + (size_t)count) < 0)
+		return -1;
+	memcpy(ms->contents + ms->position, buf, count);
+	ms->position += count;
+	ms->contents[ms->position] = '\0';
+	if (ms->size < ms->position)
+		*ms->sizeloc = ms->size = ms->position;
+
+	return count;
+}
+
+static fpos_t memstream_seek(void *cookie, fpos_t offset, int whence)
+{
+	struct memstream *ms = cookie;
+	fpos_t pos= 0;
+
+	switch (whence) {
+	case SEEK_SET:
+		pos = offset;
+		break;
+	case SEEK_CUR:
+		pos = ms->position + offset;
+		break;
+	case SEEK_END:
+		pos = ms->size + offset;
+		break;
+	default:
+		errno= EINVAL;
+		return -1;
+	}
+	if (pos >= (fpos_t)ms->capacity && memstream_grow(ms, pos) < 0)
+		return -1;
+	ms->position = pos;
+	if (ms->size < ms->position)
+		*ms->sizeloc = ms->size = ms->position;
+	return pos;
+}
+
+static int memstream_close(void *cookie)
+{
+	struct memstream *ms = cookie;
+
+	ms->size = min(ms->size, ms->position);
+	*ms->ptr = ms->contents;
+	*ms->sizeloc = ms->size;
+	ms->contents[ms->size]= 0;
+	/* ms->contents is what's returned */
+	free(ms);
+	return 0;
+}
+
+FILE *open_memstream(char **ptr, size_t *sizeloc)
+{
+	struct memstream *ms;
+	FILE *fp;
+
+	if (!ptr || !sizeloc) {
+		errno= EINVAL;
+		goto err_out;
+	}
+
+	ms = calloc(1, sizeof(struct memstream));
+	if (!ms)
+		goto err_out;
+
+	ms->position = ms->size= 0;
+	ms->capacity = 4096;
+	ms->contents = calloc(ms->capacity, 1);
+	if (!ms->contents)
+		goto err_free_ms;
+	ms->ptr = ptr;
+	ms->sizeloc = sizeloc;
+	fp= funopen(ms, memstream_read, memstream_write,
+			memstream_seek, memstream_close);
+	if (!fp)
+		goto err_free_all;
+	*ptr = ms->contents;
+	*sizeloc = ms->size;
+	return fp;
+
+err_free_all:
+	free(ms->contents);
+err_free_ms:
+	free(ms);
+err_out:
+	return NULL;
+}
+
+#endif /* __APPLE__ && _POSIX_C_SOURCE < 200809L */
+
+bool fy_tag_uri_is_valid(const char *data, size_t len)
+{
+	const char *s, *e;
+	int w, j, k, width, c;
+	uint8_t octet, esc_octets[4];
+
+	s = data;
+	e = s + len;
+
+	while ((c = fy_utf8_get(s, e - s, &w)) >= 0) {
+		if (c != '%') {
+			s += w;
+			continue;
+		}
+
+		width = 0;
+		k = 0;
+		do {
+			/* short URI escape */
+			if ((e - s) < 3)
+				return false;
+
+			if (width > 0) {
+				c = fy_utf8_get(s, e - s, &w);
+				if (c != '%')
+					return false;
+			}
+
+			s += w;
+
+			octet = 0;
+
+			for (j = 0; j < 2; j++) {
+				c = fy_utf8_get(s, e - s, &w);
+				if (!fy_is_hex(c))
+					return false;
+				s += w;
+
+				octet <<= 4;
+				if (c >= '0' && c <= '9')
+					octet |= c - '0';
+				else if (c >= 'a' && c <= 'f')
+					octet |= 10 + c - 'a';
+				else
+					octet |= 10 + c - 'A';
+			}
+			if (!width) {
+				width = fy_utf8_width_by_first_octet(octet);
+
+				if (width < 1 || width > 4)
+					return false;
+				k = 0;
+			}
+			esc_octets[k++] = octet;
+
+		} while (--width > 0);
+
+		/* now convert to utf8 */
+		c = fy_utf8_get(esc_octets, k, &w);
+
+		if (c < 0)
+			return false;
+	}
+
+	return true;
+}
+
+int fy_tag_handle_length(const char *data, size_t len)
+{
+	const char *s, *e;
+	int c, w;
+
+	s = data;
+	e = s + len;
+
+	c = fy_utf8_get(s, e - s, &w);
+	if (c != '!')
+		return -1;
+	s += w;
+
+	c = fy_utf8_get(s, e - s, &w);
+	if (c == -1)
+		return (int)len;
+
+	if (fy_is_ws(c))
+		return (int)(s - data);
+	/* if first character is !, empty handle */
+	if (c == '!') {
+		s += w;
+		return (int)(s - data);
+	}
+	if (!fy_is_first_alpha(c))
+		return -1;
+	s += w;
+	while (fy_is_alnum(c = fy_utf8_get(s, e - s, &w)))
+		s += w;
+	if (c == '!')
+		s += w;
+
+	return (int)(s - data);
+}
+
+int fy_tag_uri_length(const char *data, size_t len)
+{
+	const char *s, *e;
+	int c, w, cn, wn, uri_length;
+
+	s = data;
+	e = s + len;
+
+	while (fy_is_uri(c = fy_utf8_get(s, e - s, &w))) {
+		cn = fy_utf8_get(s + w, e - (s + w), &wn);
+		if ((fy_is_z(cn) || fy_is_blank(cn) || fy_is_any_lb(cn)) && fy_utf8_strchr(",}]", c))
+			break;
+		s += w;
+	}
+	uri_length = (int)(s - data);
+
+	if (!fy_tag_uri_is_valid(data, uri_length))
+		return -1;
+
+	return uri_length;
+}
+
+int fy_tag_scan(const char *data, size_t len, struct fy_tag_scan_info *info)
+{
+	const char *s, *e;
+	int total_length, handle_length, uri_length, prefix_length, suffix_length;
+	int c, cn, w, wn;
+	bool bare;
+
+	s = data;
+	e = s + len;
+
+	prefix_length = 0;
+
+	/* it must start with '!' */
+	c = fy_utf8_get(s, e - s, &w);
+	if (c == '!') {
+		bare = false;
+		cn = fy_utf8_get(s + w, e - (s + w), &wn);
+		if (cn == '<') {
+			prefix_length = 2;
+			suffix_length = 1;
+		} else
+			prefix_length = suffix_length = 0;
+
+		if (prefix_length) {
+			handle_length = 0; /* set the handle to '' */
+			s += prefix_length;
+		} else {
+			/* either !suffix or !handle!suffix */
+			/* we scan back to back, and split handle/suffix */
+			handle_length = fy_tag_handle_length(s, e - s);
+			if (handle_length < 0)
+				return -1;
+			s += handle_length;
+		}
+	} else {
+		bare = true;
+		/* it's just a uri */
+		prefix_length = 0;
+		handle_length = 0;
+		suffix_length = 0;
+	}
+
+	uri_length = fy_tag_uri_length(s, e - s);
+	if (uri_length < 0)
+		return -1;
+
+	/* a handle? */
+	if (!bare && !prefix_length && (handle_length == 0 || data[handle_length - 1] != '!')) {
+		/* special case, '!', handle set to '' and suffix to '!' */
+		if (handle_length == 1 && uri_length == 0) {
+			handle_length = 0;
+			uri_length = 1;
+		} else {
+			uri_length = handle_length - 1 + uri_length;
+			handle_length = 1;
+		}
+	}
+	total_length = prefix_length + handle_length + uri_length + suffix_length;
+
+	if (total_length != (int)len)
+		return -1;
+
+	info->total_length = total_length;
+	info->handle_length = handle_length;
+	info->uri_length = uri_length;
+	info->prefix_length = prefix_length;
+	info->suffix_length = suffix_length;
+
+	return 0;
+}
+
+/* simple terminal methods; mainly for getting size of terminal */
+/* These functions are not available on Windows */
+#ifndef _WIN32
+static int
+fy_term_set_raw(int fd, struct termios *oldt)
+{
+	struct termios newt, t;
+	int ret;
+
+	/* must be a terminal */
+	if (!isatty(fd))
+		return -1;
+
+	ret = tcgetattr(fd, &t);
+	if (ret != 0)
+		return ret;
+
+	newt = t;
+
+	cfmakeraw(&newt);
+    
+	ret = tcsetattr(fd, TCSANOW, &newt);
+	if (ret != 0)
+		return ret;
+
+	if (oldt)
+		*oldt = t;
+
+	return 0;
+}
+
+static int
+fy_term_restore(int fd, const struct termios *oldt)
+{
+	/* must be a terminal */
+	if (!isatty(fd))
+		return -1;
+
+	return tcsetattr(fd, TCSANOW, oldt);
+}
+
+static ssize_t
+fy_term_write(int fd, const void *data, size_t count)
+{
+	ssize_t wrn, r;
+
+	if (!isatty(fd))
+		return -1;
+	r = 0;
+	wrn = 0;
+	while (count > 0) {
+		do {
+			r = write(fd, data, count);
+		} while (r == -1 && errno == EAGAIN);
+		if (r < 0)
+			break;
+		wrn += r;
+		data += r;
+		count -= r;
+	}
+
+	/* return the amount written, or the last error code */
+	return wrn > 0 ? wrn : r;
+}
+
+static int
+fy_term_safe_write(int fd, const void *data, size_t count)
+{
+	if (!isatty(fd))
+		return -1;
+
+	return fy_term_write(fd, data, count) == (ssize_t)count ? 0 : -1;
+}
+
+static ssize_t
+fy_term_read(int fd, void *data, size_t count, int timeout_us)
+{
+	ssize_t rdn, r;
+	struct timeval tv, tvto, *tvp;
+	fd_set rdfds;
+
+	if (!isatty(fd))
+		return -1;
+
+	FD_ZERO(&rdfds);
+
+	memset(&tvto, 0, sizeof(tvto));
+	memset(&tv, 0, sizeof(tv));
+
+	if (timeout_us >= 0) {
+		tvto.tv_sec = timeout_us / 1000000;
+		tvto.tv_usec = timeout_us % 1000000;
+		tvp = &tv;
+	} else {
+		tvp = NULL;
+	}
+
+	r = 0;
+	rdn = 0;
+	while (count > 0) {
+		do {
+			FD_SET(fd, &rdfds);
+			if (tvp)
+				*tvp = tvto;
+			r = select(fd + 1, &rdfds, NULL, NULL, tvp);
+		} while (r == -1 && errno == EAGAIN);
+
+		/* select ends, or something weird */
+		if (r <= 0 || !FD_ISSET(fd, &rdfds))
+			break;
+
+		/* now read */
+		do {
+			r = read(fd, data, count);
+		} while (r == -1 && errno == EAGAIN);
+		if (r < 0)
+			break;
+
+		rdn += r;
+		data += r;
+		count -= r;
+	}
+
+	/* return the amount written, or the last error code */
+	return rdn > 0 ? rdn : r;
+}
+
+static ssize_t
+fy_term_read_escape(int fd, void *buf, size_t count)
+{
+	char *p;
+	int r, rdn;
+	char c;
+
+	/* at least 3 characters */
+	if (count < 3)
+		return -1;
+
+	p = buf;
+	rdn = 0;
+
+	/* ESC */
+	r = fy_term_read(fd, &c, 1, 100 * 1000);
+	if (r != 1 || c != '\x1b')
+		return -1;
+	*p++ = c;
+	count--;
+	rdn++;
+
+	/* [ */
+	r = fy_term_read(fd, &c, 1, 100 * 1000);
+	if (r != 1 || c != '[')
+		return rdn;
+	*p++ = c;
+	count--;
+	rdn++;
+
+	/* read until error, out of buffer, or < 0x40 || > 0x7e */
+	r = -1;
+	while (count > 0) {
+		r = fy_term_read(fd, &c, 1, 100 * 1000);
+		if (r != 1)
+			r = -1;
+		if (r != 1)
+			break;
+		*p++ = c;
+		count--;
+		rdn++;
+
+		/* end of escape */
+		if (c >= 0x40 && c <= 0x7e)
+			break;
+	}
+
+	return rdn;
+}
+
+static int
+fy_term_query_size_raw(int fd, int *rows, int *cols)
+{
+	char buf[32];
+	char *s, *e;
+	ssize_t r;
+
+	/* must be a terminal */
+	if (!isatty(fd))
+		return -1;
+
+	*rows = *cols = 0;
+
+	/* query text area */
+	r = fy_term_safe_write(fd, "\x1b[18t", 5);
+	if (r != 0)
+		return r;
+
+	/* read a character */
+	r = fy_term_read_escape(fd, buf, sizeof(buf));
+
+	/* return must be ESC[8;<height>;<width>;t */
+
+	if (r < 8 || r >= (int)sizeof(buf) - 2)	/* minimum ESC[8;1;1t */
+		return -1;
+
+	s = buf;
+	e = s + r;
+
+	/* correct response? starts with ESC[8; */
+	if (s[0] != '\x1b' || s[1] != '[' || s[2] != '8' || s[3] != ';')
+		return -1;
+	s += 4;
+
+	/* must end with t */
+	if (e[-1] != 't')
+		return -1;
+	*--e = '\0';	/* remove trailing t, and zero terminate */
+
+	/* scan two ints separated by ; */
+	r = sscanf(s, "%d;%d", rows, cols);
+	if (r != 2)
+		return -1;
+
+	return 0;
+}
+
+int fy_term_query_size(int fd, int *rows, int *cols)
+{
+	struct termios old_term;
+	int ret, r;
+
+	if (!isatty(fd))
+		return -1;
+
+	r = fy_term_set_raw(fd, &old_term);
+	if (r != 0)
+		return -1;
+
+	ret = fy_term_query_size_raw(fd, rows, cols);
+
+	r = fy_term_restore(fd, &old_term);
+	if (r != 0)
+		return -1;
+
+	return ret;
+}
+
+#else /* _WIN32 */
+
+int fy_term_query_size(int fd, int *rows, int *cols)
+{
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	HANDLE h;
+
+	if (fd != _fileno(stdout) && fd != _fileno(stderr))
+		return -1;
+
+	h = GetStdHandle(STD_OUTPUT_HANDLE);
+	if (!GetConsoleScreenBufferInfo(h, &csbi))
+		return -1;
+
+	*cols = (int)(csbi.srWindow.Right  - csbi.srWindow.Left + 1);
+	*rows = (int)(csbi.srWindow.Bottom - csbi.srWindow.Top  + 1);
+	return 0;
+}
+
+#endif /* !_WIN32 - end of terminal functions */
+
+int fy_comment_iter_begin(const char *comment, size_t size, struct fy_comment_iter *iter)
+{
+	if (!comment || !iter)
+		return -1;
+
+	memset(iter, 0, sizeof(*iter));
+	iter->start = comment;
+	iter->size = size == (size_t)-1 ? strlen(comment) : size;
+	iter->end = iter->start + iter->size;
+
+	if (!iter->size)
+		return -1;
+
+	iter->next = iter->start;
+	iter->line = 0;
+
+	return 0;
+}
+
+const char *fy_comment_iter_next_line(struct fy_comment_iter *iter, size_t *lenp)
+{
+	const char *s, *e, *le, *t;
+
+	if (!iter || !lenp || !iter->start)
+		return NULL;
+
+	/* no more */
+	if (iter->next >= iter->end)
+		return NULL;
+again:
+	*lenp = 0;
+
+	s = iter->next;
+	e = iter->end;
+
+	/* skip whitespace */
+	while (s < e && isblank((unsigned char)*s))
+		s++;
+
+	if (s >= e)
+		return NULL;
+
+	/* find end of line */
+	le = memchr(s, '\n', e - s);
+	if (!le) {
+		le = e;
+		iter->next = e;
+	} else {
+		iter->next = le + 1;
+	}
+
+	/* final? check if ends in *\/ */
+	if (le >= e && (le - s) > 2 && le[-2] == '*' && le[-1] == '/')
+		le -= 2;
+
+	/* backtrack while there's space at the end of line */
+	while (le > s && isblank((unsigned char)le[-1]))
+		le--;
+
+	/* check if the whole line is punctuation so it's formatting */
+	t = s;
+	while (t < le && ispunct((unsigned char)*t))
+		t++;
+
+	/* everything is punctuation? */
+	if (t > s && t >= le) {
+		if (((le - s) == 2 && s[0] == '/' && s[1] == '/') || 	/* '//' -> empty line */
+		    ((le - s) == 1 && s[0] == '*')) {			/* '*' -> empty line */
+			iter->line++;
+			return "";
+		}
+		/* for anything else, just try again */
+		goto again;
+	}
+
+	/* something is there, skip over '// ' or '* ' */
+	if ((le - s) > 3 && s[0] == '/' && s[1] == '/' && isblank((unsigned char)s[2]))
+		s += 3;
+	else if ((le - s) > 2 && s[0] == '*' && isblank((unsigned char)s[1]))
+		s += 2;
+	else if (iter->line == 0 && (le - s) > 3 && s[0] == '/' && s[1] == '*' && isblank((unsigned char)s[2]))
+		s += 3;
+
+	iter->line++;
+	*lenp = le - s;
+	return s;
+}
+
+void fy_comment_iter_end(struct fy_comment_iter *iter)
+{
+	/* nothing */
+}
+
+char *fy_get_cooked_comment(const char *raw_comment, size_t size)
+{
+	struct fy_memstream *fyms = NULL;
+	struct fy_comment_iter iter;
+	FILE *fp;
+	char *buf;
+	const char *line;
+	size_t len, line_len;
+	int ret;
+
+	if (!raw_comment)
+		return NULL;
+
+	fyms = fy_memstream_open(&fp);
+	if (!fyms)
+		return NULL;
+
+	ret = 0;
+	fy_comment_iter_begin(raw_comment, size, &iter);
+	while ((line = fy_comment_iter_next_line(&iter, &line_len)) != NULL) {
+		ret = fprintf(fp, "%.*s\n", (int)line_len, line);
+		if (ret < 0)
+			break;
+	}
+	fy_comment_iter_end(&iter);
+
+	buf = fy_memstream_close(fyms, &len);
+	if (ret < 0) {
+		if (buf)
+			free(buf);
+		return NULL;
+	}
+
+	/* must be freed */
+	return buf;
+}
+
+int fy_keyword_iter_begin(const char *text, size_t size, const char *keyword, struct fy_keyword_iter *iter)
+{
+	if (!text || !size || !keyword || !iter)
+		return -1;
+
+	memset(iter, 0, sizeof(*iter));
+	iter->keyword = keyword;
+	iter->keyword_len = strlen(keyword);
+	iter->start = text;
+	iter->size = size == (size_t)-1 ? strlen(text) : size;
+	iter->end = iter->start + iter->size;
+	iter->pc = '\n';
+
+	if (!iter->size)
+		return -1;
+
+	iter->next = iter->start;
+
+	return 0;
+}
+
+const char *fy_keyword_iter_next(struct fy_keyword_iter *iter)
+{
+	const char *keyword;
+	size_t keyword_len;
+	const char *s, *e;
+	int c, w, pc, mode;
+
+	if (!iter || !iter->start)
+		return NULL;
+
+	/* no more */
+	if (iter->next >= iter->end)
+		return NULL;
+
+	s = iter->next;
+	e = iter->end;
+
+	keyword = iter->keyword;
+	keyword_len = iter->keyword_len;
+
+	mode = 0;
+	pc = iter->pc;
+	while ((c = fy_utf8_get_s(s, e, &w)) >= 0) {
+
+		/* simple state machine to handle quoting */
+		switch (mode) {
+		case 0: /* unquoted */
+			if (c == keyword[0] && (fy_is_any_lb(pc) || fy_is_ws(pc)) &&
+			   (size_t)(e - s) > (keyword_len + 1) && !memcmp(s, keyword, keyword_len) &&
+			   (fy_is_ws(s[keyword_len]) || fy_is_any_lb(s[keyword_len]))) {
+
+				iter->next = s;
+				iter->pc = pc;
+				return s;
+			}
+
+			if (c == '\'')
+				mode = 1;
+			else if (c == '"')
+				mode = 3;
+			break;
+		case 1:	/* single quote */
+			if (c == '\\')
+				mode = 2;	/* escaped single quote? */
+			else if (c == '\'')
+				mode = 0;	/* back to unquoted */
+			break;
+		case 2:	/* single quote backslash */
+			mode = 1;	/* back to single quote mode always */
+			break;
+		case 3: /* double quote */
+			if (c == '\\')
+				mode = 4;	/* escaped quote? */
+			else if (c == '"')
+				mode = 0;	/* back to unquoted */
+			break;
+		case 4:
+			mode = 3;	/* back to double quote mode always */
+			break;
+		}
+		s += w;
+		pc = c;
+	}
+
+	return NULL;
+}
+
+void fy_keyword_iter_advance(struct fy_keyword_iter *iter, size_t advance)
+{
+	int w;
+	const char *prev;
+
+	if (!iter || !iter->next)
+		return;
+
+	prev = iter->next;
+
+	iter->next += advance;
+	if (iter->next >= iter->end)
+		iter->next = iter->end;
+
+	iter->pc = fy_utf8_get_right(prev, (size_t)(iter->next - prev), &w);
+	if (iter->pc < 0)
+		iter->pc = '\n';
+}
+
+void fy_keyword_iter_end(struct fy_keyword_iter *iter)
+{
+	/* nothing */
+}
+
+#define FY_XXHASH64_SEED	((uint64_t)0x1973198120142019U)
+
+uint64_t fy_iovec_xxhash64(const struct iovec *iov, int iovcnt)
+{
+	XXH64_state_t xxstate;
+	uint64_t hash;
+	int i;
+
+	XXH64_reset(&xxstate, FY_XXHASH64_SEED);
+	for (i = 0; i < iovcnt; i++)
+		XXH64_update(&xxstate, iov[i].iov_base, iov[i].iov_len);
+	hash = XXH64_digest(&xxstate);
+	/* XXX we never return a hash value of zero */
+	if (!hash)
+		hash++;
+	return hash;
+}
+
+struct fy_memstream {
+	FILE *fp;
+	char *buf;
+	size_t size;
+};
+
+struct fy_memstream *fy_memstream_open(FILE **fpp)
+{
+	struct fy_memstream *fyms;
+
+	if (!fpp)
+		return NULL;
+
+	*fpp = NULL;
+
+	fyms = malloc(sizeof(*fyms));
+	if (!fyms)
+		return NULL;
+	memset(fyms, 0, sizeof(*fyms));
+#if !defined(_WIN32)
+	fyms->fp = open_memstream(&fyms->buf, &fyms->size);
+#else
+	fyms->fp = tmpfile();
+#endif
+	if (!fyms->fp) {
+		free(fyms);
+		return NULL;
+	}
+	*fpp = fyms->fp;
+	return fyms;
+}
+
+char *fy_memstream_close(struct fy_memstream *fyms, size_t *sizep)
+{
+	char *buf;
+#if defined(_WIN32)
+	long sz;
+#endif
+
+	if (!fyms) {
+		*sizep = 0;
+		return NULL;
+	}
+
+#if defined(_WIN32)
+	if (fyms->fp && fflush(fyms->fp) == 0 &&
+	    (sz = ftell(fyms->fp)) >= 0 &&
+	    (fyms->buf = malloc((size_t)sz + 1)) != NULL) {
+		rewind(fyms->fp);
+		fyms->size = fread(fyms->buf, 1, (size_t)sz, fyms->fp);
+		fyms->buf[fyms->size] = '\0';
+	}
+#endif
+
+	if (fyms->fp)
+		fclose(fyms->fp);
+
+	/* the buffer is updated only after close */
+	buf = fyms->buf;
+	*sizep = buf ? fyms->size : 0;
+
+	free(fyms);
+
+	return buf;
+}

--- a/numcosmo/external/libfyaml/src/util/fy-utils.h
+++ b/numcosmo/external/libfyaml/src/util/fy-utils.h
@@ -1,0 +1,222 @@
+/*
+ * fy-utils.h - internal utilities header file
+ *
+ * Copyright (c) 2019 Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef FY_UTILS_H
+#define FY_UTILS_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <termios.h>
+#include <sys/uio.h>
+#endif
+
+#include "fy-win32.h"
+
+/*
+ * Define FY_CPP_SHORT_NAMES to use shortened macro names in the implementation.
+ * This significantly reduces expansion buffer usage during recursive macro expansion,
+ * which can help avoid internal compiler errors and speed up compilation.
+ *
+ * The public API (FY_CPP_*) remains the same regardless of this setting.
+ */
+
+#define FY_CPP_SHORT_NAMES
+
+#if defined(__linux__)
+#include <sys/sysmacros.h>
+#endif
+
+#include <libfyaml/libfyaml-util.h>
+
+#if !defined(NDEBUG) && defined(HAVE_DEVMODE) && HAVE_DEVMODE
+#define FY_DEVMODE
+#else
+#undef FY_DEVMODE
+#endif
+
+#ifdef FY_DEVMODE
+#define __FY_DEBUG_UNUSED__	/* nothing */
+#else
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define __FY_DEBUG_UNUSED__	__attribute__((__unused__))
+#else
+#define __FY_DEBUG_UNUSED__	/* nothing */
+#endif
+#endif
+
+#if defined(__APPLE__) && (_POSIX_C_SOURCE < 200809L)
+FILE *open_memstream(char **ptr, size_t *sizeloc);
+#endif
+
+int fy_tag_handle_length(const char *data, size_t len);
+bool fy_tag_uri_is_valid(const char *data, size_t len);
+int fy_tag_uri_length(const char *data, size_t len);
+
+struct fy_tag_scan_info {
+	int total_length;
+	int handle_length;
+	int uri_length;
+	int prefix_length;
+	int suffix_length;
+};
+
+int fy_tag_scan(const char *data, size_t len, struct fy_tag_scan_info *info);
+
+/* the non raw methods will set the terminal to raw and then restore */
+int fy_term_query_size(int fd, int *rows, int *cols);
+
+struct fy_comment_iter {
+	const char *start;
+	size_t size;
+	const char *end;
+	const char *next;
+	int line;
+};
+
+int fy_comment_iter_begin(const char *comment, size_t size, struct fy_comment_iter *iter);
+const char *fy_comment_iter_next_line(struct fy_comment_iter *iter, size_t *lenp);
+void fy_comment_iter_end(struct fy_comment_iter *iter);
+
+char *fy_get_cooked_comment(const char *raw_comment, size_t size);
+
+struct fy_keyword_iter {
+	const char *keyword;
+	size_t keyword_len;
+	const char *start;
+	size_t size;
+	const char *end;
+	const char *next;
+	int pc;
+};
+
+int fy_keyword_iter_begin(const char *text, size_t size, const char *keyword, struct fy_keyword_iter *iter);
+const char *fy_keyword_iter_next(struct fy_keyword_iter *iter);
+void fy_keyword_iter_advance(struct fy_keyword_iter *iter, size_t advance);
+void fy_keyword_iter_end(struct fy_keyword_iter *iter);
+
+#if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
+
+#if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+
+static inline void fy_strip_trailing_nl(char *str)
+{
+	char *s;
+
+	if (str) {
+		s = str + strlen(str);
+		while (s > str && s[-1] == '\n')
+			*--s = '\0';
+	}
+}
+
+static inline size_t
+fy_iovec_size(const struct iovec *iov, int iovcnt)
+{
+	size_t size;
+	int i;
+
+	size = 0;
+	for (i = 0; i < iovcnt; i++) {
+#ifndef _MSC_VER
+		if (FY_ADD_OVERFLOW(size, iov[i].iov_len, &size))
+			return SIZE_MAX;
+#else
+		/* MSVC is hopeless, just open code it */
+		if ((ssize_t)iov[i].iov_len < 0)
+			return SIZE_MAX;
+		size += iov[i].iov_len;
+		if ((ssize_t)size < 0)
+			return SIZE_MAX;
+#endif
+	}
+	return size;
+}
+
+static inline void *
+fy_iovec_copy_from(const struct iovec *iov, int iovcnt, void *dst)
+{
+	size_t size;
+	int i;
+
+	for (i = 0; i < iovcnt; i++, dst = (void *)((char *)dst + size)) {
+		size = iov[i].iov_len;
+		memcpy(dst, iov[i].iov_base, size);
+	}
+	return dst;
+}
+
+static inline const void *
+fy_iovec_copy_to(const struct iovec *iov, int iovcnt, const void *src)
+{
+	size_t size;
+	int i;
+
+	for (i = 0; i < iovcnt; i++, src = (const void *)((const char *)src + size)) {
+		size = iov[i].iov_len;
+		memcpy(iov[i].iov_base, src, size);
+	}
+	return src;
+}
+
+static inline int
+fy_iovec_cmp(const struct iovec *iov, int iovcnt, const void *data)
+{
+	const void *s = data;
+	size_t size;
+	int i, ret;
+
+	for (i = 0; i < iovcnt; i++, s = (const void *)((const char *)s + size)) {
+		size = iov[i].iov_len;
+		ret = memcmp(iov[i].iov_base, s, size);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+
+uint64_t fy_iovec_xxhash64(const struct iovec *iov, int iovcnt);
+
+/* detect whether we're running under asan */
+static inline bool
+fy_is_asan_enabled(void)
+{
+#if defined(__clang__) || defined(__GNUC__)
+#ifdef __SANITIZE_ADDRESS__
+	return true;
+#else
+	extern void __asan_init(void) __attribute__((weak));
+	return __asan_init != NULL;
+#endif
+#else
+	return false;
+#endif
+}
+
+/* wrapper for memstream, on all platforms */
+struct fy_memstream;	// opaque
+
+struct fy_memstream *fy_memstream_open(FILE **fpp);
+char *fy_memstream_close(struct fy_memstream *fyms, size_t *sizep);
+
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-vlsize.h
+++ b/numcosmo/external/libfyaml/src/util/fy-vlsize.h
@@ -1,0 +1,4 @@
+#ifndef FY_VLSIZE_H
+#define FY_VLSIZE_H
+#include <libfyaml/fy-vlsize.h>
+#endif

--- a/numcosmo/external/libfyaml/src/util/fy-win32.h
+++ b/numcosmo/external/libfyaml/src/util/fy-win32.h
@@ -1,0 +1,626 @@
+/*
+ * fy-win32.h - Windows compatibility layer
+ *
+ * Copyright (c) 2024-2026 libfyaml contributors
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * This header provides Unix-like APIs on Windows to allow libfyaml to
+ * build and run on Windows platforms.
+ */
+#ifndef FY_WIN32_H
+#define FY_WIN32_H
+
+#ifdef _WIN32
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include <windows.h>
+/* Undefine Windows macros that conflict with common identifiers */
+#ifdef near
+#undef near
+#endif
+#ifdef far
+#undef far
+#endif
+#include <io.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <direct.h>
+#include <process.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <stdarg.h>
+#include <malloc.h>
+
+/* ssize_t is not defined on Windows */
+#ifndef _SSIZE_T_DEFINED
+#define _SSIZE_T_DEFINED
+#ifdef _WIN64
+typedef __int64 ssize_t;
+#else
+typedef int ssize_t;
+#endif
+#endif
+
+/* POSIX types that MSVC only provides with underscore prefix */
+#ifndef _OFF_T_DEFINED_AS_OFF_T
+#define _OFF_T_DEFINED_AS_OFF_T
+typedef _off_t off_t;
+#endif
+#ifndef _DEV_T_DEFINED_AS_DEV_T
+#define _DEV_T_DEFINED_AS_DEV_T
+typedef _dev_t dev_t;
+#endif
+
+/* Provide SSIZE_MAX if not defined */
+#ifndef SSIZE_MAX
+#ifdef _WIN64
+#define SSIZE_MAX _I64_MAX
+#else
+#define SSIZE_MAX INT_MAX
+#endif
+#endif
+
+/*
+ * Memory mapping emulation using Windows Virtual Memory APIs
+ */
+
+/* mmap protection flags */
+#ifndef PROT_NONE
+#define PROT_NONE  0x0
+#define PROT_READ  0x1
+#define PROT_WRITE 0x2
+#define PROT_EXEC  0x4
+#endif
+
+/* mmap flags */
+#ifndef MAP_SHARED
+#define MAP_SHARED    0x01
+#define MAP_PRIVATE   0x02
+#define MAP_ANONYMOUS 0x20
+#define MAP_ANON      MAP_ANONYMOUS
+#define MAP_FAILED    ((void *)-1)
+#endif
+
+static inline void *fy_win32_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
+{
+	DWORD flProtect = 0;
+	DWORD dwDesiredAccess = 0;
+	HANDLE hFile = INVALID_HANDLE_VALUE;
+	HANDLE hMapping = NULL;
+	void *ptr = NULL;
+
+	(void)addr; /* Hint address is ignored */
+
+	/* Anonymous mapping - use VirtualAlloc */
+	if (flags & MAP_ANONYMOUS) {
+		DWORD flAllocationType = MEM_RESERVE | MEM_COMMIT;
+		DWORD flAllocProtect = 0;
+
+		if (prot == PROT_NONE)
+			flAllocProtect = PAGE_NOACCESS;
+		else if (prot & PROT_EXEC) {
+			if (prot & PROT_WRITE)
+				flAllocProtect = PAGE_EXECUTE_READWRITE;
+			else
+				flAllocProtect = PAGE_EXECUTE_READ;
+		} else if (prot & PROT_WRITE)
+			flAllocProtect = PAGE_READWRITE;
+		else
+			flAllocProtect = PAGE_READONLY;
+
+		ptr = VirtualAlloc(NULL, length, flAllocationType, flAllocProtect);
+		if (!ptr)
+			return MAP_FAILED;
+		return ptr;
+	}
+
+	/* File mapping */
+	if (fd < 0) {
+		errno = EBADF;
+		return MAP_FAILED;
+	}
+
+	hFile = (HANDLE)_get_osfhandle(fd);
+	if (hFile == INVALID_HANDLE_VALUE) {
+		errno = EBADF;
+		return MAP_FAILED;
+	}
+
+	/* Set protection and access flags */
+	if (prot == PROT_NONE) {
+		flProtect = PAGE_NOACCESS;
+		dwDesiredAccess = 0;
+	} else if (prot & PROT_EXEC) {
+		if (prot & PROT_WRITE) {
+			flProtect = PAGE_EXECUTE_READWRITE;
+			dwDesiredAccess = FILE_MAP_WRITE | FILE_MAP_EXECUTE;
+		} else {
+			flProtect = PAGE_EXECUTE_READ;
+			dwDesiredAccess = FILE_MAP_READ | FILE_MAP_EXECUTE;
+		}
+	} else if (prot & PROT_WRITE) {
+		if (flags & MAP_PRIVATE) {
+			flProtect = PAGE_WRITECOPY;
+			dwDesiredAccess = FILE_MAP_COPY;
+		} else {
+			flProtect = PAGE_READWRITE;
+			dwDesiredAccess = FILE_MAP_WRITE;
+		}
+	} else {
+		flProtect = PAGE_READONLY;
+		dwDesiredAccess = FILE_MAP_READ;
+	}
+
+	hMapping = CreateFileMapping(hFile, NULL, flProtect, 0, 0, NULL);
+	if (!hMapping) {
+		errno = ENOMEM;
+		return MAP_FAILED;
+	}
+
+	ptr = MapViewOfFile(hMapping, dwDesiredAccess,
+			    (DWORD)((uint64_t)offset >> 32), (DWORD)offset, length);
+	CloseHandle(hMapping);
+
+	if (!ptr) {
+		errno = ENOMEM;
+		return MAP_FAILED;
+	}
+
+	return ptr;
+}
+
+static inline int fy_win32_munmap(void *addr, size_t length)
+{
+	(void)length;
+
+	/*
+	 * We try both VirtualFree (for anonymous mappings) and
+	 * UnmapViewOfFile (for file mappings). One of them will succeed.
+	 */
+	if (UnmapViewOfFile(addr))
+		return 0;
+	if (VirtualFree(addr, 0, MEM_RELEASE))
+		return 0;
+
+	errno = EINVAL;
+	return -1;
+}
+
+/* Define mmap/munmap macros that use our implementations */
+#define mmap(addr, length, prot, flags, fd, offset) \
+	fy_win32_mmap(addr, length, prot, flags, fd, offset)
+#define munmap(addr, length) \
+	fy_win32_munmap(addr, length)
+
+/* mremap is not supported on Windows - will never be defined */
+
+/*
+ * File descriptor operations
+ */
+
+/* open() flags that may be missing */
+#ifndef O_RDONLY
+#define O_RDONLY _O_RDONLY
+#endif
+#ifndef O_WRONLY
+#define O_WRONLY _O_WRONLY
+#endif
+#ifndef O_RDWR
+#define O_RDWR _O_RDWR
+#endif
+#ifndef O_CREAT
+#define O_CREAT _O_CREAT
+#endif
+#ifndef O_TRUNC
+#define O_TRUNC _O_TRUNC
+#endif
+#ifndef O_APPEND
+#define O_APPEND _O_APPEND
+#endif
+#ifndef O_BINARY
+#define O_BINARY _O_BINARY
+#endif
+
+/* Standard file descriptor numbers */
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
+
+static inline int fy_win32_open(const char *pathname, int flags, ...)
+{
+	/* always use O_BINARY to avoid CRLF mangling */
+	return _open(pathname, flags | O_BINARY);
+}
+
+/* Use _open, _close on Windows */
+#ifndef open
+#define open fy_win32_open
+#endif
+#ifndef close
+#define close _close
+#endif
+
+/*
+ * Windows _read/_write use unsigned int (32-bit) for count.
+ * Provide wrappers that handle size_t properly by chunking large I/O.
+ */
+static inline ssize_t fy_win32_read(int fd, void *buf, size_t count)
+{
+	unsigned char *p = (unsigned char *)buf;
+	size_t remaining = count;
+	ssize_t total = 0;
+
+	while (remaining > 0) {
+		unsigned int chunk = (remaining > UINT_MAX) ? UINT_MAX : (unsigned int)remaining;
+		int ret = _read(fd, p, chunk);
+		if (ret < 0)
+			return total > 0 ? total : -1;
+		if (ret == 0)
+			break;
+		total += ret;
+		p += ret;
+		remaining -= ret;
+		if ((unsigned int)ret < chunk)
+			break;  /* short read */
+	}
+	return total;
+}
+
+static inline ssize_t fy_win32_write(int fd, const void *buf, size_t count)
+{
+	const unsigned char *p = (const unsigned char *)buf;
+	size_t remaining = count;
+	ssize_t total = 0;
+
+	while (remaining > 0) {
+		unsigned int chunk = (remaining > UINT_MAX) ? UINT_MAX : (unsigned int)remaining;
+		int ret = _write(fd, p, chunk);
+		if (ret < 0)
+			return total > 0 ? total : -1;
+		if (ret == 0)
+			break;
+		total += ret;
+		p += ret;
+		remaining -= ret;
+		if ((unsigned int)ret < chunk)
+			break;  /* short write */
+	}
+	return total;
+}
+
+#ifndef read
+#define read fy_win32_read
+#endif
+#ifndef write
+#define write fy_win32_write
+#endif
+#ifndef lseek
+#define lseek _lseek
+#endif
+#ifndef fileno
+#define fileno _fileno
+#endif
+#ifndef fdopen
+#define fdopen _fdopen
+#endif
+#ifndef dup
+#define dup _dup
+#endif
+#ifndef dup2
+#define dup2 _dup2
+#endif
+#ifndef access
+#define access _access
+#endif
+
+/* stat structure and functions */
+#ifndef stat
+#define stat _stat64
+#endif
+#ifndef fstat
+#define fstat _fstat64
+#endif
+
+#ifndef isatty
+
+static inline int
+fy_win32_isatty(int fd)
+{
+	HANDLE h;
+	DWORD mode;
+
+	h = (HANDLE)_get_osfhandle(fd);
+	if (h == INVALID_HANDLE_VALUE || h == NULL)
+		return 0;
+
+	return GetConsoleMode(h, &mode) != 0;
+}
+
+#define isatty(fd) fy_win32_isatty(fd)
+#endif
+
+/* S_ISREG and S_ISDIR macros */
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
+#endif
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
+#endif
+#ifndef S_IFREG
+#define S_IFREG _S_IFREG
+#endif
+#ifndef S_IFMT
+#define S_IFMT _S_IFMT
+#endif
+
+/* Unix file permission macros - Windows doesn't have these */
+#ifndef S_IRUSR
+#define S_IRUSR _S_IREAD
+#endif
+#ifndef S_IWUSR
+#define S_IWUSR _S_IWRITE
+#endif
+#ifndef S_IXUSR
+#define S_IXUSR _S_IEXEC
+#endif
+/* Group/other permissions don't exist on Windows, define as 0 */
+#ifndef S_IRGRP
+#define S_IRGRP 0
+#endif
+#ifndef S_IWGRP
+#define S_IWGRP 0
+#endif
+#ifndef S_IXGRP
+#define S_IXGRP 0
+#endif
+#ifndef S_IROTH
+#define S_IROTH 0
+#endif
+#ifndef S_IWOTH
+#define S_IWOTH 0
+#endif
+#ifndef S_IXOTH
+#define S_IXOTH 0
+#endif
+
+/*
+ * System configuration - sysconf() emulation
+ */
+#ifndef _SC_PAGESIZE
+#define _SC_PAGESIZE 1
+#endif
+#ifndef _SC_NPROCESSORS_ONLN
+#define _SC_NPROCESSORS_ONLN 2
+#endif
+
+static inline long fy_win32_sysconf(int name)
+{
+	SYSTEM_INFO si;
+
+	switch (name) {
+	case _SC_PAGESIZE:
+		GetSystemInfo(&si);
+		return (long)si.dwPageSize;
+	case _SC_NPROCESSORS_ONLN:
+		GetSystemInfo(&si);
+		return (long)si.dwNumberOfProcessors;
+	default:
+		errno = EINVAL;
+		return -1;
+	}
+}
+
+#define sysconf(name) fy_win32_sysconf(name)
+
+/*
+ * asprintf() implementation for Windows
+ */
+#ifndef HAVE_ASPRINTF
+
+static inline int fy_win32_vasprintf(char **strp, const char *fmt, va_list ap)
+{
+	int len;
+	va_list ap_copy;
+
+	va_copy(ap_copy, ap);
+	len = _vscprintf(fmt, ap_copy);
+	va_end(ap_copy);
+
+	if (len < 0) {
+		*strp = NULL;
+		return -1;
+	}
+
+	*strp = (char *)malloc(len + 1);
+	if (!*strp)
+		return -1;
+
+	len = vsprintf(*strp, fmt, ap);
+	if (len < 0) {
+		free(*strp);
+		*strp = NULL;
+		return -1;
+	}
+
+	return len;
+}
+
+static inline int fy_win32_asprintf(char **strp, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = fy_win32_vasprintf(strp, fmt, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+#define asprintf fy_win32_asprintf
+#define vasprintf fy_win32_vasprintf
+
+#endif /* HAVE_ASPRINTF */
+
+/*
+ * Directory functions
+ */
+#ifndef getcwd
+#define getcwd _getcwd
+#endif
+#ifndef mkdir
+#define mkdir(path, mode) _mkdir(path)
+#endif
+#ifndef rmdir
+#define rmdir _rmdir
+#endif
+#ifndef chdir
+#define chdir _chdir
+#endif
+
+/*
+ * Process functions
+ */
+#ifndef getpid
+#define getpid _getpid
+#endif
+
+/*
+ * String functions
+ */
+#ifndef strcasecmp
+#define strcasecmp _stricmp
+#endif
+#ifndef strncasecmp
+#define strncasecmp _strnicmp
+#endif
+#ifndef strdup
+#define strdup _strdup
+#endif
+
+/*
+ * Sleep functions
+ */
+static inline unsigned int fy_win32_sleep(unsigned int seconds)
+{
+	Sleep(seconds * 1000);
+	return 0;
+}
+
+static inline int fy_win32_usleep(unsigned int usec)
+{
+	HANDLE timer;
+	LARGE_INTEGER ft;
+
+	ft.QuadPart = -(10 * (LONGLONG)usec);
+	timer = CreateWaitableTimer(NULL, TRUE, NULL);
+	if (!timer)
+		return -1;
+	SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);
+	WaitForSingleObject(timer, INFINITE);
+	CloseHandle(timer);
+	return 0;
+}
+
+#define sleep(s) fy_win32_sleep(s)
+#define usleep(us) fy_win32_usleep(us)
+
+/*
+ * clock_gettime emulation for Windows
+ */
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 1
+#endif
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME 0
+#endif
+
+/*
+ * struct timespec is defined in UCRT's time.h for MSVC 2015+ (VS2015+)
+ * time.h is included above to ensure it's available.
+ */
+
+static inline int fy_win32_clock_gettime(int clock_id, struct timespec *tp)
+{
+	LARGE_INTEGER freq, count;
+	FILETIME ft;
+	ULARGE_INTEGER uli;
+
+	if (clock_id == CLOCK_MONOTONIC) {
+		if (!QueryPerformanceFrequency(&freq))
+			return -1;
+		if (!QueryPerformanceCounter(&count))
+			return -1;
+		tp->tv_sec = (time_t)(count.QuadPart / freq.QuadPart);
+		tp->tv_nsec = (long)((count.QuadPart % freq.QuadPart) * 1000000000LL / freq.QuadPart);
+	} else {
+		/* CLOCK_REALTIME */
+		GetSystemTimeAsFileTime(&ft);
+		uli.LowPart = ft.dwLowDateTime;
+		uli.HighPart = ft.dwHighDateTime;
+		/* FILETIME is 100-nanosecond intervals since January 1, 1601 */
+		/* Convert to Unix epoch (seconds since January 1, 1970) */
+		uli.QuadPart -= 116444736000000000ULL;
+		tp->tv_sec = (time_t)(uli.QuadPart / 10000000ULL);
+		tp->tv_nsec = (long)((uli.QuadPart % 10000000ULL) * 100);
+	}
+	return 0;
+}
+
+#define clock_gettime(clock_id, tp) fy_win32_clock_gettime(clock_id, tp)
+
+/*
+ * EAGAIN may be different from EWOULDBLOCK on some systems
+ */
+#ifndef EAGAIN
+#define EAGAIN EWOULDBLOCK
+#endif
+
+/*
+ * alloca is available as _alloca on Windows
+ */
+#ifndef alloca
+#define alloca _alloca
+#endif
+
+/*
+ * iovec structure for scatter/gather I/O
+ * Defined here since sys/uio.h doesn't exist on Windows
+ */
+#ifndef _FY_IOVEC_DEFINED
+#define _FY_IOVEC_DEFINED
+struct iovec {
+	void  *iov_base;  /* Starting address */
+	size_t iov_len;   /* Number of bytes to transfer */
+};
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+typedef union {
+    void*        p;
+    double       d;
+    __int64      i64;
+} max_align_t;
+#endif
+
+#endif /* _WIN32 */
+
+#endif /* FY_WIN32_H */

--- a/numcosmo/external/libfyaml/src/xxhash/xxhash.c
+++ b/numcosmo/external/libfyaml/src/xxhash/xxhash.c
@@ -1,0 +1,1894 @@
+/*
+xxHash - Fast Hash algorithm
+Copyright (C) 2012-2014, Yann Collet.
+BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You can contact the author at :
+- xxHash source repository : http://code.google.com/p/xxhash/
+- public discussion board : https://groups.google.com/forum/#!forum/lz4c
+*/
+
+
+//**************************************
+// Tuning parameters
+//**************************************
+// Unaligned memory access is automatically enabled for "common" CPU, such as x86.
+// For others CPU, the compiler will be more cautious, and insert extra code to ensure aligned access is respected.
+// If you know your target CPU supports unaligned memory access, you want to force this option manually to improve performance.
+// You can also enable this parameter if you know your input data will always be aligned (boundaries of 4, for U32).
+#if defined(__ARM_FEATURE_UNALIGNED) || defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
+#  define XXH_USE_UNALIGNED_ACCESS 1
+#endif
+
+// panto: disable unaligned access when running with asan
+#if defined(XXH_USE_UNALIGNED_ACCESS)
+#  if defined(__has_feature)
+#    if __has_feature(address_sanitizer)
+#      undef XXH_USE_UNALIGNED_ACCESS
+#    endif
+#  endif
+#endif
+
+// fallback for old GCC versions
+#if defined(XXH_USE_UNALIGNED_ACCESS)
+#  if defined(__SANITIZE_ADDRESS__)
+#    undef XXH_USE_UNALIGNED_ACCESS
+#  endif
+#endif
+
+// XXH_ACCEPT_NULL_INPUT_POINTER :
+// If the input pointer is a null pointer, xxHash default behavior is to trigger a memory access error, since it is a bad pointer.
+// When this option is enabled, xxHash output for null input pointers will be the same as a null-length input.
+// This option has a very small performance cost (only measurable on small inputs).
+// By default, this option is disabled. To enable it, uncomment below define :
+// #define XXH_ACCEPT_NULL_INPUT_POINTER 1
+
+// XXH_FORCE_NATIVE_FORMAT :
+// By default, xxHash library provides endian-independant Hash values, based on little-endian convention.
+// Results are therefore identical for little-endian and big-endian CPU.
+// This comes at a performance cost for big-endian CPU, since some swapping is required to emulate little-endian format.
+// Should endian-independance be of no importance for your application, you may set the #define below to 1.
+// It will improve speed for Big-endian CPU.
+// This option has no impact on Little_Endian CPU.
+#define XXH_FORCE_NATIVE_FORMAT 0
+
+//**************************************
+// Compiler Specific Options
+//**************************************
+// Disable some Visual warning messages
+#ifdef _MSC_VER  // Visual Studio
+#  pragma warning(disable : 4127)      // disable: C4127: conditional expression is constant
+#endif
+
+#ifdef _MSC_VER    // Visual Studio
+#  define FORCE_INLINE static __forceinline
+#else
+#  ifdef __GNUC__
+#    define FORCE_INLINE static inline __attribute__((always_inline))
+#  else
+#    define FORCE_INLINE static inline
+#  endif
+#endif
+
+//**************************************
+// Includes & Memory related functions
+//**************************************
+#include "xxhash.h"
+// Modify the local functions below should you wish to use some other memory routines
+// for malloc(), free()
+#include <stdlib.h>
+FORCE_INLINE void* XXH_malloc(size_t s) { return malloc(s); }
+FORCE_INLINE void  XXH_free  (void* p)  { free(p); }
+// for memcpy()
+#include <string.h>
+FORCE_INLINE void* XXH_memcpy(void* dest, const void* src, size_t size)
+{
+    return memcpy(dest,src,size);
+}
+
+//**************************************
+// Basic Types
+//**************************************
+#if defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L   // C99
+# include <stdint.h>
+typedef uint8_t  BYTE;
+typedef uint16_t U16;
+typedef uint32_t U32;
+typedef  int32_t S32;
+typedef uint64_t U64;
+#else
+typedef unsigned char      BYTE;
+typedef unsigned short     U16;
+typedef unsigned int       U32;
+typedef   signed int       S32;
+typedef unsigned long long U64;
+#endif
+
+
+#if defined(__GNUC__)  && !defined(XXH_USE_UNALIGNED_ACCESS)
+#  define _PACKED __attribute__ ((packed))
+#else
+#  define _PACKED
+#endif
+
+#if !defined(XXH_USE_UNALIGNED_ACCESS) && !defined(__GNUC__)
+#  ifdef __IBMC__
+#    pragma pack(1)
+#  else
+#    pragma pack(push, 1)
+#  endif
+#endif
+
+typedef struct _U32_S
+{
+    U32 v;
+} _PACKED U32_S;
+typedef struct _U64_S
+{
+    U64 v;
+} _PACKED U64_S;
+
+#if !defined(XXH_USE_UNALIGNED_ACCESS) && !defined(__GNUC__)
+#  pragma pack(pop)
+#endif
+
+#define A32(x) (((U32_S *)(x))->v)
+#define A64(x) (((U64_S *)(x))->v)
+
+
+//***************************************
+// Compiler-specific Functions and Macros
+//***************************************
+#define GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+
+// Note : although _rotl exists for minGW (GCC under windows), performance seems poor
+#if defined(_MSC_VER)
+#  define XXH_rotl32(x,r) _rotl(x,r)
+#  define XXH_rotl64(x,r) _rotl64(x,r)
+#else
+#  define XXH_rotl32(x,r) ((x << r) | (x >> (32 - r)))
+#  define XXH_rotl64(x,r) ((x << r) | (x >> (64 - r)))
+#endif
+
+
+#if defined(_MSC_VER)     // Visual Studio
+#  define XXH_swap32 _byteswap_ulong
+#  define XXH_swap64 _byteswap_uint64
+#elif GCC_VERSION >= 403
+#  define XXH_swap32 __builtin_bswap32
+#  define XXH_swap64 __builtin_bswap64
+#else
+FORCE_INLINE U32 XXH_swap32 (U32 x)
+{
+    return  ((x << 24) & 0xff000000 ) |
+            ((x <<  8) & 0x00ff0000 ) |
+            ((x >>  8) & 0x0000ff00 ) |
+            ((x >> 24) & 0x000000ff );
+}
+FORCE_INLINE U64 XXH_swap64 (U64 x)
+{
+    return  ((x << 56) & 0xff00000000000000ULL) |
+            ((x << 40) & 0x00ff000000000000ULL) |
+            ((x << 24) & 0x0000ff0000000000ULL) |
+            ((x << 8)  & 0x000000ff00000000ULL) |
+            ((x >> 8)  & 0x00000000ff000000ULL) |
+            ((x >> 24) & 0x0000000000ff0000ULL) |
+            ((x >> 40) & 0x000000000000ff00ULL) |
+            ((x >> 56) & 0x00000000000000ffULL);
+}
+#endif
+
+//**************************************
+// Constants
+//**************************************
+#define PRIME32_1   2654435761U
+#define PRIME32_2   2246822519U
+#define PRIME32_3   3266489917U
+#define PRIME32_4    668265263U
+#define PRIME32_5    374761393U
+
+#define PRIME64_1 11400714785074694791ULL
+#define PRIME64_2 14029467366897019727ULL
+#define PRIME64_3  1609587929392839161ULL
+#define PRIME64_4  9650029242287828579ULL
+#define PRIME64_5  2870177450012600261ULL
+
+//**************************************
+// Architecture Macros
+//**************************************
+typedef enum { XXH_bigEndian=0, XXH_littleEndian=1 } XXH_endianess;
+#ifndef XXH_CPU_LITTLE_ENDIAN   // It is possible to define XXH_CPU_LITTLE_ENDIAN externally, for example using a compiler switch
+static const int one = 1;
+#   define XXH_CPU_LITTLE_ENDIAN   (*(char*)(&one))
+#endif
+
+
+//**************************************
+// Macros
+//**************************************
+#define XXH_STATIC_ASSERT(c)   { enum { XXH_static_assert = 1/(!!(c)) }; }    // use only *after* variable declarations
+
+
+//****************************
+// Memory reads
+//****************************
+typedef enum { XXH_aligned, XXH_unaligned } XXH_alignment;
+
+FORCE_INLINE U32 XXH_readLE32_align(const U32* ptr, XXH_endianess endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? A32(ptr) : XXH_swap32(A32(ptr));
+    else
+        return endian==XXH_littleEndian ? *ptr : XXH_swap32(*ptr);
+}
+
+FORCE_INLINE U32 XXH_readLE32(const U32* ptr, XXH_endianess endian)
+{
+    return XXH_readLE32_align(ptr, endian, XXH_unaligned);
+}
+
+FORCE_INLINE U64 XXH_readLE64_align(const U64* ptr, XXH_endianess endian, XXH_alignment align)
+{
+    if (align==XXH_unaligned)
+        return endian==XXH_littleEndian ? A64(ptr) : XXH_swap64(A64(ptr));
+    else
+        return endian==XXH_littleEndian ? *ptr : XXH_swap64(*ptr);
+}
+
+FORCE_INLINE U64 XXH_readLE64(const U64* ptr, XXH_endianess endian)
+{
+    return XXH_readLE64_align(ptr, endian, XXH_unaligned);
+}
+
+//****************************
+// Simple Hash Functions
+//****************************
+FORCE_INLINE U32 XXH32_endian_align(const void* input, size_t len, U32 seed, XXH_endianess endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U32 h32;
+#define XXH_get32bits(p) XXH_readLE32_align((const U32*)p, endian, align)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (p==NULL)
+    {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)16;
+    }
+#endif
+
+    if (len>=16)
+    {
+        const BYTE* const limit = bEnd - 16;
+        U32 v1 = seed + PRIME32_1 + PRIME32_2;
+        U32 v2 = seed + PRIME32_2;
+        U32 v3 = seed + 0;
+        U32 v4 = seed - PRIME32_1;
+
+        do
+        {
+            v1 += XXH_get32bits(p) * PRIME32_2;
+            v1 = XXH_rotl32(v1, 13);
+            v1 *= PRIME32_1;
+            p+=4;
+            v2 += XXH_get32bits(p) * PRIME32_2;
+            v2 = XXH_rotl32(v2, 13);
+            v2 *= PRIME32_1;
+            p+=4;
+            v3 += XXH_get32bits(p) * PRIME32_2;
+            v3 = XXH_rotl32(v3, 13);
+            v3 *= PRIME32_1;
+            p+=4;
+            v4 += XXH_get32bits(p) * PRIME32_2;
+            v4 = XXH_rotl32(v4, 13);
+            v4 *= PRIME32_1;
+            p+=4;
+        }
+        while (p<=limit);
+
+        h32 = XXH_rotl32(v1, 1) + XXH_rotl32(v2, 7) + XXH_rotl32(v3, 12) + XXH_rotl32(v4, 18);
+    }
+    else
+    {
+        h32  = seed + PRIME32_5;
+    }
+
+    h32 += (U32) len;
+
+    while (p+4<=bEnd)
+    {
+        h32 += XXH_get32bits(p) * PRIME32_3;
+        h32  = XXH_rotl32(h32, 17) * PRIME32_4 ;
+        p+=4;
+    }
+
+    while (p<bEnd)
+    {
+        h32 += (*p) * PRIME32_5;
+        h32 = XXH_rotl32(h32, 11) * PRIME32_1 ;
+        p++;
+    }
+
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+
+    return h32;
+}
+
+
+unsigned int XXH32 (const void* input, size_t len, unsigned seed)
+{
+#if 0
+    // Simple version, good for code maintenance, but unfortunately slow for small inputs
+    XXH32_state_t state;
+    XXH32_reset(&state, seed);
+    XXH32_update(&state, input, len);
+    return XXH32_digest(&state);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+#  if !defined(XXH_USE_UNALIGNED_ACCESS)
+    if ((((size_t)input) & 3) == 0)   // Input is aligned, let's leverage the speed advantage
+    {
+        if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+            return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+        else
+            return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }
+#  endif
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH32_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+FORCE_INLINE U64 XXH64_endian_align(const void* input, size_t len, U64 seed, XXH_endianess endian, XXH_alignment align)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U64 h64;
+#define XXH_get64bits(p) XXH_readLE64_align((const U64*)p, endian, align)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (p==NULL)
+    {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)32;
+    }
+#endif
+
+    if (len>=32)
+    {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = seed + PRIME64_1 + PRIME64_2;
+        U64 v2 = seed + PRIME64_2;
+        U64 v3 = seed + 0;
+        U64 v4 = seed - PRIME64_1;
+
+        do
+        {
+            v1 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v1 = XXH_rotl64(v1, 31);
+            v1 *= PRIME64_1;
+            v2 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v2 = XXH_rotl64(v2, 31);
+            v2 *= PRIME64_1;
+            v3 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v3 = XXH_rotl64(v3, 31);
+            v3 *= PRIME64_1;
+            v4 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v4 = XXH_rotl64(v4, 31);
+            v4 *= PRIME64_1;
+        }
+        while (p<=limit);
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+
+        v1 *= PRIME64_2;
+        v1 = XXH_rotl64(v1, 31);
+        v1 *= PRIME64_1;
+        h64 ^= v1;
+        h64 = h64 * PRIME64_1 + PRIME64_4;
+
+        v2 *= PRIME64_2;
+        v2 = XXH_rotl64(v2, 31);
+        v2 *= PRIME64_1;
+        h64 ^= v2;
+        h64 = h64 * PRIME64_1 + PRIME64_4;
+
+        v3 *= PRIME64_2;
+        v3 = XXH_rotl64(v3, 31);
+        v3 *= PRIME64_1;
+        h64 ^= v3;
+        h64 = h64 * PRIME64_1 + PRIME64_4;
+
+        v4 *= PRIME64_2;
+        v4 = XXH_rotl64(v4, 31);
+        v4 *= PRIME64_1;
+        h64 ^= v4;
+        h64 = h64 * PRIME64_1 + PRIME64_4;
+    }
+    else
+    {
+        h64  = seed + PRIME64_5;
+    }
+
+    h64 += (U64) len;
+
+    while (p+8<=bEnd)
+    {
+        U64 k1 = XXH_get64bits(p);
+        k1 *= PRIME64_2;
+        k1 = XXH_rotl64(k1,31);
+        k1 *= PRIME64_1;
+        h64 ^= k1;
+        h64 = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4;
+        p+=8;
+    }
+
+    if (p+4<=bEnd)
+    {
+        h64 ^= (U64)(XXH_get32bits(p)) * PRIME64_1;
+        h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+        p+=4;
+    }
+
+    while (p<bEnd)
+    {
+        h64 ^= (*p) * PRIME64_5;
+        h64 = XXH_rotl64(h64, 11) * PRIME64_1;
+        p++;
+    }
+
+    h64 ^= h64 >> 33;
+    h64 *= PRIME64_2;
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+
+    return h64;
+
+#undef XXH_get64bits
+}
+
+
+unsigned long long XXH64 (const void* input, size_t len, unsigned long long seed)
+{
+#if 0
+    // Simple version, good for code maintenance, but unfortunately slow for small inputs
+    XXH64_state_t state;
+    XXH64_reset(&state, seed);
+    XXH64_update(&state, input, len);
+    return XXH64_digest(&state);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+#  if !defined(XXH_USE_UNALIGNED_ACCESS)
+    if ((((size_t)input) & 7)==0)   // Input is aligned, let's leverage the speed advantage
+    {
+        if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+            return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned);
+        else
+            return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned);
+    }
+#  endif
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned);
+    else
+        return XXH64_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned);
+#endif
+}
+
+FORCE_INLINE void XXH128_endian_align(const void* input, size_t len, U64 seed, XXH_endianess endian, XXH_alignment align, void* out)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U64 h1, h2;
+#define XXH_get64bits(p) XXH_readLE64_align((const U64*)p, endian, align)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (p==NULL)
+    {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)32;
+    }
+#endif
+
+    if (len>=32)
+    {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = seed + PRIME64_1 + PRIME64_2;
+        U64 v2 = seed + PRIME64_2;
+        U64 v3 = seed + 0;
+        U64 v4 = seed - PRIME64_1;
+
+        do
+        {
+            v1 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v1 = XXH_rotl64(v1, 31);
+            v1 *= PRIME64_1;
+            v2 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v2 = XXH_rotl64(v2, 31);
+            v2 *= PRIME64_1;
+            v3 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v3 = XXH_rotl64(v3, 31);
+            v3 *= PRIME64_1;
+            v4 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v4 = XXH_rotl64(v4, 31);
+            v4 *= PRIME64_1;
+        }
+        while (p<=limit);
+
+        v1 *= PRIME64_2;
+        v1 = XXH_rotl64(v1, 31);
+        v1 *= PRIME64_1;
+        h1 = v1;
+        h2 = ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_4;
+
+        v2 *= PRIME64_2;
+        v2 = XXH_rotl64(v2, 33);
+        v2 *= PRIME64_1;
+        h2 ^= v2;
+        h1 ^= ( XXH_rotl64(h2, 27) + h2 ) * PRIME64_1 + PRIME64_4;
+
+        v3 *= PRIME64_2;
+        v3 = XXH_rotl64(v3, 29);
+        v3 *= PRIME64_1;
+        h1 ^= v3;
+        h2 ^= ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_4;
+
+        v4 *= PRIME64_2;
+        v4 = XXH_rotl64(v4, 27);
+        v4 *= PRIME64_1;
+        h2 ^= v4;
+        h1 ^= ( XXH_rotl64(h2, 27) + h2 ) * PRIME64_1 + PRIME64_4;
+    }
+    else
+    {
+        h1 = seed + PRIME64_5;
+        h2 = seed + PRIME64_1;
+    }
+
+    switch(len & 31)
+    {
+    case 31:	h2 ^= ((U64)p[30]) << 48;
+		/* fall-through */
+    case 30:	h2 ^= ((U64)p[29]) << 40;
+		/* fall-through */
+    case 29:	h2 ^= ((U64)p[28]) << 32;
+		/* fall-through */
+    case 28:	h2 ^= ((U64)p[27]) << 24;
+		/* fall-through */
+    case 27:	h2 ^= ((U64)p[26]) << 16;
+		/* fall-through */
+    case 26:	h2 ^= ((U64)p[25]) << 8;
+		/* fall-through */
+    case 25:	h2 ^= ((U64)p[24]) << 0;
+    		h1 ^= XXH_rotl64(h2 * PRIME64_2, 11) * PRIME64_1;
+		/* fall-through */
+    case 24:	h1 ^= ((U64)p[23]) << 56;
+		/* fall-through */
+    case 23:	h1 ^= ((U64)p[22]) << 48;
+		/* fall-through */
+    case 22:	h1 ^= ((U64)p[21]) << 40;
+		/* fall-through */
+    case 21:	h1 ^= ((U64)p[20]) << 32;
+		/* fall-through */
+    case 20:	h1 ^= ((U64)p[19]) << 24;
+		/* fall-through */
+    case 19:	h1 ^= ((U64)p[18]) << 16;
+		/* fall-through */
+    case 18:	h1 ^= ((U64)p[17]) << 8;
+		/* fall-through */
+    case 17:	h1 ^= ((U64)p[16]) << 0;
+		h2 ^= XXH_rotl64(h1 * PRIME64_2, 11) * PRIME64_1;
+		/* fall-through */
+    case 16:	h2 ^= ((U64)p[15]) << 56;
+		/* fall-through */
+    case 15:	h2 ^= ((U64)p[14]) << 48;
+		/* fall-through */
+    case 14:	h2 ^= ((U64)p[13]) << 40;
+		/* fall-through */
+    case 13:	h2 ^= ((U64)p[12]) << 32;
+		/* fall-through */
+    case 12:	h2 ^= ((U64)p[11]) << 24;
+		/* fall-through */
+    case 11:	h2 ^= ((U64)p[10]) << 16;
+		/* fall-through */
+    case 10:	h2 ^= ((U64)p[9]) << 8;
+		/* fall-through */
+    case 9:	h2 ^= ((U64)p[8]) << 0;
+		h1 ^= XXH_rotl64(h2 * PRIME64_2, 11) * PRIME64_1;
+		/* fall-through */
+    case 8:	h1 ^= ((U64)p[7]) << 56;
+		/* fall-through */
+    case 7:	h1 ^= ((U64)p[6]) << 48;
+		/* fall-through */
+    case 6:	h1 ^= ((U64)p[5]) << 40;
+		/* fall-through */
+    case 5:	h1 ^= ((U64)p[4]) << 32;
+		/* fall-through */
+    case 4:	h1 ^= ((U64)p[3]) << 24;
+		/* fall-through */
+    case 3:	h1 ^= ((U64)p[2]) << 16;
+		/* fall-through */
+    case 2:	h1 ^= ((U64)p[1]) << 8;
+		/* fall-through */
+    case 1:	h1 ^= ((U64)p[0]) << 0;
+		h2 ^= XXH_rotl64(h1 * PRIME64_5, 11) * PRIME64_1;
+		/* fall-through */
+    }
+
+    h1 = XXH_rotl64(h2, 27) * PRIME64_1 + PRIME64_4;
+
+    h1 += (U64) len;
+    h2 += (U64) len;
+
+    h2 ^= h1 >> 33;
+    h2 *= PRIME64_2;
+    h1 ^= h2 >> 29;
+    h1 *= PRIME64_3;
+    h2 ^= h1 >> 32;
+
+    ((U64*)out)[0] = h1;
+    ((U64*)out)[1] = h2;
+
+#undef XXH_get64bits
+}
+
+void XXH128 (const void* input, size_t len, unsigned long long seed, void* out)
+{
+#if 0
+    XXH128_state_t state;
+    XXH128_reset(&state, seed);
+    XXH128_update(&state, input, len);
+    XXH128_digest(&state, out);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+#  if !defined(XXH_USE_UNALIGNED_ACCESS)
+    if ((((size_t)input) & 7)==0)   // Input is aligned, let's leverage the speed advantage
+    {
+        if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+            XXH128_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned, out);
+        else
+            XXH128_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned, out);
+    }
+#  endif
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        XXH128_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned, out);
+    else
+        XXH128_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned, out);
+#endif
+}
+
+
+FORCE_INLINE void XXH256_endian_align(const void* input, size_t len, U64 seed, XXH_endianess endian, XXH_alignment align, void* out)
+{
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* bEnd = p + len;
+    U64 h1, h2, h3, h4;
+
+#define XXH_get64bits(p) XXH_readLE64_align((const U64*)p, endian, align)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (p==NULL)
+    {
+        len=0;
+        bEnd=p=(const BYTE*)(size_t)32;
+    }
+#endif
+
+    if (len>=32)
+    {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = seed + PRIME64_1 + PRIME64_2;
+        U64 v2 = seed + PRIME64_2;
+        U64 v3 = seed + 0;
+        U64 v4 = seed - PRIME64_1;
+
+        do
+        {
+            v1 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v1 = XXH_rotl64(v1, 31);
+            v1 *= PRIME64_1;
+            v2 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v2 = XXH_rotl64(v2, 31);
+            v2 *= PRIME64_1;
+            v3 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v3 = XXH_rotl64(v3, 31);
+            v3 *= PRIME64_1;
+            v4 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v4 = XXH_rotl64(v4, 31);
+            v4 *= PRIME64_1;
+        }
+        while (p<=limit);
+
+        v1 *= PRIME64_2;
+        v1 = XXH_rotl64(v1, 31);
+        v1 *= PRIME64_1;
+        h1 = v1;
+        h2 = ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_2;
+
+        v2 *= PRIME64_2;
+        v2 = XXH_rotl64(v2, 33);
+        v2 *= PRIME64_1;
+        h2 ^= v2;
+        h3 = ( XXH_rotl64(h2, 29) + h2 ) * PRIME64_2 + PRIME64_3;
+
+        v3 *= PRIME64_2;
+        v3 = XXH_rotl64(v3, 29);
+        v3 *= PRIME64_1;
+        h3 ^= v3;
+        h4 = ( XXH_rotl64(h3, 31) + h3 ) * PRIME64_3 + PRIME64_4;
+
+        v4 *= PRIME64_2;
+        v4 = XXH_rotl64(v4, 27);
+        v4 *= PRIME64_1;
+        h4 ^= v4;
+        h1 ^= ( XXH_rotl64(h4, 33) + h4 ) * PRIME64_4 + PRIME64_5;
+    }
+    else
+    {
+        h1 = seed + PRIME64_5;
+        h2 = seed + PRIME64_1;
+        h3 = seed + PRIME64_4;
+        h4 = seed + PRIME64_2;
+    }
+
+    switch(len & 31)
+    {
+    case 31:	h4 ^= ((U64)p[30]) << 48;
+		/* fall-through */
+    case 30:	h4 ^= ((U64)p[29]) << 40;
+		/* fall-through */
+    case 29:	h4 ^= ((U64)p[28]) << 32;
+		/* fall-through */
+    case 28:	h4 ^= ((U64)p[27]) << 24;
+		/* fall-through */
+    case 27:	h4 ^= ((U64)p[26]) << 16;
+		/* fall-through */
+    case 26:	h4 ^= ((U64)p[25]) << 8;
+		/* fall-through */
+    case 25:	h4 ^= ((U64)p[24]) << 0;
+    		h3 ^= XXH_rotl64(h4 * PRIME64_5, 17) * PRIME64_1;
+		/* fall-through */
+    case 24:	h3 ^= ((U64)p[23]) << 56;
+		/* fall-through */
+    case 23:	h3 ^= ((U64)p[22]) << 48;
+		/* fall-through */
+    case 22:	h3 ^= ((U64)p[21]) << 40;
+		/* fall-through */
+    case 21:	h3 ^= ((U64)p[20]) << 32;
+		/* fall-through */
+    case 20:	h3 ^= ((U64)p[19]) << 24;
+		/* fall-through */
+    case 19:	h3 ^= ((U64)p[18]) << 16;
+		/* fall-through */
+    case 18:	h3 ^= ((U64)p[17]) << 8;
+		/* fall-through */
+    case 17:	h3 ^= ((U64)p[16]) << 0;
+		h2 ^= XXH_rotl64(h3 * PRIME64_5, 13) * PRIME64_1;
+		/* fall-through */
+    case 16:	h2 ^= ((U64)p[15]) << 56;
+		/* fall-through */
+    case 15:	h2 ^= ((U64)p[14]) << 48;
+		/* fall-through */
+    case 14:	h2 ^= ((U64)p[13]) << 40;
+		/* fall-through */
+    case 13:	h2 ^= ((U64)p[12]) << 32;
+		/* fall-through */
+    case 12:	h2 ^= ((U64)p[11]) << 24;
+		/* fall-through */
+    case 11:	h2 ^= ((U64)p[10]) << 16;
+		/* fall-through */
+    case 10:	h2 ^= ((U64)p[9]) << 8;
+		/* fall-through */
+    case 9:	h2 ^= ((U64)p[8]) << 0;
+		h1 ^= XXH_rotl64(h2 * PRIME64_5, 11) * PRIME64_1;
+		/* fall-through */
+    case 8:	h1 ^= ((U64)p[7]) << 56;
+		/* fall-through */
+    case 7:	h1 ^= ((U64)p[6]) << 48;
+		/* fall-through */
+    case 6:	h1 ^= ((U64)p[5]) << 40;
+		/* fall-through */
+    case 5:	h1 ^= ((U64)p[4]) << 32;
+		/* fall-through */
+    case 4:	h1 ^= ((U64)p[3]) << 24;
+		/* fall-through */
+    case 3:	h1 ^= ((U64)p[2]) << 16;
+		/* fall-through */
+    case 2:	h1 ^= ((U64)p[1]) << 8;
+		/* fall-through */
+    case 1:	h1 ^= ((U64)p[0]) << 0;
+		h4 ^= XXH_rotl64(h1 * PRIME64_5, 7) * PRIME64_1;
+		/* fall-through */
+    }
+
+    h2 ^= ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_4;
+    h3 ^= ( XXH_rotl64(h2, 29) + h2 ) * PRIME64_2 + PRIME64_3;
+    h4 ^= ( XXH_rotl64(h3, 31) + h3 ) * PRIME64_3 + PRIME64_2;
+    h1 ^= ( XXH_rotl64(h4, 33) + h4 ) * PRIME64_4 + PRIME64_1;
+
+    h1 += (U64) len;
+    h2 += (U64) len;
+    h3 += (U64) len;
+    h4 += (U64) len;
+
+    h4 ^= h1 >> 33;
+    h4 *= PRIME64_2;
+    h1 ^= h4 >> 29;
+    h1 *= PRIME64_3;
+    h4 ^= h1 >> 32;
+
+    h3 ^= h2 >> 33;
+    h3 *= PRIME64_2;
+    h2 ^= h3 >> 29;
+    h2 *= PRIME64_3;
+    h3 ^= h2 >> 32;
+
+    ((unsigned long long*)out)[0] = h1;
+    ((unsigned long long*)out)[1] = h2;
+    ((unsigned long long*)out)[2] = h3;
+    ((unsigned long long*)out)[3] = h4;
+
+#undef XXH_get64bits
+}
+
+void XXH256 (const void* input, size_t len, unsigned long long seed, void* out)
+{
+#if 0
+    XXH256_state_t state;
+    XXH256_reset(&state, seed);
+    XXH256_update(&state, input, len);
+    XXH256_digest(&state, out);
+#else
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+#  if !defined(XXH_USE_UNALIGNED_ACCESS)
+    if ((((size_t)input) & 7)==0)   // Input is aligned, let's leverage the speed advantage
+    {
+        if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+            XXH256_endian_align(input, len, seed, XXH_littleEndian, XXH_aligned, out);
+        else
+            XXH256_endian_align(input, len, seed, XXH_bigEndian, XXH_aligned, out);
+    }
+#  endif
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        XXH256_endian_align(input, len, seed, XXH_littleEndian, XXH_unaligned, out);
+    else
+        XXH256_endian_align(input, len, seed, XXH_bigEndian, XXH_unaligned, out);
+#endif
+}
+
+
+/****************************************************
+ *  Advanced Hash Functions
+****************************************************/
+
+/*** Allocation ***/
+typedef struct
+{
+    U64 total_len;
+    U32 seed;
+    U32 v1;
+    U32 v2;
+    U32 v3;
+    U32 v4;
+    U32 memsize;
+    char memory[16];
+} XXH_istate32_t;
+
+typedef struct
+{
+    U64 total_len;
+    U64 seed;
+    U64 v1;
+    U64 v2;
+    U64 v3;
+    U64 v4;
+    U32 memsize;
+    char memory[32];
+} XXH_istate64_t;
+
+
+typedef struct
+{
+    U64 total_len;
+    U64 seed;
+    U64 v1;
+    U64 v2;
+    U64 v3;
+    U64 v4;
+    char memory[64];
+    U32 memsize;
+} XXH_istate128_t;
+
+typedef struct
+{
+    U64 total_len;
+    U64 seed;
+    U64 v1;
+    U64 v2;
+    U64 v3;
+    U64 v4;
+    char memory[64];
+    U32 memsize;
+} XXH_istate256_t;
+
+
+XXH32_state_t* XXH32_createState(void)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH32_state_t) >= sizeof(XXH_istate32_t));   // A compilation error here means XXH32_state_t is not large enough
+    return (XXH32_state_t*)XXH_malloc(sizeof(XXH32_state_t));
+}
+XXH_errorcode XXH32_freeState(XXH32_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+};
+
+XXH64_state_t* XXH64_createState(void)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH64_state_t) >= sizeof(XXH_istate64_t));   // A compilation error here means XXH64_state_t is not large enough
+    return (XXH64_state_t*)XXH_malloc(sizeof(XXH64_state_t));
+}
+XXH_errorcode XXH64_freeState(XXH64_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+};
+
+XXH128_state_t* XXH128_createState(void)
+{
+    XXH_STATIC_ASSERT(sizeof(XXH128_state_t) >= sizeof(XXH_istate128_t));   // A compilation error here means XXH128_state_t is not large enough
+    return (XXH128_state_t*)XXH_malloc(sizeof(XXH128_state_t));
+}
+XXH_errorcode XXH128_freeState(XXH128_state_t* statePtr)
+{
+    XXH_free(statePtr);
+    return XXH_OK;
+}
+
+
+/*** Hash feed ***/
+
+XXH_errorcode XXH32_reset(XXH32_state_t* state_in, U32 seed)
+{
+    XXH_istate32_t* state = (XXH_istate32_t*) state_in;
+    state->seed = seed;
+    state->v1 = seed + PRIME32_1 + PRIME32_2;
+    state->v2 = seed + PRIME32_2;
+    state->v3 = seed + 0;
+    state->v4 = seed - PRIME32_1;
+    state->total_len = 0;
+    state->memsize = 0;
+    return XXH_OK;
+}
+
+XXH_errorcode XXH64_reset(XXH64_state_t* state_in, unsigned long long seed)
+{
+    XXH_istate64_t* state = (XXH_istate64_t*) state_in;
+    state->seed = seed;
+    state->v1 = seed + PRIME64_1 + PRIME64_2;
+    state->v2 = seed + PRIME64_2;
+    state->v3 = seed + 0;
+    state->v4 = seed - PRIME64_1;
+    state->total_len = 0;
+    state->memsize = 0;
+    return XXH_OK;
+}
+
+XXH_errorcode XXH128_reset(XXH128_state_t* state_in, unsigned long long seed)
+{
+    XXH_istate128_t* state = (XXH_istate128_t*) state_in;
+    state->seed = seed;
+    state->v1 = seed + PRIME64_1 + PRIME64_2;
+    state->v2 = seed + PRIME64_2;
+    state->v3 = seed + 0;
+    state->v4 = seed - PRIME64_1;
+    state->total_len = 0;
+    state->memsize = 0;
+    return XXH_OK;
+}
+
+XXH_errorcode XXH256_reset(XXH256_state_t* state_in, unsigned long long seed)
+{
+    XXH_istate256_t* state = (XXH_istate256_t*) state_in;
+    state->seed = seed;
+    state->v1 = seed + PRIME64_1 + PRIME64_2;
+    state->v2 = seed + PRIME64_2;
+    state->v3 = seed + 0;
+    state->v4 = seed - PRIME64_1;
+    state->total_len = 0;
+    state->memsize = 0;
+    return XXH_OK;
+}
+
+
+FORCE_INLINE XXH_errorcode XXH32_update_endian (XXH32_state_t* state_in, const void* input, size_t len, XXH_endianess endian)
+{
+    XXH_istate32_t* state = (XXH_istate32_t *) state_in;
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (input==NULL) return XXH_ERROR;
+#endif
+
+    state->total_len += len;
+
+    if (state->memsize + len < 16)   // fill in tmp buffer
+    {
+        XXH_memcpy(state->memory + state->memsize, input, len);
+        state->memsize += (U32)len;
+        return XXH_OK;
+    }
+
+    if (state->memsize)   // some data left from previous update
+    {
+        XXH_memcpy(state->memory + state->memsize, input, 16-state->memsize);
+        {
+            const U32* p32 = (const U32*)state->memory;
+            state->v1 += XXH_readLE32(p32, endian) * PRIME32_2;
+            state->v1 = XXH_rotl32(state->v1, 13);
+            state->v1 *= PRIME32_1;
+            p32++;
+            state->v2 += XXH_readLE32(p32, endian) * PRIME32_2;
+            state->v2 = XXH_rotl32(state->v2, 13);
+            state->v2 *= PRIME32_1;
+            p32++;
+            state->v3 += XXH_readLE32(p32, endian) * PRIME32_2;
+            state->v3 = XXH_rotl32(state->v3, 13);
+            state->v3 *= PRIME32_1;
+            p32++;
+            state->v4 += XXH_readLE32(p32, endian) * PRIME32_2;
+            state->v4 = XXH_rotl32(state->v4, 13);
+            state->v4 *= PRIME32_1;
+            p32++;
+        }
+        p += 16-state->memsize;
+        state->memsize = 0;
+    }
+
+    if (p <= bEnd-16)
+    {
+        const BYTE* const limit = bEnd - 16;
+        U32 v1 = state->v1;
+        U32 v2 = state->v2;
+        U32 v3 = state->v3;
+        U32 v4 = state->v4;
+
+        do
+        {
+            v1 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v1 = XXH_rotl32(v1, 13);
+            v1 *= PRIME32_1;
+            p+=4;
+            v2 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v2 = XXH_rotl32(v2, 13);
+            v2 *= PRIME32_1;
+            p+=4;
+            v3 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v3 = XXH_rotl32(v3, 13);
+            v3 *= PRIME32_1;
+            p+=4;
+            v4 += XXH_readLE32((const U32*)p, endian) * PRIME32_2;
+            v4 = XXH_rotl32(v4, 13);
+            v4 *= PRIME32_1;
+            p+=4;
+        }
+        while (p<=limit);
+
+        state->v1 = v1;
+        state->v2 = v2;
+        state->v3 = v3;
+        state->v4 = v4;
+    }
+
+    if (p < bEnd)
+    {
+        XXH_memcpy(state->memory, p, bEnd-p);
+        state->memsize = (int)(bEnd-p);
+    }
+
+    return XXH_OK;
+}
+
+XXH_errorcode XXH32_update (XXH32_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH32_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+
+FORCE_INLINE U32 XXH32_digest_endian (const XXH32_state_t* state_in, XXH_endianess endian)
+{
+    XXH_istate32_t* state = (XXH_istate32_t*) state_in;
+    const BYTE * p = (const BYTE*)state->memory;
+    BYTE* bEnd = (BYTE*)state->memory + state->memsize;
+    U32 h32;
+
+    if (state->total_len >= 16)
+    {
+        h32 = XXH_rotl32(state->v1, 1) + XXH_rotl32(state->v2, 7) + XXH_rotl32(state->v3, 12) + XXH_rotl32(state->v4, 18);
+    }
+    else
+    {
+        h32  = state->seed + PRIME32_5;
+    }
+
+    h32 += (U32) state->total_len;
+
+    while (p+4<=bEnd)
+    {
+        h32 += XXH_readLE32((const U32*)p, endian) * PRIME32_3;
+        h32  = XXH_rotl32(h32, 17) * PRIME32_4;
+        p+=4;
+    }
+
+    while (p<bEnd)
+    {
+        h32 += (*p) * PRIME32_5;
+        h32 = XXH_rotl32(h32, 11) * PRIME32_1;
+        p++;
+    }
+
+    h32 ^= h32 >> 15;
+    h32 *= PRIME32_2;
+    h32 ^= h32 >> 13;
+    h32 *= PRIME32_3;
+    h32 ^= h32 >> 16;
+
+    return h32;
+}
+
+
+U32 XXH32_digest (const XXH32_state_t* state_in)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH32_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH32_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+FORCE_INLINE XXH_errorcode XXH64_update_endian (XXH64_state_t* state_in, const void* input, size_t len, XXH_endianess endian)
+{
+    XXH_istate64_t * state = (XXH_istate64_t *) state_in;
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (input==NULL) return XXH_ERROR;
+#endif
+
+    state->total_len += len;
+
+    if (state->memsize + len < 32)   // fill in tmp buffer
+    {
+        XXH_memcpy(state->memory + state->memsize, input, len);
+        state->memsize += (U32)len;
+        return XXH_OK;
+    }
+
+    if (state->memsize)   // some data left from previous update
+    {
+        XXH_memcpy(state->memory + state->memsize, input, 32-state->memsize);
+        {
+            const U64* p64 = (const U64*)state->memory;
+            state->v1 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v1 = XXH_rotl64(state->v1, 31);
+            state->v1 *= PRIME64_1;
+            p64++;
+            state->v2 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v2 = XXH_rotl64(state->v2, 31);
+            state->v2 *= PRIME64_1;
+            p64++;
+            state->v3 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v3 = XXH_rotl64(state->v3, 31);
+            state->v3 *= PRIME64_1;
+            p64++;
+            state->v4 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v4 = XXH_rotl64(state->v4, 31);
+            state->v4 *= PRIME64_1;
+            p64++;
+        }
+        p += 32-state->memsize;
+        state->memsize = 0;
+    }
+
+    if (p+32 <= bEnd)
+    {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        do
+        {
+            v1 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v1 = XXH_rotl64(v1, 31);
+            v1 *= PRIME64_1;
+            p+=8;
+            v2 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v2 = XXH_rotl64(v2, 31);
+            v2 *= PRIME64_1;
+            p+=8;
+            v3 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v3 = XXH_rotl64(v3, 31);
+            v3 *= PRIME64_1;
+            p+=8;
+            v4 += XXH_readLE64((const U64*)p, endian) * PRIME64_2;
+            v4 = XXH_rotl64(v4, 31);
+            v4 *= PRIME64_1;
+            p+=8;
+        }
+        while (p<=limit);
+
+        state->v1 = v1;
+        state->v2 = v2;
+        state->v3 = v3;
+        state->v4 = v4;
+    }
+
+    if (p < bEnd)
+    {
+        XXH_memcpy(state->memory, p, bEnd-p);
+        state->memsize = (int)(bEnd-p);
+    }
+
+    return XXH_OK;
+}
+
+XXH_errorcode XXH64_update (XXH64_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH64_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+
+FORCE_INLINE U64 XXH64_digest_endian (const XXH64_state_t* state_in, XXH_endianess endian)
+{
+    XXH_istate64_t * state = (XXH_istate64_t *) state_in;
+    const BYTE * p = (const BYTE*)state->memory;
+    BYTE* bEnd = (BYTE*)state->memory + state->memsize;
+    U64 h64;
+
+    if (state->total_len >= 32)
+    {
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        h64 = XXH_rotl64(v1, 1) + XXH_rotl64(v2, 7) + XXH_rotl64(v3, 12) + XXH_rotl64(v4, 18);
+
+        v1 *= PRIME64_2;
+        v1 = XXH_rotl64(v1, 31);
+        v1 *= PRIME64_1;
+        h64 ^= v1;
+        h64 = h64*PRIME64_1 + PRIME64_4;
+
+        v2 *= PRIME64_2;
+        v2 = XXH_rotl64(v2, 31);
+        v2 *= PRIME64_1;
+        h64 ^= v2;
+        h64 = h64*PRIME64_1 + PRIME64_4;
+
+        v3 *= PRIME64_2;
+        v3 = XXH_rotl64(v3, 31);
+        v3 *= PRIME64_1;
+        h64 ^= v3;
+        h64 = h64*PRIME64_1 + PRIME64_4;
+
+        v4 *= PRIME64_2;
+        v4 = XXH_rotl64(v4, 31);
+        v4 *= PRIME64_1;
+        h64 ^= v4;
+        h64 = h64*PRIME64_1 + PRIME64_4;
+    }
+    else
+    {
+        h64  = state->seed + PRIME64_5;
+    }
+
+    h64 += (U64) state->total_len;
+
+    while (p+8<=bEnd)
+    {
+        U64 k1 = XXH_readLE64((const U64*)p, endian);
+        k1 *= PRIME64_2;
+        k1 = XXH_rotl64(k1,31);
+        k1 *= PRIME64_1;
+        h64 ^= k1;
+        h64 = XXH_rotl64(h64,27) * PRIME64_1 + PRIME64_4;
+        p+=8;
+    }
+
+    if (p+4<=bEnd)
+    {
+        h64 ^= (U64)(XXH_readLE32((const U32*)p, endian)) * PRIME64_1;
+        h64 = XXH_rotl64(h64, 23) * PRIME64_2 + PRIME64_3;
+        p+=4;
+    }
+
+    while (p<bEnd)
+    {
+        h64 ^= (*p) * PRIME64_5;
+        h64 = XXH_rotl64(h64, 11) * PRIME64_1;
+        p++;
+    }
+
+    h64 ^= h64 >> 33;
+    h64 *= PRIME64_2;
+    h64 ^= h64 >> 29;
+    h64 *= PRIME64_3;
+    h64 ^= h64 >> 32;
+
+    return h64;
+}
+
+
+unsigned long long XXH64_digest (const XXH64_state_t* state_in)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH64_digest_endian(state_in, XXH_littleEndian);
+    else
+        return XXH64_digest_endian(state_in, XXH_bigEndian);
+}
+
+
+FORCE_INLINE XXH_errorcode XXH128_update_endian (XXH128_state_t* state_in, const void* input, size_t len, XXH_endianess endian)
+{
+    XXH_istate128_t * state = (XXH_istate128_t *) state_in;
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+#define XXH_get64bits(p) XXH_readLE64((const U64*)p, endian)
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (input==NULL) return XXH_ERROR;
+#endif
+
+    state->total_len += len;
+
+    if (state->memsize + len < 32)   // fill in tmp buffer
+    {
+        XXH_memcpy(state->memory + state->memsize, input, len);
+        state->memsize += (U32)len;
+        return XXH_OK;
+    }
+
+    if (state->memsize)   // some data left from previous update
+    {
+        XXH_memcpy(state->memory + state->memsize, input, 32-state->memsize);
+        {
+            const BYTE* ps = (const BYTE*)state->memory;
+            state->v1 += XXH_get64bits(ps) * PRIME64_2;
+            state->v1 = XXH_rotl64(state->v1, 31);
+            state->v1 *= PRIME64_1;
+            ps+=8;
+            state->v2 += XXH_get64bits(ps) * PRIME64_2;
+            state->v2 = XXH_rotl64(state->v2, 31);
+            state->v2 *= PRIME64_1;
+            ps+=8;
+            state->v3 += XXH_get64bits(ps) * PRIME64_2;
+            state->v3 = XXH_rotl64(state->v3, 31);
+            state->v3 *= PRIME64_1;
+            ps+=8;
+            state->v4 += XXH_get64bits(ps) * PRIME64_2;
+            state->v4 = XXH_rotl64(state->v4, 31);
+            state->v4 *= PRIME64_1;
+            ps+=8;
+        }
+        p += 32-state->memsize;
+        state->memsize = 0;
+    }
+
+    if (p+32 <= bEnd)
+    {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        do
+        {
+            v1 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v1 = XXH_rotl64(v1, 31);
+            v1 *= PRIME64_1;
+            v2 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v2 = XXH_rotl64(v2, 31);
+            v2 *= PRIME64_1;
+            v3 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v3 = XXH_rotl64(v3, 31);
+            v3 *= PRIME64_1;
+            v4 += XXH_get64bits(p) * PRIME64_2;
+            p+=8;
+            v4 = XXH_rotl64(v4, 31);
+            v4 *= PRIME64_1;
+        }
+        while (p<=limit);
+
+        state->v1 = v1;
+        state->v2 = v2;
+        state->v3 = v3;
+        state->v4 = v4;
+    }
+
+    if (p < bEnd)
+    {
+        XXH_memcpy(state->memory, p, bEnd-p);
+        state->memsize = (int)(bEnd-p);
+    }
+
+    return XXH_OK;
+
+#undef XXH_get64bits
+}
+
+XXH_errorcode XXH128_update (XXH128_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH128_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH128_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+FORCE_INLINE void XXH128_digest_endian (const XXH128_state_t* state_in, XXH_endianess endian, void* out)
+{
+	(void)endian;
+    XXH_istate128_t * state = (XXH_istate128_t *) state_in;
+    const BYTE * p = (const BYTE*)state->memory;
+    U64 h1, h2;
+
+    if (state->total_len >= 32)
+    {
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        v1 *= PRIME64_2;
+        v1 = XXH_rotl64(v1, 31);
+        v1 *= PRIME64_1;
+        h1 = v1;
+        h2 = ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_4;
+
+        v2 *= PRIME64_2;
+        v2 = XXH_rotl64(v2, 33);
+        v2 *= PRIME64_1;
+        h2 ^= v2;
+        h1 ^= ( XXH_rotl64(h2, 27) + h2 ) * PRIME64_1 + PRIME64_4;
+
+        v3 *= PRIME64_2;
+        v3 = XXH_rotl64(v3, 29);
+        v3 *= PRIME64_1;
+        h1 ^= v3;
+        h2 ^= ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_4;
+
+        v4 *= PRIME64_2;
+        v4 = XXH_rotl64(v4, 27);
+        v4 *= PRIME64_1;
+        h2 ^= v4;
+        h1 ^= ( XXH_rotl64(h2, 27) + h2 ) * PRIME64_1 + PRIME64_4;
+    }
+    else
+    {
+    	h1 = state->seed + PRIME64_5;
+    	h2 = state->seed + PRIME64_1;
+    }
+
+    switch(state->total_len & 31)
+    {
+    case 31:	h2 ^= ((U64)p[30]) << 48;
+		/* fall-through */
+    case 30:	h2 ^= ((U64)p[29]) << 40;
+		/* fall-through */
+    case 29:	h2 ^= ((U64)p[28]) << 32;
+		/* fall-through */
+    case 28:	h2 ^= ((U64)p[27]) << 24;
+		/* fall-through */
+    case 27:	h2 ^= ((U64)p[26]) << 16;
+		/* fall-through */
+    case 26:	h2 ^= ((U64)p[25]) << 8;
+		/* fall-through */
+    case 25:	h2 ^= ((U64)p[24]) << 0;
+    		h1 ^= XXH_rotl64(h2 * PRIME64_2, 11) * PRIME64_1;
+		/* fall-through */
+    case 24:	h1 ^= ((U64)p[23]) << 56;
+		/* fall-through */
+    case 23:	h1 ^= ((U64)p[22]) << 48;
+		/* fall-through */
+    case 22:	h1 ^= ((U64)p[21]) << 40;
+		/* fall-through */
+    case 21:	h1 ^= ((U64)p[20]) << 32;
+		/* fall-through */
+    case 20:	h1 ^= ((U64)p[19]) << 24;
+		/* fall-through */
+    case 19:	h1 ^= ((U64)p[18]) << 16;
+		/* fall-through */
+    case 18:	h1 ^= ((U64)p[17]) << 8;
+		/* fall-through */
+    case 17:	h1 ^= ((U64)p[16]) << 0;
+		h2 ^= XXH_rotl64(h1 * PRIME64_2, 11) * PRIME64_1;
+		/* fall-through */
+    case 16:	h2 ^= ((U64)p[15]) << 56;
+		/* fall-through */
+    case 15:	h2 ^= ((U64)p[14]) << 48;
+		/* fall-through */
+    case 14:	h2 ^= ((U64)p[13]) << 40;
+		/* fall-through */
+    case 13:	h2 ^= ((U64)p[12]) << 32;
+		/* fall-through */
+    case 12:	h2 ^= ((U64)p[11]) << 24;
+		/* fall-through */
+    case 11:	h2 ^= ((U64)p[10]) << 16;
+		/* fall-through */
+    case 10:	h2 ^= ((U64)p[9]) << 8;
+		/* fall-through */
+    case 9:	h2 ^= ((U64)p[8]) << 0;
+		h1 ^= XXH_rotl64(h2 * PRIME64_2, 11) * PRIME64_1;
+		/* fall-through */
+    case 8:	h1 ^= ((U64)p[7]) << 56;
+		/* fall-through */
+    case 7:	h1 ^= ((U64)p[6]) << 48;
+		/* fall-through */
+    case 6:	h1 ^= ((U64)p[5]) << 40;
+		/* fall-through */
+    case 5:	h1 ^= ((U64)p[4]) << 32;
+		/* fall-through */
+    case 4:	h1 ^= ((U64)p[3]) << 24;
+		/* fall-through */
+    case 3:	h1 ^= ((U64)p[2]) << 16;
+		/* fall-through */
+    case 2:	h1 ^= ((U64)p[1]) << 8;
+		/* fall-through */
+    case 1:	h1 ^= ((U64)p[0]) << 0;
+		h2 ^= XXH_rotl64(h1 * PRIME64_5, 11) * PRIME64_1;
+		/* fall-through */
+    }
+
+    h1 = XXH_rotl64(h2, 27) * PRIME64_1 + PRIME64_4;
+
+    h1 += (U64) state->total_len;
+    h2 += (U64) state->total_len;
+
+    h2 ^= h1 >> 33;
+    h2 *= PRIME64_2;
+    h1 ^= h2 >> 29;
+    h1 *= PRIME64_3;
+    h2 ^= h1 >> 32;
+
+    ((U64*)out)[0] = h1;
+    ((U64*)out)[1] = h2;
+}
+
+void XXH128_digest (const XXH128_state_t* state_in, void* out)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        XXH128_digest_endian(state_in, XXH_littleEndian, (unsigned long long*)out);
+    else
+        XXH128_digest_endian(state_in, XXH_bigEndian, (unsigned long long*)out);
+}
+
+
+FORCE_INLINE XXH_errorcode XXH256_update_endian (XXH256_state_t* state_in, const void* input, size_t len, XXH_endianess endian)
+{
+    XXH_istate256_t * state = (XXH_istate256_t *) state_in;
+    const BYTE* p = (const BYTE*)input;
+    const BYTE* const bEnd = p + len;
+
+#ifdef XXH_ACCEPT_NULL_INPUT_POINTER
+    if (input==NULL) return XXH_ERROR;
+#endif
+
+    state->total_len += len;
+
+    if (state->memsize + len < 32)   // fill in tmp buffer
+    {
+        XXH_memcpy(state->memory + state->memsize, input, len);
+        state->memsize += (U32)len;
+        return XXH_OK;
+    }
+
+    if (state->memsize)   // some data left from previous update
+    {
+        XXH_memcpy(state->memory + state->memsize, input, 32-state->memsize);
+        {
+            const U64* p64 = (const U64*)state->memory;
+            state->v1 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v1 = XXH_rotl64(state->v1, 31);
+            state->v1 *= PRIME64_1;
+            p64++;
+            state->v2 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v2 = XXH_rotl64(state->v2, 31);
+            state->v2 *= PRIME64_1;
+            p64++;
+            state->v3 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v3 = XXH_rotl64(state->v3, 31);
+            state->v3 *= PRIME64_1;
+            p64++;
+            state->v4 += XXH_readLE64(p64, endian) * PRIME64_2;
+            state->v4 = XXH_rotl64(state->v4, 31);
+            state->v4 *= PRIME64_1;
+            p64++;
+        }
+        p += 32-state->memsize;
+        state->memsize = 0;
+    }
+
+    if (p+32 <= bEnd)
+    {
+        const BYTE* const limit = bEnd - 32;
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        do
+        {
+            v1 += XXH_readLE64((const U64*)p+0, endian) * PRIME64_2;
+            v1 = XXH_rotl64(v1, 31) * PRIME64_1;
+
+            v2 += XXH_readLE64((const U64*)p+1, endian) * PRIME64_2;
+            v2 = XXH_rotl64(v2, 31) * PRIME64_1;
+
+            v3 += XXH_readLE64((const U64*)p+2, endian) * PRIME64_2;
+            v3 = XXH_rotl64(v3, 31) * PRIME64_1;
+
+            v4 += XXH_readLE64((const U64*)p+3, endian) * PRIME64_2;
+            v4 = XXH_rotl64(v4, 31) * PRIME64_1;
+
+            p+=32;
+        }
+        while (p<=limit);
+
+        state->v1 = v1;
+        state->v2 = v2;
+        state->v3 = v3;
+        state->v4 = v4;
+    }
+
+    if (p < bEnd)
+    {
+        XXH_memcpy(state->memory, p, bEnd-p);
+        state->memsize = (int)(bEnd-p);
+    }
+
+    return XXH_OK;
+}
+
+XXH_errorcode XXH256_update (XXH256_state_t* state_in, const void* input, size_t len)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        return XXH256_update_endian(state_in, input, len, XXH_littleEndian);
+    else
+        return XXH256_update_endian(state_in, input, len, XXH_bigEndian);
+}
+
+
+FORCE_INLINE void XXH256_digest_endian (const XXH256_state_t* state_in, XXH_endianess endian, void* out)
+{
+	(void)endian;
+    XXH_istate256_t * state = (XXH_istate256_t *) state_in;
+    const BYTE * p = (const BYTE*)state->memory;
+    U64 h1, h2, h3, h4;
+
+    if (state->total_len >= 32)
+    {
+        U64 v1 = state->v1;
+        U64 v2 = state->v2;
+        U64 v3 = state->v3;
+        U64 v4 = state->v4;
+
+        v1 *= PRIME64_2;
+        v1 = XXH_rotl64(v1, 31);
+        v1 *= PRIME64_1;
+        h1 = v1;
+        h2 = ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_2;
+
+        v2 *= PRIME64_2;
+        v2 = XXH_rotl64(v2, 33);
+        v2 *= PRIME64_1;
+        h2 ^= v2;
+        h3 = ( XXH_rotl64(h2, 29) + h2 ) * PRIME64_2 + PRIME64_3;
+
+        v3 *= PRIME64_2;
+        v3 = XXH_rotl64(v3, 29);
+        v3 *= PRIME64_1;
+        h3 ^= v3;
+        h4 = ( XXH_rotl64(h3, 31) + h3 ) * PRIME64_3 + PRIME64_4;
+
+        v4 *= PRIME64_2;
+        v4 = XXH_rotl64(v4, 27);
+        v4 *= PRIME64_1;
+        h4 ^= v4;
+        h1 ^= ( XXH_rotl64(h4, 33) + h4 ) * PRIME64_4 + PRIME64_5;
+    }
+    else
+    {
+        h1 = state->seed + PRIME64_5;
+        h2 = state->seed + PRIME64_1;
+        h3 = state->seed + PRIME64_4;
+        h4 = state->seed + PRIME64_2;
+    }
+
+    switch(state->total_len & 31)
+    {
+    case 31:	h4 ^= ((U64)p[30]) << 48;
+		/* fall-through */
+    case 30:	h4 ^= ((U64)p[29]) << 40;
+		/* fall-through */
+    case 29:	h4 ^= ((U64)p[28]) << 32;
+		/* fall-through */
+    case 28:	h4 ^= ((U64)p[27]) << 24;
+		/* fall-through */
+    case 27:	h4 ^= ((U64)p[26]) << 16;
+		/* fall-through */
+    case 26:	h4 ^= ((U64)p[25]) << 8;
+		/* fall-through */
+    case 25:	h4 ^= ((U64)p[24]) << 0;
+		h3 ^= XXH_rotl64(h4 * PRIME64_5, 17) * PRIME64_1;
+		/* fall-through */
+    case 24:	h3 ^= ((U64)p[23]) << 56;
+		/* fall-through */
+    case 23:	h3 ^= ((U64)p[22]) << 48;
+		/* fall-through */
+    case 22:	h3 ^= ((U64)p[21]) << 40;
+		/* fall-through */
+    case 21:	h3 ^= ((U64)p[20]) << 32;
+		/* fall-through */
+    case 20:	h3 ^= ((U64)p[19]) << 24;
+		/* fall-through */
+    case 19:	h3 ^= ((U64)p[18]) << 16;
+		/* fall-through */
+    case 18:	h3 ^= ((U64)p[17]) << 8;
+		/* fall-through */
+    case 17:	h3 ^= ((U64)p[16]) << 0;
+		h2 ^= XXH_rotl64(h3 * PRIME64_5, 13) * PRIME64_1;
+		/* fall-through */
+    case 16:	h2 ^= ((U64)p[15]) << 56;
+		/* fall-through */
+    case 15:	h2 ^= ((U64)p[14]) << 48;
+		/* fall-through */
+    case 14:	h2 ^= ((U64)p[13]) << 40;
+		/* fall-through */
+    case 13:	h2 ^= ((U64)p[12]) << 32;
+		/* fall-through */
+    case 12:	h2 ^= ((U64)p[11]) << 24;
+		/* fall-through */
+    case 11:	h2 ^= ((U64)p[10]) << 16;
+		/* fall-through */
+    case 10:	h2 ^= ((U64)p[9]) << 8;
+		/* fall-through */
+    case 9:	h2 ^= ((U64)p[8]) << 0;
+		h1 ^= XXH_rotl64(h2 * PRIME64_5, 11) * PRIME64_1;
+		/* fall-through */
+    case 8:	h1 ^= ((U64)p[7]) << 56;
+		/* fall-through */
+    case 7:	h1 ^= ((U64)p[6]) << 48;
+		/* fall-through */
+    case 6:	h1 ^= ((U64)p[5]) << 40;
+		/* fall-through */
+    case 5:	h1 ^= ((U64)p[4]) << 32;
+		/* fall-through */
+    case 4:	h1 ^= ((U64)p[3]) << 24;
+		/* fall-through */
+    case 3:	h1 ^= ((U64)p[2]) << 16;
+		/* fall-through */
+    case 2:	h1 ^= ((U64)p[1]) << 8;
+		/* fall-through */
+    case 1:	h1 ^= ((U64)p[0]) << 0;
+		h4 ^= XXH_rotl64(h1 * PRIME64_5, 7) * PRIME64_1;
+		/* fall-through */
+    }
+
+    h2 ^= ( XXH_rotl64(h1, 27) + h1 ) * PRIME64_1 + PRIME64_4;
+    h3 ^= ( XXH_rotl64(h2, 29) + h2 ) * PRIME64_2 + PRIME64_3;
+    h4 ^= ( XXH_rotl64(h3, 31) + h3 ) * PRIME64_3 + PRIME64_2;
+    h1 ^= ( XXH_rotl64(h4, 33) + h4 ) * PRIME64_4 + PRIME64_1;
+
+    h1 += (U64) state->total_len;
+    h2 += (U64) state->total_len;
+    h3 += (U64) state->total_len;
+    h4 += (U64) state->total_len;
+
+    h4 ^= h1 >> 33;
+    h4 *= PRIME64_2;
+    h1 ^= h4 >> 29;
+    h1 *= PRIME64_3;
+    h4 ^= h1 >> 32;
+
+    h3 ^= h2 >> 33;
+    h3 *= PRIME64_2;
+    h2 ^= h3 >> 29;
+    h2 *= PRIME64_3;
+    h3 ^= h2 >> 32;
+
+    ((unsigned long long*)out)[0] = h1;
+    ((unsigned long long*)out)[1] = h2;
+    ((unsigned long long*)out)[2] = h3;
+    ((unsigned long long*)out)[3] = h4;
+}
+
+void XXH256_digest (const XXH256_state_t* state_in, void* out)
+{
+    XXH_endianess endian_detected = (XXH_endianess)XXH_CPU_LITTLE_ENDIAN;
+
+    if ((endian_detected==XXH_littleEndian) || XXH_FORCE_NATIVE_FORMAT)
+        XXH256_digest_endian(state_in, XXH_littleEndian, (unsigned long long*)out);
+    else
+        XXH256_digest_endian(state_in, XXH_bigEndian, (unsigned long long*)out);
+}

--- a/numcosmo/external/libfyaml/src/xxhash/xxhash.h
+++ b/numcosmo/external/libfyaml/src/xxhash/xxhash.h
@@ -1,0 +1,193 @@
+#ifndef XXHASH_H
+#define XXHASH_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+/*
+   xxHash - Extremely Fast Hash algorithm
+   Header File
+   Copyright (C) 2012-2014, Yann Collet.
+   BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+       * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following disclaimer
+   in the documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   You can contact the author at :
+   - xxHash source repository : http://code.google.com/p/xxhash/
+
+   Modified for internal use for libfyaml by:
+   Pantelis Antoniou <pantelis.antoniou@konsulko.com>
+
+   Minor cosmetic and warning fixes
+*/
+
+/* Notice extracted from xxHash homepage :
+
+xxHash is an extremely fast Hash algorithm, running at RAM speed limits.
+It also successfully passes all tests from the SMHasher suite.
+
+Comparison (single thread, Windows Seven 32 bits, using SMHasher on a Core 2 Duo @3GHz)
+
+Name            Speed       Q.Score   Author
+xxHash          5.4 GB/s     10
+CrapWow         3.2 GB/s      2       Andrew
+MumurHash 3a    2.7 GB/s     10       Austin Appleby
+SpookyHash      2.0 GB/s     10       Bob Jenkins
+SBox            1.4 GB/s      9       Bret Mulvey
+Lookup3         1.2 GB/s      9       Bob Jenkins
+SuperFastHash   1.2 GB/s      1       Paul Hsieh
+CityHash64      1.05 GB/s    10       Pike & Alakuijala
+FNV             0.55 GB/s     5       Fowler, Noll, Vo
+CRC32           0.43 GB/s     9
+MD5-32          0.33 GB/s    10       Ronald L. Rivest
+SHA1-32         0.28 GB/s    10
+
+Q.Score is a measure of quality of the hash function.
+It depends on successfully passing SMHasher test set.
+10 is a perfect score.
+*/
+
+#pragma once
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+
+/*****************************
+   Includes
+*****************************/
+#include <stddef.h>   /* size_t */
+
+
+/*****************************
+   Type
+*****************************/
+typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
+
+
+
+/*****************************
+   Simple Hash Functions
+*****************************/
+
+unsigned int       XXH32 (const void* input, size_t length, unsigned seed);
+unsigned long long XXH64 (const void* input, size_t length, unsigned long long seed);
+void 		   XXH128 (const void* input, size_t length, unsigned long long seed, void* out);
+void 		   XXH256 (const void* input, size_t length, unsigned long long seed, void* out);
+
+/*
+XXH32() :
+    Calculate the 32-bits hash of sequence "length" bytes stored at memory address "input".
+    The memory between input & input+length must be valid (allocated and read-accessible).
+    "seed" can be used to alter the result predictably.
+    This function successfully passes all SMHasher tests.
+    Speed on Core 2 Duo @ 3 GHz (single thread, SMHasher benchmark) : 5.4 GB/s
+XXH64() :
+    Calculate the 64-bits hash of sequence of length "len" stored at memory address "input".
+XXH128():
+    Calculate the 128-bits hash of sequence of length "len" stored at memory address "input".
+    Output is stored in the 16 byte array "out"
+XXH256():
+    Calculate the 256-bits hash of sequence of length "len" stored at memory address "input".
+    Output is stored in the 32 byte array "out"
+*/
+
+
+
+/*****************************
+   Advanced Hash Functions
+*****************************/
+typedef struct { long long ll[ 6]; } XXH32_state_t;
+typedef struct { long long ll[11]; } XXH64_state_t;
+typedef struct { long long ll[28]; } XXH128_state_t;
+typedef struct { long long ll[28]; } XXH256_state_t;
+
+/*
+These structures allow static allocation of XXH states.
+States must then be initialized using XXHnn_reset() before first use.
+
+If you prefer dynamic allocation, please refer to functions below.
+*/
+
+XXH32_state_t* XXH32_createState(void);
+XXH_errorcode  XXH32_freeState(XXH32_state_t* statePtr);
+
+XXH64_state_t* XXH64_createState(void);
+XXH_errorcode  XXH64_freeState(XXH64_state_t* statePtr);
+
+XXH128_state_t* XXH128_createState(void);
+XXH_errorcode   XXH128_freeState(XXH128_state_t* statePtr);
+
+XXH256_state_t* XXH256_createState(void);
+XXH_errorcode   XXH256_freeState(XXH256_state_t* statePtr);
+
+/*
+These functions create and release memory for XXH state.
+States must then be initialized using XXHnn_reset() before first use.
+*/
+
+
+XXH_errorcode		XXH32_reset  (XXH32_state_t* statePtr, unsigned seed);
+XXH_errorcode		XXH32_update (XXH32_state_t* statePtr, const void* input, size_t length);
+unsigned int		XXH32_digest (const XXH32_state_t* statePtr);
+
+XXH_errorcode		XXH64_reset  (XXH64_state_t* statePtr, unsigned long long seed);
+XXH_errorcode		XXH64_update (XXH64_state_t* statePtr, const void* input, size_t length);
+unsigned long long	XXH64_digest (const XXH64_state_t* statePtr);
+
+XXH_errorcode		XXH128_reset  (XXH128_state_t* statePtr, unsigned long long seed);
+XXH_errorcode		XXH128_update (XXH128_state_t* statePtr, const void* input, size_t length);
+void			XXH128_digest (const XXH128_state_t* statePtr, void* out);
+
+XXH_errorcode		XXH256_reset  (XXH256_state_t* statePtr, unsigned long long seed);
+XXH_errorcode		XXH256_update (XXH256_state_t* statePtr, const void* input, size_t length);
+void			XXH256_digest (const XXH256_state_t* statePtr, void* out);
+
+/*
+These functions calculate the xxHash of an input provided in multiple smaller packets,
+as opposed to an input provided as a single block.
+
+XXH state space must first be allocated, using either static or dynamic method provided above.
+
+Start a new hash by initializing state with a seed, using XXHnn_reset().
+
+Then, feed the hash state by calling XXHnn_update() as many times as necessary.
+Obviously, input must be valid, meaning allocated and read accessible.
+The function returns an error code, with 0 meaning OK, and any other value meaning there is an error.
+
+Finally, you can produce a hash anytime, by using XXHnn_digest().
+This function returns the final nn-bits hash.
+You can nonetheless continue feeding the hash state with more input,
+and therefore get some new hashes, by calling again XXHnn_digest().
+
+When you are done, don't forget to free XXH state space, using typically XXHnn_freeState().
+*/
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/numcosmo/meson.build
+++ b/numcosmo/meson.build
@@ -18,6 +18,7 @@ subdir('external/toeplitz')
 subdir('external/class')
 subdir('external/plc')
 subdir('external/lintegrate')
+subdir('external/libfyaml')
 
 ncm_sources = files(
     'ncm/specfunc/ncm_binsplit.c',
@@ -750,56 +751,53 @@ nc_enum_types = gnome.mkenums(
     install_dir: numcosmo_includedir,
 )
 
-ncm_fit_nlopt_enum_types = []
-if nlopt_dep.found()
-    message('Generating ncm_fit_nlopt_enum_meta.h')
+message('Generating ncm_fit_nlopt_enum_meta.h')
 
-    process_nlopt_enum = find_program('process_nlopt_enum.py', required: true)
-    glib_mkenums = find_program('glib-mkenums', required: true)
+process_nlopt_enum = find_program('process_nlopt_enum.py', required: true)
+glib_mkenums = find_program('glib-mkenums', required: true)
 
-    nlopt_header_tmp = cc.preprocess(
-        'ncm_fit_nlopt_enum_meta.c',
-        output: 'ncm_fit_nlopt_enum_meta.i',
-        dependencies: nlopt_dep,
-    )
+nlopt_header_tmp = cc.preprocess(
+    'ncm_fit_nlopt_enum_meta.c',
+    output: 'ncm_fit_nlopt_enum_meta.i',
+    dependencies: nlopt_dep,
+)
 
-    nlopt_enum_meta = custom_target(
-        'ncm_fit_nlopt_enum_meta.h',
-        input: nlopt_header_tmp,
-        output: 'ncm_fit_nlopt_enum_meta.h',
-        command: [process_nlopt_enum, '@INPUT@', '@OUTPUT@'],
-    )
+nlopt_enum_meta = custom_target(
+    'ncm_fit_nlopt_enum_meta.h',
+    input: nlopt_header_tmp,
+    output: 'ncm_fit_nlopt_enum_meta.h',
+    command: [process_nlopt_enum, '@INPUT@', '@OUTPUT@'],
+)
 
-    ncm_fit_nlopt_enum_h = custom_target(
-        'ncm_fit_nlopt_enum.h',
-        input: nlopt_enum_meta,
-        output: 'ncm_fit_nlopt_enum.h',
-        command: [
-            glib_mkenums,
-            '--template', meson.current_source_dir() / 'ncm_fit_nlopt_enum.h.template',
-            '@INPUT@',
-        ],
-        capture: true,
-        install: true,
-        install_dir: numcosmo_includedir,
-    )
+ncm_fit_nlopt_enum_h = custom_target(
+    'ncm_fit_nlopt_enum.h',
+    input: nlopt_enum_meta,
+    output: 'ncm_fit_nlopt_enum.h',
+    command: [
+        glib_mkenums,
+        '--template', meson.current_source_dir() / 'ncm_fit_nlopt_enum.h.template',
+        '@INPUT@',
+    ],
+    capture: true,
+    install: true,
+    install_dir: numcosmo_includedir,
+)
 
-    ncm_fit_nlopt_enum_c = custom_target(
-        'ncm_fit_nlopt_enum.c',
-        input: nlopt_enum_meta,
-        output: 'ncm_fit_nlopt_enum.c',
-        command: [
-            glib_mkenums,
-            '--template', meson.current_source_dir() / 'ncm_fit_nlopt_enum.c.template',
-            '@INPUT@',
-        ],
-        capture: true,
-    )
+ncm_fit_nlopt_enum_c = custom_target(
+    'ncm_fit_nlopt_enum.c',
+    input: nlopt_enum_meta,
+    output: 'ncm_fit_nlopt_enum.c',
+    command: [
+        glib_mkenums,
+        '--template', meson.current_source_dir() / 'ncm_fit_nlopt_enum.c.template',
+        '@INPUT@',
+    ],
+    capture: true,
+)
 
-    ncm_fit_nlopt_enum_types += [ncm_fit_nlopt_enum_c, ncm_fit_nlopt_enum_h]
-    ncm_sources += 'ncm/fit/ncm_fit_nlopt.c'
-    ncm_headers += 'ncm/fit/ncm_fit_nlopt.h'
-endif
+ncm_fit_nlopt_enum_types = [ncm_fit_nlopt_enum_c, ncm_fit_nlopt_enum_h]
+ncm_sources += 'ncm/fit/ncm_fit_nlopt.c'
+ncm_headers += 'ncm/fit/ncm_fit_nlopt.h'
 
 install_headers(
     ncm_headers + nc_headers + [
@@ -813,11 +811,11 @@ install_headers(
 sundials_inc = include_directories('external/sundials/include')
 libcuba_inc = include_directories('external/libcuba')
 lintegrate_inc = include_directories('external/lintegrate')
+libfyaml_inc = include_directories('external/libfyaml/include')
 
 libnumcosmo_dep_list = [
     mpi_c_dep,
     cfitsio_dep,
-    libfyaml_dep,
     fftw3_dep,
     fftw3f_dep,
     gio_dep,
@@ -859,12 +857,28 @@ libnumcosmo = library(
     install: true,
     # intl.lib is not compatible with SAFESEH
     link_args: [noseh_link_args],
-    include_directories: [configinc, sundials_inc, libcuba_inc, plc_inc, lintegrate_inc],
+    include_directories: [
+        configinc,
+        sundials_inc,
+        libcuba_inc,
+        plc_inc,
+        lintegrate_inc,
+        libfyaml_inc,
+    ],
     # Planck likelihood code uses dlsym to load the Planck likelihood library
     # components. This requires linking with link_whole to ensure that the
     # symbols are available at runtime.
     link_whole: [libplc],
-    link_with: [libsundials, libcuba, liblevmar, libmisc, libtoeplitz, libclass, liblintegrate],
+    link_with: [
+        libsundials,
+        libcuba,
+        liblevmar,
+        libmisc,
+        libtoeplitz,
+        libclass,
+        liblintegrate,
+        libfyaml,
+    ],
     dependencies: libnumcosmo_dep_list,
     c_args: numcosmo_c_args,
 )
@@ -872,11 +886,8 @@ libnumcosmo = library(
 libnumcosmo_dep_sources = [
     ncm_enum_types[1],
     nc_enum_types[1],
+    ncm_fit_nlopt_enum_types[1],
 ]
-
-if nlopt_dep.found()
-    libnumcosmo_dep_sources += ncm_fit_nlopt_enum_types[1]
-endif
 
 libnumcosmo_dep = declare_dependency(
     link_with: libnumcosmo,

--- a/numcosmo/ncm/algebra/ncm_vector.c
+++ b/numcosmo/ncm/algebra/ncm_vector.c
@@ -45,9 +45,7 @@
 
 #ifndef NUMCOSMO_GIR_SCAN
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 #endif /* NUMCOSMO_GIR_SCAN */
 
 enum
@@ -242,20 +240,12 @@ ncm_vector_new_full (gdouble *d, gsize size, gsize stride, gpointer pdata, GDest
 NcmVector *
 ncm_vector_new_fftw (guint size)
 {
-#ifdef HAVE_FFTW3
   gdouble *d    = fftw_alloc_real (size);
   NcmVector *cv = ncm_vector_new_full (d, size, 1, d, (GDestroyNotify) fftw_free);
 
   cv->type = NCM_VECTOR_MALLOC;
 
   return cv;
-
-#else
-  g_error ("ncm_vector_new_fftw: fftw3 not available");
-
-  return NULL;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**

--- a/numcosmo/ncm/core/ncm_cfg.c
+++ b/numcosmo/ncm/core/ncm_cfg.c
@@ -260,9 +260,7 @@
 #ifndef NUMCOSMO_GIR_SCAN
 #include <stdlib.h>
 #include <gio/gio.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 #include <cuba.h>
 
 #ifdef HAVE_MPI
@@ -435,9 +433,7 @@ _ncm_cfg_exit (void)
   }
 
 #endif /* HAVE_MPI */
-#ifdef HAVE_FFTW3
   fftw_forget_wisdom ();
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -531,14 +527,10 @@ ncm_cfg_init_full_ptr (gint *argc, gchar ***argv)
   if (numcosmo_init)
     return;
 
-#ifdef HAVE_FFTW3
-
   ncm_cfg_set_fftw_default_from_env_str (NUMCOSMO_FFTW_PLAN, -1.0, NULL);
 
   if (sizeof (NcmComplex) != sizeof (fftw_complex))
     g_warning ("NcmComplex is not binary compatible with complex double, expect problems with it!");
-
-#endif /* HAVE_FFTW3 */
 
   home          = g_get_home_dir ();
   numcosmo_path = g_build_filename (home, ".numcosmo", NULL);
@@ -562,9 +554,7 @@ ncm_cfg_init_full_ptr (gint *argc, gchar ***argv)
 
   gsl_err = gsl_set_error_handler_off ();
 
-#ifdef HAVE_FFTW3
   fftw_set_timelimit (10.0);
-#endif /* HAVE_FFTW3 */
 #ifdef HAVE_FFTW3F
   fftwf_set_timelimit (10.0);
 #endif /* HAVE_FFTW3F */
@@ -707,9 +697,7 @@ ncm_cfg_register_objects (void)
   ncm_cfg_register_obj (NCM_TYPE_FIT_GSL_MM);
   ncm_cfg_register_obj (NCM_TYPE_FIT_GSL_MMS);
 
-#ifdef HAVE_NLOPT
   ncm_cfg_register_obj (NCM_TYPE_FIT_NLOPT);
-#endif /* HAVE_NLOPT */
 
   ncm_cfg_register_obj (NCM_TYPE_PRIOR_GAUSS_PARAM);
   ncm_cfg_register_obj (NCM_TYPE_PRIOR_GAUSS_FUNC);
@@ -1905,8 +1893,6 @@ ncm_cfg_enum_print_all (GType enum_type, const gchar *header)
   g_type_class_unref (enum_class);
 }
 
-#ifdef HAVE_FFTW3
-
 G_LOCK_DEFINE_STATIC (fftw_saveload_lock);
 
 G_LOCK_DEFINE_STATIC (fftw_plan_lock);
@@ -2092,8 +2078,6 @@ ncm_cfg_save_fftw_wisdom (const gchar *filename, ...)
 
   return TRUE;
 }
-
-#endif /* HAVE_FFTW3 */
 
 /**
  * ncm_cfg_exists:
@@ -2317,8 +2301,6 @@ ncm_cfg_array_to_variant (GArray *a, const GVariantType *etype)
 
   return g_variant_ref_sink (vvar);
 }
-
-#ifdef HAVE_FFTW3
 
 static guint __fftw_default_flags = FFTW_MEASURE;
 static gdouble __fftw_timelimit   = 60.0;
@@ -2557,11 +2539,6 @@ ncm_cfg_get_fftw_timelimit (void)
 {
   return __fftw_timelimit;
 }
-
-#else
-guint fftw_default_flags = 0;
-
-#endif /* HAVE_FFTW3 */
 
 /**
  * ncm_cfg_get_version:

--- a/numcosmo/ncm/core/ncm_serialize.c
+++ b/numcosmo/ncm/core/ncm_serialize.c
@@ -63,9 +63,7 @@
 #include <errno.h>
 
 #ifndef NUMCOSMO_GIR_SCAN
-#ifdef HAVE_LIBFYAML
 #include <libfyaml.h>
-#endif /* HAVE_LIBFYAML */
 #endif /* NUMCOSMO_GIR_SCAN */
 
 enum
@@ -1044,8 +1042,6 @@ ncm_serialize_from_string (NcmSerialize *ser, const gchar *obj_ser)
 
 static const GVariantType *_ncm_serialize_gtype_to_gvariant_type (GType t);
 
-#ifdef HAVE_LIBFYAML
-
 GObject *
 _ncm_serialize_from_node (NcmSerialize *ser, struct fy_node *root)
 {
@@ -1452,8 +1448,6 @@ _ncm_serialize_from_node (NcmSerialize *ser, struct fy_node *root)
   return obj;
 }
 
-#endif /* HAVE_LIBFYAML */
-
 /**
  * ncm_serialize_from_yaml:
  * @ser: a #NcmSerialize
@@ -1466,8 +1460,6 @@ _ncm_serialize_from_node (NcmSerialize *ser, struct fy_node *root)
 GObject *
 ncm_serialize_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_build_from_string (NULL, yaml_obj, strlen (yaml_obj));
 
   if (doc == NULL)
@@ -1506,17 +1498,7 @@ ncm_serialize_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
       return obj;
     }
   }
-
-#else
-
-  g_error ("ncm_serialize_from_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif /* HAVE_LIBFYAML */
 }
-
-#ifdef HAVE_LIBFYAML
 
 static NcmObjArray *
 _ncm_serialize_array_from_yaml_node (NcmSerialize *ser, struct fy_node *root)
@@ -1546,8 +1528,6 @@ _ncm_serialize_array_from_yaml_node (NcmSerialize *ser, struct fy_node *root)
   return array;
 }
 
-#endif /* HAVE_LIBFYAML */
-
 /**
  * ncm_serialize_array_from_yaml:
  * @ser: a #NcmSerialize
@@ -1560,8 +1540,6 @@ _ncm_serialize_array_from_yaml_node (NcmSerialize *ser, struct fy_node *root)
 NcmObjArray *
 ncm_serialize_array_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_build_from_string (NULL, yaml_obj, strlen (yaml_obj));
 
   if (doc == NULL)
@@ -1581,14 +1559,6 @@ ncm_serialize_array_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 
     return array;
   }
-
-#else
-
-  g_error ("ncm_serialize_array_from_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif /* HAVE_LIBFYAML */
 }
 
 /**
@@ -1604,8 +1574,6 @@ ncm_serialize_array_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 NcmObjDictStr *
 ncm_serialize_dict_str_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_build_from_string (NULL, yaml_obj, strlen (yaml_obj));
 
   if (doc == NULL)
@@ -1648,14 +1616,6 @@ ncm_serialize_dict_str_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 
     return dict;
   }
-
-#else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_dict_str_from_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif /* HAVE_LIBFYAML */
 }
 
 /**
@@ -1671,8 +1631,6 @@ ncm_serialize_dict_str_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 NcmObjDictInt *
 ncm_serialize_dict_int_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_build_from_string (NULL, yaml_obj, strlen (yaml_obj));
 
   if (doc == NULL)
@@ -1722,14 +1680,6 @@ ncm_serialize_dict_int_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 
     return dict;
   }
-
-#else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_dict_int_from_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif /* HAVE_LIBFYAML */
 }
 
 /**
@@ -1745,8 +1695,6 @@ ncm_serialize_dict_int_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 NcmVarDict *
 ncm_serialize_var_dict_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_build_from_string (NULL, yaml_obj, strlen (yaml_obj));
 
   if (doc == NULL)
@@ -1795,14 +1743,6 @@ ncm_serialize_var_dict_from_yaml (NcmSerialize *ser, const gchar *yaml_obj)
 
     return dict;
   }
-
-  #else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_var_dict_from_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif /* HAVE_LIBFYAML */
 }
 
 /**
@@ -3010,10 +2950,7 @@ ncm_serialize_var_dict_to_variant (NcmSerialize *ser, NcmVarDict *vd)
   return var;
 }
 
-#ifdef HAVE_LIBFYAML
 static struct fy_node *_ncm_serialize_to_yaml_node (NcmSerialize *ser, struct fy_document *doc, GVariant *var_obj);
-
-#endif /* HAVE_LIBFYAML */
 
 /**
  * ncm_serialize_variant_to_yaml:
@@ -3027,7 +2964,6 @@ static struct fy_node *_ncm_serialize_to_yaml_node (NcmSerialize *ser, struct fy
 gchar *
 ncm_serialize_variant_to_yaml (NcmSerialize *ser, GVariant *var_obj)
 {
-#ifdef HAVE_LIBFYAML
   g_assert (var_obj != NULL);
   g_assert (g_variant_is_of_type (var_obj, G_VARIANT_TYPE (NCM_SERIALIZE_OBJECT_TYPE)));
 
@@ -3044,15 +2980,7 @@ ncm_serialize_variant_to_yaml (NcmSerialize *ser, GVariant *var_obj)
 
     return yaml;
   }
-#else
-  g_error ("ncm_serialize_variant_to_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif /* HAVE_LIBFYAML */
 }
-
-#ifdef HAVE_LIBFYAML
 
 static struct fy_node *
 
@@ -3240,8 +3168,6 @@ _ncm_serialize_to_yaml_node (NcmSerialize *ser, struct fy_document *doc, GVarian
   return root;
 }
 
-#endif /* HAVE_LIBFYAML */
-
 /**
  * ncm_serialize_to_string:
  * @ser: a #NcmSerialize.
@@ -3322,8 +3248,6 @@ ncm_serialize_to_yaml (NcmSerialize *ser, GObject *obj)
 gchar *
 ncm_serialize_array_to_yaml (NcmSerialize *ser, NcmObjArray *oa)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_create (NULL);
   struct fy_node *root    = fy_node_create_sequence (doc);
   gchar *yaml_str         = NULL;
@@ -3345,14 +3269,6 @@ ncm_serialize_array_to_yaml (NcmSerialize *ser, NcmObjArray *oa)
   g_ptr_array_set_size (ser->dangling_anchors, 0);
 
   return yaml_str;
-
-#else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_array_to_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif
 }
 
 /**
@@ -3367,7 +3283,6 @@ ncm_serialize_array_to_yaml (NcmSerialize *ser, NcmObjArray *oa)
 gchar *
 ncm_serialize_dict_str_to_yaml (NcmSerialize *ser, NcmObjDictStr *ods)
 {
-#ifdef HAVE_LIBFYAML
   struct fy_document *doc = fy_document_create (NULL);
   struct fy_node *root    = fy_node_create_mapping (doc);
   gchar *yaml_str         = NULL;
@@ -3394,14 +3309,6 @@ ncm_serialize_dict_str_to_yaml (NcmSerialize *ser, NcmObjDictStr *ods)
   g_ptr_array_set_size (ser->dangling_anchors, 0);
 
   return yaml_str;
-
-#else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_dict_str_to_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif
 }
 
 /**
@@ -3416,8 +3323,6 @@ ncm_serialize_dict_str_to_yaml (NcmSerialize *ser, NcmObjDictStr *ods)
 gchar *
 ncm_serialize_dict_int_to_yaml (NcmSerialize *ser, NcmObjDictInt *odi)
 {
-#ifdef HAVE_LIBFYAML
-
   struct fy_document *doc = fy_document_create (NULL);
   struct fy_node *root    = fy_node_create_mapping (doc);
   gchar *yaml_str         = NULL;
@@ -3444,14 +3349,6 @@ ncm_serialize_dict_int_to_yaml (NcmSerialize *ser, NcmObjDictInt *odi)
   g_ptr_array_set_size (ser->dangling_anchors, 0);
 
   return yaml_str;
-
-#else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_dict_int_to_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif
 }
 
 /**
@@ -3466,7 +3363,6 @@ ncm_serialize_dict_int_to_yaml (NcmSerialize *ser, NcmObjDictInt *odi)
 gchar *
 ncm_serialize_var_dict_to_yaml (NcmSerialize *ser, NcmVarDict *dict)
 {
-#ifdef HAVE_LIBFYAML
   struct fy_document *doc = fy_document_create (NULL);
   struct fy_node *root    = fy_node_create_mapping (doc);
   gchar *yaml_str         = NULL;
@@ -3490,14 +3386,6 @@ ncm_serialize_var_dict_to_yaml (NcmSerialize *ser, NcmVarDict *dict)
   g_ptr_array_set_size (ser->dangling_anchors, 0);
 
   return yaml_str;
-
-#else /* HAVE_LIBFYAML */
-
-  g_error ("ncm_serialize_var_dict_to_yaml: libfyaml not available.");
-
-  return NULL;
-
-#endif
 }
 
 /**

--- a/numcosmo/ncm/core/ncm_util.c
+++ b/numcosmo/ncm/core/ncm_util.c
@@ -51,9 +51,7 @@
 #include <gsl/gsl_sf_hyperg.h>
 
 #include <cvode/cvode.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 #ifdef HAVE_CFITSIO
 #include <fitsio.h>
 #endif /* HAVE_CFITSIO */

--- a/numcosmo/ncm/fftlog/ncm_fftlog.c
+++ b/numcosmo/ncm/fftlog/ncm_fftlog.c
@@ -60,15 +60,11 @@
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_poly.h>
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 #endif /* NUMCOSMO_GIR_SCAN */
 
-#ifndef HAVE_FFTW3_ALLOC
 #define fftw_alloc_real(n) (double *) fftw_malloc (sizeof (double) * (n))
 #define fftw_alloc_complex(n) (fftw_complex *) fftw_malloc (sizeof (fftw_complex) * (n))
-#endif /* HAVE_FFTW3_ALLOC */
 
 typedef struct _NcmFftlogPrivate
 {
@@ -98,14 +94,12 @@ typedef struct _NcmFftlogPrivate
   GPtrArray *Gr_s;
   GPtrArray *Ym;
 
-#ifdef HAVE_FFTW3
   fftw_complex *Fk;
   fftw_complex *Cm;
   fftw_complex *Gr;
   fftw_complex *CmYm;
   fftw_plan p_Fk2Cm;
   fftw_plan p_CmYm2Gr;
-#endif /* HAVE_FFTW3 */
 } NcmFftlogPrivate;
 
 enum
@@ -162,7 +156,6 @@ ncm_fftlog_init (NcmFftlog *fftlog)
   g_ptr_array_set_free_func (self->Gr_vec, (GDestroyNotify) ncm_vector_free);
   g_ptr_array_set_free_func (self->Gr_s, (GDestroyNotify) ncm_spline_free);
 
-#ifdef HAVE_FFTW3
   self->Fk        = NULL;
   self->Cm        = NULL;
   self->Gr        = NULL;
@@ -171,7 +164,6 @@ ncm_fftlog_init (NcmFftlog *fftlog)
   self->p_Fk2Cm   = NULL;
   self->p_CmYm2Gr = NULL;
   g_ptr_array_set_free_func (self->Ym, (GDestroyNotify) fftw_free);
-#endif /* HAVE_FFTW3 */
 }
 
 #define ncm_fftlog_array_pos(fftlog, array)
@@ -291,8 +283,6 @@ _ncm_fftlog_get_property (GObject *object, guint prop_id, GValue *value, GParamS
   }
 }
 
-#ifdef HAVE_FFTW3
-
 static void
 _ncm_fftlog_free_all (NcmFftlog *fftlog)
 {
@@ -313,12 +303,9 @@ _ncm_fftlog_free_all (NcmFftlog *fftlog)
   g_ptr_array_set_size (self->Ym, 0);
 }
 
-#endif /* HAVE_FFTW3 */
-
 static void
 _ncm_fftlog_finalize (GObject *object)
 {
-#ifdef HAVE_FFTW3
   NcmFftlog *fftlog             = NCM_FFTLOG (object);
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
 
@@ -328,7 +315,6 @@ _ncm_fftlog_finalize (GObject *object)
   g_clear_pointer (&self->Gr_s,   g_ptr_array_unref);
   g_clear_pointer (&self->Ym,     g_ptr_array_unref);
 
-#endif /* HAVE_FFTW3 */
 
   /* Chain up : end */
   G_OBJECT_CLASS (ncm_fftlog_parent_class)->finalize (object);
@@ -623,7 +609,6 @@ ncm_fftlog_reset (NcmFftlog *fftlog)
 void
 ncm_fftlog_set_nderivs (NcmFftlog *fftlog, guint nderivs)
 {
-#ifdef HAVE_FFTW3
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
 
   if (self->nderivs != nderivs)
@@ -657,8 +642,6 @@ ncm_fftlog_set_nderivs (NcmFftlog *fftlog, guint nderivs)
 
     self->nderivs = nderivs;
   }
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -762,7 +745,6 @@ ncm_fftlog_get_lnk0 (NcmFftlog *fftlog)
 void
 ncm_fftlog_set_size (NcmFftlog *fftlog, guint n)
 {
-#ifdef HAVE_FFTW3
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
   gint nt                       = n * (1.0 + self->pad_p);
   gint n_new;
@@ -818,8 +800,6 @@ ncm_fftlog_set_size (NcmFftlog *fftlog, guint n)
 
     ncm_fftlog_reset (fftlog);
   }
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1100,8 +1080,6 @@ ncm_fftlog_get_eval_r_max (NcmFftlog *fftlog)
   return self->eval_r_max;
 }
 
-#ifdef HAVE_FFTW3
-
 static void
 _ncm_fftlog_eval (NcmFftlog *fftlog)
 {
@@ -1208,8 +1186,6 @@ _ncm_fftlog_eval (NcmFftlog *fftlog)
   self->evaluated = TRUE;
 }
 
-#endif /* HAVE_FFTW3 */
-
 /**
  * ncm_fftlog_get_Ym:
  * @fftlog: a #NcmFftlog
@@ -1222,7 +1198,6 @@ _ncm_fftlog_eval (NcmFftlog *fftlog)
 gdouble *
 ncm_fftlog_get_Ym (NcmFftlog *fftlog, guint *size)
 {
-#ifdef HAVE_FFTW3
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
 
   fftw_complex *Ym_0 = g_ptr_array_index (self->Ym, 0);
@@ -1232,12 +1207,6 @@ ncm_fftlog_get_Ym (NcmFftlog *fftlog, guint *size)
   size[0] = ncm_fftlog_get_full_size (fftlog) * 2;
 
   return (gdouble *) Ym_0;
-
-#else
-
-  return NULL;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1268,7 +1237,6 @@ ncm_fftlog_get_lnk_vector (NcmFftlog *fftlog, NcmVector *lnk)
 static void
 _ncm_fftlog_add_smooth_padding (NcmFftlog *fftlog)
 {
-#ifdef HAVE_FFTW3
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
   gint size                     = 3;
   gdouble dd1[3], xa1[3], ya1[3];
@@ -1300,8 +1268,6 @@ _ncm_fftlog_add_smooth_padding (NcmFftlog *fftlog)
 
     /*printf ("%8d % 22.15g %8d % 22.15g\n", i, creal (self->Fk[i]), self->pad + self->N + i, creal (self->Fk[self->pad + self->N + i]));*/
   }
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1315,7 +1281,6 @@ _ncm_fftlog_add_smooth_padding (NcmFftlog *fftlog)
 void
 ncm_fftlog_eval_by_vector (NcmFftlog *fftlog, NcmVector *Fk)
 {
-#ifdef HAVE_FFTW3
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
   gint i;
 
@@ -1332,8 +1297,6 @@ ncm_fftlog_eval_by_vector (NcmFftlog *fftlog, NcmVector *Fk)
     _ncm_fftlog_add_smooth_padding (fftlog);
 
   _ncm_fftlog_eval (fftlog);
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1347,7 +1310,6 @@ ncm_fftlog_eval_by_vector (NcmFftlog *fftlog, NcmVector *Fk)
 void
 ncm_fftlog_eval_by_gsl_function (NcmFftlog *fftlog, gsl_function *Fk)
 {
-#ifdef HAVE_FFTW3
   NcmFftlogPrivate * const self = ncm_fftlog_get_instance_private (fftlog);
   gint i;
 
@@ -1367,7 +1329,6 @@ ncm_fftlog_eval_by_gsl_function (NcmFftlog *fftlog, gsl_function *Fk)
     _ncm_fftlog_add_smooth_padding (fftlog);
 
   _ncm_fftlog_eval (fftlog);
-#endif /* HAVE_FFTW3 */
 }
 
 /**

--- a/numcosmo/ncm/fftlog/ncm_fftlog_gausswin2.c
+++ b/numcosmo/ncm/fftlog/ncm_fftlog_gausswin2.c
@@ -63,9 +63,7 @@
 #include <gsl/gsl_sf_trig.h>
 #include <gsl/gsl_math.h>
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 
 #endif /* NUMCOSMO_GIR_SCAN */
 
@@ -108,7 +106,6 @@ _ncm_fftlog_gausswin2_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
   const gdouble twopi_Lt = 2.0 * M_PI / ncm_fftlog_get_full_length (fftlog);
   const gint Nf          = ncm_fftlog_get_full_size (fftlog);
 
-#ifdef HAVE_FFTW3
   fftw_complex *Ym_base = (fftw_complex *) Ym_0;
   gint i;
 
@@ -126,8 +123,6 @@ _ncm_fftlog_gausswin2_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
 
     Ym_base[i] = U;
   }
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**

--- a/numcosmo/ncm/fftlog/ncm_fftlog_sbessel_j.c
+++ b/numcosmo/ncm/fftlog/ncm_fftlog_sbessel_j.c
@@ -113,9 +113,7 @@
 #include <gsl/gsl_sf_trig.h>
 #include <gsl/gsl_math.h>
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 #include <math.h>
 #ifdef HAVE_ACB_H
 #ifdef HAVE_FLINT_ACB_H
@@ -260,7 +258,6 @@ _ncm_fftlog_sbessel_j_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
   const gdouble twopi_Lt = 2.0 * M_PI / ncm_fftlog_get_full_length (fftlog);
   const gint Nf          = ncm_fftlog_get_full_size (fftlog);
 
-#ifdef HAVE_FFTW3
   fftw_complex *Ym_base = (fftw_complex *) Ym_0;
   gint i;
 
@@ -311,8 +308,6 @@ _ncm_fftlog_sbessel_j_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
       Ym_base[i] = pi_sqrt * two_x_m1 * U;
     }
   }
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**

--- a/numcosmo/ncm/fftlog/ncm_fftlog_sbessel_jljm.c
+++ b/numcosmo/ncm/fftlog/ncm_fftlog_sbessel_jljm.c
@@ -60,9 +60,7 @@
 #include <gsl/gsl_sf_hyperg.h>
 #include <gsl/gsl_math.h>
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 
 #ifdef HAVE_ACB_H
 #ifdef HAVE_FLINT_ACB_H
@@ -266,7 +264,7 @@ ncm_fftlog_sbessel_jljm_class_init (NcmFftlogSBesselJLJMClass *klass)
   fftlog_class->compute_Ym = &_ncm_fftlog_sbessel_jljm_compute_Ym;
 }
 
-#if defined (HAVE_FFTW3) && defined (HAVE_ACB_H)
+#ifdef HAVE_ACB_H
 
 static gint _ncm_fftlog_sbessel_jljm_cpu_integrate_2f1_f (sunrealtype x, N_Vector y, N_Vector ydot, gpointer f_data);
 static gint _ncm_fftlog_sbessel_jljm_cpu_integrate_2f1_jac (gdouble x, N_Vector y, N_Vector fy, SUNMatrix Jac, gpointer user_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3);
@@ -526,14 +524,14 @@ _ncm_fftlog_sbessel_jljm_compute_2f1 (NcmFftlog *fftlog)
   printf ("# RES % 22.15g % 22.15g\n", creal (res), cimag (res));
 }
 
-#endif /* defined (HAVE_FFTW3) && defined (HAVE_ACB_H) */
+#endif /* HAVE_ACB_H */
 
 #define _NCM_FFTLOG_SBESSEL_JLJM_CACHE_FILE "ncm_fftlog_sbessel_j%dj%d_lnw%.14g_L%.14g.fftlog", self->ell, self->ell + self->dell, self->lnw, ncm_fftlog_get_full_length (fftlog)
 
 static void
 _ncm_fftlog_sbessel_jljm_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
 {
-#if defined (HAVE_FFTW3) && defined (HAVE_ACB_H)
+#ifdef HAVE_ACB_H
   NcmFftlogSBesselJLJM *fftlog_jljm        = NCM_FFTLOG_SBESSEL_JLJM (fftlog);
   NcmFftlogSBesselJLJMPrivate * const self = ncm_fftlog_sbessel_jljm_get_instance_private (fftlog_jljm);
   const guint maxprec                      = 64 * 64;
@@ -824,8 +822,8 @@ _ncm_fftlog_sbessel_jljm_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
   }
 
 #else
-  g_error ("_ncm_fftlog_sbessel_jljm_compute_Ym: this object requires both FFTW3 and ARB dependencies.");
-#endif /* HAVE_FFTW3 */
+  g_error ("_ncm_fftlog_sbessel_jljm_compute_Ym: this object requires the ARB dependency.");
+#endif /* HAVE_ACB_H */
 }
 
 /**

--- a/numcosmo/ncm/fftlog/ncm_fftlog_tophatwin2.c
+++ b/numcosmo/ncm/fftlog/ncm_fftlog_tophatwin2.c
@@ -66,9 +66,7 @@
 #include <gsl/gsl_sf_trig.h>
 #include <gsl/gsl_math.h>
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 
 #ifdef HAVE_ACB_H
 #ifdef HAVE_FLINT_ACB_H
@@ -115,7 +113,6 @@ ncm_fftlog_tophatwin2_class_init (NcmFftlogTophatwin2Class *klass)
 static void
 _ncm_fftlog_tophatwin2_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
 {
-#ifdef HAVE_FFTW3
 #if defined (HAVE_ACB_H) && defined (NCM_FFTLOG_USE_ACB)
   const guint prec      = 120;
   const gint Nf         = ncm_fftlog_get_full_size (fftlog);
@@ -239,7 +236,6 @@ _ncm_fftlog_tophatwin2_compute_Ym (NcmFftlog *fftlog, gpointer Ym_0)
   }
 
 #endif /* HAVE_ACB_H */
-#endif /* HAVE_FFTW3 */
 }
 
 /**

--- a/numcosmo/ncm/fit/ncm_fit.c
+++ b/numcosmo/ncm/fit/ncm_fit.c
@@ -618,14 +618,12 @@ ncm_fit_factory (NcmFitType ftype, gchar *algo_name, NcmLikelihood *lh, NcmMSet 
       return ncm_fit_levmar_new_by_name (lh, mset, gtype, algo_name);
 
       break;
-#ifdef HAVE_NLOPT
     case NCM_FIT_TYPE_NLOPT:
       return ncm_fit_nlopt_new_by_name (lh, mset, gtype, algo_name);
 
       break;
-#endif /* HAVE_NLOPT */
     default:
-      g_error ("ncm_fit_factory: fit-type not found %d, try to compile the library with the optional package NLOpt.", ftype);
+      g_error ("ncm_fit_factory: fit-type not found %d.", ftype);
       break;
   }
 }

--- a/numcosmo/ncm/fit/ncm_fit_nlopt.c
+++ b/numcosmo/ncm/fit/ncm_fit_nlopt.c
@@ -37,8 +37,6 @@
 #endif /* HAVE_CONFIG_H */
 #include "build_cfg.h"
 
-#ifdef HAVE_NLOPT
-
 #include "ncm/fit/ncm_fit_nlopt.h"
 #include "ncm/core/ncm_cfg.h"
 #include "ncm_fit_nlopt_enum.h"
@@ -59,12 +57,10 @@ struct _NcmFitNLOpt
 {
   /*< private >*/
   NcmFit parent_instance;
-#ifdef HAVE_NLOPT
   nlopt_opt nlopt;
   nlopt_opt local_nlopt;
   NcmFitNloptAlgorithm nlopt_algo;
   NcmFitNloptAlgorithm local_nlopt_algo;
-#endif /* HAVE_NLOPT */
   NcmVector *lb;
   NcmVector *ub;
   NcmVector *pabs;
@@ -712,6 +708,4 @@ ncm_fit_nlopt_set_local_algo (NcmFitNLOpt *fit_nlopt, NcmFitNloptAlgorithm algo)
     g_clear_pointer (&fit_nlopt->desc, g_free);
   }
 }
-
-#endif /* HAVE_NLOPT */
 

--- a/numcosmo/ncm/fit/ncm_fit_nlopt.h
+++ b/numcosmo/ncm/fit/ncm_fit_nlopt.h
@@ -31,7 +31,6 @@
 #include <numcosmo/build_cfg.h>
 #include <numcosmo/ncm/fit/ncm_fit.h>
 
-#ifdef NUMCOSMO_HAVE_NLOPT
 #include <numcosmo/ncm_fit_nlopt_enum.h>
 
 G_BEGIN_DECLS
@@ -50,6 +49,5 @@ NcmFit *ncm_fit_nlopt_new_default (NcmLikelihood *lh, NcmMSet *mset, NcmFitGradT
 
 G_END_DECLS
 
-#endif /* NUMCOSMO_HAVE_NLOPT */
 #endif /* _NCM_FIT_NLOPT_H_ */
 

--- a/numcosmo/ncm/stats/ncm_stats_dist1d_epdf.c
+++ b/numcosmo/ncm/stats/ncm_stats_dist1d_epdf.c
@@ -47,9 +47,7 @@
 
 #ifndef NUMCOSMO_GIR_SCAN
 #include <complex.h>
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 #include <gsl/gsl_sort.h>
 #endif /* NUMCOSMO_GIR_SCAN */
 
@@ -244,10 +242,8 @@ ncm_stats_dist1d_epdf_finalize (GObject *object)
 {
   NcmStatsDist1dEPDF *epdf1d = NCM_STATS_DIST1D_EPDF (object);
 
-#ifdef HAVE_FFTW3
   g_clear_pointer (&epdf1d->fft_data_to_tilde, fftw_destroy_plan);
   g_clear_pointer (&epdf1d->fft_tilde_to_est, fftw_destroy_plan);
-#endif /* HAVE_FFTW3 */
 
   /* Chain up : end */
   G_OBJECT_CLASS (ncm_stats_dist1d_epdf_parent_class)->finalize (object);
@@ -452,7 +448,6 @@ _ncm_stats_dist1d_epdf_estimate_h (NcmVector *p_tilde2, NcmVector *Iv, const gui
 static void
 _ncm_stats_dist1d_epdf_autobw (NcmStatsDist1dEPDF *epdf1d)
 {
-#ifdef HAVE_FFTW3
   const guint nbins        = exp2 (14.0 /*ceil (log2 (epdf1d->obs->len * 10))*/);
   const gdouble delta_l    = (epdf1d->max - epdf1d->min) * 2.0;
   const gdouble deltax     = delta_l / nbins;
@@ -600,10 +595,6 @@ _ncm_stats_dist1d_epdf_autobw (NcmStatsDist1dEPDF *epdf1d)
 
     ncm_spline_prepare (epdf1d->ph_spline);
   }
-
-#else
-  g_error ("ncm_stats_dist1d_epdf_autobw: FFTW3 not available."); /* LCOV_EXCL_LINE */
-#endif /* HAVE_FFTW3 */
 }
 
 static void

--- a/numcosmo/ncm/stats/ncm_stats_vec.c
+++ b/numcosmo/ncm/stats/ncm_stats_vec.c
@@ -83,9 +83,7 @@
 #include "ncm_enum_types.h"
 
 #ifndef NUMCOSMO_GIR_SCAN
-#ifdef HAVE_FFTW3
 #include <fftw3.h>
-#endif /* HAVE_FFTW3 */
 
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_blas.h>
@@ -130,14 +128,12 @@ struct _NcmStatsVec
   GPtrArray *saved_x;
   GPtrArray *q_array;
 
-#ifdef HAVE_FFTW3
   guint fft_size;
   guint fft_plan_size;
   gdouble *param_data;
   fftw_complex *param_fft;
   fftw_plan param_r2c;
   fftw_plan param_c2r;
-#endif /* HAVE_FFTW3 */
 };
 
 G_DEFINE_TYPE (NcmStatsVec, ncm_stats_vec, G_TYPE_OBJECT)
@@ -170,14 +166,12 @@ ncm_stats_vec_init (NcmStatsVec *svec)
   svec->q_array = g_ptr_array_new ();
   g_ptr_array_set_free_func (svec->q_array, (GDestroyNotify) gsl_rstat_quantile_free);
 
-#ifdef HAVE_FFTW3
   svec->fft_size      = 0;
   svec->fft_plan_size = 0;
   svec->param_data    = NULL;
   svec->param_fft     = NULL;
   svec->param_r2c     = NULL;
   svec->param_c2r     = NULL;
-#endif /* HAVE_FFTW3 */
 }
 
 static void
@@ -211,12 +205,10 @@ _ncm_stats_vec_finalize (GObject *object)
 {
   NcmStatsVec *svec = NCM_STATS_VEC (object);
 
-#ifdef HAVE_FFTW3
   g_clear_pointer (&svec->param_fft,  fftw_free);
   g_clear_pointer (&svec->param_data, fftw_free);
   g_clear_pointer (&svec->param_c2r,  fftw_destroy_plan);
   g_clear_pointer (&svec->param_r2c,  fftw_destroy_plan);
-#endif /* HAVE_FFTW3 */
 
   /* Chain up : end */
   G_OBJECT_CLASS (ncm_stats_vec_parent_class)->finalize (object);
@@ -1005,7 +997,6 @@ ncm_stats_vec_get_quantile_all (NcmStatsVec *svec, guint i)
 static void
 _ncm_stats_vec_get_autocorr_alloc (NcmStatsVec *svec, guint size)
 {
-#ifdef HAVE_FFTW3
   const guint effsize      = ncm_util_fact_size (2 * size);
   guint fftw_default_flags = ncm_cfg_get_fftw_default_flag ();
 
@@ -1043,14 +1034,11 @@ _ncm_stats_vec_get_autocorr_alloc (NcmStatsVec *svec, guint size)
     svec->fft_plan_size = effsize;
     /*g_debug ("# _ncm_stats_vec_get_autocorr_alloc: calculated  wisdom %u\n", effsize);*/
   }
-
-#endif /* HAVE_FFTW3 */
 }
 
 static void
 _ncm_stats_vec_get_autocov (NcmStatsVec *svec, guint p, guint subsample, guint pad)
 {
-#ifdef HAVE_FFTW3
   guint eff_nitens = svec->nitens / subsample - pad;
 
   g_assert_cmpuint (svec->nitens / subsample, >, pad);
@@ -1104,7 +1092,6 @@ _ncm_stats_vec_get_autocov (NcmStatsVec *svec, guint p, guint subsample, guint p
 
     fftw_execute (svec->param_c2r);
   }
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1123,7 +1110,6 @@ _ncm_stats_vec_get_autocov (NcmStatsVec *svec, guint p, guint subsample, guint p
 NcmVector *
 ncm_stats_vec_get_autocorr (NcmStatsVec *svec, guint p)
 {
-#ifdef HAVE_FFTW3
   _ncm_stats_vec_get_autocov (svec, p, 1, 0);
   {
     NcmVector *autocor = ncm_vector_new_data_dup (svec->param_data, svec->nitens, 1);
@@ -1132,12 +1118,6 @@ ncm_stats_vec_get_autocorr (NcmStatsVec *svec, guint p)
 
     return autocor;
   }
-#else
-  g_error ("ncm_stats_vec_get_autocorr: recompile NumCosmo with fftw support.");
-
-  return NULL;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1157,7 +1137,6 @@ ncm_stats_vec_get_autocorr (NcmStatsVec *svec, guint p)
 NcmVector *
 ncm_stats_vec_get_subsample_autocorr (NcmStatsVec *svec, guint p, guint subsample)
 {
-#ifdef HAVE_FFTW3
   _ncm_stats_vec_get_autocov (svec, p, subsample, 0);
   g_assert_cmpuint (svec->nitens, >=, subsample);
   {
@@ -1167,12 +1146,6 @@ ncm_stats_vec_get_subsample_autocorr (NcmStatsVec *svec, guint p, guint subsampl
 
     return autocor;
   }
-#else
-  g_error ("ncm_stats_vec_get_subsample_autocorr: recompile NumCosmo with fftw support.");
-
-  return NULL;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -1194,7 +1167,6 @@ ncm_stats_vec_get_subsample_autocorr (NcmStatsVec *svec, guint p, guint subsampl
 gboolean
 ncm_stats_vec_fit_ar_model (NcmStatsVec *svec, guint p, const guint order, NcmStatsVecARType ar_crit, NcmVector **rho, NcmVector **pacf, gdouble *ivar, guint *c_order)
 {
-#ifdef HAVE_FFTW3
   _ncm_stats_vec_get_autocov (svec, p, 1, 0);
   {
     const gint aorder          = (order == 0) ? GSL_MIN (GSL_MAX (svec->nitens - 2, 1), floor (10 * log10 (svec->nitens))) : order;
@@ -1365,12 +1337,6 @@ ncm_stats_vec_fit_ar_model (NcmStatsVec *svec, guint p, const guint order, NcmSt
 
     return ((guint) aorder == c_order[0]);
   }
-#else
-  g_error ("ncm_stats_vec_get_autocorr: recompile NumCosmo with fftw support.");
-
-  return FALSE;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -2127,7 +2093,6 @@ ncm_stats_vec_compute_cov_robust_ogk (NcmStatsVec *svec)
 gdouble
 ncm_stats_vec_get_autocorr_tau (NcmStatsVec *svec, const guint p, const guint max_lag)
 {
-#ifdef HAVE_FFTW3
   guint i;
   gdouble tau          = 0.0;
   const guint Imax_lag = (max_lag == 0) ? svec->nitens / 10 : max_lag;
@@ -2150,13 +2115,6 @@ ncm_stats_vec_get_autocorr_tau (NcmStatsVec *svec, const guint p, const guint ma
   tau = 1.0 + 2.0 * tau;
 
   return tau;
-
-#else
-  g_error ("ncm_stats_vec_get_autocorr: recompile NumCosmo with fftw support.");
-
-  return 0.0;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**
@@ -2174,7 +2132,6 @@ ncm_stats_vec_get_autocorr_tau (NcmStatsVec *svec, const guint p, const guint ma
 gdouble
 ncm_stats_vec_get_subsample_autocorr_tau (NcmStatsVec *svec, const guint p, const guint subsample, const guint max_lag)
 {
-#ifdef HAVE_FFTW3
   guint i;
   gdouble tau          = 0.0;
   guint eff_nitens     = svec->nitens / subsample;
@@ -2196,13 +2153,6 @@ ncm_stats_vec_get_subsample_autocorr_tau (NcmStatsVec *svec, const guint p, cons
   tau = 1.0 + 2.0 * tau;
 
   return tau;
-
-#else
-  g_error ("ncm_stats_vec_get_autocorr: recompile NumCosmo with fftw support.");
-
-  return 0.0;
-
-#endif /* HAVE_FFTW3 */
 }
 
 /**

--- a/numcosmo/numcosmo-math.h
+++ b/numcosmo/numcosmo-math.h
@@ -150,10 +150,8 @@
 
 /* Likelihood object */
 #include <numcosmo/ncm/fit/ncm_fit.h>
-#ifdef NUMCOSMO_HAVE_NLOPT
 #include <numcosmo/ncm/fit/ncm_fit_nlopt.h>
 #include <numcosmo/ncm_fit_nlopt_enum.h>
-#endif /* NUMCOSMO_HAVE_NLOPT */
 #include <numcosmo/ncm/fit/ncm_fit_levmar.h>
 #include <numcosmo/ncm/fit/ncm_fit_gsl_ls.h>
 #include <numcosmo/ncm/fit/ncm_fit_gsl_mm.h>

--- a/tests/c/ncm/core/test_ncm_cfg.c
+++ b/tests/c/ncm/core/test_ncm_cfg.c
@@ -151,7 +151,6 @@ test_ncm_cfg_misc (TesNcmCfg *test, gconstpointer pdata)
 void
 test_ncm_cfg_fftw_planner (TesNcmCfg *test, gconstpointer pdata)
 {
-#ifdef HAVE_FFTW3
   const gchar *flags[] = {"estimate", "measure", "patient", "exhaustive"};
   GError *error        = NULL;
   guint i;
@@ -192,7 +191,6 @@ test_ncm_cfg_fftw_planner (TesNcmCfg *test, gconstpointer pdata)
 
   /* Restore the build default for the remaining tests. */
   ncm_cfg_set_fftw_default_flag_str ("estimate", 60.0, NULL);
-#endif /* HAVE_FFTW3 */
 }
 
 void

--- a/tests/c/ncm/core/test_ncm_serialize.c
+++ b/tests/c/ncm/core/test_ncm_serialize.c
@@ -195,12 +195,10 @@ static void test_ncm_serialize_from_string_nest_samename (TestNcmSerialize *test
 static void test_ncm_serialize_to_file_from_file (TestNcmSerialize *test, gconstpointer pdata);
 static void test_ncm_serialize_to_binfile_from_binfile (TestNcmSerialize *test, gconstpointer pdata);
 
-#ifdef HAVE_LIBFYAML
 static void test_ncm_serialize_to_yaml_from_yaml (TestNcmSerialize *test, gconstpointer pdata);
 static void test_ncm_serialize_from_yaml_special_types (TestNcmSerialize *test, gconstpointer pdata);
 static void test_ncm_serialize_from_yaml_special_types_block_flow (TestNcmSerialize *test, gconstpointer pdata);
 
-#endif /* HAVE_LIBFYAML */
 
 static void test_ncm_serialize_reset_autosave_only (TestNcmSerialize *test, gconstpointer pdata);
 
@@ -260,7 +258,6 @@ main (gint argc, gchar *argv[])
               &test_ncm_serialize_new_noclean_dup,
               &test_ncm_serialize_to_binfile_from_binfile,
               &test_ncm_serialize_free);
-#ifdef HAVE_LIBFYAML
   g_test_add ("/ncm/serialize/to_yaml/from_yaml", TestNcmSerialize, NULL,
               &test_ncm_serialize_new,
               &test_ncm_serialize_to_yaml_from_yaml,
@@ -274,7 +271,6 @@ main (gint argc, gchar *argv[])
               &test_ncm_serialize_from_yaml_special_types_block_flow,
               &test_ncm_serialize_free);
 
-#endif /* HAVE_LIBFYAML */
 
   g_test_add ("/ncm/serialize/traps", TestNcmSerialize, NULL,
               &test_ncm_serialize_new,
@@ -654,8 +650,6 @@ test_ncm_serialize_to_binfile_from_binfile (TestNcmSerialize *test, gconstpointe
   g_free (tmp_dir);
 }
 
-#ifdef HAVE_LIBFYAML
-
 static void
 test_ncm_serialize_to_yaml_from_yaml (TestNcmSerialize *test, gconstpointer pdata)
 {
@@ -794,8 +788,6 @@ test_ncm_serialize_from_yaml_special_types_block_flow (TestNcmSerialize *test, g
     ncm_matrix_free (matrix);
   }
 }
-
-#endif /* HAVE_LIBFYAML */
 
 void
 test_ncm_serialize_traps (TestNcmSerialize *test, gconstpointer pdata)

--- a/tests/c/ncm/fftlog/test_ncm_fftlog.c
+++ b/tests/c/ncm/fftlog/test_ncm_fftlog.c
@@ -101,9 +101,9 @@ TestCases fixtures[] = {
   {"gausswin2", &test_ncm_fftlog_gausswin2_new},
   {"sbessel_j", &test_ncm_fftlog_sbessel_j_new},
   {"sbessel_j_q0_5", &test_ncm_fftlog_sbessel_j_q0_5_new},
-#if defined (HAVE_FFTW3) && defined (HAVE_ACB_H)
+#ifdef HAVE_ACB_H
   {"sbessel_jljm", &test_ncm_fftlog_sbessel_jljm_new},
-#endif /* defined (HAVE_FFTW3) && defined (HAVE_ACB_H) */
+#endif /* HAVE_ACB_H */
 };
 
 #define NUMINT_RELTOL1 1.0e-3
@@ -152,14 +152,14 @@ main (gint argc, gchar *argv[])
               &test_ncm_fftlog_sbessel_j_traps,
               &test_ncm_fftlog_free);
 
-#if defined (HAVE_FFTW3) && defined (HAVE_ACB_H)
+#ifdef HAVE_ACB_H
 
   g_test_add ("/ncm/fftlog/sbessel_jljm/traps", TestNcmFftlog, NULL,
               &test_ncm_fftlog_sbessel_jljm_new,
               &test_ncm_fftlog_sbessel_jljm_traps,
               &test_ncm_fftlog_free);
 
-#endif /* defined (HAVE_FFTW3) && defined (HAVE_ACB_H) */
+#endif /* HAVE_ACB_H */
 
   g_test_add ("/ncm/fftlog/tophatwin2/invalid/st/subprocess", TestNcmFftlog, NULL,
               &test_ncm_fftlog_tophatwin2_new,
@@ -178,9 +178,7 @@ main (gint argc, gchar *argv[])
               &test_ncm_fftlog_invalid_st,
               &test_ncm_fftlog_free);
 
-#ifdef HAVE_FFTW3
   g_test_run ();
-#endif
 }
 
 #define NTESTS 20

--- a/tests/c/ncm/fit/test_ncm_fit.c
+++ b/tests/c/ncm/fit/test_ncm_fit.c
@@ -177,7 +177,7 @@ typedef struct _TestNcmFit
                     &test_ncm_fit_sub_fit_set,                                              \
                     &test_ncm_fit_free);                                                    \
                                                                                             \
-        g_test_add ("/ncm/fit/" #lib "/" #algo "/sub_fit/save_mset", TestNcmFit, NULL,     \
+        g_test_add ("/ncm/fit/" #lib "/" #algo "/sub_fit/save_mset", TestNcmFit, NULL,      \
                     &test_ncm_fit_ ## lib ## _ ## algo ## _new,                             \
                     &test_ncm_fit_sub_fit_save_mset,                                        \
                     &test_ncm_fit_free);                                                    \
@@ -299,10 +299,8 @@ typedef struct _TestNcmFit
           g_test_trap_assert_failed ();                                                        \
         }
 
-#ifdef HAVE_NLOPT
 TESTS_NCM_DECL (nlopt, neldermead)
 TESTS_NCM_DECL (nlopt, slsqp)
-#endif /* HAVE_NLOPT */
 
 TESTS_NCM_DECL (gsl, ls)
 
@@ -367,10 +365,8 @@ main (gint argc, gchar *argv[])
 
   /* g_test_set_nonfatal_assertions (); */
 
-#ifdef HAVE_NLOPT
   TESTS_NCM_ADD (nlopt, neldermead)
   TESTS_NCM_ADD (nlopt, slsqp)
-#endif /* HAVE_NLOPT */
 
   TESTS_NCM_ADD (gsl, ls)
 
@@ -389,10 +385,8 @@ main (gint argc, gchar *argv[])
   TESTS_NCM_ADD (levmar, bc_der)
   TESTS_NCM_ADD (levmar, bc_dif)
 
-#ifdef HAVE_NLOPT
   TESTS_NCM_ADD_INVALID (nlopt, neldermead)
   TESTS_NCM_ADD_INVALID (nlopt, slsqp)
-#endif /* HAVE_NLOPT */
 
   TESTS_NCM_ADD_INVALID (gsl, ls)
 
@@ -414,10 +408,8 @@ main (gint argc, gchar *argv[])
   g_test_run ();
 }
 
-#ifdef HAVE_NLOPT
 TESTS_NCM_NEW (nlopt, neldermead, NCM_FIT_TYPE_NLOPT, FIT_NLOPT, "ln-neldermead", TEST_NCM_FIT_DIM, NCM_FIT_DEFAULT_MAXITER)
 TESTS_NCM_NEW (nlopt, slsqp,      NCM_FIT_TYPE_NLOPT, FIT_NLOPT, "ld-slsqp",      TEST_NCM_FIT_DIM, NCM_FIT_DEFAULT_MAXITER)
-#endif /* HAVE_NLOPT */
 
 TESTS_NCM_NEW (gsl, ls, NCM_FIT_TYPE_GSL_LS, FIT_GSL_LS, NULL, TEST_NCM_FIT_DIM, 10000000)
 
@@ -1253,12 +1245,12 @@ test_ncm_fit_sub_fit_save_mset (TestNcmFit *test, gconstpointer pdata)
   ncm_fit_run (test->fit, NCM_FIT_RUN_MSGS_NONE);
 
   {
-    gchar **main_fmap       = ncm_mset_get_fmap (mset);
-    guint main_fparam_len   = ncm_mset_fparam_len (mset);
-    NcmSerialize *ser       = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
-    gchar *tmpfile          = g_strdup_printf ("%s/test_ncm_fit_sub_fit_save_mset_XXXXXX.mset",
-                                               g_get_tmp_dir ());
-    gint fd                 = g_mkstemp (tmpfile);
+    gchar **main_fmap     = ncm_mset_get_fmap (mset);
+    guint main_fparam_len = ncm_mset_fparam_len (mset);
+    NcmSerialize *ser     = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
+    gchar *tmpfile        = g_strdup_printf ("%s/test_ncm_fit_sub_fit_save_mset_XXXXXX.mset",
+                                             g_get_tmp_dir ());
+    gint fd = g_mkstemp (tmpfile);
     NcmMSet *loaded_mset;
     gchar **loaded_fmap;
     guint loaded_fparam_len;
@@ -1301,7 +1293,6 @@ test_ncm_fit_equality_constraints (TestNcmFit *test, gconstpointer pdata)
 
   ncm_fit_add_equality_constraint (fit, func, 1.0e-5);
 
-#ifdef HAVE_NLOPT
 
   if (NCM_IS_FIT_NLOPT (fit))
   {
@@ -1346,7 +1337,6 @@ test_ncm_fit_equality_constraints (TestNcmFit *test, gconstpointer pdata)
   ncm_fit_remove_equality_constraints (fit);
   g_assert_true (ncm_fit_equality_constraints_len (fit) == 0);
 
-#endif /* HAVE_NLOPT */
   ncm_mset_func_free (func);
 }
 
@@ -1358,7 +1348,6 @@ test_ncm_fit_inequality_constraints (TestNcmFit *test, gconstpointer pdata)
 
   ncm_fit_add_inequality_constraint (fit, func, 1.0e-5);
 
-#ifdef HAVE_NLOPT
 
   if (NCM_IS_FIT_NLOPT (fit))
   {
@@ -1403,7 +1392,6 @@ test_ncm_fit_inequality_constraints (TestNcmFit *test, gconstpointer pdata)
   ncm_fit_remove_inequality_constraints (fit);
   g_assert_true (ncm_fit_inequality_constraints_len (fit) == 0);
 
-#endif /* HAVE_NLOPT */
   ncm_mset_func_free (func);
 }
 
@@ -1685,10 +1673,8 @@ test_ncm_fit_fisher_bias_gauss (TestNcmFit *test, gconstpointer pdata)
   ncm_vector_free (bias);
 }
 
-#ifdef HAVE_NLOPT
 TESTS_NCM_TRAPS (nlopt, neldermead)
 TESTS_NCM_TRAPS (nlopt, slsqp)
-#endif /* HAVE_NLOPT */
 
 TESTS_NCM_TRAPS (gsl, ls)
 

--- a/tools/cmb_maps.c
+++ b/tools/cmb_maps.c
@@ -56,12 +56,10 @@ main (void)
   NcSphereMap *omap      = nc_sphere_healpix_read_map (argv[1], NULL);
   NcSphereMap *map       = nc_sphere_map_clone (omap);
 
-#ifdef HAVE_FFTW3
   GTimer *global_bench = g_timer_new ();
   NcSphereMapSHT *mapsht;
   gsl_matrix *cls;
 
-#endif /* HAVE_FFTW3 */
   gint i = 1000;
   gdouble noise;
 
@@ -102,7 +100,6 @@ main (void)
   nc_sphere_mapalm_init (mapalm, 1024);
   printf ("# New mapalm with [%ld] pixels and lmax [%d] took %fs\n", map->npix, mapalm->lmax, g_timer_elapsed (bench, NULL));
 
-#ifdef HAVE_FFTW3
   g_timer_start (bench);
   mapsht = nc_sphere_mapsht_new (map, mapalm, FFTW_ESTIMATE); /*FFTW_ESTIMATE, FFTW_MEASURE, FFTW_PATIENT, FFTW_EXHAUSTIVE */
   printf ("# New SHT with [%ld] pixels and lmax [%d] took %fs\n", map->npix, mapalm->lmax, g_timer_elapsed (bench, NULL));
@@ -186,7 +183,6 @@ main (void)
     /*printf ("[%ld] (% .12e, % .12e) = % .12e\n", i, gsl_vector_get (map->theta, i), gsl_vector_get (map->phi, i), map->fmap[i]); */
   }
 
-#endif /* HAVE_FFTW3 */
 #else
   g_error ("chealpix or cfitsio not installed.");
 #endif /* defined HAVE_CHEALPIX && defined HAVE_CFITSIO */

--- a/tools/darkenergy.c
+++ b/tools/darkenergy.c
@@ -633,13 +633,7 @@ main (gint argc, gchar *argv[])
     fiduc = ncm_mset_ref (mset);
 
   if (de_fit.fit_type == NULL)
-  {
-#ifdef HAVE_NLOPT
     de_fit.fit_type = g_strdup ("nlopt");
-#else
-    de_fit.fit_type = g_strdup ("gsl-mms");
-#endif
-  }
 
   if (de_fit.fit_diff == NULL)
     de_fit.fit_diff = g_strdup ("numdiff-forward");

--- a/tools/de_options.c
+++ b/tools/de_options.c
@@ -202,9 +202,7 @@ _nc_de_print_fit_list (const gchar *option_name, const gchar *value, gpointer da
   ncm_cfg_enum_print_all (NCM_TYPE_FIT_GSLMM_ALGOS, "Minimization algorithms [gsl-mm]");
   ncm_cfg_enum_print_all (NCM_TYPE_FIT_GSLMMS_ALGOS, "Minimization algorithms [gsl-mms]");
   ncm_cfg_enum_print_all (NCM_TYPE_FIT_LEVMAR_ALGOS, "Minimization algorithms [levmar]");
-#ifdef HAVE_NLOPT
   ncm_cfg_enum_print_all (NCM_TYPE_FIT_NLOPT_ALGORITHM, "Minimization algorithms [nlopt]");
-#endif
   ncm_cfg_enum_print_all (NCM_TYPE_FIT_GRAD_TYPE, "Differentiation methods");
 
   return TRUE;


### PR DESCRIPTION
## Summary
- Make FFTW3 (double precision) a hard requirement, removing ~90 optional-dependency guards across the library, tests, and tools. `fftw3f` (single precision) stays optional, still gating the fast path in `ncm_sphere_map.c`.
- Make NLopt a hard requirement, removing its optional-dependency guards.
- Vendor libfyaml v0.9.6 into `numcosmo/external/libfyaml` (minimal core parser/emitter subset only -- no CLI tool, reflection/libclang backend, python bindings, or test harness), matching the existing `libcuba`/`sundials` vendoring pattern. This replaces the system/conda-forge dependency, which has had real packaging problems in the past (`environment.yml` was pinning `libfyaml < 0.9.6` to dodge a broken conda-forge build).
  - Fixed 4 genuine upstream bugs in libfyaml's non-C11 `<stdatomic.h>` fallback path (undeclared variables, a bad pointer dereference, a missing closing paren), which only surfaced because NumCosmo compiles at `-std=gnu99`.
- Updated CI workflows, `environment.yml`, and `docs/install.qmd` to match: dropped `libfyaml-dev`/`libfyaml`/pkg-config workarounds, moved NLopt into the documented Requirements.

## Test plan
- [x] `meson setup --reconfigure` + full clean `ninja` rebuild succeeds
- [x] Full test suite passes: `meson test --num-processes=24` -- 84/84 suites OK (C + Python, including MPI/OMP/acceptance lanes)
- [x] `uncrustify --check` passes on all touched/new C files (vendored libfyaml excluded, per the existing `numcosmo/external` exclusion)
- [x] Confirmed the vendored libfyaml functions correctly end-to-end via `ncm_serialize`'s YAML round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)