### PR TITLE
Build test_ncm_fit.c once per optimizer group instead of as one binary

### DIFF
--- a/tests/c/meson.build
+++ b/tests/c/meson.build
@@ -139,9 +139,44 @@ math_tests = [
         'name': 'ncm_serialize',
         'sources': ['ncm/core/test_ncm_serialize.c'],
     },
+    # test_ncm_fit.c builds once per optimizer group rather than as one binary.
+    # `meson test --num-processes` cannot split a single executable, so as one
+    # target these took 177 s and set the whole C suite's wall clock on their
+    # own. The groups are independent and the source gates on TEST_FIT_* -- see
+    # the top of main() there. Undefined means all, so a hand build still runs
+    # everything.
     {
-        'name': 'ncm_fit',
+        'name': 'ncm_fit_nlopt',
         'sources': ['ncm/fit/test_ncm_fit.c'],
+        'c_args': ['-DTEST_FIT_GROUP', '-DTEST_FIT_NLOPT'],
+        'priority': 6,
+        'timeout': 0,
+    },
+    {
+        'name': 'ncm_fit_gsl_ls',
+        'sources': ['ncm/fit/test_ncm_fit.c'],
+        'c_args': ['-DTEST_FIT_GROUP', '-DTEST_FIT_GSL_LS'],
+        'priority': 6,
+        'timeout': 0,
+    },
+    {
+        'name': 'ncm_fit_gsl_mm',
+        'sources': ['ncm/fit/test_ncm_fit.c'],
+        'c_args': ['-DTEST_FIT_GROUP', '-DTEST_FIT_GSL_MM'],
+        'priority': 6,
+        'timeout': 0,
+    },
+    {
+        'name': 'ncm_fit_gsl_simplex',
+        'sources': ['ncm/fit/test_ncm_fit.c'],
+        'c_args': ['-DTEST_FIT_GROUP', '-DTEST_FIT_GSL_SIMPLEX'],
+        'priority': 6,
+        'timeout': 0,
+    },
+    {
+        'name': 'ncm_fit_levmar',
+        'sources': ['ncm/fit/test_ncm_fit.c'],
+        'c_args': ['-DTEST_FIT_GROUP', '-DTEST_FIT_LEVMAR'],
         'priority': 6,
         'timeout': 0,
     },

--- a/tests/c/ncm/fit/test_ncm_fit.c
+++ b/tests/c/ncm/fit/test_ncm_fit.c
@@ -365,45 +365,71 @@ main (gint argc, gchar *argv[])
 
   /* g_test_set_nonfatal_assertions (); */
 
+  /* One source, several binaries. Every algorithm pair below is independent, so
+   * the registrations are gated on a group symbol and meson builds one
+   * executable per group -- see tests/c/meson.build. Undefined means "all", so
+   * building this file by hand still runs everything.
+   *
+   * The point is wall clock: as a single binary these took 177 s, which is 37%
+   * of all C test work and more than `meson test --num-processes` can divide,
+   * because it cannot split one executable. */
+#if !defined (TEST_FIT_GROUP)
+#define TEST_FIT_NLOPT
+#define TEST_FIT_GSL_LS
+#define TEST_FIT_GSL_MM
+#define TEST_FIT_GSL_SIMPLEX
+#define TEST_FIT_LEVMAR
+#endif
+
+#ifdef TEST_FIT_NLOPT
   TESTS_NCM_ADD (nlopt, neldermead)
   TESTS_NCM_ADD (nlopt, slsqp)
 
+  TESTS_NCM_ADD_INVALID (nlopt, neldermead)
+  TESTS_NCM_ADD_INVALID (nlopt, slsqp)
+#endif /* TEST_FIT_NLOPT */
+
+#ifdef TEST_FIT_GSL_LS
   TESTS_NCM_ADD (gsl, ls)
 
+  TESTS_NCM_ADD_INVALID (gsl, ls)
+#endif /* TEST_FIT_GSL_LS */
+
+#ifdef TEST_FIT_GSL_MM
   TESTS_NCM_ADD (gsl, mm_conjugate_fr)
   TESTS_NCM_ADD (gsl, mm_conjugate_pr)
   TESTS_NCM_ADD (gsl, mm_vector_bfgs)
   TESTS_NCM_ADD (gsl, mm_vector_bfgs2)
   TESTS_NCM_ADD (gsl, mm_steepest_descent)
 
-  TESTS_NCM_ADD (gsl, nmsimplex)
-  TESTS_NCM_ADD (gsl, nmsimplex2)
-  TESTS_NCM_ADD (gsl, nmsimplex2rand)
-
-  TESTS_NCM_ADD (levmar, der)
-  TESTS_NCM_ADD (levmar, dif)
-  TESTS_NCM_ADD (levmar, bc_der)
-  TESTS_NCM_ADD (levmar, bc_dif)
-
-  TESTS_NCM_ADD_INVALID (nlopt, neldermead)
-  TESTS_NCM_ADD_INVALID (nlopt, slsqp)
-
-  TESTS_NCM_ADD_INVALID (gsl, ls)
-
   TESTS_NCM_ADD_INVALID (gsl, mm_conjugate_fr)
   TESTS_NCM_ADD_INVALID (gsl, mm_conjugate_pr)
   TESTS_NCM_ADD_INVALID (gsl, mm_vector_bfgs)
   TESTS_NCM_ADD_INVALID (gsl, mm_vector_bfgs2)
   TESTS_NCM_ADD_INVALID (gsl, mm_steepest_descent)
+#endif /* TEST_FIT_GSL_MM */
+
+#ifdef TEST_FIT_GSL_SIMPLEX
+  TESTS_NCM_ADD (gsl, nmsimplex)
+  TESTS_NCM_ADD (gsl, nmsimplex2)
+  TESTS_NCM_ADD (gsl, nmsimplex2rand)
 
   TESTS_NCM_ADD_INVALID (gsl, nmsimplex)
   TESTS_NCM_ADD_INVALID (gsl, nmsimplex2)
   TESTS_NCM_ADD_INVALID (gsl, nmsimplex2rand)
+#endif /* TEST_FIT_GSL_SIMPLEX */
+
+#ifdef TEST_FIT_LEVMAR
+  TESTS_NCM_ADD (levmar, der)
+  TESTS_NCM_ADD (levmar, dif)
+  TESTS_NCM_ADD (levmar, bc_der)
+  TESTS_NCM_ADD (levmar, bc_dif)
 
   TESTS_NCM_ADD_INVALID (levmar, der)
   TESTS_NCM_ADD_INVALID (levmar, dif)
   TESTS_NCM_ADD_INVALID (levmar, bc_der)
   TESTS_NCM_ADD_INVALID (levmar, bc_dif)
+#endif /* TEST_FIT_LEVMAR */
 
   g_test_run ();
 }


### PR DESCRIPTION
## Why

`meson test --num-processes` parallelizes across *executables*, so it could do nothing with `ncm_fit`: **177 s in a single target**, 37% of all C test work, and the whole C suite's wall clock on its own.

## What

The fourteen `(library, algorithm)` pairs registered in `main()` are independent, so they're gated on a `TEST_FIT_*` symbol and meson builds one executable per group — `nlopt`, `gsl_ls`, `gsl_mm`, `gsl_simplex`, `levmar`. One source, five targets. With no symbol defined every group registers, so building the file by hand still runs everything.

## Result

| | before | after |
|---|---|---|
| longest C binary | **177 s** | **57 s** |
| binaries | 75 | 79 |
| serial work | 475 s | 478 s |
| failures | 0 | 0 |

Serial work is unchanged — this redistributes, it doesn't remove.

## Coverage is exactly preserved

Counted per group rather than assumed:

```
nlopt        70
gsl_ls       35
gsl_mm      175
gsl_simplex 105
levmar      140
            ---
            525   ← the original binary reported 1..525
```

## One thing that didn't work, recorded so it isn't retried

Splitting via GLib's `-p` path filter looks like the obvious no-source-change route. It doesn't work here: `-p /ncm/fit` and `-p /ncm/fit/gsl` select **zero** tests, and `-p /ncm/fit/gsl/ls` selects **9 of the 36** registered at that path. It would have silently dropped coverage while appearing to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)