### PR TITLE
Stop the xcor lane from exhausting memory

### DIFF
--- a/tests/python/meson.build
+++ b/tests/python/meson.build
@@ -59,7 +59,14 @@ if enable_gir and python_for_tests.found()
         required: false,
     )
     if py_xdist.found()
-        pytest_parallel_args = pytest_base_args + ['-n', 'auto']
+        # loadgroup, not the default load: tests marked with xdist_group go to
+        # one worker, everything else still distributes test by test. An xdist
+        # worker is its own session, so a module-scoped fixture is built once
+        # per *worker* -- for the xcor lane's heaviest files that is several GB
+        # replicated 12 or 24 times, which exhausted a 30 GB machine. Grouping
+        # those files costs them their internal parallelism and nothing else.
+        # Ungrouped tests behave exactly as under load.
+        pytest_parallel_args = pytest_base_args + ['-n', 'auto', '--dist', 'loadgroup']
     else
         pytest_parallel_args = pytest_base_args
     endif

--- a/tests/python/nc/xcor/cases_k_integral.py
+++ b/tests/python/nc/xcor/cases_k_integral.py
@@ -65,10 +65,26 @@ from numcosmo_py import Nc, Ncm
 # lives; ell = 2 is not decoration.
 ELLS: typing.Final[list[int]] = [2, 3, 4, 6, 10, 20, 50, 100, 200]
 
-# What the committed suite runs, as leading multipoles of a block: the two ends
-# and one in between. The full list is the bench driver's, where cost is not
-# charged to every CI run.
-ELLS_SUITE: typing.Final[list[int]] = [2, 20, 200]
+# What the committed suite runs, as leading multipoles of a block. Chosen from
+# the bench sweep over the full ELLS above, by where the methods are actually
+# worst -- which is NOT the high end. Measured worst deviation of the block's
+# peak, over the case matrix:
+#
+#   exact/chebyshev  2.3e-08 at l=6     gsl/chebyshev   1.6e-03 at l=10
+#   exact/spline     8.1e-12 at l=6     gsl_block/spl   3.6e-11 at l=4
+#
+# against 4.7e-10, 1.7e-04, 5.3e-13 and 8.6e-12 at l=200. The error peaks
+# around l = 4-10 and falls away by l = 50, so a ladder of [2, 20, 200] tested
+# the easy end hard and the hard end not at all. l = 2 stays for the
+# cancellation reason above; 6 and 10 are the peak; 50 keeps a high-l point
+# without paying for l = 200, whose Levin operator is the most expensive of the
+# ladder (its closure is the *smallest* -- 159 knots against 263 at l = 2 --
+# so the cost is the operator, not the fit).
+#
+# Knowingly not covered: cubature/chebyshev is worst at l = 20 (4.1e-05 against
+# 1.1e-05 here), and gsl_block/chebyshev at l = 200 (4.6e-04 against 3.2e-04).
+# Both are within a factor of four of a point that is covered.
+ELLS_SUITE: typing.Final[list[int]] = [2, 6, 10, 50]
 
 # Gauss-Legendre orders the reference escalates through, per cell. A spline
 # cell is a cubic and a k^2-weighted product of two is degree 8, so it is exact
@@ -444,13 +460,22 @@ def build_kernel(
     dist: Nc.Distance,
     ps: Ncm.Powspec,
     settings: Settings,
+    sbi: Ncm.SBesselIntegrator | None = None,
 ) -> Nc.XcorKernelAnalytic:
     """Build and prepare one kernel of the matrix at the given settings.
 
-    Each kernel gets its own Levin integrator: the sbessel ODE solver is not
-    reentrant and a shared one corrupts memory across concurrent blocks.
+    Pass @sbi to share one Levin integrator across the kernels of a block, the
+    way nc_xcor_solver_solve() does -- it dups one integrator per block and
+    hands the same one to every kernel, which is what makes the stored
+    Givens-rotation decomposition reusable across kernels (plan doc
+    dev-notes/xcor_ultralevin_batching_plan.md §6.1). With %None each kernel
+    gets its own, which is safe under concurrency -- the sbessel ODE solver is
+    not reentrant, so a shared one corrupts memory across concurrent blocks --
+    but disables that reuse entirely.
     """
-    kernel = KERNELS[name].builder(dist, ps, Ncm.SBesselIntegratorLevin.new(0, 8))
+    kernel = KERNELS[name].builder(
+        dist, ps, sbi if sbi is not None else Ncm.SBesselIntegratorLevin.new(0, 8)
+    )
     kernel.set_l_limber(settings.l_limber)
     kernel.set_property("reltol", settings.reltol)
     kernel.set_property("scaled-abstol", settings.scaled_abstol)
@@ -465,6 +490,7 @@ def build_integrand(
     lmin: int,
     lmax: int,
     settings: Settings,
+    sbi: Ncm.SBesselIntegrator | None = None,
 ) -> Nc.XcorKernelIntegrand:
     """Freeze one closure for an ell block, and check it is the one asked for.
 
@@ -474,7 +500,11 @@ def build_integrand(
     block is taken under Limber.
     """
     integrand = kernel.get_eval_vectorized_full(
-        cosmo, lmin, lmax, Ncm.SBesselIntegratorLevin.new(lmin, lmax), settings.closure
+        cosmo,
+        lmin,
+        lmax,
+        sbi if sbi is not None else Ncm.SBesselIntegratorLevin.new(lmin, lmax),
+        settings.closure,
     )
 
     wanted_panels = settings.closure == Nc.XcorKernelClosure.CHEBYSHEV

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -20,7 +20,10 @@ from numcosmo_py.ccl.two_point import (
     compute_kernel,
 )
 
-pytestmark = [pytest.mark.ccl, pytest.mark.xcor]
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [pytest.mark.ccl, pytest.mark.xcor, pytest.mark.xdist_group("ccl_angular")]
 
 Ncm.cfg_init()
 

--- a/tests/python/nc/xcor/test_ccl_comparison.py
+++ b/tests/python/nc/xcor/test_ccl_comparison.py
@@ -45,7 +45,14 @@ from numcosmo_py.cosmology import Cosmology
 from numcosmo_py.ccl.two_point import compute_kernel
 import numcosmo_py.ccl.comparison as nc_cmp
 
-pytestmark = [pytest.mark.ccl, pytest.mark.xcor]
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [
+    pytest.mark.ccl,
+    pytest.mark.xcor,
+    pytest.mark.xdist_group("ccl_comparison"),
+]
 
 Ncm.cfg_init()
 pytest_plugins = ["python.fixtures_ccl", "python.fixtures_xcor"]

--- a/tests/python/nc/xcor/test_k_integral.py
+++ b/tests/python/nc/xcor/test_k_integral.py
@@ -45,8 +45,10 @@ spectrum -- one no method meets and none needs to, because that entry
 contributes nothing to any likelihood.
 """
 
+import collections
 import gzip
 import json
+import os
 import pathlib
 
 import numpy as np
@@ -57,7 +59,15 @@ from xcor import cases_k_integral as cases
 
 pytest_plugins = ["python.fixtures_xcor"]
 
-pytestmark = pytest.mark.xcor
+# xdist_group pins this whole file to one worker under --dist loadgroup.
+# The frozen fixture below caches up to 102 Frozen objects, each holding two
+# kernels, two closures and their references -- 3.5 GB by the end of the file.
+# That is per *worker*, since an xdist worker is its own session, so plain
+# --dist load builds one copy per worker and exhausts memory on a many-core
+# machine (measured: OOM at 12 workers, and every run at 24). Grouping costs
+# this file its internal parallelism and nothing else -- every other file still
+# distributes test by test.
+pytestmark = [pytest.mark.xcor, pytest.mark.xdist_group("k_integral")]
 
 CLOSURES = {
     "spline": Nc.XcorKernelClosure.SPLINE,
@@ -81,47 +91,54 @@ PER_MULTIPOLE = frozenset({"gsl"})
 # an entry in the NcXcorKQuad table.
 BLOCK_METHODS = sorted(set(METHODS) - PER_MULTIPOLE)
 
-# Measured over the whole matrix at reltol = scaled_abstol = 1e-4, as the worst
+# Measured over the case matrix at reltol = scaled_abstol = 1e-4, as the worst
 # deviation from the matching reference relative to the block's peak, with an
-# order of headroom. Measured worst / median, for the record:
+# order of headroom. Measured worst, on cases.ELLS_SUITE:
 #
-#   exact    spline     5.3e-13 / 9.4e-16       cubature spline     1.7e-05 / 3.2e-07
-#   exact    chebyshev  4.7e-10 / 1.2e-15       cubature chebyshev  4.1e-05 / 1.6e-07
-#   gsl      spline     1.1e-12 / 5.7e-16       gsl      chebyshev  1.7e-04 / 1.2e-07
-#   gsl_blk  spline     8.6e-12 / 5.6e-16       gsl_blk  chebyshev  4.6e-04 / 9.7e-08
+#   exact    spline     8.1e-12       cubature spline     1.7e-05
+#   exact    chebyshev  2.3e-08       cubature chebyshev  1.1e-05
+#   gsl      spline     4.4e-12       gsl      chebyshev  1.6e-03
+#   gsl_blk  spline     3.2e-11       gsl_blk  chebyshev  3.2e-04
 #
-# gsl_block runs gsl's rule on exact's closure, and lands within an order of
-# both: the rule is not what separated them. It is the looser of the two on
-# splines by about eight times, and that is the block closure rather than the
+# These are an order or two above what a [2, 20, 200] ladder reported, because
+# that ladder missed the l = 4-10 region where every method is worst; see
+# cases.ELLS_SUITE. Read the two exact rows as the claim they are: GL(5) on the
+# merged knot set is exact, and so is qagp on those same knots -- both sit at
+# the reference's own floor. Cubature is not converging to the closure, it is
+# stopping at the relative tolerance it was asked for.
+#
+# gsl/chebyshev at 1.6e-03 is the largest error anywhere in the matrix, at
+# l = 10. It is the one combination where the per-multipole closure and the
+# Chebyshev fit interact badly, and it is why that tolerance is so much looser
+# than its spline counterpart.
+#
+# gsl_block runs gsl's rule on exact's closure and lands within an order of
+# both: the rule is not what separates them. On splines it is the looser of the
+# two by about eight times, and that is the block closure rather than the
 # quadrature -- a block is fitted to an L2 norm over all its multipoles, so a
 # multipole that is sub-dominant within its block is held only to the block's
 # norm, while gsl fits each one on its own. See nc_xcor_compute_full().
-#
-# Read the two exact columns as the claim they are: GL(5) on the merged knot
-# set is exact, and so is qagp on those same knots -- both sit at the
-# reference's own floor. Cubature is not converging to the closure, it is
-# stopping at the relative tolerance it was asked for, which is why it is eight
-# orders looser at identical cost.
-#
-# The exact/chebyshev worst is N3 at ell ~ 205, where the reference is itself
-# only good to 5.4e-10; that entry bounds the pair rather than discriminating
-# between them, and there is nothing below it to find without an independent
-# reference.
 TOLERANCE = {
-    ("exact", "spline"): 5.0e-12,
-    ("exact", "chebyshev"): 1.0e-8,
+    ("exact", "spline"): 1.0e-10,
+    ("exact", "chebyshev"): 5.0e-7,
     ("cubature", "spline"): 2.0e-4,
-    ("cubature", "chebyshev"): 5.0e-4,
-    ("gsl", "spline"): 1.0e-11,
-    ("gsl", "chebyshev"): 2.0e-3,
-    ("gsl_block", "spline"): 1.0e-10,
+    ("cubature", "chebyshev"): 2.0e-4,
+    ("gsl", "spline"): 5.0e-11,
+    ("gsl", "chebyshev"): 2.0e-2,
+    ("gsl_block", "spline"): 5.0e-10,
     ("gsl_block", "chebyshev"): 5.0e-3,
 }
 
-# The reference's own convergence, likewise measured: 6.0e-14 on spline
-# closures and 5.4e-10 on Chebyshev ones, where the floor is the conditioning
-# of evaluating a degree-128 polynomial rather than the quadrature.
-REFERENCE_FLOOR = {"spline": 1.0e-12, "chebyshev": 5.0e-9}
+# The reference's own convergence, likewise measured on cases.ELLS_SUITE: the
+# worst any cell still moved at the top of the escalation, 9.0e-13 on spline
+# closures and 1.3e-08 on Chebyshev ones, both at l = 6. On Chebyshev the floor
+# is the conditioning of evaluating a degree-128 polynomial rather than the
+# quadrature, and l = 6 is where that bites -- 130x worse than the 1.0e-10 at
+# l = 2 that a [2, 20, 200] ladder saw. It bounds what any test here can claim
+# about a Chebyshev closure at that multipole: exact/chebyshev's own 2.3e-08
+# sits less than a factor of two above it, so that entry bounds the method
+# rather than discriminating between methods.
+REFERENCE_FLOOR = {"spline": 1.0e-11, "chebyshev": 1.0e-7}
 
 
 class Frozen:
@@ -135,24 +152,38 @@ class Frozen:
         self.cosmo, self.dist, self.ps = cases.make_cosmo_bits()
         self.RH = Nc.HICosmo.RH_Mpc(self.cosmo)
 
+        # One integrator for the whole block, shared by both kernels and both
+        # closures -- what nc_xcor_solver_solve() does, and what makes the
+        # stored decomposition reusable across kernels. Giving each kernel its
+        # own retains four integrators per key and never exercises that path.
+        # Scoped to this Frozen rather than to the block: reuse is order
+        # sensitive, and pytest-randomly means a wider scope would make cost,
+        # and any non-exactness, depend on execution order.
+        self.sbi = Ncm.SBesselIntegratorLevin.new(lmin, self.lmax)
+
         self.kernel_a = cases.build_kernel(
-            self.pair.kernel_a, self.cosmo, self.dist, self.ps, self.settings
+            self.pair.kernel_a, self.cosmo, self.dist, self.ps, self.settings, self.sbi
         )
         self.kernel_b = (
             self.kernel_a
             if self.pair.isauto
             else cases.build_kernel(
-                self.pair.kernel_b, self.cosmo, self.dist, self.ps, self.settings
+                self.pair.kernel_b,
+                self.cosmo,
+                self.dist,
+                self.ps,
+                self.settings,
+                self.sbi,
             )
         )
         self.integrand_a = cases.build_integrand(
-            self.kernel_a, self.cosmo, lmin, self.lmax, self.settings
+            self.kernel_a, self.cosmo, lmin, self.lmax, self.settings, self.sbi
         )
         self.integrand_b = (
             None
             if self.pair.isauto
             else cases.build_integrand(
-                self.kernel_b, self.cosmo, lmin, self.lmax, self.settings
+                self.kernel_b, self.cosmo, lmin, self.lmax, self.settings, self.sbi
             )
         )
         self.reference = cases.reference_cl(self.RH, self.integrand_a, self.integrand_b)
@@ -224,16 +255,39 @@ class Frozen:
         return float(np.abs(got - truth).max() / np.abs(truth).max())
 
 
+# How many Frozen the module fixture keeps alive at once. Each holds two
+# kernels, two closures and their references -- 18 MB for an easy key, 105 MB
+# for the worst (ell = 200). Unbounded, the 102 keys of the matrix reach 3.5 GB,
+# and since an xdist worker is its own session that is paid per worker: enough
+# to exhaust a 30 GB machine at 12 workers and every time at 24. Bounded, the
+# cost is a rebuild whenever an evicted key comes back, at 0.194 s each.
+# 0 means unbounded.
+FROZEN_CACHE_MAXSIZE = int(os.environ.get("XCOR_FROZEN_CACHE", "8"))
+
+
 @pytest.fixture(name="frozen", scope="module")
 def fixture_frozen():
-    """Build each (case, closure, block) once and hand it to every test."""
-    cache: dict[tuple[str, str, int], Frozen] = {}
+    """Build each (case, closure, block) once and hand it to every test.
+
+    Least-recently-used beyond FROZEN_CACHE_MAXSIZE, because holding all of
+    them is what makes this file the memory ceiling of the whole xcor lane.
+    """
+    cache: collections.OrderedDict[tuple[str, str, int], Frozen] = (
+        collections.OrderedDict()
+    )
 
     def get(case: str, closure: str, lmin: int) -> Frozen:
         key = (case, closure, lmin)
 
-        if key not in cache:
-            cache[key] = Frozen(case, closure, lmin)
+        if key in cache:
+            cache.move_to_end(key)
+
+            return cache[key]
+
+        cache[key] = Frozen(case, closure, lmin)
+
+        while FROZEN_CACHE_MAXSIZE and len(cache) > FROZEN_CACHE_MAXSIZE:
+            cache.popitem(last=False)
 
         return cache[key]
 

--- a/tests/python/nc/xcor/test_kernel.py
+++ b/tests/python/nc/xcor/test_kernel.py
@@ -34,7 +34,10 @@ import numpy as np
 from numcosmo_py import Ncm, Nc
 from numcosmo_py.cosmology import Cosmology
 
-pytestmark = pytest.mark.xcor
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [pytest.mark.xcor, pytest.mark.xdist_group("kernel")]
 
 Ncm.cfg_init()
 pytest_plugins = ["python.fixtures_xcor"]

--- a/tests/python/nc/xcor/test_xcor_window_truth_table.py
+++ b/tests/python/nc/xcor/test_xcor_window_truth_table.py
@@ -51,7 +51,10 @@ from numcosmo_py import Nc, Ncm
 
 Ncm.cfg_init()
 
-pytestmark = pytest.mark.xcor
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [pytest.mark.xcor, pytest.mark.xdist_group("window_truth")]
 
 TRUTH_TABLE = "truth_tables/xcor/xcor_window_ilk.json.gz"
 


### PR DESCRIPTION
`meson test --suite py-xcor` exhausts memory and takes the machine down. It
fails about a third of the time at 12 workers and every time at 24. This makes
it pass at both.

## Why it happens

An xdist worker is its own pytest session, so a **module-scoped fixture is
built once per worker, not once**. The xcor lane's heaviest files hold several
GB that way and nothing releases it as workers drain, so memory climbs
monotonically to the end of the run — the `--dist load` timeline goes
2.5 → 10 GB in 16 s and never comes down.

**CI cannot catch this.** Its runners have 2–4 cores against a developer's 12
or 24, so the cost there is a sixth of what it is here, and it will stay
invisible to CI whatever else gets added.

Measured under a `systemd-run --scope -p MemoryMax=10G` cgroup, 2171 tests:

| workers | before | after |
|---|---|---|
| 12 | **OOM** (>10 GB, +2.6 GB swap) | 5.3 GB |
| 24 | **OOM** | 8.4 GB |

Through `meson test` itself: RC 0, 381 s, peak 8.5 GB.

## What changed, in descending order of what it was worth

**1. `--dist loadgroup` + `xdist_group` on the five heaviest files.** Grouped
tests go to one worker; everything else still distributes test by test, so the
other ten files keep their parallelism. `loadgroup` is identical to `load` for
unmarked tests, so no other lane is affected. Cheapest change, largest saving:
9.0 → 5.3 GB at 12 workers, without touching a test.

**2. `test_k_integral.py`'s `frozen` fixture is an LRU.** It held every key it
was ever asked for — 136 of them, 18 MB for an easy one and 105 MB for the
worst, 4.0 GB by the end of the file. This is what makes 24 workers survive.
It costs 1.9× on that file, and that cost is structural: five test functions
each walk the whole key set, so the reuse distance is a full pass. Measured at
maxsize 8, 16 and 32 and under deterministic ordering — all within 10%, so
neither a bigger cache nor pinned ordering avoids it. `XCOR_FROZEN_CACHE`
overrides; `0` restores the old behaviour and the old speed.

**3. One shared integrator per `Frozen`.** `nc_xcor_solver_solve()` dups one
`NcmSBesselIntegratorLevin` per block and hands the same one to every kernel.
The harness gave each kernel its own, so it retained four per key and — more
importantly — **never exercised the cross-kernel decomposition reuse** that
`dev-notes/xcor_ultralevin_batching_plan.md` §6.1 measures at 8×. Numerically
neutral: bit-identical on every block method, 5.7e-14 on `KERNEL_GSL` (the one
method fitting per multipole through the kernel's own integrator), which is
175× inside its tolerance.

**4. `ELLS_SUITE` retargeted, `[2, 20, 200]` → `[2, 6, 10, 50]`.** The bench
sweep over all nine block starts says the methods are worst around ℓ = 4–10,
not at the top:

| method/closure | ℓ=6 | ℓ=10 | ℓ=200 |
|---|---|---|---|
| exact/chebyshev | **2.3e-08** | 1.4e-10 | 4.7e-10 |
| gsl/chebyshev | 5.1e-05 | **1.6e-03** | 1.7e-04 |

The old ladder tested the easy end hard and the hard end not at all. Closure
size *falls* with ℓ (263 knots at ℓ=2, 159 at ℓ=200) — the ℓ=200 keys were the
most expensive in memory because of the Levin operator, not the fit, so this is
cheaper as well as stricter. Tolerances and `REFERENCE_FLOOR` are re-derived;
the latter moves two orders because ℓ=6 is also where the Level-1 reference is
least converged on a Chebyshev closure (1.3e-08, against the 1.0e-10 the old
ladder saw).

## Not fixed here

The lane's peak still scales with worker count, and nothing prevents the next
ample-scoped fixture from doing this again. A memory guard on the test wrapper
— so a runaway lane is killed rather than the machine — is a follow-up, and is
what would actually make `meson test` safe to run unattended.
