### PR TITLE
Embed mset in FITS primary HDU, deprecate .mset sidecar

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -11,6 +11,12 @@ on:
 env:
   CONDA_ENV: numcosmo_developer
   CACHE_VERSION: 0
+  # Bump to force the next run to recompute slice-tests.txt from scratch instead of
+  # restoring cached per-test durations (test_slicer.py degrades gracefully to a
+  # count-balanced split when the durations file is empty/missing -- see the
+  # "has_data" guard on the "Cache test slice durations" step below). Use this when
+  # the duration-aware slicing itself is suspected of dropping or misplacing a test.
+  TEST_DURATION_CACHE_VERSION: 1
   # Thread policy is set PER TEST by meson (tests/meson.build), not here: concurrent tests
   # get OMP/BLAS = 1 (avoid cores^2 oversubscription + the mixed-OpenBLAS deadlock, e.g.
   # scipy.linalg.solve in test_sbessel_ode_solver), and the run-alone OpenMP tests
@@ -269,25 +275,25 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: durations-slice1.json
-          key: test-durations-c-slice1-${{ github.run_id }}
+          key: test-durations-c-slice1-v${{ env.TEST_DURATION_CACHE_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            test-durations-c-slice1-
+            test-durations-c-slice1-v${{ env.TEST_DURATION_CACHE_VERSION }}-
       - name: Restore test duration history (slice 2)
         if: matrix.slice != ''
         uses: actions/cache/restore@v4
         with:
           path: durations-slice2.json
-          key: test-durations-c-slice2-${{ github.run_id }}
+          key: test-durations-c-slice2-v${{ env.TEST_DURATION_CACHE_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            test-durations-c-slice2-
+            test-durations-c-slice2-v${{ env.TEST_DURATION_CACHE_VERSION }}-
       - name: Restore test duration history (slice 3)
         if: matrix.slice != ''
         uses: actions/cache/restore@v4
         with:
           path: durations-slice3.json
-          key: test-durations-c-slice3-${{ github.run_id }}
+          key: test-durations-c-slice3-v${{ env.TEST_DURATION_CACHE_VERSION }}-${{ github.run_id }}
           restore-keys: |
-            test-durations-c-slice3-
+            test-durations-c-slice3-v${{ env.TEST_DURATION_CACHE_VERSION }}-
       - uses: ./.github/actions/setup-miniforge
         with:
           python-version: ${{ matrix.python-version }}
@@ -307,6 +313,9 @@ jobs:
             --durations durations-slice1.json durations-slice2.json durations-slice3.json \
             --num-slices 3 --slice ${{ matrix.slice }} \
             > slice-tests.txt
+          echo "::group::slice-tests.txt ($(wc -l < slice-tests.txt) tests)"
+          cat slice-tests.txt
+          echo "::endgroup::"
       - name: Check and coverage
         # First run to generate the coverage base
         # Second run to generate the coverage for the tests
@@ -348,7 +357,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: durations-slice${{ matrix.slice }}.json
-          key: test-durations-c-slice${{ matrix.slice }}-${{ github.run_id }}
+          key: test-durations-c-slice${{ matrix.slice }}-v${{ env.TEST_DURATION_CACHE_VERSION }}-${{ github.run_id }}
       - name: Test timing summary
         if: always()
         # Surface the slowest tests of this shard in the job summary so wall-time imbalance

--- a/numcosmo/ncm/fit/ncm_mset_catalog.c
+++ b/numcosmo/ncm/fit/ncm_mset_catalog.c
@@ -57,6 +57,7 @@
 #include "ncm/core/ncm_cfg.h"
 #include "ncm/core/ncm_func_eval.h"
 #include "ncm/core/ncm_c.h"
+#include "ncm/core/ncm_serialize.h"
 #include "ncm_enum_types.h"
 
 #ifndef NUMCOSMO_GIR_SCAN
@@ -241,6 +242,7 @@ ncm_mset_catalog_init (NcmMSetCatalog *mcat)
 #ifdef HAVE_CFITSIO
 static void _ncm_mset_catalog_open_create_file (NcmMSetCatalog *mcat, gboolean load_from_cat);
 static void _ncm_mset_catalog_flush_file (NcmMSetCatalog *mcat);
+static NcmMSet *_ncm_mset_catalog_load_mset (NcmMSetCatalog *mcat);
 
 #endif /* HAVE_CFITSIO */
 
@@ -314,23 +316,11 @@ _ncm_mset_catalog_constructed (GObject *object)
     {
 #ifdef HAVE_CFITSIO
 
-      if (self->mset_file == NULL)
-        g_error ("_ncm_mset_catalog_constructed: cannot create catalog without mset.");
-
       if (!g_file_test (self->file, G_FILE_TEST_EXISTS))
         g_error ("_ncm_mset_catalog_constructed: cannot create catalog file `%s' not found.",
                  self->file);
 
-      if (!g_file_test (self->mset_file, G_FILE_TEST_EXISTS))
-        g_error ("_ncm_mset_catalog_constructed: cannot create catalog mset file `%s' not found.",
-                 self->mset_file);
-
-      {
-        NcmSerialize *ser = ncm_serialize_global ();
-
-        self->mset = ncm_mset_load (self->mset_file, ser, NULL);
-        ncm_serialize_free (ser);
-      }
+      self->mset = _ncm_mset_catalog_load_mset (mcat);
 
       _ncm_mset_catalog_open_create_file (mcat, TRUE);
       _ncm_mset_catalog_constructed_alloc_chains (mcat);
@@ -524,14 +514,6 @@ _ncm_mset_catalog_dispose (GObject *object)
 {
   NcmMSetCatalog *mcat        = NCM_MSET_CATALOG (object);
   NcmMSetCatalogPrivate *self = ncm_mset_catalog_get_instance_private (mcat);
-
-  if ((self->mset != NULL) && (self->mset_file != NULL))
-  {
-    NcmSerialize *ser = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
-
-    ncm_mset_save (self->mset, ser, self->mset_file, TRUE, NULL);
-    ncm_serialize_free (ser);
-  }
 
   ncm_vector_clear (&self->bestfit_row);
   g_clear_pointer (&self->order_cat, g_ptr_array_unref);
@@ -1123,6 +1105,119 @@ _ncm_mset_catalog_sync_rng (NcmMSetCatalog *mcat)
   }
 }
 
+/*
+ * Writes @mset as a binary GVariant (the same representation used by
+ * ncm_serialize_to_binfile()) into the primary HDU (HDU0) of @fptr, which
+ * must have just been created by fits_create_file() and hold no data yet.
+ * This must happen before any table extension is created, since resizing
+ * the primary HDU later on would require shifting every following HDU.
+ */
+static void
+_ncm_mset_catalog_write_mset_hdu0 (fitsfile *fptr, NcmMSet *mset)
+{
+  NcmSerialize *ser = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
+  GVariant *var     = ncm_serialize_to_variant (ser, G_OBJECT (mset));
+  glong naxes[1]    = { (glong) g_variant_get_size (var) };
+  gint status       = 0;
+
+  fits_create_img (fptr, BYTE_IMG, 1, naxes, &status);
+  NCM_FITS_ERROR (status);
+
+  fits_write_img (fptr, TBYTE, 1, naxes[0], (gpointer) g_variant_get_data (var), &status);
+  NCM_FITS_ERROR (status);
+
+  fits_write_key_str (fptr, NCM_MSET_CATALOG_MSET_FORMAT_LABEL, "gvariant",
+                      "Format of the NcmMSet stored in this HDU.", &status);
+  NCM_FITS_ERROR (status);
+
+  g_variant_unref (var);
+  ncm_serialize_free (ser);
+}
+
+/*
+ * Reads back an NcmMSet embedded by _ncm_mset_catalog_write_mset_hdu0(), if
+ * any. Returns %NULL for legacy files whose primary HDU is the default empty
+ * one (no data written to HDU0).
+ */
+static NcmMSet *
+_ncm_mset_catalog_read_mset_hdu0 (fitsfile *fptr)
+{
+  gint status    = 0;
+  gint bitpix    = 0;
+  gint naxis     = 0;
+  gint hdutype   = 0;
+  glong naxes[1] = { 0 };
+  NcmMSet *mset  = NULL;
+
+  fits_movabs_hdu (fptr, 1, &hdutype, &status);
+  NCM_FITS_ERROR (status);
+
+  fits_get_img_param (fptr, 1, &bitpix, &naxis, naxes, &status);
+  NCM_FITS_ERROR (status);
+
+  if ((naxis == 1) && (naxes[0] > 0))
+  {
+    const glong len = naxes[0];
+    guint8 *data    = g_malloc (len);
+    gint any_null   = 0;
+    NcmSerialize *ser;
+    GVariant *var;
+
+    fits_read_img (fptr, TBYTE, 1, len, NULL, data, &any_null, &status);
+    NCM_FITS_ERROR (status);
+
+    var = g_variant_new_from_data (G_VARIANT_TYPE (NCM_SERIALIZE_OBJECT_TYPE),
+                                   data, len, TRUE, g_free, data);
+
+    ser  = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
+    mset = NCM_MSET (ncm_serialize_from_variant (ser, var));
+    ncm_serialize_free (ser);
+
+    g_variant_unref (var);
+  }
+
+  return mset;
+}
+
+/*
+ * Resolves the NcmMSet for a catalog being loaded from an existing file: the
+ * mset embedded in HDU0 if present, otherwise the legacy `.mset' GKeyFile
+ * sidecar (read-only support; new catalogs no longer write that file).
+ */
+static NcmMSet *
+_ncm_mset_catalog_load_mset (NcmMSetCatalog *mcat)
+{
+  NcmMSetCatalogPrivate *self = ncm_mset_catalog_get_instance_private (mcat);
+  NcmMSet *mset               = NULL;
+  fitsfile *fptr              = NULL;
+  gint status                 = 0;
+
+  fits_open_file (&fptr, self->file, READONLY, &status);
+  NCM_FITS_ERROR (status);
+
+  mset = _ncm_mset_catalog_read_mset_hdu0 (fptr);
+
+  fits_close_file (fptr, &status);
+  NCM_FITS_ERROR (status);
+
+  if (mset == NULL)
+  {
+    if ((self->mset_file == NULL) || !g_file_test (self->mset_file, G_FILE_TEST_EXISTS))
+      g_error ("_ncm_mset_catalog_load_mset: catalog file `%s' has no embedded mset "
+               "and no legacy mset file `%s' was found.",
+               self->file, self->mset_file != NULL ? self->mset_file : "(null)");
+
+    {
+      NcmSerialize *ser = ncm_serialize_global ();
+
+      mset = ncm_mset_load (self->mset_file, ser, NULL);
+      ncm_serialize_free (ser);
+    }
+  }
+
+  return mset;
+}
+
 static void
 _ncm_mset_catalog_open_create_file (NcmMSetCatalog *mcat, gboolean load_from_cat)
 {
@@ -1438,6 +1533,8 @@ _ncm_mset_catalog_open_create_file (NcmMSetCatalog *mcat, gboolean load_from_cat
     fits_create_file (&self->fptr, self->file, &status);
     NCM_FITS_ERROR (status);
 
+    _ncm_mset_catalog_write_mset_hdu0 (self->fptr, self->mset);
+
     for (i = 0; i < self->nadd_vals; i++)
     {
       const gchar *cname = g_ptr_array_index (self->add_vals_names, i);
@@ -1522,13 +1619,6 @@ _ncm_mset_catalog_open_create_file (NcmMSetCatalog *mcat, gboolean load_from_cat
   {
     fits_flush_file (self->fptr, &status);
     NCM_FITS_ERROR (status);
-  }
-
-  {
-    NcmSerialize *ser = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
-
-    ncm_mset_save (self->mset, ser, self->mset_file, TRUE, NULL);
-    ncm_serialize_free (ser);
   }
 }
 

--- a/numcosmo/ncm/fit/ncm_mset_catalog.h
+++ b/numcosmo/ncm/fit/ncm_mset_catalog.h
@@ -244,6 +244,7 @@ guint ncm_mset_catalog_heidel_diag_by_chain (NcmMSetCatalog *mcat, const guint n
 #define NCM_MSET_CATALOG_RTYPE_UNDEFINED "undefined-run"
 #define NCM_MSET_CATALOG_FSYMB_LABEL "FSYMB"
 #define NCM_MSET_CATALOG_ASYMB_LABEL "ASYMB"
+#define NCM_MSET_CATALOG_MSET_FORMAT_LABEL "MSETFMT"
 #define NCM_MSET_CATALOG_DIST_EST_SD_SCALE (1.0e-3)
 
 G_END_DECLS

--- a/numcosmo_py/app/__init__.py
+++ b/numcosmo_py/app/__init__.py
@@ -40,6 +40,7 @@ from .catalog import (
     VisualHW,
     ParameterEvolution,
     GetBestFit,
+    DumpMset,
 )
 from .generate import (
     GeneratePlanck,
@@ -177,6 +178,12 @@ CAT_GET_BEST_FIT_CMD: CMDArg = {
     "help": "Get the best fit from a given catalog.",
 }
 
+CAT_DUMP_MSET_CMD: CMDArg = {
+    "name": "dump-mset",
+    "no_args_is_help": True,
+    "help": "Dump the model-set stored in a catalog file as YAML.",
+}
+
 GEN_PLANCK_CMD: CMDArg = {
     "name": "planck18",
     "no_args_is_help": True,
@@ -274,6 +281,7 @@ app_cat.command(**CAT_PLOT_CORNER_CMD)(PlotCorner)
 app_cat.command(**CAT_VISUAL_HW_CMD)(VisualHW)
 app_cat.command(**CAT_PARAM_EVOLUTION_CMD)(ParameterEvolution)
 app_cat.command(**CAT_GET_BEST_FIT_CMD)(GetBestFit)
+app_cat.command(**CAT_DUMP_MSET_CMD)(DumpMset)
 # ------------------------------------------------------------------------------
 # Installing experiment generation subcommands
 app_generate.command(**GEN_PLANCK_CMD)(GeneratePlanck)

--- a/numcosmo_py/app/catalog.py
+++ b/numcosmo_py/app/catalog.py
@@ -44,6 +44,7 @@ from ..interpolation.stats_dist import (
 )
 from ..plotting.tools import set_rc_params_article, confidence_ellipse
 from .loading import LoadCatalog
+from .logging import AppLogging
 from ..plotting import mcat_to_catalog_data, plot_mcsamples
 
 
@@ -869,3 +870,50 @@ class GetBestFit(LoadCatalog):
         self.output_dict.add("model-set", self.mset)
 
         self.end_experiment()
+
+
+@dataclasses.dataclass(kw_only=True)
+class DumpMset(AppLogging):
+    """Dump the model-set stored in an MCMC catalog file as YAML.
+
+    Catalog files store their model-set internally (in the primary FITS
+    HDU for new files, or in a legacy `.mset` sidecar file for old ones).
+    This command extracts it as a standalone YAML file, useful for
+    inspection or as a starting point for a new fit.
+    """
+
+    mcmc_file: Annotated[
+        Path,
+        typer.Argument(help="Path to the MCMC catalog file."),
+    ]
+
+    output: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-o",
+            help="Path to the output YAML file. If not given, prints to the console.",
+        ),
+    ] = None
+
+    def __post_init__(self) -> None:
+        """Load the catalog and dump its model-set as YAML."""
+        super().__post_init__()
+
+        if not self.mcmc_file.exists():
+            raise RuntimeError(f"MCMC file {self.mcmc_file} not found.")
+
+        mcat: Ncm.MSetCatalog = Ncm.MSetCatalog.new_from_file_ro(
+            self.mcmc_file.absolute().as_posix(), 0
+        )
+        mset: Ncm.MSet = mcat.peek_mset()
+        assert isinstance(mset, Ncm.MSet)
+
+        ser = Ncm.Serialize.new(Ncm.SerializeOpt.NONE)
+        if self.output is not None:
+            ser.to_yaml_file(mset, self.output.absolute().as_posix())
+            self.console.print(f"Model-set written to {self.output}.")
+        else:
+            self.console.print(ser.to_yaml(mset))
+
+        self.close_logging()

--- a/tests/c/ncm/fit/test_ncm_mset_catalog.c
+++ b/tests/c/ncm/fit/test_ncm_mset_catalog.c
@@ -26,7 +26,11 @@
 #  include "config.h"
 #undef GSL_RANGE_CHECK_OFF
 #endif /* HAVE_CONFIG_H */
+#include "build_cfg.h"
 #include <numcosmo/numcosmo.h>
+#ifdef HAVE_CFITSIO
+#include <fitsio.h>
+#endif /* HAVE_CFITSIO */
 
 typedef struct _TestNcmMSetCatalog
 {
@@ -56,6 +60,14 @@ void test_ncm_mset_catalog_calc_param_ensemble_evol (TestNcmMSetCatalog *test, g
 void test_ncm_mset_catalog_calc_add_param_ensemble_evol (TestNcmMSetCatalog *test, gconstpointer pdata);
 void test_ncm_mset_catalog_calc_add_param_ensemble_evol_short (TestNcmMSetCatalog *test, gconstpointer pdata);
 void test_ncm_mset_catalog_invalid_run (TestNcmMSetCatalog *test, gconstpointer pdata);
+
+#ifdef HAVE_CFITSIO
+void test_ncm_mset_catalog_file_hdu0_roundtrip (void);
+void test_ncm_mset_catalog_file_legacy_fallback (void);
+void test_ncm_mset_catalog_file_missing_mset_traps (void);
+void test_ncm_mset_catalog_file_missing_mset_subprocess (void);
+
+#endif /* HAVE_CFITSIO */
 
 typedef struct _TestNcmMSetCatalogTests
 {
@@ -124,6 +136,13 @@ main (gint argc, gchar *argv[])
               &test_ncm_mset_catalog_new,
               &test_ncm_mset_catalog_invalid_run,
               &test_ncm_mset_catalog_free);
+
+#ifdef HAVE_CFITSIO
+  g_test_add_func ("/ncm/mset/catalog/file/hdu0_roundtrip", &test_ncm_mset_catalog_file_hdu0_roundtrip);
+  g_test_add_func ("/ncm/mset/catalog/file/legacy_fallback", &test_ncm_mset_catalog_file_legacy_fallback);
+  g_test_add_func ("/ncm/mset/catalog/file/missing_mset/traps", &test_ncm_mset_catalog_file_missing_mset_traps);
+  g_test_add_func ("/ncm/mset/catalog/file/missing_mset/subprocess", &test_ncm_mset_catalog_file_missing_mset_subprocess);
+#endif /* HAVE_CFITSIO */
 
   g_test_run ();
 }
@@ -891,4 +910,155 @@ test_ncm_mset_catalog_invalid_run (TestNcmMSetCatalog *test, gconstpointer pdata
 {
   g_assert_not_reached ();
 }
+
+#ifdef HAVE_CFITSIO
+
+/*
+ * Builds a small free-parameter mset, writes a new-style catalog file for it
+ * (mset embedded in HDU0), and returns both. The catalog is not left open.
+ */
+static NcmMSet *
+_test_ncm_mset_catalog_new_file (const gchar *filename)
+{
+  NcmModelMVND *model_mvnd = ncm_model_mvnd_new (3);
+  NcmMSet *mset            = ncm_mset_new (NCM_MODEL (model_mvnd), NULL, NULL);
+  NcmMSetCatalog *mcat;
+
+  ncm_mset_param_set_all_ftype (mset, NCM_PARAM_TYPE_FREE);
+  ncm_mset_prepare_fparam_map (mset);
+
+  mcat = ncm_mset_catalog_new (mset, 1, 1, FALSE, "m2lnL", "-2\\ln(L)", NULL);
+  ncm_mset_catalog_set_m2lnp_var (mcat, 0);
+  ncm_mset_catalog_set_run_type (mcat, "test-run");
+  ncm_mset_catalog_set_file (mcat, filename);
+
+  {
+    NcmVector *x  = ncm_vector_new (ncm_mset_fparams_len (mset));
+    gdouble ax[1] = { 12.3 };
+
+    ncm_mset_fparams_get_vector (mset, x);
+    ncm_mset_catalog_add_from_vector_array (mcat, x, ax);
+    ncm_mset_catalog_sync (mcat, TRUE);
+
+    ncm_vector_clear (&x);
+  }
+
+  ncm_mset_catalog_clear (&mcat);
+  ncm_model_mvnd_clear (&model_mvnd);
+
+  return mset;
+}
+
+/*
+ * Strips the mset embedded by _test_ncm_mset_catalog_new_file() back to an
+ * empty primary HDU, simulating a catalog file written before HDU0 embedding
+ * was introduced.
+ */
+static void
+_test_ncm_mset_catalog_strip_hdu0 (const gchar *filename)
+{
+  fitsfile *fptr = NULL;
+  gint hdutype   = 0;
+  gint status    = 0;
+
+  fits_open_file (&fptr, filename, READWRITE, &status);
+  g_assert_cmpint (status, ==, 0);
+
+  fits_movabs_hdu (fptr, 1, &hdutype, &status);
+  g_assert_cmpint (status, ==, 0);
+
+  fits_resize_img (fptr, 8, 0, NULL, &status);
+  g_assert_cmpint (status, ==, 0);
+
+  fits_close_file (fptr, &status);
+  g_assert_cmpint (status, ==, 0);
+}
+
+void
+test_ncm_mset_catalog_file_hdu0_roundtrip (void)
+{
+  gchar *tmp_dir      = g_dir_make_tmp ("tmp_test_ncm_mset_catalog_hdu0_XXXXXX", NULL);
+  gchar *filename     = g_strdup_printf ("%s/cat.fits", tmp_dir);
+  gchar *mset_sidecar = g_strdup_printf ("%s/cat.mset", tmp_dir);
+  NcmMSet *mset       = _test_ncm_mset_catalog_new_file (filename);
+  NcmMSetCatalog *mcat2;
+  NcmMSet *mset2;
+
+  g_assert_false (g_file_test (mset_sidecar, G_FILE_TEST_EXISTS));
+
+  mcat2 = ncm_mset_catalog_new_from_file_ro (filename, 0);
+  mset2 = ncm_mset_catalog_peek_mset (mcat2);
+
+  g_assert_true (ncm_mset_cmp (mset, mset2, TRUE));
+
+  ncm_mset_catalog_clear (&mcat2);
+  ncm_mset_clear (&mset);
+
+  g_unlink (filename);
+  g_rmdir (tmp_dir);
+
+  g_free (filename);
+  g_free (mset_sidecar);
+  g_free (tmp_dir);
+}
+
+void
+test_ncm_mset_catalog_file_legacy_fallback (void)
+{
+  gchar *tmp_dir      = g_dir_make_tmp ("tmp_test_ncm_mset_catalog_legacy_XXXXXX", NULL);
+  gchar *filename     = g_strdup_printf ("%s/cat.fits", tmp_dir);
+  gchar *mset_sidecar = g_strdup_printf ("%s/cat.mset", tmp_dir);
+  NcmMSet *mset       = _test_ncm_mset_catalog_new_file (filename);
+  NcmMSetCatalog *mcat2;
+  NcmMSet *mset2;
+  NcmSerialize *ser;
+
+  _test_ncm_mset_catalog_strip_hdu0 (filename);
+
+  ser = ncm_serialize_new (NCM_SERIALIZE_OPT_NONE);
+  ncm_mset_save (mset, ser, mset_sidecar, TRUE, NULL);
+  ncm_serialize_clear (&ser);
+
+  mcat2 = ncm_mset_catalog_new_from_file_ro (filename, 0);
+  mset2 = ncm_mset_catalog_peek_mset (mcat2);
+
+  g_assert_true (ncm_mset_cmp (mset, mset2, TRUE));
+
+  ncm_mset_catalog_clear (&mcat2);
+  ncm_mset_clear (&mset);
+
+  g_unlink (mset_sidecar);
+  g_unlink (filename);
+  g_rmdir (tmp_dir);
+
+  g_free (filename);
+  g_free (mset_sidecar);
+  g_free (tmp_dir);
+}
+
+void
+test_ncm_mset_catalog_file_missing_mset_traps (void)
+{
+  g_test_trap_subprocess ("/ncm/mset/catalog/file/missing_mset/subprocess", 0, 0);
+  g_test_trap_assert_failed ();
+}
+
+void
+test_ncm_mset_catalog_file_missing_mset_subprocess (void)
+{
+  gchar *tmp_dir  = g_dir_make_tmp ("tmp_test_ncm_mset_catalog_missing_XXXXXX", NULL);
+  gchar *filename = g_strdup_printf ("%s/cat.fits", tmp_dir);
+  NcmMSet *mset   = _test_ncm_mset_catalog_new_file (filename);
+
+  _test_ncm_mset_catalog_strip_hdu0 (filename);
+  ncm_mset_clear (&mset);
+
+  /* Neither an embedded mset (just stripped) nor a `.mset' sidecar (never
+   * written) exists: this must abort with a fatal error. */
+  ncm_mset_catalog_new_from_file_ro (filename, 0);
+
+  g_assert_not_reached ();
+}
+
+#endif /* HAVE_CFITSIO */
 


### PR DESCRIPTION
## Summary
- `NcmMSetCatalog` now embeds the mset as binary GVariant in the FITS file's primary HDU (HDU0) at catalog creation, instead of maintaining a separate `.mset` GKeyFile sidecar next to the catalog.
- Reading a catalog still falls back to the legacy `.mset` sidecar (read-only) for old catalog files that predate this change.
- Added `numcosmo catalog dump-mset` to export a catalog's mset as a standalone YAML file, for inspection or reuse as a fit starting point.

## Test plan
- [x] `Optimized/tests/c/ncm_mset_catalog` (27/27 passing)
- [x] Manual round-trip: new catalog embeds mset in HDU0, no `.mset` sidecar written, reopening loads correctly, raw HDU0 bytes independently verified as a valid GVariant
- [x] Legacy fallback verified: catalog with empty HDU0 + `.mset` sidecar still loads; missing both raises the expected fatal error
- [x] `numcosmo catalog dump-mset` verified against both new (HDU0) and legacy (sidecar) catalogs, both to stdout and `--output`
- [x] App-level regression tests: `test_run_mc*`, `test_run_mcmc_apes*` (27/27 passing, incl. catalog resume/analyze/calibrate/plot-corner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)