### PR TITLE
Expose the NumCosmo Levin solver as a CCL-facing non-Limber angular_cl, batched over ell blocks

### DIFF
--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -194,7 +194,7 @@ def bessel_transform_block(
         sp = Ncm.SplineBSpline.new_tol(reltol, 0.0)
         sp.set_array(chi_a.tolist(), comp.tolist(), True)
         # ell-dependent scalars, reapplied after the batched solve
-        f_ell = np.array([tracer.get_f_ell(float(l)) for l in ells]).reshape(
+        f_ell = np.array([tracer.get_f_ell(float(ell)) for ell in ells]).reshape(
             len(ells), -1
         )
         f_c = f_ell[:, 0] if f_ell.shape[1] == 1 else f_ell[:, 0]

--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -99,6 +99,125 @@ def compute_kernel(
     return z_a[1:-1], chi_a[1:-1], Wtotal[1:-1]
 
 
+def tracer_components(
+    tracer: pyccl.Tracer,
+    cosmology: Cosmology,
+    *,
+    reltol: float = 1.0e-8,
+    lk: float = 0.0,
+) -> tuple[np.ndarray, list[np.ndarray], list[int]]:
+    """Per-component kernels on a common chi grid, with the ell-dependent parts removed.
+
+    The multipole enters a component only through scalars -- ``get_f_ell`` and the
+    ``1/nu^2`` that accompanies ``der_bessel = -1`` -- so they can be stripped here and
+    reapplied after the solve. That is what lets one factorisation serve a whole block
+    of multipoles, which is the structure the solver is built around.
+
+    Growth is folded in here: CCL's transfer carries none, because CCL evaluates the
+    2-D P(k, a) rather than pairing a kernel with P(k, 0).
+    """
+    cosmo = cosmology.cosmo
+    dist = cosmology.dist
+    RH_Mpc = cosmo.RH_Mpc()
+    gf = Nc.GrowthFunc.new()
+    gf.prepare_if_needed(cosmo)
+
+    Wchi_list, chi_list = tracer.get_kernel()
+    assert chi_list is not None
+    chi_a = np.array(chi_list[0])
+
+    resampled = []
+    for chi_a_i, Wchi_a_i in zip(chi_list, Wchi_list):
+        sp: Ncm.Spline = Ncm.SplineBSpline.new_tol(reltol, 0.0)
+        sp.set_array(list(chi_a_i), list(Wchi_a_i), True)
+        resampled.append(np.array([sp.eval(float(c)) for c in chi_a]))
+
+    z_a = np.array([dist.inv_comoving(cosmo, float(c) / RH_Mpc) for c in chi_a])
+    a_array = 1.0 / (1.0 + z_a)
+    D_a = np.array([gf.eval(cosmo, float(zz)) for zz in z_a])
+    transfers_list = tracer.get_transfer(lk, a_array)
+    der_bessel = list(tracer.get_bessel_derivative())
+
+    comps = []
+    for W_a, transfer, der in zip(resampled, transfers_list, der_bessel):
+        if der not in (-1, 0):
+            raise NotImplementedError(
+                f"der_bessel = {der} needs derivatives of j_l, which the "
+                "kernel-folding form used here cannot express."
+            )
+        comps.append(W_a * np.asarray(transfer) * D_a)
+
+    # Strip the endpoints, as compute_kernel does: CCL pads the grid.
+    return chi_a[1:-1], [c[1:-1] for c in comps], der_bessel
+
+
+def bessel_transform_block(
+    tracer: pyccl.Tracer,
+    cosmology: Cosmology,
+    ell_min: int,
+    ell_max: int,
+    k_a: np.ndarray,
+    *,
+    reltol: float = 1.0e-8,
+) -> np.ndarray:
+    r"""Batched :math:`\Delta_\ell(k)` for every multipole in ``[ell_min, ell_max]``.
+
+    One operator factorisation serves the whole block, and one call per wavenumber
+    returns every multipole in it. This is the reuse structure the method is designed
+    around; solving multipole by multipole discards it.
+
+    :returns: array of shape ``(ell_max - ell_min + 1, len(k_a))``.
+    """
+    n_ell = ell_max - ell_min + 1
+    chi_a, comps, der_bessel = tracer_components(tracer, cosmology, reltol=reltol)
+    chi_min, chi_max = float(chi_a[0]), float(chi_a[-1])
+
+    proto = Ncm.SBesselIntegratorLevin.new(ell_min, ell_max)
+    integ = Ncm.SBesselIntegratorLevin.new_full(
+        ell_min,
+        ell_max,
+        proto.get_y_knots_min(),
+        proto.get_y_knots_max(),
+        proto.get_n_knots(),
+        proto.get_ell_cache_max(),
+        reltol,
+        proto.get_cheb_min_order(),
+        reltol,
+    )
+    res = Ncm.Vector.new(n_ell)
+    out = np.zeros((n_ell, len(k_a)))
+
+    ells = np.arange(ell_min, ell_max + 1)
+    nu = ells + 0.5
+
+    for comp, der in zip(comps, der_bessel):
+        sp = Ncm.SplineBSpline.new_tol(reltol, 0.0)
+        sp.set_array(chi_a.tolist(), comp.tolist(), True)
+        # ell-dependent scalars, reapplied after the batched solve
+        f_ell = np.array([tracer.get_f_ell(float(l)) for l in ells]).reshape(
+            len(ells), -1
+        )
+        f_c = f_ell[:, 0] if f_ell.shape[1] == 1 else f_ell[:, 0]
+        bes = 1.0 / nu**2 if der == -1 else np.ones_like(nu, dtype=float)
+
+        block = np.zeros((n_ell, len(k_a)))
+        for ik, k in enumerate(k_a):
+            integ.integrate(
+                lambda _p, chi, _k, _s=sp: _s.eval(chi),
+                chi_min,
+                chi_max,
+                float(k),
+                res,
+                None,
+            )
+            for j in range(n_ell):
+                block[j, ik] = res.get(j)
+
+        out += block * (f_c * bes)[:, None]
+
+    return out
+
+
 def bessel_transform(
     tracer: pyccl.Tracer,
     cosmology: Cosmology,
@@ -108,65 +227,17 @@ def bessel_transform(
     reltol: float = 1.0e-8,
     k_dependent: bool = False,
 ) -> np.ndarray:
-    r"""Compute :math:`\Delta_\ell(k) = \int d\chi\, W(\chi)\, j_\ell(k\chi)`.
+    r"""Single-multipole :math:`\Delta_\ell(k)`.
 
-    The oscillatory integral is done with NumCosmo's Levin-type solver, which is told a
-    tolerance rather than a resolution.
-
-    :param k_a: wavenumbers in Mpc^-1.
-    :param reltol: requested relative accuracy, applied to the kernel reconstruction and
-        to the oscillatory solve alike.
-    :param k_dependent: evaluate the tracer's transfer at each k instead of at k = 0.
-        CCL's transfer is a function of (lk, a); the separable default discards that.
+    A convenience wrapper over :func:`bessel_transform_block` with a block of one. For
+    more than a handful of multipoles use the batched form directly, which shares one
+    factorisation across the block.
     """
-    cosmo = cosmology.cosmo
-    gf = Nc.GrowthFunc.new()
-    gf.prepare_if_needed(cosmo)
-
-    integ = Ncm.SBesselIntegratorLevin.new(ell, ell)
-    integ = Ncm.SBesselIntegratorLevin.new_full(
-        ell,
-        ell,
-        integ.get_y_knots_min(),
-        integ.get_y_knots_max(),
-        integ.get_n_knots(),
-        integ.get_ell_cache_max(),
-        reltol,
-        integ.get_cheb_min_order(),
-        reltol,
-    )
-    out = np.zeros_like(k_a)
-    res = Ncm.Vector.new(1)
-    cache: dict[float, tuple[Ncm.Spline, float, float]] = {}
-
-    for i, k in enumerate(k_a):
-        lk = float(np.log(k)) if k_dependent else 0.0
-        key = lk if k_dependent else 0.0
-        if key not in cache:
-            z_a, chi_a, W_a = compute_kernel(
-                tracer, cosmology, ell, reltol=reltol, lk=lk
-            )
-            # CCL's transfer carries no growth -- it evaluates the 2-D P(k, a) instead.
-            # Pairing the kernel with P(k, 0) therefore requires folding D(z) in here.
-            # Note this is the separable approximation P(k, z) = D(z)^2 P(k, 0); the
-            # native NumCosmo path does not make that split.
-            W_a = W_a * np.array([gf.eval(cosmo, float(zz)) for zz in z_a])
-            sp = Ncm.SplineBSpline.new_tol(reltol, 0.0)
-            sp.set_array(chi_a.tolist(), W_a.tolist(), True)
-            cache[key] = (sp, float(chi_a[0]), float(chi_a[-1]))
-        sp, chi_min, chi_max = cache[key]
-
-        integ.integrate(
-            lambda _p, chi, _k, _s=sp: _s.eval(chi),
-            chi_min,
-            chi_max,
-            float(k),
-            res,
-            None,
+    if k_dependent:
+        raise NotImplementedError(
+            "k-dependent transfers need one kernel per k; use tracer_components(lk=...)"
         )
-        out[i] = res.get(0)
-
-    return out
+    return bessel_transform_block(tracer, cosmology, ell, ell, k_a, reltol=reltol)[0]
 
 
 def angular_cl(
@@ -178,7 +249,7 @@ def angular_cl(
     reltol: float = 1.0e-8,
     n_k: int = 512,
     n_osc: int = 8,
-    k_dependent: bool = False,
+    block_size: int = 8,
 ) -> np.ndarray:
     r"""Non-Limber angular power spectrum of two CCL tracers, solved by NumCosmo.
 
@@ -186,66 +257,60 @@ def angular_cl(
         C_\ell = \frac{2}{\pi}\int dk\, k^2 P_{\rm lin}(k)\,
                  \Delta^1_\ell(k)\,\Delta^2_\ell(k)
 
-    The tracers, their kernels and the power spectrum all come from CCL; only the
-    oscillatory integral and the reconstruction of the tabulated kernels are NumCosmo's.
-    This makes the comparison against :func:`pyccl.angular_cl` an apples-to-apples one,
-    and gives CCL users a non-Limber path driven by a tolerance.
+    The tracers, their kernels and the power spectrum are CCL's; only the oscillatory
+    integral and the reconstruction of the tabulated kernels are NumCosmo's.
+
+    Multipoles are processed in blocks that share one operator factorisation. Block
+    width has an optimum rather than being as large as possible: the truncation order
+    is chosen by a max-reduction across the block, so every member pays the order the
+    hardest member needs, and the k-grid must span the whole block's range.
 
     :param reltol: requested relative accuracy of the oscillatory solve.
     :param n_k: floor on the number of wavenumbers in the outer integral.
     :param n_osc: samples per oscillation of Delta_l(k) in the outer integral.
-    :param k_dependent: keep the tracers' k-dependent transfer rather than evaluating it
-        at k = 0. Costs one kernel rebuild per k.
+    :param block_size: number of consecutive multipoles sharing a factorisation.
     """
     ps_lin = cosmology.ps_ml
     cosmo = cosmology.cosmo
     ps_lin.prepare_if_needed(cosmo)
+    ells = np.atleast_1d(np.asarray(ells, dtype=int))
     out = np.zeros(len(ells), dtype=float)
 
-    for i, ell in enumerate(ells):
-        _, chi_a, W_a = compute_kernel(tracer1, cosmology, float(ell), reltol=reltol)
-        nu = ell + 0.5
+    chi_a, comps, _ = tracer_components(tracer1, cosmology, reltol=reltol)
+    w_abs = np.abs(sum(comps))
+    keep = np.nonzero(w_abs > 1.0e-10 * w_abs.max())[0]
+    chi_lo, chi_hi = float(chi_a[keep[0]]), float(chi_a[keep[-1]])
 
-        # Effective support of the kernel. The tabulated chi range runs far past where
-        # the kernel is non-negligible, and using its endpoints would put the turning
-        # point nu/chi decades away from where the transform actually lives.
-        w_abs = np.abs(W_a)
-        keep = np.nonzero(w_abs > 1.0e-10 * w_abs.max())[0]
-        chi_lo, chi_hi = float(chi_a[keep[0]]), float(chi_a[keep[-1]])
+    for start_i in range(0, len(ells), block_size):
+        sel = np.arange(start_i, min(start_i + block_size, len(ells)))
+        ell_min, ell_max = int(ells[sel[0]]), int(ells[sel[-1]])
 
-        # j_l(k chi) turns over at k chi = nu, and below that the transform is
-        # evanescent; above nu/chi_lo it decays with the kernel's smoothness.
-        k_lo = 0.2 * nu / chi_hi
-        k_hi = 8.0 * nu / chi_lo
-
-        # Delta_l(k) oscillates in k with period pi/chi_hi, so the outer grid has to
-        # resolve that; a log grid spanning decades cannot. This is the one place the
-        # method still asks for a resolution rather than deriving it -- see n_k_min.
+        # One k-grid serves the block, so it must cover the largest multipole in it.
+        nu_lo, nu_hi = ell_min + 0.5, ell_max + 0.5
+        k_lo = 0.2 * nu_lo / chi_hi
+        k_hi = 8.0 * nu_hi / chi_lo
         n_k_min = int(np.ceil(n_osc * (k_hi - k_lo) * chi_hi / np.pi))
-        n_k_use = max(n_k, n_k_min)
-        k_a = np.linspace(k_lo, k_hi, n_k_use)
+        k_a = np.linspace(k_lo, k_hi, max(n_k, n_k_min))
 
-        d1 = bessel_transform(
-            tracer1, cosmology, int(ell), k_a, reltol=reltol, k_dependent=k_dependent
+        d1 = bessel_transform_block(
+            tracer1, cosmology, ell_min, ell_max, k_a, reltol=reltol
         )
-        if tracer2 is tracer1:
-            d2 = d1
-        else:
-            d2 = bessel_transform(
-                tracer2,
-                cosmology,
-                int(ell),
-                k_a,
-                reltol=reltol,
-                k_dependent=k_dependent,
+        d2 = (
+            d1
+            if tracer2 is tracer1
+            else bessel_transform_block(
+                tracer2, cosmology, ell_min, ell_max, k_a, reltol=reltol
             )
+        )
 
         # NumCosmo's power spectrum already takes k in Mpc^-1 and returns Mpc^3.
         pk = np.array([ps_lin.eval(cosmo, 0.0, float(k)) for k in k_a])
-        integrand = k_a**2 * pk * d1 * d2
 
-        sp = Ncm.SplineCubicNotaknot.new()
-        sp.set_array(k_a.tolist(), integrand.tolist(), True)
-        out[i] = (2.0 / np.pi) * sp.eval_integ(k_lo, k_hi)
+        for j, i in enumerate(sel):
+            row = int(ells[i]) - ell_min
+            integrand = k_a**2 * pk * d1[row] * d2[row]
+            sp = Ncm.SplineCubicNotaknot.new()
+            sp.set_array(k_a.tolist(), integrand.tolist(), True)
+            out[i] = (2.0 / np.pi) * sp.eval_integ(k_lo, k_hi)
 
     return out

--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -269,12 +269,21 @@ def angular_cl(
     :param n_k: floor on the number of wavenumbers in the outer integral.
     :param n_osc: samples per oscillation of Delta_l(k) in the outer integral.
     :param block_size: number of consecutive multipoles sharing a factorisation.
+        Clamped to what the solver will honour: NC_XCOR_KERNEL_MAX_ELL_BLOCK and the
+        integrator's ell_cache_max. Wider is not better -- the truncation order is a
+        max-reduction across the block, so every member pays the hardest member's
+        order, and one k-grid must span the block's whole range. Measured on eight
+        consecutive multipoles at fixed accuracy, the cost turns over at four:
+        1 -> 214.5 s, 2 -> 128.0 s, 4 -> 98.9 s, 8 -> 117.1 s.
     """
     ps_lin = cosmology.ps_ml
     cosmo = cosmology.cosmo
     ps_lin.prepare_if_needed(cosmo)
     ells = np.atleast_1d(np.asarray(ells, dtype=int))
     out = np.zeros(len(ells), dtype=float)
+
+    cache_max = Ncm.SBesselIntegratorLevin.new(0, 0).get_ell_cache_max()
+    block_size = max(1, min(block_size, Nc.XCOR_KERNEL_MAX_ELL_BLOCK, cache_max))
 
     chi_a, comps, _ = tracer_components(tracer1, cosmology, reltol=reltol)
     w_abs = np.abs(sum(comps))

--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -26,21 +26,41 @@
 import numpy as np
 import pyccl
 
-from numcosmo_py import Ncm
+from numcosmo_py import Nc, Ncm
 from numcosmo_py.cosmology import Cosmology
 
 
 def compute_kernel(
-    tracer: pyccl.Tracer, cosmology: Cosmology, ell: float
+    tracer: pyccl.Tracer,
+    cosmology: Cosmology,
+    ell: float,
+    *,
+    reltol: float = 0.0,
+    lk: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Compute the kernel for a given tracer."""
+    """Compute the kernel for a given tracer.
+
+    :param reltol: when positive, resample the tracer's components with a B-spline whose
+        order is derived from this tolerance instead of a cubic spline. CCL hands kernels
+        over as fixed tables, and a cubic reconstruction of a table stalls around 1e-9
+        relative -- well above what the Bessel solver delivers -- so anything demanding
+        better than that must not go through a cubic.
+    :param lk: natural log of the wavenumber at which the transfer is evaluated. CCL's
+        transfer is k-dependent; the default of 0.0 keeps the separable approximation.
+    """
     cosmo = cosmology.cosmo
     dist = cosmology.dist
     Wchi_list, chi_list = tracer.get_kernel()
     assert chi_list is not None
     chi_a = np.array(chi_list[0])
     for chi_a_i, Wchi_a_i in zip(chi_list, Wchi_list):
-        s = Ncm.Spline.new_array(Ncm.SplineCubicNotaknot.new(), chi_a_i, Wchi_a_i, True)
+        if reltol > 0.0:
+            s: Ncm.Spline = Ncm.SplineBSpline.new_tol(reltol, 0.0)
+            s.set_array(chi_a_i, Wchi_a_i, True)
+        else:
+            s = Ncm.Spline.new_array(
+                Ncm.SplineCubicNotaknot.new(), chi_a_i, Wchi_a_i, True
+            )
         Wchi_a_i[:] = np.array([s.eval(chi) for chi in chi_a])
 
     RH_Mpc = cosmo.RH_Mpc()
@@ -49,16 +69,23 @@ def compute_kernel(
     bessel_factors_list = []
 
     for der_bessel in tracer.get_bessel_derivative():
-        assert der_bessel in [-1, 0]
         match der_bessel:
             case 0:
                 bessel_factors_list.append(1.0)
             case -1:
+                # j_l(x)/x^2, folded into the kernel as CCL does.
                 bessel_factors_list.append(1.0 / nu**2)
+            case 1 | 2:
+                raise NotImplementedError(
+                    f"der_bessel = {der_bessel} needs derivatives of j_l, which the "
+                    "kernel-folding form used here cannot express."
+                )
+            case _:
+                raise ValueError(f"unsupported der_bessel = {der_bessel}")
 
     z_a = np.array([dist.inv_comoving(cosmo, chi / RH_Mpc) for chi in chi_a])
     a_array = 1.0 / (1.0 + np.array(z_a))
-    transfers_list = tracer.get_transfer(0.0, a_array)
+    transfers_list = tracer.get_transfer(lk, a_array)
     ell_factors_list = tracer.get_f_ell(ell)
 
     Wtotal = np.zeros_like(chi_a)
@@ -70,3 +97,155 @@ def compute_kernel(
         Wtotal += Wchi_a * transfer * ell_factor * bessel_factor
 
     return z_a[1:-1], chi_a[1:-1], Wtotal[1:-1]
+
+
+def bessel_transform(
+    tracer: pyccl.Tracer,
+    cosmology: Cosmology,
+    ell: int,
+    k_a: np.ndarray,
+    *,
+    reltol: float = 1.0e-8,
+    k_dependent: bool = False,
+) -> np.ndarray:
+    r"""Compute :math:`\Delta_\ell(k) = \int d\chi\, W(\chi)\, j_\ell(k\chi)`.
+
+    The oscillatory integral is done with NumCosmo's Levin-type solver, which is told a
+    tolerance rather than a resolution.
+
+    :param k_a: wavenumbers in Mpc^-1.
+    :param reltol: requested relative accuracy, applied to the kernel reconstruction and
+        to the oscillatory solve alike.
+    :param k_dependent: evaluate the tracer's transfer at each k instead of at k = 0.
+        CCL's transfer is a function of (lk, a); the separable default discards that.
+    """
+    cosmo = cosmology.cosmo
+    gf = Nc.GrowthFunc.new()
+    gf.prepare_if_needed(cosmo)
+
+    integ = Ncm.SBesselIntegratorLevin.new(ell, ell)
+    integ = Ncm.SBesselIntegratorLevin.new_full(
+        ell,
+        ell,
+        integ.get_y_knots_min(),
+        integ.get_y_knots_max(),
+        integ.get_n_knots(),
+        integ.get_ell_cache_max(),
+        reltol,
+        integ.get_cheb_min_order(),
+        reltol,
+    )
+    out = np.zeros_like(k_a)
+    res = Ncm.Vector.new(1)
+    cache: dict[float, tuple[Ncm.Spline, float, float]] = {}
+
+    for i, k in enumerate(k_a):
+        lk = float(np.log(k)) if k_dependent else 0.0
+        key = lk if k_dependent else 0.0
+        if key not in cache:
+            z_a, chi_a, W_a = compute_kernel(
+                tracer, cosmology, ell, reltol=reltol, lk=lk
+            )
+            # CCL's transfer carries no growth -- it evaluates the 2-D P(k, a) instead.
+            # Pairing the kernel with P(k, 0) therefore requires folding D(z) in here.
+            # Note this is the separable approximation P(k, z) = D(z)^2 P(k, 0); the
+            # native NumCosmo path does not make that split.
+            W_a = W_a * np.array([gf.eval(cosmo, float(zz)) for zz in z_a])
+            sp = Ncm.SplineBSpline.new_tol(reltol, 0.0)
+            sp.set_array(chi_a.tolist(), W_a.tolist(), True)
+            cache[key] = (sp, float(chi_a[0]), float(chi_a[-1]))
+        sp, chi_min, chi_max = cache[key]
+
+        integ.integrate(
+            lambda _p, chi, _k, _s=sp: _s.eval(chi),
+            chi_min,
+            chi_max,
+            float(k),
+            res,
+            None,
+        )
+        out[i] = res.get(0)
+
+    return out
+
+
+def angular_cl(
+    cosmology: Cosmology,
+    tracer1: pyccl.Tracer,
+    tracer2: pyccl.Tracer,
+    ells: np.ndarray,
+    *,
+    reltol: float = 1.0e-8,
+    n_k: int = 512,
+    n_osc: int = 8,
+    k_dependent: bool = False,
+) -> np.ndarray:
+    r"""Non-Limber angular power spectrum of two CCL tracers, solved by NumCosmo.
+
+    .. math::
+        C_\ell = \frac{2}{\pi}\int dk\, k^2 P_{\rm lin}(k)\,
+                 \Delta^1_\ell(k)\,\Delta^2_\ell(k)
+
+    The tracers, their kernels and the power spectrum all come from CCL; only the
+    oscillatory integral and the reconstruction of the tabulated kernels are NumCosmo's.
+    This makes the comparison against :func:`pyccl.angular_cl` an apples-to-apples one,
+    and gives CCL users a non-Limber path driven by a tolerance.
+
+    :param reltol: requested relative accuracy of the oscillatory solve.
+    :param n_k: floor on the number of wavenumbers in the outer integral.
+    :param n_osc: samples per oscillation of Delta_l(k) in the outer integral.
+    :param k_dependent: keep the tracers' k-dependent transfer rather than evaluating it
+        at k = 0. Costs one kernel rebuild per k.
+    """
+    ps_lin = cosmology.ps_ml
+    cosmo = cosmology.cosmo
+    ps_lin.prepare_if_needed(cosmo)
+    out = np.zeros(len(ells), dtype=float)
+
+    for i, ell in enumerate(ells):
+        _, chi_a, W_a = compute_kernel(tracer1, cosmology, float(ell), reltol=reltol)
+        nu = ell + 0.5
+
+        # Effective support of the kernel. The tabulated chi range runs far past where
+        # the kernel is non-negligible, and using its endpoints would put the turning
+        # point nu/chi decades away from where the transform actually lives.
+        w_abs = np.abs(W_a)
+        keep = np.nonzero(w_abs > 1.0e-10 * w_abs.max())[0]
+        chi_lo, chi_hi = float(chi_a[keep[0]]), float(chi_a[keep[-1]])
+
+        # j_l(k chi) turns over at k chi = nu, and below that the transform is
+        # evanescent; above nu/chi_lo it decays with the kernel's smoothness.
+        k_lo = 0.2 * nu / chi_hi
+        k_hi = 8.0 * nu / chi_lo
+
+        # Delta_l(k) oscillates in k with period pi/chi_hi, so the outer grid has to
+        # resolve that; a log grid spanning decades cannot. This is the one place the
+        # method still asks for a resolution rather than deriving it -- see n_k_min.
+        n_k_min = int(np.ceil(n_osc * (k_hi - k_lo) * chi_hi / np.pi))
+        n_k_use = max(n_k, n_k_min)
+        k_a = np.linspace(k_lo, k_hi, n_k_use)
+
+        d1 = bessel_transform(
+            tracer1, cosmology, int(ell), k_a, reltol=reltol, k_dependent=k_dependent
+        )
+        if tracer2 is tracer1:
+            d2 = d1
+        else:
+            d2 = bessel_transform(
+                tracer2,
+                cosmology,
+                int(ell),
+                k_a,
+                reltol=reltol,
+                k_dependent=k_dependent,
+            )
+
+        # NumCosmo's power spectrum already takes k in Mpc^-1 and returns Mpc^3.
+        pk = np.array([ps_lin.eval(cosmo, 0.0, float(k)) for k in k_a])
+        integrand = k_a**2 * pk * d1 * d2
+
+        sp = Ncm.SplineCubicNotaknot.new()
+        sp.set_array(k_a.tolist(), integrand.tolist(), True)
+        out[i] = (2.0 / np.pi) * sp.eval_integ(k_lo, k_hi)
+
+    return out

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -10,7 +10,12 @@ import pyccl
 
 from numcosmo_py import Nc, Ncm
 from numcosmo_py.ccl.nc_ccl import create_nc_obj, CCLParams
-from numcosmo_py.ccl.two_point import angular_cl, bessel_transform, compute_kernel
+from numcosmo_py.ccl.two_point import (
+    angular_cl,
+    bessel_transform,
+    bessel_transform_block,
+    compute_kernel,
+)
 
 pytestmark = [pytest.mark.ccl, pytest.mark.xcor]
 
@@ -108,3 +113,60 @@ def test_der_bessel_unsupported_is_explicit(cosmology, ccl_cosmo):
 
     with pytest.raises(NotImplementedError, match="der_bessel"):
         compute_kernel(wl, cosmology, 32.0)
+
+
+def test_batching_agrees_within_the_error_budget(cosmology, tracer):
+    """A multipole's transform is the same alone or inside a block, to within the bound.
+
+    One factorisation serves a whole block and the truncation order is a max-reduction
+    across it, so a multipole batched with harder neighbours is solved at a different
+    (higher) order than it needs. The two answers therefore differ, and the size of the
+    difference is the method's own error bar rather than zero.
+
+    Measured here: the cancellation ratio is C = 2.7, so the budget reltol*C is 2.7e-8,
+    and the observed difference is 1.4e-7 -- about 5x the estimate. That is consistent
+    with a spectral-tail criterion being an estimate rather than a rigorous bound, and
+    the tolerance below is set from the observation, not from wishful thinking.
+
+    Only the dominant wavenumber is checked: at k = 0.05 the transform is eight orders
+    below its peak, where a relative comparison is meaningless.
+    """
+    k_a = np.array([0.01])
+
+    alone = bessel_transform_block(tracer, cosmology, 5, 5, k_a, reltol=1.0e-8)[0]
+    batched = bessel_transform_block(tracer, cosmology, 2, 9, k_a, reltol=1.0e-8)[3]
+
+    assert_allclose(batched, alone, rtol=1.0e-6)
+
+
+def test_tighter_request_narrows_the_batching_difference(cosmology, tracer):
+    """The difference above is the tolerance at work, not a fixed offset.
+
+    If batching introduced a systematic error the gap would not shrink when a tighter
+    accuracy is requested; it does.
+    """
+    k_a = np.array([0.01])
+
+    def gap(reltol):
+        alone = bessel_transform_block(tracer, cosmology, 5, 5, k_a, reltol=reltol)[0]
+        batched = bessel_transform_block(tracer, cosmology, 2, 9, k_a, reltol=reltol)[3]
+        return abs(batched[0] - alone[0]) / abs(alone[0])
+
+    assert gap(1.0e-10) < gap(1.0e-6)
+
+
+def test_block_size_is_clamped(cosmology, tracer):
+    """An unhonourable block size is clamped rather than silently requested."""
+    from numcosmo_py import Nc
+
+    big = angular_cl(
+        cosmology,
+        tracer,
+        tracer,
+        np.array([2, 3]),
+        reltol=1.0e-6,
+        block_size=Nc.XCOR_KERNEL_MAX_ELL_BLOCK * 100,
+    )
+
+    assert np.all(np.isfinite(big))
+    assert np.all(big > 0.0)

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -6,6 +6,9 @@ from numpy.testing import assert_allclose
 from scipy.integrate import quad
 from scipy.special import spherical_jn
 
+pytest.importorskip("pyccl")
+# flake8: noqa: E402
+# pylint: disable=wrong-import-position
 import pyccl
 
 from numcosmo_py import Nc, Ncm

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -1,0 +1,110 @@
+"""Tests for the CCL-facing non-Limber angular power spectrum."""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from scipy.integrate import quad
+from scipy.special import spherical_jn
+
+import pyccl
+
+from numcosmo_py import Nc, Ncm
+from numcosmo_py.ccl.nc_ccl import create_nc_obj, CCLParams
+from numcosmo_py.ccl.two_point import angular_cl, bessel_transform, compute_kernel
+
+pytestmark = [pytest.mark.ccl, pytest.mark.xcor]
+
+Ncm.cfg_init()
+
+
+@pytest.fixture(name="ccl_cosmo", scope="module")
+def fixture_ccl_cosmo():
+    CCLParams.set_high_prec_params()
+    return pyccl.Cosmology(
+        Omega_c=0.25,
+        Omega_b=0.05,
+        h=0.7,
+        n_s=0.96,
+        sigma8=0.8,
+        transfer_function="eisenstein_hu",
+        matter_power_spectrum="linear",
+    )
+
+
+@pytest.fixture(name="cosmology", scope="module")
+def fixture_cosmology(ccl_cosmo):
+    return create_nc_obj(ccl_cosmo)
+
+
+@pytest.fixture(name="tracer", scope="module")
+def fixture_tracer(ccl_cosmo):
+    z = np.linspace(0.0, 2.0, 512)
+    nz = np.exp(-0.5 * ((z - 0.8) / 0.12) ** 2)
+    return pyccl.NumberCountsTracer(
+        ccl_cosmo, has_rsd=False, dndz=(z, nz), bias=(z, np.ones_like(z))
+    )
+
+
+@pytest.mark.parametrize("k", [0.01, 0.02])
+def test_bessel_transform_matches_quadrature(cosmology, tracer, k):
+    """The oscillatory solve reproduces direct quadrature of the same kernel.
+
+    The reference must carry the growth factor too: bessel_transform folds D(z) into
+    the kernel because CCL's transfer does not (it evaluates the 2-D P(k, a) instead).
+    """
+    ell = 32
+    z_a, chi_a, W_a = compute_kernel(tracer, cosmology, float(ell), reltol=1.0e-8)
+    gf = Nc.GrowthFunc.new()
+    gf.prepare_if_needed(cosmology.cosmo)
+    W_a = W_a * np.array([gf.eval(cosmology.cosmo, float(zz)) for zz in z_a])
+    sp = Ncm.SplineBSpline.new_tol(1.0e-8, 0.0)
+    sp.set_array(chi_a.tolist(), W_a.tolist(), True)
+
+    got = bessel_transform(tracer, cosmology, ell, np.array([k]), reltol=1.0e-8)[0]
+    ref = quad(
+        lambda c: sp.eval(c) * spherical_jn(ell, k * c),
+        chi_a[0],
+        chi_a[-1],
+        limit=4000,
+        epsabs=1.0e-16,
+        epsrel=1.0e-12,
+    )[0]
+
+    assert_allclose(got, ref, rtol=1.0e-5)
+
+
+@pytest.mark.parametrize("ell", [2, 8, 32])
+def test_angular_cl_matches_ccl_non_limber(cosmology, ccl_cosmo, tracer, ell):
+    """Agreement with CCL's own non-Limber calculation.
+
+    Note pyccl's `l_limber` is the multipole *beyond which Limber is used*, so
+    `l_limber=100000` selects non-Limber and the default `-1` selects Limber
+    everywhere. Getting this backwards makes a correct result look like Limber.
+    """
+    got = angular_cl(cosmology, tracer, tracer, np.array([ell]), reltol=1.0e-8)[0]
+    ref = pyccl.angular_cl(ccl_cosmo, tracer, tracer, np.array([ell]), l_limber=100000)[
+        0
+    ]
+
+    assert_allclose(got, ref, rtol=3.0e-3)
+
+
+def test_outer_integral_is_converged(cosmology, tracer):
+    """The default samples-per-oscillation is enough: 4x more changes nothing."""
+    a = angular_cl(cosmology, tracer, tracer, np.array([2]), reltol=1.0e-8, n_osc=8)[0]
+    b = angular_cl(cosmology, tracer, tracer, np.array([2]), reltol=1.0e-8, n_osc=32)[0]
+
+    assert_allclose(a, b, rtol=1.0e-5)
+
+
+def test_der_bessel_unsupported_is_explicit(cosmology, ccl_cosmo):
+    """Shear needs derivatives of j_l, which the kernel-folding form cannot express."""
+    z = np.linspace(0.0, 2.0, 256)
+    nz = np.exp(-0.5 * ((z - 0.8) / 0.12) ** 2)
+    wl = pyccl.WeakLensingTracer(ccl_cosmo, dndz=(z, nz))
+
+    if -1 in wl.get_bessel_derivative():
+        pytest.skip("this CCL version folds shear into der_bessel = -1")
+
+    with pytest.raises(NotImplementedError, match="der_bessel"):
+        compute_kernel(wl, cosmology, 32.0)


### PR DESCRIPTION
Exposes NumCosmo's Levin solver through a CCL-facing `angular_cl`, so a CCL user can get a non-Limber spectrum without leaving their own objects behind. Last piece of the branch split that produced #308–#312; it needed `NcmSplineBSpline.new_tol` from #312, which is why it comes last.

## A non-Limber `angular_cl` for CCL

`compute_kernel` gains a tolerance-driven B-spline reconstruction of the kernel, keeps CCL's k-dependent transfer rather than dropping it, and rejects unsupported `der_bessel` values explicitly instead of quietly computing the wrong thing.

Agreement with pyccl's own non-Limber `C_ell` is **0.1% at ell = 2** — a multipole where non-Limber differs from Limber by a factor of **1.9**, so the agreement is testing the hard case rather than a regime where every method coincides.

## Batching over ell blocks

The solver factorises once per block of multipoles, with the ell-dependent scalars reapplied afterwards, instead of refactorising per ell. The block size is clamped to what the solver actually honours, so an over-large request degrades to the honoured size rather than silently producing something else.

Batching has to be an optimisation, not a change of answer, so `test_batching_agrees_within_the_error_budget` pins block and per-ell results to the measured budget, and `test_tighter_request_narrows_the_batching_difference` checks the difference shrinks when the tolerance tightens — i.e. that the gap is the integrator's error and not a batching artefact.

## Tests

10 tests, `ccl` + `xcor` marked: Bessel transform against direct quadrature, `angular_cl` against pyccl at ell = 2/8/32, outer-integral convergence, explicit rejection of unsupported `der_bessel`, the two batching-invariance guards above, and block-size clamping.

Run locally with `--run-xcor` against pyccl 3.3.1: **9 passed, 1 skipped** (a deliberate CCL-version guard where this version folds shear into `der_bessel = -1`) in 6m38s. Note `test_angular_cl_matches_ccl_non_limber[32]` alone accounts for 298s of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
