### PR TITLE
Do not mark delegation-only prepare() methods as current

### DIFF
--- a/numcosmo/nc/lss/halo/nc_halo_position.c
+++ b/numcosmo/nc/lss/halo/nc_halo_position.c
@@ -269,7 +269,6 @@ nc_halo_position_prepare (NcHaloPosition *hp, NcHICosmo *cosmo)
   NcHaloPositionPrivate *self = nc_halo_position_get_instance_private (hp);
 
   nc_distance_prepare_if_needed (self->dist, cosmo);
-  ncm_model_ctrl_update (self->ctrl_cosmo, NCM_MODEL (cosmo));
 }
 
 /**

--- a/numcosmo/nc/lss/wl/nc_wl_surface_mass_density.c
+++ b/numcosmo/nc/lss/wl/nc_wl_surface_mass_density.c
@@ -281,7 +281,6 @@ void
 nc_wl_surface_mass_density_prepare (NcWLSurfaceMassDensity *smd, NcHICosmo *cosmo)
 {
   nc_distance_prepare_if_needed (smd->dist, cosmo);
-  ncm_model_ctrl_update (smd->ctrl_cosmo, NCM_MODEL (cosmo));
 }
 
 /**

--- a/tests/c/nc/lss/halo/test_nc_halo_position.c
+++ b/tests/c/nc/lss/halo/test_nc_halo_position.c
@@ -49,6 +49,7 @@ static void test_nc_halo_position_model_id (TestNcHaloPosition *test, gconstpoin
 
 static void test_nc_halo_position_polar_angles (TestNcHaloPosition *test, gconstpointer pdata);
 static void test_nc_halo_position_projected_radius (TestNcHaloPosition *test, gconstpointer pdata);
+static void test_nc_halo_position_shared_distance (TestNcHaloPosition *test, gconstpointer pdata);
 
 gint
 main (gint argc, gchar *argv[])
@@ -75,6 +76,11 @@ main (gint argc, gchar *argv[])
   g_test_add ("/nc/halo_position/projected_radius", TestNcHaloPosition, NULL,
               &test_nc_halo_position_new,
               &test_nc_halo_position_projected_radius,
+              &test_nc_halo_position_free);
+
+  g_test_add ("/nc/halo_position/shared_distance", TestNcHaloPosition, NULL,
+              &test_nc_halo_position_new,
+              &test_nc_halo_position_shared_distance,
               &test_nc_halo_position_free);
 
   g_test_run ();
@@ -190,5 +196,41 @@ test_nc_halo_position_projected_radius (TestNcHaloPosition *test, gconstpointer 
   g_assert_cmpfloat (r, >=, 0.0);
 
   nc_hicosmo_clear (&cosmo);
+}
+
+static void
+test_nc_halo_position_shared_distance (TestNcHaloPosition *test, gconstpointer pdata)
+{
+  /* nc_halo_position_prepare() has no local state: it only delegates to
+   * nc_distance_prepare_if_needed(), which carries its own control. So it must
+   * not mark itself current -- doing so lets prepare_if_needed() skip the
+   * delegation, and a NcDistance shared with a second cosmology then stays
+   * driven by that other cosmology. Regression for PR #318. */
+  NcDistance *dist   = nc_distance_new (1100.0);
+  NcHaloPosition *hp = nc_halo_position_new (dist);
+  NcHICosmo *cosmo_a = NC_HICOSMO (nc_hicosmo_de_xcdm_new ());
+  NcHICosmo *cosmo_b = NC_HICOSMO (nc_hicosmo_de_xcdm_new ());
+  const gdouble z    = 1.0;
+  gdouble d_a, d_after;
+
+  ncm_model_param_set_by_name (NCM_MODEL (cosmo_a), "Omegac", 0.25, NULL);
+  ncm_model_param_set_by_name (NCM_MODEL (cosmo_b), "Omegac", 0.40, NULL);
+
+  nc_halo_position_prepare (hp, cosmo_a);
+  d_a = nc_distance_comoving (dist, cosmo_a, z);
+
+  /* Another consumer drives the shared distance to the second cosmology. */
+  nc_distance_prepare_if_needed (dist, cosmo_b);
+
+  /* This call must restore it. */
+  nc_halo_position_prepare_if_needed (hp, cosmo_a);
+  d_after = nc_distance_comoving (dist, cosmo_a, z);
+
+  ncm_assert_cmpdouble_e (d_after, ==, d_a, 1.0e-14, 0.0);
+
+  nc_halo_position_free (hp);
+  nc_distance_free (dist);
+  nc_hicosmo_free (cosmo_a);
+  nc_hicosmo_free (cosmo_b);
 }
 


### PR DESCRIPTION
Follow-up to #318. Two of the six `prepare()` methods it touched have no local
state to record, and marking them current introduced a staleness regression.

## The problem

`nc_halo_position_prepare()` and `nc_wl_surface_mass_density_prepare()` only
delegate to `nc_distance_prepare_if_needed()`, which carries its own control.
The ctrl update #318 added therefore cannot save any work, and it lets
`prepare_if_needed()` skip a delegation the dependency did need:

```
prepare(hp, A)                      -> dist@A, hp.ctrl = A
another consumer drives dist with B -> dist@B
prepare_if_needed(hp, A)            -> hp.ctrl unchanged, delegation SKIPPED
```

The shared `NcDistance` stays driven by the second cosmology. Measured:
`nc_distance_comoving(dist, A, 1.0)` returns 0.74162 instead of 0.77292, a **4%
error**, and `nc_halo_position_projected_radius_from_ra_dec()` moves with it.

Before #318 this could not happen: `prepare()` left the control stale, so the
next `prepare_if_needed()` always fired once and restored the dependency.

## The rule

The ctrl update from #318 is correct for a `prepare()` that has local state to
record — `ncm_powspec`, `ncm_powspec_filter`, `ncm_powspec_sphere_proj` and
`nc_cbe_thermodyn` all keep it, including the 70-80 ms double-preparation fix
that motivated #318. It is wrong for a `prepare()` that only delegates.

## Testing

Adds `/nc/halo_position/shared_distance`, which no existing test covered — the
`serialize` test calls `prepare_if_needed()` on a fresh duplicate, where the
control fires regardless. The test was validated by reinstating the bug: it
aborts with `diff_rel 0.040`.

With the fix: `nc_halo_position` 5 subtests, `nc_wl_surface_mass_density` 16
subtests, `tests/python/nc/lss` 1363 passed.

## Known limitation, not addressed here

A model control answers "did *my* model change", which is only a proxy for "am I
current" while the object's state is a pure function of that model. A shared
dependency prepared externally breaks the proxy. The robust fix is to register
dependencies and query them — a preparation serial per object, compared at
`prepare_if_needed()` — rather than more ctrl updates. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)