### PR TITLE
Cut the Planck test runtime and gate the data tests properly

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -110,6 +110,7 @@ they are heavy or special. Gated by a `--run-*` flag (the skip logic lives in
 |--------|-------|-------------|
 | `mpi` | MPI runtime (`mpiexec`) | `--run-mpi` |
 | `app` | CLI dependencies / heavy app flows | `--run-app` |
+| `planck_data` | a local `plc_3.0` Planck tree under `~/.numcosmo` | `--run-planck-data` |
 | `powspec` | power-spectrum extras | `--run-powspec` |
 | `xcor` | cross-correlation extras | `--run-xcor` |
 | `sphere_map` | sphere-map extras | `--run-sphere-map` |

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -101,6 +101,12 @@ def pytest_addoption(parser):
         default=False,
         help="Run tests marked with app",
     )
+    parser.addoption(
+        "--run-planck-data",
+        action="store_true",
+        default=False,
+        help="Run tests marked with planck_data",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -110,12 +116,14 @@ def pytest_collection_modifyitems(config, items):
     run_xcor = config.getoption("--run-xcor")
     run_sphere_map = config.getoption("--run-sphere-map")
     run_app = config.getoption("--run-app")
+    run_planck_data = config.getoption("--run-planck-data")
 
     skip_mpi = pytest.mark.skip(reason="Need --run-mpi option to run")
     skip_powspec = pytest.mark.skip(reason="Need --run-powspec option to run")
     skip_xcor = pytest.mark.skip(reason="Need --run-xcor option to run")
     skip_sphere_map = pytest.mark.skip(reason="Need --run-sphere-map option to run")
     skip_app = pytest.mark.skip(reason="Need --run-app option to run")
+    skip_planck_data = pytest.mark.skip(reason="Need --run-planck-data option to run")
 
     for item in items:
         if "mpi" in item.keywords and not run_mpi:
@@ -128,6 +136,8 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_sphere_map)
         if "app" in item.keywords and not run_app:
             item.add_marker(skip_app)
+        if "planck_data" in item.keywords and not run_planck_data:
+            item.add_marker(skip_planck_data)
 
 
 @pytest.fixture(name="prim")

--- a/tests/python/nc/data/test_planck_commander.py
+++ b/tests/python/nc/data/test_planck_commander.py
@@ -65,7 +65,7 @@ def test_construct_and_serialize_roundtrip():
     assert cmd2.get_length() == 28
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data
 def test_matches_clik_reference():
     """Native commander m2lnL agrees with the clik low-ell TT reference.
@@ -101,7 +101,7 @@ def test_matches_clik_reference():
     assert np.isfinite(native.m2lnL_val(mset))
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data
 def test_clik_pi_compat_matches_clik():
     """clik_pi_compat lands the native m2lnL on clik, to the last few ULP.

--- a/tests/python/nc/data/test_planck_commander.py
+++ b/tests/python/nc/data/test_planck_commander.py
@@ -29,6 +29,7 @@ import pytest
 
 from python.fixtures_planck import (
     COMMANDER_NL,
+    FixedClBoltzmann,
     commander_tables,
     make_commander_cldf,
     planck_mset,
@@ -165,18 +166,18 @@ def test_synthetic_matches_closed_form(tmp_path):
     covariance inversion and the A_planck rescaling.
     """
     clik = make_commander_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     calib = 1.003
     mset, _ = planck_mset(A_planck=calib)
 
-    cmd = build_commander(clik, cbe)
+    cmd = build_commander(clik, pb)
     assert cmd.get_length() == COMMANDER_NL
 
     cmd.prepare(mset)
 
     xa, ya, _, mu, cov, mu_sigma = commander_tables()
     ell = np.arange(2, 2 + COMMANDER_NL)
-    cl = theory_cls(cbe, "TT", 1 + COMMANDER_NL)[2:]
+    cl = theory_cls(pb, "TT", 1 + COMMANDER_NL)[2:]
     dl = cl / calib**2 * ell * (ell + 1.0) / (2.0 * np.pi)
 
     expected = -2.0 * (
@@ -188,11 +189,11 @@ def test_synthetic_matches_closed_form(tmp_path):
 def test_synthetic_clik_pi_compat_shifts_result(tmp_path):
     """clik_pi_compat changes the Dl conversion, and so the answer, slightly."""
     clik = make_commander_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    exact = build_commander(clik, cbe)
-    compat = build_commander(clik, cbe, clik_pi_compat=True)
+    exact = build_commander(clik, pb)
+    compat = build_commander(clik, pb, clik_pi_compat=True)
     assert compat.get_property("clik-pi-compat")
     assert not exact.get_property("clik-pi-compat")
 
@@ -208,11 +209,11 @@ def test_synthetic_clik_pi_compat_shifts_result(tmp_path):
 def test_synthetic_out_of_prior_range(tmp_path):
     """A theory Dl outside the tabulated range is rejected, not extrapolated."""
     clik = make_commander_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     # A tiny calibration blows Dl = Cl/A^2 * l(l+1)/2pi past the table's top end.
     mset, _ = planck_mset(A_planck=0.01)
 
-    cmd = build_commander(clik, cbe)
+    cmd = build_commander(clik, pb)
     cmd.prepare(mset)
 
     assert cmd.m2lnL_val(mset) == 1.0e30
@@ -221,10 +222,10 @@ def test_synthetic_out_of_prior_range(tmp_path):
 def test_synthetic_serialize_roundtrip(tmp_path):
     """A synthetic commander survives a serialization round trip unchanged."""
     clik = make_commander_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    cmd = build_commander(clik, cbe)
+    cmd = build_commander(clik, pb)
     cmd.prepare(mset)
     m2lnl = cmd.m2lnL_val(mset)
 
@@ -232,7 +233,7 @@ def test_synthetic_serialize_roundtrip(tmp_path):
     cmd2 = ser.from_variant(ser.to_variant(cmd))
     assert isinstance(cmd2, Nc.DataPlanckCommander)
 
-    cmd2.set_hipert_boltzmann(cbe)
+    cmd2.set_hipert_boltzmann(pb)
     cmd2.prepare(mset)
     assert cmd2.m2lnL_val(mset) == m2lnl
 

--- a/tests/python/nc/data/test_planck_golden.py
+++ b/tests/python/nc/data/test_planck_golden.py
@@ -125,7 +125,7 @@ def _compute_all():
     return values
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 def test_planck_m2lnl_golden():
     """Native Planck m2lnL values match the stored fixed-cosmology reference."""
     for name, relpath, _ in _CASES:

--- a/tests/python/nc/data/test_planck_lensing.py
+++ b/tests/python/nc/data/test_planck_lensing.py
@@ -30,6 +30,7 @@ import pytest
 from python.fixtures_planck import (
     LENSING_LMAX,
     LENSING_NBINS,
+    FixedClBoltzmann,
     lensing_tables,
     make_lensing_cldf,
     model_vector,
@@ -160,7 +161,7 @@ def test_prepare_self_configures_boltzmann():
 # -----------------------------------------------------------------------------
 
 
-def _expected_bandpowers(cbe, marged, calib, has_calib=True):
+def _expected_bandpowers(pb, marged, calib, has_calib=True):
     """Closed-form band-power model of the synthetic lensing file."""
     hascl, bins, cor0, cors, _, _ = lensing_tables(marged)
     nl = LENSING_LMAX + 1
@@ -168,7 +169,7 @@ def _expected_bandpowers(cbe, marged, calib, has_calib=True):
     w_pp = ell**2 * (ell + 1.0) ** 2 / (2.0 * np.pi)
     w_cmb = ell * (ell + 1.0) / (2.0 * np.pi)
 
-    phi = theory_cls(cbe, "PHIPHI", LENSING_LMAX)
+    phi = theory_cls(pb, "PHIPHI", LENSING_LMAX)
     expected = bins @ (phi * w_pp) - cor0 + cors[:, :nl] @ (phi * w_pp)
 
     # hascl flags [TT, EE, BB, TE, TB, EB]; blocks follow in that order, each
@@ -177,7 +178,7 @@ def _expected_bandpowers(cbe, marged, calib, has_calib=True):
     names = [n for n, f in zip(("TT", "EE", "BB", "TE", "TB", "EB"), hascl) if f]
     for k, name in enumerate(names):
         block = cors[:, (k + 1) * nl : (k + 2) * nl]
-        expected += block @ (theory_cls(cbe, name, LENSING_LMAX) * w_cmb) * scale
+        expected += block @ (theory_cls(pb, name, LENSING_LMAX) * w_cmb) * scale
 
     return expected
 
@@ -191,44 +192,68 @@ def test_synthetic_matches_closed_form(tmp_path, marged):
     carries the phi block alone.
     """
     clik = make_lensing_cldf(tmp_path, marged=marged)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     calib = 1.0  # exercised separately below
     mset, _ = planck_mset(A_planck=calib)
 
-    lens = build_lensing(clik, cbe)
+    lens = build_lensing(clik, pb)
     assert lens.get_length() == LENSING_NBINS
 
     lens.prepare(mset)
     model = model_vector(lens, mset)
 
-    assert model == pytest.approx(_expected_bandpowers(cbe, marged, calib), rel=1.0e-12)
+    assert model == pytest.approx(_expected_bandpowers(pb, marged, calib), rel=1.0e-12)
+
+
+def test_synthetic_prepare_self_configures_boltzmann(tmp_path):
+    """Lensing raises the Boltzmann targets and lmax itself, on synthetic data.
+
+    The data-backed twin of this (test_prepare_self_configures_boltzmann) needs a
+    local plc_3.0 tree, so it only runs on a dev machine. The self-configuration
+    is base-class #NcHIPertBoltzmann state, so a fixed-spectra Boltzmann drives
+    the same code path here -- and, since nothing is solved, for free.
+    """
+    clik = make_lensing_cldf(tmp_path)
+    pb = FixedClBoltzmann()
+    pb.set_target_Cls(Nc.DataCMBDataType.TT)  # bare: TT only, no phi-phi
+    for name in ("TT", "EE", "TE", "PHIPHI"):
+        getattr(pb, f"set_{name}_lmax")(30)
+    mset, _ = planck_mset()
+
+    lens = build_lensing(clik, pb)
+    lens.prepare(mset)
+
+    target = pb.get_target_Cls()
+    assert target & Nc.DataCMBDataType.PHIPHI
+    for name in ("TT", "EE", "TE", "PHIPHI"):
+        assert getattr(pb, f"get_{name}_lmax")() >= LENSING_LMAX
 
 
 def test_synthetic_calibration_scales_cmb_block(tmp_path):
     """A_planck rescales the CMB renormalization block, not the phi projection."""
     clik = make_lensing_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
 
     mset_one, _ = planck_mset(A_planck=1.0)
     mset_cal, _ = planck_mset(A_planck=1.05)
 
-    lens = build_lensing(clik, cbe)
+    lens = build_lensing(clik, pb)
     lens.prepare(mset_one)
     model_one = model_vector(lens, mset_one)
     model_cal = model_vector(lens, mset_cal)
 
     assert model_cal != pytest.approx(model_one, rel=1.0e-10)
     assert model_cal == pytest.approx(
-        _expected_bandpowers(cbe, False, 1.05), rel=1.0e-12
+        _expected_bandpowers(pb, False, 1.05), rel=1.0e-12
     )
 
 
 def test_synthetic_no_calibration(tmp_path):
     """With has_calib off the CMB block is not rescaled by A_planck."""
     clik = make_lensing_cldf(tmp_path, has_calib=False)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
 
-    lens = build_lensing(clik, cbe)
+    lens = build_lensing(clik, pb)
     assert not lens.get_property("has-calib")
 
     mset_one, _ = planck_mset(A_planck=1.0)
@@ -243,10 +268,10 @@ def test_synthetic_no_calibration(tmp_path):
 def test_synthetic_resample_and_serialize(tmp_path):
     """A synthetic lensing block resamples and survives serialization."""
     clik = make_lensing_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    lens = build_lensing(clik, cbe)
+    lens = build_lensing(clik, pb)
     lens.prepare(mset)
     assert np.isfinite(lens.m2lnL_val(mset))
 
@@ -258,7 +283,7 @@ def test_synthetic_resample_and_serialize(tmp_path):
     lens2 = ser.from_variant(ser.to_variant(lens))
     assert isinstance(lens2, Nc.DataPlanckLensing)
 
-    lens2.set_hipert_boltzmann(cbe)
+    lens2.set_hipert_boltzmann(pb)
     lens2.prepare(mset)
     assert lens2.m2lnL_val(mset) == lens.m2lnL_val(mset)
 

--- a/tests/python/nc/data/test_planck_lensing.py
+++ b/tests/python/nc/data/test_planck_lensing.py
@@ -100,7 +100,7 @@ def test_construct_and_serialize_roundtrip(flavor):
     assert lens2.get_length() == 9
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @pytest.mark.parametrize("flavor", list(_FLAVORS))
 def test_matches_clik_reference(flavor):
     """Native lensing m2lnL agrees with the clik lensing reference.
@@ -129,7 +129,7 @@ def test_matches_clik_reference(flavor):
     assert np.isfinite(native.m2lnL_val(mset))
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 def test_prepare_self_configures_boltzmann():
     """Lensing raises the Boltzmann targets/lmax itself on a bare CBE.
 

--- a/tests/python/nc/data/test_planck_plik_lite.py
+++ b/tests/python/nc/data/test_planck_plik_lite.py
@@ -29,6 +29,7 @@ import pytest
 
 from python.fixtures_planck import (
     PLIK_LITE_LMAX,
+    FixedClBoltzmann,
     make_plik_lite_cldf,
     model_vector,
     planck_mset,
@@ -153,13 +154,13 @@ def test_matches_clik_reference():
 _NBIN = {"TT": NBIN_TT, "TE": NBIN_TE, "EE": NBIN_EE}
 
 
-def _expected_bandpowers(cbe, spectra, calib):
+def _expected_bandpowers(pb, spectra, calib):
     """Closed-form bandpower model: binned raw Cl over each bin / A_planck^2."""
     _, _, blmin, blmax, bweight = plik_lite_tables()
     expected = []
     for name in spectra:
         nbin = _NBIN[name]
-        cl = theory_cls(cbe, name, PLIK_LITE_LMAX)
+        cl = theory_cls(pb, name, PLIK_LITE_LMAX)
         for b in range(nbin):
             lo, hi = int(blmin[b]), int(blmax[b])
             window = bweight[lo : hi + 1]
@@ -177,42 +178,42 @@ def test_synthetic_matches_closed_form(tmp_path, spectra):
     ``has_cl``, and the native mean_func must bin the matching theory spectrum.
     """
     clik = make_plik_lite_cldf(tmp_path, spectra=spectra)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     calib = 1.004
     mset, _ = planck_mset(A_planck=calib)
 
-    plik = build_plik_lite(clik, cbe, lmax=PLIK_LITE_LMAX)
+    plik = build_plik_lite(clik, pb, lmax=PLIK_LITE_LMAX)
     assert plik.get_size() == sum(_NBIN[name] for name in spectra)
 
     plik.prepare(mset)
 
     assert model_vector(plik, mset) == pytest.approx(
-        _expected_bandpowers(cbe, spectra, calib), rel=1.0e-13
+        _expected_bandpowers(pb, spectra, calib), rel=1.0e-13
     )
 
 
 def test_synthetic_spectra_override(tmp_path):
     """An explicit @spectra list overrides the file's has_cl selection."""
     clik = make_plik_lite_cldf(tmp_path, spectra=["TT", "TE", "EE"])
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    plik = build_plik_lite(clik, cbe, spectra=["EE"], lmax=PLIK_LITE_LMAX)
+    plik = build_plik_lite(clik, pb, spectra=["EE"], lmax=PLIK_LITE_LMAX)
     assert plik.get_size() == NBIN_EE
 
     plik.prepare(mset)
     assert model_vector(plik, mset) == pytest.approx(
-        _expected_bandpowers(cbe, ["EE"], 1.0), rel=1.0e-13
+        _expected_bandpowers(pb, ["EE"], 1.0), rel=1.0e-13
     )
 
 
 def test_synthetic_tt_helper_and_resample(tmp_path):
     """build_plik_lite_tt selects TT only, and the result resamples."""
     clik = make_plik_lite_cldf(tmp_path, spectra=["TT", "TE", "EE"])
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    plik = build_plik_lite_tt(clik, cbe, lmax=PLIK_LITE_LMAX)
+    plik = build_plik_lite_tt(clik, pb, lmax=PLIK_LITE_LMAX)
     assert plik.get_size() == NBIN_TT
 
     plik.prepare(mset)
@@ -226,10 +227,10 @@ def test_synthetic_tt_helper_and_resample(tmp_path):
 def test_synthetic_serialize_roundtrip(tmp_path):
     """A synthetic plik_lite survives a serialization round trip unchanged."""
     clik = make_plik_lite_cldf(tmp_path)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    plik = build_plik_lite(clik, cbe, lmax=PLIK_LITE_LMAX)
+    plik = build_plik_lite(clik, pb, lmax=PLIK_LITE_LMAX)
     plik.prepare(mset)
     m2lnl = plik.m2lnL_val(mset)
 

--- a/tests/python/nc/data/test_planck_plik_lite.py
+++ b/tests/python/nc/data/test_planck_plik_lite.py
@@ -92,7 +92,7 @@ def test_construct_and_serialize_roundtrip():
             assert cov2.get(i, j) == cov.get(i, j)
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data
 def test_matches_clik_reference():
     """Native m2lnL equals the clik plik_lite reference on a CLASS cosmology.

--- a/tests/python/nc/data/test_planck_release.py
+++ b/tests/python/nc/data/test_planck_release.py
@@ -63,7 +63,7 @@ _EXPECTED_TYPE = {
 }
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data
 def test_build_release_and_load(tmp_path):
     """build_release writes serialized objects that reload to the right types."""
@@ -79,7 +79,7 @@ def test_build_release_and_load(tmp_path):
         assert data.__class__.__name__ == _EXPECTED_TYPE[rid]
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data
 def test_release_block_evaluates(tmp_path):
     """A block loaded from the release self-configures its CBE and evaluates."""

--- a/tests/python/nc/data/test_planck_release.py
+++ b/tests/python/nc/data/test_planck_release.py
@@ -30,7 +30,11 @@ import shutil
 import numpy as np
 import pytest
 
-from python.fixtures_planck import make_commander_cldf, planck_mset
+from python.fixtures_planck import (
+    FixedClBoltzmann,
+    make_commander_cldf,
+    planck_mset,
+)
 from numcosmo_py import Ncm, Nc
 from numcosmo_py.experiments.planck_lite import find_baseline_file
 from numcosmo_py.experiments.planck_commander import COMMANDER_RELPATH, build_commander
@@ -139,10 +143,10 @@ def test_load_from_cache_without_download(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pnr.urllib.request, "urlretrieve", _no_network)
 
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
     data = load_planck_release(
-        PlanckReleaseId.PR3_COMMANDER, cbe, cache_dir=str(tmp_path)
+        PlanckReleaseId.PR3_COMMANDER, pb, cache_dir=str(tmp_path)
     )
 
     assert isinstance(data, Nc.DataPlanckCommander)

--- a/tests/python/nc/data/test_planck_simall.py
+++ b/tests/python/nc/data/test_planck_simall.py
@@ -34,6 +34,8 @@ from python.fixtures_planck import (
     SIMALL_LMIN,
     SIMALL_LMAX,
     SIMALL_STEP,
+    FixedClBoltzmann,
+    fixed_spectra,
     make_simall_cldf,
     planck_mset,
     theory_cls,
@@ -126,11 +128,11 @@ def test_synthetic_matches_table_lookup(tmp_path):
     lookup in the same table.
     """
     clik = make_simall_cldf(tmp_path, spectra=("EE", "BB"))
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     calib = 1.003
     mset, _ = planck_mset(A_planck=calib)
 
-    simall = build_simall(clik, cbe)
+    simall = build_simall(clik, pb)
     assert simall.get_length() == 2 * (SIMALL_LMAX - SIMALL_LMIN + 1)
 
     simall.prepare(mset)
@@ -140,11 +142,17 @@ def test_synthetic_matches_table_lookup(tmp_path):
     lnl = 0.0
     for tag in ("EE", "BB"):
         table = fits.getdata(os.path.join(clik, "clik", "lkl_0", f"prob{tag}"))
-        cl = theory_cls(cbe, tag, SIMALL_LMAX)[SIMALL_LMIN:]
+        cl = theory_cls(pb, tag, SIMALL_LMAX)[SIMALL_LMIN:]
         dl = cl / calib**2 * ell * (ell + 1.0) / (2.0 * np.pi)
         position = (dl / SIMALL_STEP).astype(int)
         assert np.all((position >= 0) & (position < table.shape[1]))
-        lnl += np.sum(table[np.arange(nell), position])
+        # Accumulate the way the C does -- one running sum per spectrum, then
+        # added together -- so "to the last bit" holds by construction instead
+        # of depending on numpy's pairwise summation order.
+        res = 0.0
+        for i in range(nell):
+            res += float(table[i, position[i]])
+        lnl += res
 
     assert simall.m2lnL_val(mset) == -2.0 * lnl
 
@@ -153,10 +161,10 @@ def test_synthetic_out_of_range_table(tmp_path):
     """A theory Dl past the end of the table returns the rejected-point value."""
     # One step of 1e-12 puts every low-l EE bandpower beyond the last column.
     clik = make_simall_cldf(tmp_path, spectra=("EE",), nsteps=4, step=1.0e-12)
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    simall = build_simall(clik, cbe)
+    simall = build_simall(clik, pb)
     simall.prepare(mset)
 
     assert simall.m2lnL_val(mset) == 1.0e30
@@ -165,26 +173,30 @@ def test_synthetic_out_of_range_table(tmp_path):
 def test_synthetic_te_spectrum(tmp_path):
     """A file with a TE table is read and evaluated through the TE code path."""
     clik = make_simall_cldf(tmp_path, spectra=("EE", "TE"))
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    # The rejection below needs a TE that is below the tabulated range; ask for
+    # it explicitly rather than relying on the stand-in spectrum's sign.
+    spectra = fixed_spectra()
+    spectra["TE"] = -np.abs(spectra["TE"]) - 1.0e-12
+    pb = FixedClBoltzmann(spectra)
     mset, _ = planck_mset()
 
-    simall = build_simall(clik, cbe)
+    simall = build_simall(clik, pb)
     assert simall.get_property("step-te") == SIMALL_STEP
     assert simall.get_property("prob-te") is not None
 
     simall.prepare(mset)
-    # Low-l TE is negative, i.e. below the tabulated range: the likelihood must
-    # reject the point rather than index the table out of bounds.
+    # A negative TE is below the tabulated range: the likelihood must reject
+    # the point rather than index the table out of bounds.
     assert simall.m2lnL_val(mset) == 1.0e30
 
 
 def test_synthetic_serialize_roundtrip(tmp_path):
     """A synthetic simall survives a serialization round trip unchanged."""
     clik = make_simall_cldf(tmp_path, spectra=("EE", "BB"))
-    cbe = Nc.HIPertBoltzmannCBE.new()
+    pb = FixedClBoltzmann()
     mset, _ = planck_mset()
 
-    simall = build_simall(clik, cbe)
+    simall = build_simall(clik, pb)
     simall.prepare(mset)
     m2lnl = simall.m2lnL_val(mset)
 
@@ -193,7 +205,7 @@ def test_synthetic_serialize_roundtrip(tmp_path):
     assert isinstance(simall2, Nc.DataPlanckSimall)
     assert simall2.get_length() == simall.get_length()
 
-    simall2.set_hipert_boltzmann(cbe)
+    simall2.set_hipert_boltzmann(pb)
     simall2.prepare(mset)
     assert simall2.m2lnL_val(mset) == m2lnl
 

--- a/tests/python/nc/data/test_planck_simall.py
+++ b/tests/python/nc/data/test_planck_simall.py
@@ -72,7 +72,7 @@ def test_construct_and_serialize_roundtrip():
     assert simall2.get_length() == 28
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @pytest.mark.parametrize(
     "relpath,enum,length",
     [

--- a/tests/python/nc/data/test_planck_smica.py
+++ b/tests/python/nc/data/test_planck_smica.py
@@ -31,6 +31,7 @@ from python.fixtures_planck import (
     SMICA_LMIN,
     SMICA_LMAX,
     SMICA_NBINS,
+    FixedClBoltzmann,
     make_smica_cldf,
     model_vector,
     planck_mset,
@@ -189,10 +190,14 @@ def test_ttteee_matches_clik_reference():
 # -----------------------------------------------------------------------------
 
 
-@pytest.fixture(name="synthetic_cbe", scope="module")
-def fixture_synthetic_cbe():
-    """One CBE shared by the synthetic tests (they all use the same cosmology)."""
-    return Nc.HIPertBoltzmannCBE.new()
+@pytest.fixture(name="synthetic_pb", scope="module")
+def fixture_synthetic_pb():
+    """One fixed-spectra Boltzmann shared by the synthetic tests.
+
+    They all read the same stored spectra, so nothing is solved and the closed
+    forms below are exact functions of the committed inputs.
+    """
+    return FixedClBoltzmann()
 
 
 @pytest.fixture(name="synthetic_tt_clik", scope="module")
@@ -236,12 +241,12 @@ _CMB_ONLY = {
 }
 
 
-def _expected_cmb_only(cbe, m):
+def _expected_cmb_only(pb, m):
     """Closed-form R_q with every foreground off: binned CMB plus point sources."""
     bin_lmin, bin_lmax, _ = smica_binning()
     _, _, quad = smica_mask_and_ordering(m)
 
-    cl = theory_cls(cbe, "TT", SMICA_LMAX)
+    cl = theory_cls(pb, "TT", SMICA_LMAX)
     band = np.array(
         [
             np.mean(cl[SMICA_LMIN + lo : SMICA_LMIN + hi + 1])
@@ -260,7 +265,7 @@ def _expected_cmb_only(cbe, m):
     return (band[:, None, None] + ps[None, :, :]).ravel()[quad]
 
 
-def test_synthetic_cmb_only_closed_form(synthetic_tt_clik, synthetic_cbe):
+def test_synthetic_cmb_only_closed_form(synthetic_tt_clik, synthetic_pb):
     """With every foreground off, R_q reduces to the binned CMB plus point sources.
 
     This pins the parts of the assembly that have a closed form -- the CMB
@@ -268,27 +273,27 @@ def test_synthetic_cmb_only_closed_form(synthetic_tt_clik, synthetic_cbe):
     calibration factors and the masked-entry extraction -- to machine precision,
     which the real (opaque) plik data cannot do.
     """
-    clik, cbe = synthetic_tt_clik, synthetic_cbe
+    clik, pb = synthetic_tt_clik, synthetic_pb
     mset, _ = planck_mset(**_CMB_ONLY)
 
-    smica = build_smica_tt(clik, cbe)
+    smica = build_smica_tt(clik, pb)
     smica.prepare(mset)
 
     assert model_vector(smica, mset) == pytest.approx(
-        _expected_cmb_only(cbe, 3), rel=1.0e-13
+        _expected_cmb_only(pb, 3), rel=1.0e-13
     )
 
 
-def test_synthetic_calibration_rescales_model(synthetic_tt_clik, synthetic_cbe):
+def test_synthetic_calibration_rescales_model(synthetic_tt_clik, synthetic_pb):
     """calib_100T/calib_217T/A_planck rescale R_q by the documented factors.
 
     R_q[i,j] *= cal_i cal_j / A_planck^2 with cal = 1/sqrt(calib_fT) (143 is the
     reference channel), applied after the whole component assembly.
     """
-    clik, cbe = synthetic_tt_clik, synthetic_cbe
+    clik, pb = synthetic_tt_clik, synthetic_pb
     mset, _ = planck_mset(**_CMB_ONLY)
 
-    smica = build_smica_tt(clik, cbe)
+    smica = build_smica_tt(clik, pb)
     smica.prepare(mset)
     plain = model_vector(smica, mset)
 
@@ -313,14 +318,14 @@ def test_synthetic_calibration_rescales_model(synthetic_tt_clik, synthetic_cbe):
     assert scaled == pytest.approx(plain * per_entry, rel=1.0e-13)
 
 
-def test_synthetic_all_foregrounds_evaluate(synthetic_tt_clik, synthetic_cbe):
+def test_synthetic_all_foregrounds_evaluate(synthetic_tt_clik, synthetic_pb):
     """With every foreground amplitude on, the full assembly stays finite.
 
     Drives the components with no closed form here (CIB, tSZ, kSZ, CIBxtSZ,
     galactic dust with its pivot normalization, subpixel and beam leakage) and
     checks they actually move the model.
     """
-    clik, cbe = synthetic_tt_clik, synthetic_cbe
+    clik, pb = synthetic_tt_clik, synthetic_pb
 
     mset_off, _ = planck_mset(**_CMB_ONLY)
     mset_on, _ = planck_mset(
@@ -342,7 +347,7 @@ def test_synthetic_all_foregrounds_evaluate(synthetic_tt_clik, synthetic_cbe):
         )
     )
 
-    smica = build_smica_tt(clik, cbe)
+    smica = build_smica_tt(clik, pb)
     smica.prepare(mset_off)
 
     model_off = model_vector(smica, mset_off)
@@ -353,17 +358,17 @@ def test_synthetic_all_foregrounds_evaluate(synthetic_tt_clik, synthetic_cbe):
     assert np.isfinite(smica.m2lnL_val(mset_on))
 
 
-def test_synthetic_ttteee(synthetic_ttteee_clik, synthetic_cbe):
+def test_synthetic_ttteee(synthetic_ttteee_clik, synthetic_pb):
     """The TTTEEE (six-channel) build evaluates, resamples and serializes.
 
     Covers the polarization-only paths: the T/E field map, the TE/EE CMB mixing,
     the galactic power-law dust components, the end-to-end EE correlated noise
     and the two-term icalTP calibration mixing.
     """
-    clik, cbe = synthetic_ttteee_clik, synthetic_cbe
+    clik, pb = synthetic_ttteee_clik, synthetic_pb
     mset, _ = planck_mset(pol=True)
 
-    smica = build_smica_ttteee(clik, cbe)
+    smica = build_smica_ttteee(clik, pb)
     assert smica.get_length() == len(smica_mask_and_ordering(6)[2])
 
     smica.prepare(mset)
@@ -382,12 +387,12 @@ def test_synthetic_ttteee(synthetic_ttteee_clik, synthetic_cbe):
     assert smica2.get_length() == smica.get_length()
 
 
-def test_synthetic_serialize_roundtrip(synthetic_tt_clik, synthetic_cbe):
+def test_synthetic_serialize_roundtrip(synthetic_tt_clik, synthetic_pb):
     """A synthetic TT SMICA survives a serialization round trip unchanged."""
-    clik, cbe = synthetic_tt_clik, synthetic_cbe
+    clik, pb = synthetic_tt_clik, synthetic_pb
     mset, _ = planck_mset()
 
-    smica = build_smica_tt(clik, cbe)
+    smica = build_smica_tt(clik, pb)
     smica.prepare(mset)
     m2lnl = smica.m2lnL_val(mset)
 

--- a/tests/python/nc/data/test_planck_smica.py
+++ b/tests/python/nc/data/test_planck_smica.py
@@ -90,7 +90,7 @@ def test_construct_and_serialize_roundtrip():
         assert mean2.get(i) == mean.get(i)
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data
 def test_matches_clik_reference():
     """Native SMICA m2lnL agrees with the clik plik TT reference on a CLASS cosmology.
@@ -145,7 +145,7 @@ def test_ttteee_construct_and_serialize_roundtrip():
         assert mean2.get(i) == mean.get(i)
 
 
-@pytest.mark.app
+@pytest.mark.planck_data
 @needs_data_ttteee
 def test_ttteee_matches_clik_reference():
     """Native TTTEEE (m=6) SMICA m2lnL agrees with the clik reference.

--- a/tests/python/nc/perturbations/test_hipert_boltzmann_cbe.py
+++ b/tests/python/nc/perturbations/test_hipert_boltzmann_cbe.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+#
+# test_hipert_boltzmann_cbe.py
+#
+# Sat August 29 2026
+# Copyright  2026  Sandro Dias Pinto Vitenti
+# <vitenti@uel.br>
+#
+# test_hipert_boltzmann_cbe.py
+# Copyright (C) 2026 Sandro Dias Pinto Vitenti <vitenti@uel.br>
+#
+# numcosmo is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# numcosmo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the CLASS-backed Boltzmann, #NcHIPertBoltzmannCBE.
+
+The CMB likelihoods are tested against stored spectra (see
+tests/python/fixtures_planck.py), which deliberately takes CLASS out of their
+loop. This module is the other half of that split: it checks that the CBE
+actually produces sane spectra, on its own and cheaply.
+
+The assertions are physical invariants rather than reference values -- positive
+auto-spectra, the Cauchy-Schwarz bound on TE, the first acoustic peak, and
+lensing moving the damping tail -- so this stays a fast sanity check that does
+not need a golden table or a tight tolerance. A multipole range well below
+Planck's is enough for all of them, which is what keeps it cheap.
+"""
+
+import numpy as np
+import pytest
+
+from numcosmo_py import Ncm, Nc
+from numcosmo_py.cosmology import create_cosmo, HIPrimModel
+
+Ncm.cfg_init()
+
+LMAX = 1000
+_SPECTRA = Nc.DataCMBDataType.TT | Nc.DataCMBDataType.EE | Nc.DataCMBDataType.TE
+
+
+def _cbe(lensed: bool, phiphi: bool = True):
+    """A CBE targeting TT/EE/TE (+PHIPHI) up to LMAX."""
+    pb = Nc.HIPertBoltzmannCBE.new()
+    target = _SPECTRA | Nc.DataCMBDataType.PHIPHI if phiphi else _SPECTRA
+    pb.set_target_Cls(target)
+    for name in ("TT", "EE", "TE"):
+        getattr(pb, f"set_{name}_lmax")(LMAX)
+    if phiphi:
+        pb.set_PHIPHI_lmax(LMAX)
+    pb.set_lensed_Cls(lensed)
+
+    return pb
+
+
+def _cls(pb, name: str) -> np.ndarray:
+    """The prepared $C_\\ell$ of @name as a numpy array."""
+    vec = Ncm.Vector.new(LMAX + 1)
+    getattr(pb, f"get_{name}_Cls")(vec)
+
+    return np.array([vec.get(i) for i in range(LMAX + 1)])
+
+
+@pytest.fixture(name="lensed_cls", scope="module")
+def fixture_lensed_cls():
+    """One lensed solve shared by the whole module (one CLASS run)."""
+    cosmo = create_cosmo(prim_model=HIPrimModel.POWER_LAW)
+    pb = _cbe(lensed=True)
+    pb.prepare(cosmo)
+
+    return {name: _cls(pb, name) for name in ("TT", "EE", "TE", "PHIPHI")}
+
+
+def test_auto_spectra_are_positive(lensed_cls):
+    """TT, EE and phi-phi are positive definite over the whole range."""
+    for name in ("TT", "EE", "PHIPHI"):
+        cl = lensed_cls[name][2:]
+        assert np.all(np.isfinite(cl)), f"{name} has non-finite entries"
+        assert np.all(cl > 0.0), f"{name} is not positive"
+
+
+def test_te_obeys_cauchy_schwarz(lensed_cls):
+    """|C_l^TE| <= sqrt(C_l^TT C_l^EE): TE is a cross-spectrum of the same fields.
+
+    A tolerance-free invariant -- it holds for any cosmology, so it catches a
+    mis-scaled or mis-indexed TE without pinning a reference value.
+    """
+    tt, ee, te = (lensed_cls[n][2:] for n in ("TT", "EE", "TE"))
+
+    assert np.all(np.abs(te) <= np.sqrt(tt * ee))
+
+
+def test_te_changes_sign(lensed_cls):
+    """TE oscillates about zero, unlike the auto-spectra."""
+    te = lensed_cls["TE"][2:]
+
+    assert np.any(te > 0.0) and np.any(te < 0.0)
+
+
+def test_first_acoustic_peak(lensed_cls):
+    """D_l^TT peaks near l ~ 220, the standard LCDM first acoustic peak."""
+    ell = np.arange(LMAX + 1, dtype=float)
+    dl = np.zeros(LMAX + 1)
+    dl[2:] = lensed_cls["TT"][2:] * ell[2:] * (ell[2:] + 1.0) / (2.0 * np.pi)
+
+    assert 180 <= int(np.argmax(dl[2:400])) + 2 <= 260
+
+
+def test_lensing_smooths_the_damping_tail():
+    """Lensing leaves the large scales alone and fills in the high-l tail.
+
+    Two solves of the same cosmology differing only in lensed_Cls, which is the
+    switch the CMB likelihoods rely on.
+    """
+    cosmo = create_cosmo(prim_model=HIPrimModel.POWER_LAW)
+
+    unlensed_pb = _cbe(lensed=False)
+    unlensed_pb.prepare(cosmo)
+    unlensed = _cls(unlensed_pb, "TT")
+
+    lensed_pb = _cbe(lensed=True)
+    lensed_pb.prepare(cosmo)
+    lensed = _cls(lensed_pb, "TT")
+
+    # Large scales are essentially untouched by lensing.
+    assert lensed[2:30] == pytest.approx(unlensed[2:30], rel=1.0e-2)
+    # The damping tail is not: lensing transfers power into the troughs.
+    assert np.max(np.abs(lensed[800:] / unlensed[800:] - 1.0)) > 1.0e-2

--- a/tests/python/numcosmo_py/app/test_generate.py
+++ b/tests/python/numcosmo_py/app/test_generate.py
@@ -60,6 +60,7 @@ def test_generate_jpas_invalid_suffix(tmp_path: Path):
 
 
 # Native Planck
+@pytest.mark.planck_data
 def test_generate_planck_native(tmp_path: Path):
     """Native Planck experiment generates all-native, clik-free serialized blocks."""
     # pylint: disable=import-outside-toplevel
@@ -106,6 +107,7 @@ def test_generate_planck_native(tmp_path: Path):
     assert np.isfinite(dset.m2lnL_val(mset))
 
 
+@pytest.mark.planck_data
 def test_build_planck_release(tmp_path: Path):
     """The publish command writes serialized native Planck release objects."""
     # pylint: disable=import-outside-toplevel

--- a/tests/python/numcosmo_py/experiments/test_planck18_native.py
+++ b/tests/python/numcosmo_py/experiments/test_planck18_native.py
@@ -26,15 +26,17 @@
 
 ``generate_planck18_native`` glues the four native likelihood blocks onto one
 shared CBE. The blocks themselves are covered by the per-likelihood tests; here
-they are stood in for by synthetic ones (see tests/python/fixtures_planck.py) so
-the assembly, the priors and the derived-function wiring are exercised without a
-local ``plc_3.0`` tree.
+they are stood in for by synthetic ones (see tests/python/fixtures_planck.py),
+driven by a fixed-spectra Boltzmann, so the assembly, the priors and the
+derived-function wiring are exercised without a local ``plc_3.0`` tree and
+without a Boltzmann solve.
 """
 
 import numpy as np
 import pytest
 
 from python.fixtures_planck import (
+    FixedClBoltzmann,
     make_commander_cldf,
     make_lensing_cldf,
     make_simall_cldf,
@@ -56,11 +58,11 @@ from numcosmo_py.experiments.planck_smica import build_smica_tt, build_smica_ttt
 Ncm.cfg_init()
 
 
-@pytest.fixture(name="synthetic_blocks", scope="module")
-def fixture_synthetic_blocks(tmp_path_factory):
-    """Builders for the synthetic stand-ins, keyed by release id."""
+@pytest.fixture(name="synthetic_trees", scope="module")
+def fixture_synthetic_trees(tmp_path_factory):
+    """The synthetic cldf trees and their builders, keyed by release id."""
     root = tmp_path_factory.mktemp("planck_native")
-    trees = {
+    return {
         pnr.PlanckReleaseId.PR3_SIMALL_EE: (make_simall_cldf(root), build_simall),
         pnr.PlanckReleaseId.PR3_COMMANDER: (make_commander_cldf(root), build_commander),
         pnr.PlanckReleaseId.PR3_PLIK_TT: (make_smica_cldf(root), build_smica_tt),
@@ -71,12 +73,32 @@ def fixture_synthetic_blocks(tmp_path_factory):
         pnr.PlanckReleaseId.PR3_LENSING: (make_lensing_cldf(root), build_lensing),
     }
 
+
+def _release_loader(trees, boltzmann=None):
+    """Stand in for ``load_planck_release``, optionally overriding the Boltzmann.
+
+    @boltzmann replaces the CBE the experiment assembles, so the blocks read
+    stored spectra and nothing is solved; None keeps the experiment's own CBE.
+    """
+
     def load(rid, pb=None, cache_dir=None):  # signature of load_planck_release
         del cache_dir
         clik, builder = trees[rid]
-        return builder(clik, pb)
+        return builder(clik, pb if boltzmann is None else boltzmann)
 
     return load
+
+
+@pytest.fixture(name="synthetic_blocks", scope="module")
+def fixture_synthetic_blocks(synthetic_trees):
+    """Release loader whose blocks are driven by #FixedClBoltzmann.
+
+    The assembly, the priors and the derived-function wiring are what these tests
+    check; a Boltzmann solve at Planck precision would dominate their runtime
+    without covering any of it. The coupling to CLASS is covered separately by
+    ``test_generate_native_evaluates_on_cbe``.
+    """
+    return _release_loader(synthetic_trees, FixedClBoltzmann())
 
 
 @pytest.mark.parametrize(
@@ -121,6 +143,33 @@ def test_generate_native_from_release(
     assert mfunc_array.len() == 4
 
     mset_set_parameters(mset, data_type, HIPrimModel.POWER_LAW)
+    mset.prepare_fparam_map()
+    for i in range(dset.get_ndata()):
+        dset.get_data(i).prepare(mset)
+    assert np.isfinite(dset.m2lnL_val(mset))
+
+
+@pytest.mark.acceptance
+def test_generate_native_evaluates_on_cbe(monkeypatch, synthetic_trees):
+    """The assembled experiment evaluates against a real CBE.
+
+    The cases above swap the Boltzmann out, so this is what covers the blocks
+    self-configuring the shared CBE (targets and lmax) and the resulting solve
+    feeding a finite $-2\\ln L$. One combination is enough: the block-by-block
+    self-configuration is covered by the per-likelihood tests.
+    """
+    monkeypatch.setattr(pnr, "load_planck_release", _release_loader(synthetic_trees))
+
+    experiment, _ = generate_planck18_native(
+        data_type=Planck18Types.TT,
+        use_lensing_likelihood=True,
+        from_release=True,
+    )
+
+    mset = experiment.peek("model-set")
+    dset = experiment.peek("likelihood").peek_dataset()
+
+    mset_set_parameters(mset, Planck18Types.TT, HIPrimModel.POWER_LAW)
     mset.prepare_fparam_map()
     for i in range(dset.get_ndata()):
         dset.get_data(i).prepare(mset)

--- a/tests/python/pytest.ini
+++ b/tests/python/pytest.ini
@@ -17,6 +17,7 @@ markers =
     xcor: Cross-correlation tests (run with --run-xcor)
     mpi: MPI-parallel tests (run with --run-mpi)
     app: Application/CLI tests, incl. parallel ESMCMC (run with --run-app)
+    planck_data: Needs a local plc_3.0 Planck tree (run with --run-planck-data)
     sphere_map: Sphere-map tests (run with --run-sphere-map)
     omp: Has an OpenMP-parallel path; additionally run in a dedicated OMP_NUM_THREADS>1 lane
     # Optional-dependency label: auto-skipped via pytest.importorskip when pyccl is absent.


### PR DESCRIPTION
The Planck PR added ~17.6 min to `Cov-python` and ~8.1 min to the fast lanes: every synthetic test spun a full CLASS solve where only the likelihood assembly was under test. Those now run on `FixedClBoltzmann`.

Since `HIPertBoltzmannCBE` appeared only in the Planck test files, the CBE gets its own cheap test rather than losing coverage.

Also stops using `app` (application/CLI) as a Planck-data gate: the real-data tests move to a `planck_data` marker + `--run-planck-data`.

Local: the touched files go 98 s -> 20 s. Expected CI recovery ~16 min on `Cov-python`, ~7.5 min on the fast lanes.

Separate finding, not fixed here: `_nc_hicosmo_de_Yp_4He` writes its BBN value back into the model, bumping the cosmo pkey mid-solve, so every parameter change costs one redundant Boltzmann solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)