### PR TITLE
Two profiling fixes: the growth special function at z=0, and angular_cl's k-grid

### DIFF
--- a/numcosmo/ncm/powspec/tests/ncm_powspec_analytic.c
+++ b/numcosmo/ncm/powspec/tests/ncm_powspec_analytic.c
@@ -632,6 +632,15 @@ _ncm_powspec_analytic_growth (NcmPowspecAnalytic *psa, const gdouble z)
 {
   const gdouble a = 1.0 / (1.0 + z);
 
+  /* D is normalized to D(0) = 1, so z = 0 is exactly one and needs no special
+   * function. Worth the branch: every Tier A evaluation is at z = 0 by
+   * construction (the analytic xcor kernels fold all evolution into the window
+   * and call ncm_powspec_eval() with z = 0.0), and the LCDM branch below costs
+   * a gsl_sf_hyperg_2F1 per call -- measured at 29% of an xcor solve driven by
+   * this object, all of it spent returning 1.0. */
+  if (z == 0.0)
+    return 1.0;
+
   switch (psa->growth)
   {
     case NCM_POWSPEC_ANALYTIC_GROWTH_NONE:

--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -250,6 +250,7 @@ def angular_cl(
     n_k: int = 512,
     n_osc: int = 8,
     block_size: int = 8,
+    support_tol: float = 1.0e-6,
 ) -> np.ndarray:
     r"""Non-Limber angular power spectrum of two CCL tracers, solved by NumCosmo.
 
@@ -268,6 +269,14 @@ def angular_cl(
     :param reltol: requested relative accuracy of the oscillatory solve.
     :param n_k: floor on the number of wavenumbers in the outer integral.
     :param n_osc: samples per oscillation of Delta_l(k) in the outer integral.
+    :param support_tol: fraction of the kernel's peak below which its tail is
+        treated as outside the support. This is the dominant cost control, not a
+        safety margin: the grid's upper end is ``k_hi = 8 nu / chi_lo``, so
+        shrinking ``chi_lo`` raises ``k_hi`` and the point count with it. On the
+        Gaussian test tracer at ell = 32, 1e-10 (the old value) admits tail down
+        to chi = 16.7 Mpc and needs 180,720 wavenumbers for 293 s; 1e-6 needs
+        3,945 for 2.4 s, and the two C_ell agree to 2.6e-9. Tighten it only with
+        a measurement in hand.
     :param block_size: number of consecutive multipoles sharing a factorisation.
         Clamped to what the solver will honour: NC_XCOR_KERNEL_MAX_ELL_BLOCK and the
         integrator's ell_cache_max. Wider is not better -- the truncation order is a
@@ -287,7 +296,8 @@ def angular_cl(
 
     chi_a, comps, _ = tracer_components(tracer1, cosmology, reltol=reltol)
     w_abs = np.abs(sum(comps))
-    keep = np.nonzero(w_abs > 1.0e-10 * w_abs.max())[0]
+    # See support_tol: chi_lo sets k_hi, so this threshold sets the grid size.
+    keep = np.nonzero(w_abs > support_tol * w_abs.max())[0]
     chi_lo, chi_hi = float(chi_a[keep[0]]), float(chi_a[keep[-1]])
 
     for start_i in range(0, len(ells), block_size):


### PR DESCRIPTION
Two unrelated-looking fixes that came out of the same profiling session. Both are pure performance — no behaviour change, verified against certified references.

## 1. `NcmPowspecAnalytic`: skip the special function at z = 0

`growth = LCDM` evaluates a `gsl_sf_hyperg_2F1` on **every** call. Every Tier A evaluation is at z = 0 — the analytic xcor kernels fold all evolution into the window and call `ncm_powspec_eval()` with a literal `0.0` — and D is normalized to D(0) = 1, so all of that work returned exactly 1.0.

Profiling an xcor solve driven by this object put **29% of the run** in that one call.

| | |
|---|---|
| 20 solves | 27.95 s → **18.58 s** (1.50×) |
| GSL in profile | 29% → **0.01%** |
| vs certified Arb | 2.71e-15, unchanged |

Exact by the normalization, so the short-circuit isn't an approximation.

## 2. `angular_cl`: make the kernel support threshold a parameter, and widen it

The k-grid's top end is `k_hi = 8·ν/chi_lo`, and `chi_lo` came from a hardcoded **1e-10** relative mask on the tracer kernel. On a kernel spanning 3×10²¹ in magnitude that admits tail down to χ = 16.7 Mpc, dragging `k_hi` to 15.5 Mpc⁻¹ and the grid to **180,720 wavenumbers**.

At ℓ = 32 on the Gaussian test tracer:

| mask | n_k | time | vs CCL | vs mask=1e-10 |
|---|---|---|---|---|
| 1e-10 | 180,720 | 293 s | 7.89e-05 | — |
| **1e-06** | **3,945** | **2.4 s** | 7.89e-05 | 2.6e-09 |
| 1e-04 | 2,277 | 1.4 s | 7.89e-05 | 8.8e-10 |

Identical to nine digits, and the CCL agreement doesn't move — against a test asserting `3e-3`.

Now a documented `support_tol` argument defaulting to 1e-6. A parameter rather than a looser constant because this is the *dominant cost control*, not a safety margin, and a bare constant that reads like a margin will drift back toward "safer".

**The py-xcor lane goes from 403.6 s to 31.3 s**, 1025 tests passing unchanged.

## What was ruled out first

Loosening `reltol` — the obvious suspect, since the test requests `1e-8` but asserts `3e-3`. Measured: 1e-8 → 1e-3 buys only 38% (293 s → 179 s) and the agreement barely moves. The cost was the grid size and nothing else.

Also worth recording: the 294 s was **not** pyccl. CCL computes every multipole at once and caches, so after the first call the reference side is free — at ℓ=32 it was NumCosmo 290.6 s against pyccl ~0 s.

## Tests

`1025 passed, 17 skipped` on the xcor lane; 38 unit tests on `NcmPowspecAnalytic`; both Arb comparisons re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)