### PR TITLE
xcor: register NcXcorKernelCMBISW, export two missing headers, and record the ISW Limber step analysis

### DIFF
--- a/dev-notes/xcor_isw_limber_step.md
+++ b/dev-notes/xcor_isw_limber_step.md
@@ -1,0 +1,158 @@
+# The ISW Limber step: why GH #297 aborts, and the shape of the fix
+
+Branch `xcor-isw-aborts`, off `d2fd03b3`. Everything below is measured, not
+estimated. Visual write-up of the same material:
+<https://claude.ai/code/artifact/6d88e2fa-5b01-411f-a0de-bb5cf1f0d2af>
+
+## 1. The math
+
+The outer integral, as the code computes it (`nc_xcor.c`, variable `ln k`):
+
+```
+C_l = 2 / (pi RH^3) * INT d ln k  k^3 W_l^(1)(k) W_l^(2)(k)
+```
+
+Exactly, the kernel is
+
+```
+W_l(k) = INT_{xi_min}^{xi_max} d xi  K(xi, k) j_l(k xi)
+```
+
+which is **smooth in k for every k**: k enters through a smooth `K` and an
+entire `j_l`, over a *fixed* interval. The true `C_l` has no feature at any
+special k. Every discontinuity discussed here is created by the approximation.
+
+Limber collapses that integral to a single point at `xi = nu / k`, `nu = l+1/2`:
+
+```
+W_l^Limber(k) = sqrt (pi / (2 nu)) * (1/k) * K (nu/k, k)
+```
+
+The kernel has compact support, so `K = 0` for `xi > xi_max`, and under Limber
+that becomes a condition on k:
+
+```
+nu/k > xi_max   <=>   k < k_min_l = nu / xi_max      (likewise k_max_l = nu / xi_min)
+```
+
+So `W_l` is identically zero below `k_min_l` and jumps there by an amount set by
+one number: **the kernel's value at the edge of its own support**. And
+`k_min_l` is *linear in l*, so a multipole batch produces a comb of steps, ~5%
+apart at l ~ 20.
+
+## 2. Why ISW and not weak lensing
+
+`K(xi, k=10)` approaching `xi_max`:
+
+| 1 - xi/xi_max | weak lensing | ISW |
+|---|---|---|
+| 1e-02 | 2.87e-17 | 5.12e+00 |
+| 1e-04 | 1.55e-21 | 1.24e+01 |
+| 1e-06 | 1.54e-25 | 1.25e+01 |
+| 0 | **0** | **1.25e+01** |
+
+The lensing efficiency vanishes at its support edge, so its Limber integrand is
+continuous and batching never creates a step. The ISW kernel is still at its
+plateau when the integration is truncated at recombination
+(`xi_max ~ 3.18 RH ~ 13600 Mpc`) -- a modelling truncation that becomes a cliff.
+
+`W_l(k)` for the batch l = 20..23, showing the comb:
+
+| k/k_min - 1 | l=20 | l=21 | l=22 | l=23 |
+|---|---|---|---|---|
+| 0 | 2.64e+00 | 0 | 0 | 0 |
+| 3e-02 | 3.18e-01 | 7.1e-223 | 0 | 0 |
+| 1e-01 | 3.49e-02 | **1.25e-01** | **1.57e+00** | 1.3e-244 |
+| 2e-01 | 6.93e-03 | 1.31e-02 | 3.04e-02 | **1.03e-01** |
+
+## 3. Cross-correlation is immune, and why
+
+Cross-spectra integrate the *intersection* of the two k-ranges
+(`k_min = MAX(k1,k2)`, `k_max = MIN(k1,k2)`). A low-z tracer has a far larger
+`k_min`, which cuts the ISW comb off entirely:
+
+| spectrum | k range | interior breakpoints | result |
+|---|---|---|---|
+| ISW x ISW | [6.45, 402] | 3 | **aborts** |
+| ISW x WL | [24.18, 402] | none (all below 24.18) | works |
+
+So ISW is only in trouble in **auto-spectra**, or in any pairing whose
+intersection dips below ~`nu/xi_max`.
+
+## 4. Why the code extends beyond the natural interval at all
+
+Structural, not physical. `_nc_xcor_kernel_build_spline_integrand` fits **one**
+`NcmSplineVec` for the whole multipole batch over **one** k-grid. A vector
+spline needs a value for every component at every knot, but each l has a
+different natural interval, so the shared grid spans the union and every
+not-yet-active component needs something filled in below its own start. That
+"something" is the `DECAY_RATE` extrapolation in
+`_component_states_compute_limber`.
+
+`DECAY_RATE = 1e10` makes `exp (-(1e10 dk/k)^2)` fall from 1 to underflow across
+`dk/k ~ 1e-9`. It is not a taper, it is a step at machine resolution -- and on
+the way down it passes through the subnormal range, emitting sign-flipping
+garbage that the spline then interpolates.
+
+Verified with a marker test (temporarily returning 0.5 from the decay): the raw
+Limber value is exactly 0 where `_spline_integrand_eval` returns
++/-1e-226 ... 1e-206. The noise is real and is what the quadrature is asked to
+fit at reltol 1e-6 with `abstol = 0`.
+
+## 5. What was tried, and why each failed
+
+| attempt | result |
+|---|---|
+| `CUBATURE_H_V` instead of `_P_V` | fixes #297; WL agrees to ~1e-7; but h-adaptive must *discover* a 220-order step by bisection, and its error estimate straddling a step is not trustworthy. ISW cost 64x WL. |
+| Split at analytic breakpoints (B) | works as designed: WL **bit-identical** and zero added cost (the collector rejects edges where the kernel vanishes); ISW splits at exactly the right k; two methods agree to ~1e-8. **But** it manufactures pieces where some multipoles contribute nothing, and `abstol = 0` makes those unconvergeable. |
+| abstol = 1e-16 * `k_max^3 max|W|^2 * width` | far too generous (|W| peaks at small k, k^3 at large k). Fixed #297, broke 2 tests. |
+| abstol = 1e-16 * sampled max integrand * width | correctly tight, the 2 tests recover, but no longer rescues #297. **Not diagnosed -- open thread.** |
+
+**Correction to an earlier claim in this effort:** the abstol is *not* orthogonal
+to the split. Splitting manufactures the zero-component problem; B depends on
+the tolerance rather than composing with it.
+
+## 6. The shape the fix should take (not built)
+
+Zeroing components exactly outside their own interval is necessary but not
+sufficient: it turns the comb into genuine hard steps, and splitting at them
+puts the jump on a *shared endpoint*, where the two pieces need different
+one-sided values. Clenshaw-Curtis weights endpoints, so whichever piece gets the
+wrong one picks up a spurious contribution that moves under refinement.
+
+The clean resolution is to **stop sharing an interval across multipoles**:
+integrate each l over its own `[nu/xi_max, nu/xi_min]`, intersected with the
+fitted spline domain (and the second kernel's interval for a cross-spectrum).
+The discontinuity is then exactly *at the integration limit*, where it is not a
+discontinuity of the integrand at all -- the function is smooth over the whole
+interval and the endpoint is the correct one-sided limit.
+
+Consequences: `abstol = 0` stays, `pcubature` stays, no breakpoint machinery, no
+masking, no floor to size. `DECAY_RATE` and `last_values_left/right` become dead
+code.
+
+The batching that this gives up is batching of the part that costs nothing --
+§9.6 of the batching plan measured the outer k-integral at **~0%, noise-level**;
+all cost is the closure build, which stays once per block.
+
+Three things to check before building it:
+
+1. `k_max_l = nu/xi_min` with `xi_min ~ 1e-6` gives `k_max_l ~ 2e7`, far outside
+   the fitted spline domain, so it clips to the spline's `k_max`. Confirm the
+   clip does not reintroduce an edge.
+2. Cost: §9.6 measured 23 l's in *one* call; 23 calls carry per-call setup.
+   Measure it -- the same mistake made twice already in this effort was
+   asserting a cost without measuring.
+3. WL must stay bit-identical (its per-l intervals are wider than the fitted
+   domain at the bottom, so it should clip to today's range -- a prediction to
+   verify, not a claim).
+
+## 7. State
+
+- `0be5fdea` on `xcor-isw-aborts`: ISW type registration + the two umbrella
+  headers. Green, 906 xcor tests.
+- WIP for the split/decay/abstol attempts: branch `xcor-isw-split-wip`. Does not
+  work; kept only as a record of the measurements above.
+- GH #297, #298 remain open. **#298 has not been touched** -- it reports
+  `roundoff error` from `KERNEL_GSL`, a different path, and may or may not share
+  this root cause. Measure before assuming.

--- a/numcosmo/ncm/core/ncm_cfg.c
+++ b/numcosmo/ncm/core/ncm_cfg.c
@@ -254,6 +254,7 @@
 #include "nc/xcor/nc_xcor_kernel_gal.h"
 #include "nc/xcor/nc_xcor_kernel_cluster.h"
 #include "nc/xcor/nc_xcor_kernel_cluster_tophat.h"
+#include "nc/xcor/nc_xcor_kernel_cmb_isw.h"
 #include "nc/xcor/nc_xcor_kernel_CMB_lensing.h"
 #include "nc/xcor/nc_xcor_kernel_weak_lensing.h"
 #include "nc/xcor/nc_xcor_kernel_tSZ.h"
@@ -919,6 +920,7 @@ ncm_cfg_register_objects (void)
   ncm_cfg_register_obj (NC_TYPE_XCOR_KERNEL_CLUSTER_TOPHAT);
   ncm_cfg_register_obj (NC_TYPE_XCOR_KERNEL_TSZ);
   ncm_cfg_register_obj (NC_TYPE_XCOR_KERNEL_CMB_LENSING);
+  ncm_cfg_register_obj (NC_TYPE_XCOR_KERNEL_CMB_ISW);
   ncm_cfg_register_obj (NC_TYPE_XCOR_KERNEL_WEAK_LENSING);
   ncm_cfg_register_obj (NC_TYPE_DATA_XCOR);
   ncm_cfg_register_obj (NC_TYPE_XCOR_AB);

--- a/numcosmo/numcosmo.h
+++ b/numcosmo/numcosmo.h
@@ -237,9 +237,11 @@
 #include <numcosmo/nc/xcor/nc_xcor_kernel_gal.h>
 #include <numcosmo/nc/xcor/nc_xcor_kernel_cluster.h>
 #include <numcosmo/nc/xcor/nc_xcor_kernel_cluster_tophat.h>
+#include <numcosmo/nc/xcor/nc_xcor_kernel_cmb_isw.h>
 #include <numcosmo/nc/xcor/nc_xcor_kernel_CMB_lensing.h>
 #include <numcosmo/nc/xcor/nc_xcor_kernel_weak_lensing.h>
 #include <numcosmo/nc/xcor/nc_xcor_kernel_tSZ.h>
+#include <numcosmo/nc/xcor/nc_xcor_lensing_efficiency.h>
 #include <numcosmo/nc/xcor/nc_xcor_solver.h>
 
 #endif /* _NUMCOSMO_H */

--- a/tests/python/nc/xcor/test_kernel_serialization.py
+++ b/tests/python/nc/xcor/test_kernel_serialization.py
@@ -320,3 +320,91 @@ def test_serializer_options(kernel: Nc.XcorKernel, cosmology: Cosmology) -> None
 
     assert_allclose(result_orig, result_clean, rtol=1e-15)
     assert_allclose(result_orig, result_none, rtol=1e-15)
+
+
+_REGISTRY_CHILD = """
+import sys
+from numcosmo_py import Ncm
+from gi.repository import GObject
+
+Ncm.cfg_init()
+
+missing = []
+for name in sys.argv[1:]:
+    try:
+        GObject.type_from_name(name)
+    except RuntimeError:
+        missing.append(name)
+print(",".join(missing))
+"""
+
+
+def test_every_kernel_type_is_registered_in_a_fresh_process() -> None:
+    """Concrete kernel types must resolve by name after cfg_init() alone.
+
+    ncm_serialize_from_name_params() resolves a serialized name with
+    g_type_from_name(), which only succeeds once the GType has been realized in
+    the process. ncm_cfg_register_objects() realizes it at startup; otherwise
+    merely touching the class from Python realizes it too, which is why
+    dup_obj-based tests -- and even a to_string/from_string round-trip on a live
+    instance -- pass for a kernel that was never registered. Reading a YAML
+    experiment in a fresh process does neither, so it aborts with "object `X' is
+    not registered". This ran green while NcXcorKernelCMBISW was missing from
+    ncm_cfg_register_objects(), so it must not construct anything.
+    """
+    import subprocess
+    import sys
+
+    # Names are collected here, where realizing the classes is harmless; the
+    # child only ever looks them up.
+    names = sorted(
+        "Nc" + n
+        for n in dir(Nc)
+        if n.startswith("XcorKernel")
+        and not n.endswith(("SParams", "VParams", "Class", "Impl", "Integrand"))
+        and n not in ("XcorKernel", "XcorKernelComponent")
+    )
+    assert "NcXcorKernelCMBISW" in names, "ISW kernel dropped from the sweep"
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _REGISTRY_CHILD, *names],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    missing = [n for n in proc.stdout.strip().split(",") if n]
+    assert not missing, (
+        f"not passed to ncm_cfg_register_obj(): {missing} -- these cannot be "
+        f"built from a serialized name in a fresh process"
+    )
+
+
+def test_kernel_reconstructible_by_type_name(
+    kernel: Nc.XcorKernel, cosmology: Cosmology
+) -> None:
+    """Every kernel type must be reconstructible from its serialized name.
+
+    Ncm.Serialize.dup_obj() resolves the GType from the live instance, so it
+    works whether or not the type was passed to ncm_cfg_register_obj(). Going
+    through a *string* does not: ncm_serialize_from_name_params() looks the name
+    up in that registry and aborts if it is absent. That is the path YAML
+    experiment files, the CLI and ncm_obj_array take, so a kernel missing from
+    ncm_cfg_register_objects() is unusable there while every dup_obj-based test
+    still passes -- which is exactly how NcXcorKernelCMBISW stayed broken.
+    """
+    ser = Ncm.Serialize.new(Ncm.SerializeOpt.CLEAN_DUP)
+
+    # The GType name keeps the Nc namespace that introspection strips, and it
+    # is the name the registry is keyed on.
+    gtype_name = kernel.__gtype__.name
+    serialized = ser.to_string(kernel, False)
+    assert serialized.startswith(gtype_name)
+
+    rebuilt = ser.from_string(serialized)
+
+    assert rebuilt is not kernel
+    assert isinstance(rebuilt, type(kernel))
+    rebuilt.prepare(cosmology.cosmo)


### PR DESCRIPTION
Fixes a registration gap that made `NcXcorKernelCMBISW` unusable outside a live process, exports two headers that were installed but unreachable, and records the analysis of the ISW Limber discontinuity behind #297.

## `NcXcorKernelCMBISW` was never registered

Every other xcor kernel is passed to `ncm_cfg_register_obj()`; the ISW kernel was not. `ncm_serialize_from_name_params()` resolves a serialized name with `g_type_from_name()`, so building it from a name aborted outright:

```
NUMCOSMO-ERROR: ncm_serialize_from_name_params: object `NcXcorKernelCMBISW' is not registered.
```

That blocks every path that reaches an object by name — YAML experiment files, the CLI, `NcmObjArray` — while leaving in-process use working, which is why it went unnoticed.

**The existing tests could not have caught it.** `test_kernel_serialization_basic` already ran on `kernel_cmb_isw` and passed: `duplicate_via_serialization` uses `Ncm.Serialize.dup_obj()`, which takes the GType from the live instance and never consults the registry. A `to_string`/`from_string` round-trip does not catch it either, because constructing the object first realizes the GType and `g_type_from_name()` then succeeds.

The new test therefore runs in a **fresh subprocess** that only calls `cfg_init()` and looks names up, constructing nothing — the real scenario of reading a YAML experiment in a new process. It sweeps every concrete xcor kernel type, so a future omission is caught too, and fails with:

```
AssertionError: not passed to ncm_cfg_register_obj(): ['NcXcorKernelCMBISW']
```

## Two headers installed but not exported

`nc_xcor_kernel_cmb_isw.h` and `nc_xcor_lensing_efficiency.h` were in `meson.build`'s installed list but absent from `numcosmo/numcosmo.h`, which CONTRIBUTING §"Adding a new class" step 3 makes the only supported public include surface. Both are now exported.

An audit found 9 further headers in the same state repo-wide. They are deliberately **not** touched here: they are not all the same bug (`nc_galaxy_shape_pop_gauss_private.h` looks like it belongs in the internal list, the `nogi` BLAS/LAPACK glue may be intentionally outside the public surface), so each needs its own judgement.

## Analysis of #297, recorded

`dev-notes/xcor_isw_limber_step.md` documents the root cause, with every number measured:

- The exact `W_l(k)` is **smooth in k**. The discontinuity is an artifact of Limber collapsing the line-of-sight integral to `xi = nu/k`, which inherits the kernel's support edge as a step at `k = nu/xi_max` — one per multipole, linear in `l`.
- The discriminant is the kernel's value at its own support edge: the lensing efficiency vanishes there (1.5e-25), ISW is still at its plateau (12.5) because the integration is truncated at recombination. That is why only ISW aborts.
- Cross-spectra are immune: the intersection with a low-z tracer cuts the comb off entirely (ISW auto integrates [6.45, 402] with 3 interior breakpoints; ISW×WL integrates [24.18, 402] with none).
- `DECAY_RATE = 1e10` makes the "exponential extrapolation" a step at machine resolution, emitting subnormal sign-flipping noise that the spline then interpolates.

The note also records four attempted fixes and why each failed, and the per-multipole-interval approach that avoids the shared-endpoint problem the others ran into. **#297 and #298 remain open**; #298 is untouched and reports a different error from a different path.

Work-in-progress for the attempted fixes is preserved on `xcor-isw-split-wip` — it does not work and is not part of this PR.

## Testing

Full xcor lane 906 passed / 18 skipped; `ncm_generic` green.
