### PR TITLE
xcor view: angular power spectra, and fix inert integrator tolerance options

### DIFF
--- a/numcosmo/ncm/specfunc/ncm_sbessel_integrator_levin.c
+++ b/numcosmo/ncm/specfunc/ncm_sbessel_integrator_levin.c
@@ -32,9 +32,21 @@
  * functions using a Levin-type method for low multipoles and vector cubature
  * integration for high multipoles.
  *
- * For low ell values, the method solves the differential equation $x^2 y''(x) + 2x y'(x) + (x^2 -
- * \ell(\ell+1)) y(x) = f(x)$ with boundary conditions $y(x_n) = 0 = y(x_{n+1})$. The
- * integral is then given by $I_n = j_\ell(x_{n+1}) y'(x_{n+1}) - j_\ell(x_n) y'(x_n)$.
+ * The integral is written in the dimensionless variable $y = k x$, so that
+ * $\int K(x, k) j_\ell(k x) \mathrm{d}x = \int F(y) j_\ell(y) \mathrm{d}y$ with
+ * $F(y) = K(y / k, k) / k$. This is what allows one panel set to serve every $k$.
+ *
+ * For low ell values, the contribution of a panel $[a, b]$ is obtained by solving
+ * $y^2 w''(y) + 2 y w'(y) + (y^2 - \ell(\ell+1)) w(y) = F(y)$ with boundary conditions
+ * $w(a) = w(b) = 0$. Since $j_\ell$ solves the homogeneous equation, the combination
+ * $y^2 (w' j_\ell - j_\ell' w)$ has derivative $F j_\ell$, so the panel integral is
+ * the boundary term $b^2 w'(b) j_\ell(b) - a^2 w'(a) j_\ell(a)$.
+ *
+ * In practice the equation is solved for $u = y w$, which removes the first-derivative
+ * term and yields $y^2 u'' + (y^2 - \ell(\ell+1)) u = y F(y)$ --- the forcing handed to
+ * #NcmSBesselOdeSolver is the weighted $y F(y)$. Because $w$ vanishes at the endpoints,
+ * $u'(a) = a w'(a)$ and $u'(b) = b w'(b)$ there, and the panel contribution actually
+ * evaluated is $b j_\ell(b) u'(b) - a j_\ell(a) u'(a)$.
  *
  * For high ell values, it uses vector cubature integration where the integrand evaluates
  * $f(x)$ and all $j_\ell(x)$ values simultaneously for efficiency.

--- a/numcosmo_py/app/xcor/view.py
+++ b/numcosmo_py/app/xcor/view.py
@@ -24,6 +24,8 @@
 """CLI command for viewing cross-correlation kernels."""
 
 import dataclasses
+import enum
+import time
 from typing import Annotated, Optional
 from pathlib import Path
 
@@ -50,6 +52,28 @@ from .kernels import (
 )
 
 Ncm.cfg_init()
+
+
+class XcorMethodOption(str, enum.Enum):
+    """Quadrature methods available for the C_ell computation."""
+
+    CUBATURE = "cubature"
+    GSL = "gsl"
+    FIXED = "fixed"
+
+    def to_nc(self) -> Nc.XcorMethod:
+        """Convert to the corresponding #NcXcorMethod value.
+
+        :return: The NumCosmo enumeration value.
+        """
+        match self:
+            case XcorMethodOption.CUBATURE:
+                return Nc.XcorMethod.KERNEL_CUBATURE
+            case XcorMethodOption.GSL:
+                return Nc.XcorMethod.KERNEL_GSL
+            case XcorMethodOption.FIXED:
+                return Nc.XcorMethod.KERNEL_FIXED
+        raise ValueError(f"Unknown method: {self}")
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -409,6 +433,43 @@ class ViewKernel:
         ),
     ] = None
 
+    cls: Annotated[
+        bool,
+        typer.Option(
+            help=(
+                "Also compute and plot the angular power spectra C_ell for every "
+                "auto- and cross-pair of the requested kernels, over the multipole "
+                "range set by --ell/--n-ell."
+            ),
+            show_default=True,
+        ),
+    ] = False
+
+    cls_method: Annotated[
+        XcorMethodOption,
+        typer.Option(
+            help=(
+                "Quadrature used for the C_ell computation. 'cubature' and 'gsl' "
+                "target a tolerance and abort if they cannot reach it; 'fixed' "
+                "needs no tolerance and cannot fail to converge."
+            ),
+            show_default=True,
+        ),
+    ] = XcorMethodOption.CUBATURE
+
+    cls_block_size: Annotated[
+        int,
+        typer.Option(
+            min=1,
+            help=(
+                "Multipole block size handed to NcXcorSolver.plan_blocks(). "
+                "Eight is the empirical sweet spot; see "
+                "dev-notes/xcor_ultralevin_batching_plan.md section 1.3."
+            ),
+            show_default=True,
+        ),
+    ] = 8
+
     def __post_init__(self) -> None:
         """Execute the kernel view command.
 
@@ -463,6 +524,7 @@ class ViewKernel:
             print(f"  ✓ Evaluating single multipole: ell = {self.ell}")
         print()
         kernel_evals = []
+        kernel_objs: list[tuple[str, Nc.XcorKernel]] = []
         for k0 in self.kernel:
             kernel_name, kernel_config = parse_kernel_spec(k0)
             print(f"  ✓ Kernel type: {kernel_name}")
@@ -471,12 +533,20 @@ class ViewKernel:
 
             # Create kernel(s)
             kernel_label, kernel_obj = self._create_kernels(kernel_config)
+            kernel_objs.append((kernel_label, kernel_obj))
 
             # Evaluate kernels
             kernel_evals += self._evaluate_kernels(kernel_label, kernel_obj)
 
         # Plot results
         self._plot_results(kernel_evals)
+
+        if self.cls:
+            cls_main = self._compute_cls(kernel_objs, self.l_limber)
+            cls_limber = (
+                self._compute_cls(kernel_objs, 0) if self.compare_limber else None
+            )
+            self._plot_cls(kernel_objs, cls_main, cls_limber)
 
         print()
         print("✓ Kernel visualization complete!")
@@ -771,6 +841,134 @@ class ViewKernel:
         print()
 
         return [KernelVariants(main=kernel_eval, alternative=kernel_eval_limber)]
+
+    def _compute_cls(
+        self, kernels: list[tuple[str, Nc.XcorKernel]], l_limber: int
+    ) -> dict[tuple[int, int], np.ndarray]:
+        """Compute C_ell for every auto- and cross-pair of the given kernels.
+
+        The multipole range is the one set by ``--ell``/``--n-ell``. Every kernel is
+        put in the requested Limber mode first: :meth:`_evaluate_kernels` leaves the
+        kernels in Limber mode when ``--compare-limber`` is used, so the mode must be
+        set explicitly here rather than assumed.
+
+        :param kernels: List of (label, kernel object) pairs.
+        :param l_limber: Limber threshold to apply to every kernel.
+        :return: Mapping from (i, j) kernel index pair to the C_ell array.
+        """
+        lmin = self.ell
+        lmax = self.ell + self.n_ell - 1
+        method_label = (
+            "non-Limber"
+            if l_limber < 0
+            else ("Limber" if l_limber == 0 else f"Limber(ell>={l_limber})")
+        )
+        n_kernels = len(kernels)
+        pairs = [(i, j) for i in range(n_kernels) for j in range(i, n_kernels)]
+
+        print(f"Computing C_ell ({method_label}) for ell = {lmin} to {lmax}...")
+        print(
+            f"  {n_kernels} kernel(s), {len(pairs)} spectra, "
+            f"method={self.cls_method.value}, block size={self.cls_block_size}"
+        )
+
+        self.dist.prepare_if_needed(self.cosmo)
+        self.ps_ml.prepare_if_needed(self.cosmo)
+
+        for _, kernel_obj in kernels:
+            kernel_obj.set_l_limber(l_limber)
+
+        xcor = Nc.Xcor.new(self.dist, self.ps_ml, self.cls_method.to_nc())
+
+        solver = Nc.XcorSolver.new()
+        ids = [solver.register_kernel(kernel_obj) for _, kernel_obj in kernels]
+        for i, j in pairs:
+            solver.request_cl(ids[i], ids[j], lmin, lmax)
+        solver.plan_blocks(self.cls_block_size)
+
+        start = time.monotonic()
+        solver.solve(xcor, self.cosmo)
+        elapsed = time.monotonic() - start
+
+        result = {
+            (i, j): np.array(solver.get_result(request).dup_array())
+            for request, (i, j) in enumerate(pairs)
+        }
+
+        print(
+            f"  ✓ {len(pairs)} spectra in {elapsed:.2f} s "
+            f"({solver.get_n_blocks()} multipole block(s))"
+        )
+        print()
+
+        return result
+
+    def _plot_cls(
+        self,
+        kernels: list[tuple[str, Nc.XcorKernel]],
+        cls_main: dict[tuple[int, int], np.ndarray],
+        cls_limber: dict[tuple[int, int], np.ndarray] | None,
+    ) -> None:
+        """Plot the angular power spectra, optionally against the Limber result.
+
+        :param kernels: List of (label, kernel object) pairs.
+        :param cls_main: C_ell computed with the primary Limber mode.
+        :param cls_limber: C_ell computed with the Limber approximation, or None.
+        """
+        print("Plotting C_ell...")
+
+        ells = np.arange(self.ell, self.ell + self.n_ell)
+        colors = plt.cm.tab10.colors  # type: ignore # pylint: disable=no-member
+        ax1: plt.Axes
+
+        if cls_limber is not None:
+            fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 10), sharex=True)
+        else:
+            fig, ax1 = plt.subplots(1, 1, figsize=(10, 6))
+            ax2 = None
+
+        for idx, ((i, j), cl) in enumerate(cls_main.items()):
+            color = colors[idx % len(colors)]
+            label = kernels[i][0] if i == j else f"{kernels[i][0]} x {kernels[j][0]}"
+            ax1.plot(ells, np.abs(cl), color=color, label=label)
+            if cls_limber is not None and ax2 is not None:
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    ratio = np.where(cl != 0.0, cls_limber[(i, j)] / cl - 1.0, np.nan)
+                ax2.plot(ells, ratio, color=color, label=label)
+
+        ax1.set_ylabel(r"$|C_\ell|$")
+        ax1.set_yscale("log")
+        if self.n_ell > 1:
+            ax1.set_xscale("log")
+        ax1.grid(True, alpha=0.3)
+        ax1.legend(fontsize=8)
+        ax1.set_title("Angular power spectra", fontweight="bold")
+
+        if ax2 is not None:
+            ax2.axhline(0.0, color="black", lw=0.8)
+            ax2.set_ylabel(r"$C_\ell^{\rm Limber}/C_\ell - 1$")
+            ax2.set_xlabel(r"$\ell$")
+            if self.n_ell > 1:
+                ax2.set_xscale("log")
+            ax2.grid(True, alpha=0.3)
+        else:
+            ax1.set_xlabel(r"$\ell$")
+
+        fig.tight_layout()
+
+        if self.output is not None:
+            cls_output = self.output.with_name(
+                f"{self.output.stem}_cls{self.output.suffix}"
+            )
+            fig.savefig(cls_output, dpi=150, bbox_inches="tight")
+            print(f"  ✓ Saved to {cls_output}")
+
+        if self.show_plot:
+            plt.show()
+        else:
+            plt.close(fig)
+
+        print()
 
     def _plot_results(self, kernel_vars: list[KernelVariants]) -> None:
         """Plot kernel evaluation results.

--- a/numcosmo_py/app/xcor/view.py
+++ b/numcosmo_py/app/xcor/view.py
@@ -498,13 +498,36 @@ class ViewKernel:
         print(f"  ✓ Maximum redshift: {dist_max_z}")
         print()
 
-        # Create integrator (matching fixtures pattern)
+        # Create integrator.
+        #
+        # The tolerances must be passed at CONSTRUCTION. An ODE operator takes the
+        # tolerance in force when it is built and keeps it for its whole life, and
+        # the panel operators are built as soon as the multipole range is known --
+        # so ncm_sbessel_integrator_levin_set_reltol() on an already-constructed
+        # integrator updates the getter but never reaches the computation. Building
+        # first and then setting, which is what this command used to do, silently
+        # ignored --integrator-reltol and --integrator-cheb-reltol.
         print("Creating integrator...")
-        self.integrator = Ncm.SBesselIntegratorLevin.new(0, 8)
-        if self.integrator_reltol is not None:
-            self.integrator.set_reltol(self.integrator_reltol)
-        if self.integrator_cheb_reltol is not None:
-            self.integrator.set_cheb_reltol(self.integrator_cheb_reltol)
+        defaults = Ncm.SBesselIntegratorLevin.new(0, 8)
+        self.integrator = Ncm.SBesselIntegratorLevin.new_full(
+            0,
+            8,
+            defaults.get_y_knots_min(),
+            defaults.get_y_knots_max(),
+            defaults.get_n_knots(),
+            defaults.get_ell_cache_max(),
+            (
+                self.integrator_reltol
+                if self.integrator_reltol is not None
+                else defaults.get_reltol()
+            ),
+            defaults.get_cheb_min_order(),
+            (
+                self.integrator_cheb_reltol
+                if self.integrator_cheb_reltol is not None
+                else defaults.get_cheb_reltol()
+            ),
+        )
         if self.integrator_max_order is not None:
             self.integrator.set_max_order(self.integrator_max_order)
         print(

--- a/tests/python/numcosmo_py/app/test_xcor_view_app.py
+++ b/tests/python/numcosmo_py/app/test_xcor_view_app.py
@@ -161,3 +161,41 @@ def test_view_kernel_cls_fixed_method() -> None:
 
     assert result.exit_code == 0, result.output
     assert "method=fixed" in result.output
+
+
+def test_integrator_tolerance_must_be_set_at_construction() -> None:
+    """Guards the construction pattern the view command depends on.
+
+    An ODE operator keeps the tolerance in force when it was built, so setting a
+    tolerance on an already-constructed integrator leaves the result at the
+    quality it was constructed with. The view command therefore builds its
+    integrator with ``new_full``. If that regressed to ``new()`` followed by
+    ``set_reltol()``, ``--integrator-reltol`` would silently do nothing -- which
+    the reported-value assertions above cannot catch, since the getter agrees
+    either way.
+    """
+    args = (5.0, 1.0, 0.1, 10.0, 50.0, 2)
+
+    def build(tol: float) -> float:
+        sbi = Ncm.SBesselIntegratorLevin.new_full(
+            2, 2, 1e-4, 1e6, 21, 1200, tol, 2, tol
+        )
+        return sbi.integrate_gaussian_ell(*args)
+
+    loose, tight = build(1e-4), build(1e-12)
+
+    # Construction-time tolerance reaches the computation, and matters a lot here.
+    assert abs(loose / tight - 1.0) > 1.0
+
+    # Setting a tighter tolerance afterwards does not buy the tighter answer:
+    # the result stays with the tolerance the operators were built at.
+    relaxed = Ncm.SBesselIntegratorLevin.new_full(
+        2, 2, 1e-4, 1e6, 21, 1200, 1e-4, 2, 1e-4
+    )
+    relaxed.set_reltol(1e-12)
+    relaxed.set_cheb_reltol(1e-12)
+    after = relaxed.integrate_gaussian_ell(*args)
+
+    assert relaxed.get_reltol() == 1e-12  # the getter reports the new value ...
+    assert abs(after / loose - 1.0) < 1e-6  # ... but the answer is the loose one
+    assert abs(after / tight - 1.0) > 1.0

--- a/tests/python/numcosmo_py/app/test_xcor_view_app.py
+++ b/tests/python/numcosmo_py/app/test_xcor_view_app.py
@@ -105,3 +105,59 @@ def test_view_kernel_defaults_leave_library_precision_alone() -> None:
     assert result.exit_code == 0, result.output
     assert "reltol=1.0e-13" in result.output
     assert "cheb_reltol=1.0e-08" in result.output
+
+
+def test_view_kernel_cls_single() -> None:
+    """--cls computes the auto-spectrum of a single kernel."""
+    result = _view("--cls")
+
+    assert result.exit_code == 0, result.output
+    assert "Computing C_ell (non-Limber)" in result.output
+    assert "1 kernel(s), 1 spectra" in result.output
+
+
+def test_view_kernel_cls_pairs() -> None:
+    """Every auto- and cross-pair of the requested kernels is computed."""
+    result = runner.invoke(
+        app,
+        [
+            "xcor",
+            "kernel",
+            "view",
+            "--kernel",
+            KERNEL,
+            "--kernel",
+            "number-counts survey=LSST-Y1 bin_idx=0 bias=1.5",
+            "--ell",
+            "2",
+            "--n-ell",
+            "2",
+            "--no-show-plot",
+            "--cls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "2 kernel(s), 3 spectra" in result.output
+
+
+def test_view_kernel_cls_compare_limber() -> None:
+    """--compare-limber adds a second, Limber, C_ell computation.
+
+    The kernels are left in Limber mode by the k-space evaluation step, so this
+    also covers that the Limber mode is set explicitly before each solve rather
+    than inherited from whatever ran last.
+    """
+    result = _view("--cls", "--compare-limber")
+
+    assert result.exit_code == 0, result.output
+    assert "Computing C_ell (non-Limber)" in result.output
+    assert "Computing C_ell (Limber)" in result.output
+
+
+def test_view_kernel_cls_fixed_method() -> None:
+    """The fixed-knot quadrature is reachable for the C_ell computation."""
+    result = _view("--cls", "--cls-method", "fixed")
+
+    assert result.exit_code == 0, result.output
+    assert "method=fixed" in result.output

--- a/tests/python/numcosmo_py/app/test_xcor_view_app.py
+++ b/tests/python/numcosmo_py/app/test_xcor_view_app.py
@@ -34,8 +34,11 @@ matplotlib.use("Agg")
 # flake8: noqa: E402
 # pylint: disable=wrong-import-position
 
+import numpy as np
+
 from numcosmo_py import Ncm
 from numcosmo_py.app import app
+from numcosmo_py.app.xcor import view
 
 pytestmark = pytest.mark.app
 runner = CliRunner()
@@ -163,16 +166,14 @@ def test_view_kernel_cls_fixed_method() -> None:
     assert "method=fixed" in result.output
 
 
-def test_integrator_tolerance_must_be_set_at_construction() -> None:
-    """Guards the construction pattern the view command depends on.
+def test_integrator_tolerance_is_fixed_at_construction() -> None:
+    """The library semantics that make ``--integrator-reltol`` easy to get wrong.
 
-    An ODE operator keeps the tolerance in force when it was built, so setting a
-    tolerance on an already-constructed integrator leaves the result at the
-    quality it was constructed with. The view command therefore builds its
-    integrator with ``new_full``. If that regressed to ``new()`` followed by
-    ``set_reltol()``, ``--integrator-reltol`` would silently do nothing -- which
-    the reported-value assertions above cannot catch, since the getter agrees
-    either way.
+    An ODE operator keeps the tolerance in force when it was built, so a tolerance
+    set on an already-constructed integrator does not buy the answer that
+    constructing at that tolerance would have given. This states the library
+    behaviour only; that the view command actually relies on it is covered by
+    ``test_view_kernel_integrator_reltol_reaches_the_computation``.
     """
     args = (5.0, 1.0, 0.1, 10.0, 50.0, 2)
 
@@ -184,8 +185,11 @@ def test_integrator_tolerance_must_be_set_at_construction() -> None:
 
     loose, tight = build(1e-4), build(1e-12)
 
-    # Construction-time tolerance reaches the computation, and matters a lot here.
-    assert abs(loose / tight - 1.0) > 1.0
+    # The construction-time tolerance reaches the computation. How large the gap
+    # is depends on how accurate the solver is at loose tolerances, which is not
+    # a fixed property: the resolution floors shrank this case from ~1e2 to ~4e-2.
+    # The threshold therefore only has to clear the loose-regime spread.
+    assert abs(loose / tight - 1.0) > 1e-3
 
     # Setting a tighter tolerance afterwards does not buy the tighter answer:
     # the result stays with the tolerance the operators were built at.
@@ -198,4 +202,40 @@ def test_integrator_tolerance_must_be_set_at_construction() -> None:
 
     assert relaxed.get_reltol() == 1e-12  # the getter reports the new value ...
     assert abs(after / loose - 1.0) < 1e-6  # ... but the answer is the loose one
-    assert abs(after / tight - 1.0) > 1.0
+    assert abs(after / tight - 1.0) > 1e-3
+
+
+def test_view_kernel_integrator_reltol_reaches_the_computation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--integrator-reltol`` must change the numbers, not just the report.
+
+    The command has to hand the tolerance to ``new_full``; building the integrator
+    first and applying the tolerance with setters afterwards leaves the
+    computation at the quality it was constructed with, while ``get_reltol()``
+    still reports the requested value. The reported-value assertions above cannot
+    tell those two spellings apart, so compare the evaluated kernel itself.
+    """
+    captured: list[np.ndarray] = []
+    evaluate = view.KernelEvaluation.evaluate
+
+    def spy(self: view.KernelEvaluation, k_Mpc: np.ndarray) -> np.ndarray:
+        values = evaluate(self, k_Mpc)
+        captured.append(np.asarray(values, dtype=float).copy())
+        return values
+
+    monkeypatch.setattr(view.KernelEvaluation, "evaluate", spy)
+
+    for reltol in ("1e-4", "1e-12"):
+        result = _view(
+            "--integrator-reltol", reltol, "--integrator-cheb-reltol", reltol
+        )
+        assert result.exit_code == 0, result.output
+
+    loose, tight = captured
+    assert loose.shape == tight.shape
+
+    # Built at the requested tolerances the two runs differ by ~9e-5 here. Were
+    # the tolerance applied after construction instead, both runs would compute
+    # at the library default and agree to ~1e-9.
+    assert np.abs(loose / tight - 1.0).max() > 1e-6


### PR DESCRIPTION
Extends the `xcor view` command to compute and plot angular power spectra, and fixes a bug in how its existing tolerance options were applied. Last piece split out of a larger xcor branch; the sbessel solver work it was developed alongside merged as #309 and #310.

## Angular power spectra in `xcor view`

Adds `--cls`, `--cls-method` and `--cls-block-size`: `C_ell` for every auto- and cross-pair over the existing `--ell`/`--n-ell` range, computed through `NcXcorSolver`. With `--compare-limber` the Limber spectra and their fractional difference are plotted alongside, which is the point of the feature — seeing where Limber stops being adequate for a given kernel pair.

Also corrects the `NcmSBesselIntegratorLevin` class documentation: the endpoint formula was missing its factors of `y`, and the working variable is `y = kx`, not `x`.

## Tolerance options were silently inert

`--integrator-reltol` and `--integrator-cheb-reltol` were applied with setters *after* the integrator was built. The library documents this as a no-op — an ODE operator keeps the tolerance that was in force when it was created. So both options changed the values the command reported while never changing the computation.

Now passed at construction. The regression test drives the computation rather than asserting the reported values, since reading back what the command printed is exactly what failed to catch this the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
