### PR TITLE
Cache the downloaded data files in CI

### DIFF
--- a/.github/actions/data-cache/action.yml
+++ b/.github/actions/data-cache/action.yml
@@ -1,0 +1,72 @@
+name: 'NumCosmo data cache'
+description: >-
+  Restores the on-demand data files (Planck baseline, SNIa catalogs, curated
+  weak-lensing catalogs and native Planck likelihoods) that NumCosmo otherwise
+  downloads from the GitHub release on first use -- around 470 MB per job, on
+  every job, on every run. Restore only: the caller decides whether to write
+  the entry back, since a partial or failed run must not be what gets stored.
+  See CONTRIBUTING.md, section "CI data-file cache".
+
+inputs:
+  version:
+    description: >-
+      Bump to discard every stored copy -- for a data file replaced in place
+      under an unchanged release tag, or any other reason the cached copy is no
+      longer the right one. Passed by the caller from a single workflow-level
+      env var.
+    required: true
+
+outputs:
+  key:
+    description: 'Cache key this job restored from, for a matching save step.'
+    value: ${{ steps.key.outputs.value }}
+  paths:
+    description: 'Newline-separated cached paths, for a matching save step.'
+    value: ${{ steps.key.outputs.paths }}
+  hit:
+    description: "'true' when the entry was restored, so no save is needed."
+    value: ${{ steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute data cache key
+      id: key
+      shell: bash
+      run: |
+        set -eu
+        # Second staleness trigger, alongside the version input: the assets live
+        # in a tagged GitHub release, so a new release means new files. The tag
+        # is read back out of the sources that name it rather than repeated
+        # here, so bumping it there is enough.
+        # -I: skip binary files. Without it a stray __pycache__/*.pyc gets
+        # reported as "binary file matches" straight into the key.
+        tags=$(grep -rhoIE 'datafile-release-v[0-9]+(\.[0-9]+)*' numcosmo numcosmo_py | sort -u | paste -sd_ -)
+        if [ -z "${tags}" ]; then
+          echo "::error title=Data cache::No datafile-release tag found in numcosmo/ or numcosmo_py/. The cache key would be constant and would never go stale; fix the pattern in .github/actions/data-cache."
+          exit 1
+        fi
+        echo "value=numcosmo-data-${RUNNER_OS}-v${{ inputs.version }}-${tags}" >> "$GITHUB_OUTPUT"
+        # Only the downloaded files. The FFTW wisdom (*.fftw3, *.fftw3f) and
+        # the FFTLog tables the library writes into the same directory are
+        # deliberately left out: they are a record of what one machine measured
+        # to be fastest, and restoring them would hand a later run plans that
+        # were never timed on it. Absolute paths rather than ~/..., so the
+        # globs need no tilde expansion.
+        {
+          echo "paths<<EOF"
+          echo "${HOME}/.numcosmo/baseline"
+          echo "${HOME}/.numcosmo/*.fits"
+          echo "${HOME}/.numcosmo/*.gvar"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+    - name: Restore data cache
+      id: restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.key.outputs.paths }}
+        key: ${{ steps.key.outputs.value }}
+        # No restore-keys on purpose. A partial match would reuse files whose
+        # name is unchanged but whose content the new release replaced, and the
+        # library only downloads what is missing -- so the stale copy would
+        # never be corrected.

--- a/.github/scripts/prefetch_data.py
+++ b/.github/scripts/prefetch_data.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# prefetch_data.py
+#
+# Sun August 30 2026
+# Copyright  2026  Sandro Dias Pinto Vitenti
+# <vitenti@uel.br>
+#
+# prefetch_data.py
+# Copyright (C) 2026 Sandro Dias Pinto Vitenti <vitenti@uel.br>
+#
+# numcosmo is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# numcosmo is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Download every data file NumCosmo fetches on demand into its data directory.
+
+CI caches that directory between runs (see .github/actions/data-cache). The
+cache is written under an exact key, so it is never refreshed while the key
+holds: whatever the writing job downloaded is what every other job gets. A job
+only downloads what its own tests touch, so a cache written from an ordinary
+test run would leave the rest of the assets re-downloaded on every run,
+forever. This fills the directory with all of them first, so the one job that
+writes the cache writes a complete one.
+
+The asset lists come from the enums themselves, so a catalog added to any of
+them is picked up here without editing this script.
+"""
+
+import sys
+
+from numcosmo_py import Nc, Ncm
+from numcosmo_py.experiments import planck_native_release as pnr
+
+
+def _enum_members(enum_cls, prefix: str = "") -> list[int]:
+    """Enum values of @enum_cls whose name is uppercase and starts with @prefix.
+
+    Introspected enums are plain ints carrying the members as class attributes,
+    alongside int's own lowercase methods -- hence the isupper() filter.
+    """
+    return [
+        getattr(enum_cls, name)
+        for name in dir(enum_cls)
+        if name.isupper() and name.startswith(prefix)
+    ]
+
+
+def main() -> int:
+    """Fetch every on-demand data file, reporting each one."""
+    Ncm.cfg_init()
+    base = Ncm.cfg_get_fullpath_base()
+    print(f"# Prefetching NumCosmo data files into {base}", flush=True)
+
+    # Planck baseline (plc_3.0): a tarball unpacked into <base>/baseline.
+    Nc.DataPlanckLKL.download_baseline(base)
+
+    # SNIa covariance catalogs. Only the COV_* ids are downloaded; the SIMPLE_*
+    # ones are built in.
+    for cat_id in _enum_members(Nc.DataSNIAId, "COV_"):
+        print(f"# {Nc.DataSNIACov.get_catalog_by_id(cat_id)}", flush=True)
+
+    # Curated weak-lensing catalogs.
+    for cat_id in _enum_members(Nc.GalaxyWLObsCatalogId):
+        print(f"# {Nc.galaxy_wl_obs_catalog_id_get_filename(cat_id)}", flush=True)
+
+    # Curated native Planck likelihoods. Loading, not just downloading: a
+    # truncated .gvar then fails here instead of inside a test.
+    for release_id in pnr.PlanckReleaseId:
+        pnr.load_planck_release(release_id)
+        print(f"# {pnr.release_filename(release_id)}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -12,6 +12,12 @@ env:
   CONDA_ENV: numcosmo_developer
   # Bump to force recomputing slice-tests.txt from scratch instead of restoring cached durations.
   TEST_DURATION_CACHE_VERSION: 0
+  # Bump to discard the cached data files (~470 MB of Planck/SNIa/weak-lensing
+  # assets) and download them again. The cache also goes stale on its own when
+  # the datafile release tag changes; this knob covers everything else, such as
+  # a file replaced in place under an unchanged tag. See
+  # .github/actions/data-cache.
+  DATA_CACHE_VERSION: 0
   # Thread policy is set PER TEST by meson (tests/meson.build), not here: concurrent tests
   # get OMP/BLAS = 1 (avoid cores^2 oversubscription + the mixed-OpenBLAS deadlock, e.g.
   # scipy.linalg.solve in test_sbessel_ode_solver), and the run-alone OpenMP tests
@@ -65,6 +71,11 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
     - uses: actions/checkout@v4
+    - name: Restore data cache
+      id: data-cache
+      uses: ./.github/actions/data-cache
+      with:
+        version: ${{ env.DATA_CACHE_VERSION }}
     - uses: actions/setup-python@v6
       with:
         python-version: '3.13'
@@ -78,6 +89,14 @@ jobs:
       run: meson setup build -Dbuildtype=release -Dnumcosmo_py=true -Dfftw-planner=estimate -Ddocumentation=false --prefix=/usr || (cat build/meson-logs/meson-log.txt && exit 1)
     - name: Building NumCosmo
       run: meson compile -C build
+    - name: Prefetch data files
+      # This job writes the Linux data cache, so it fetches every asset, not
+      # just the ones its own tests happen to touch -- see the step at the end
+      # of the job and prefetch_data.py.
+      if: steps.data-cache.outputs.hit != 'true'
+      run: |
+        source build/numcosmo_export.sh
+        python3 .github/scripts/prefetch_data.py
     - name: Checking indentation
       run: |
         find numcosmo -path numcosmo/external -prune -o \( -name '*.c' -o -name '*.h' \) -print0 \
@@ -117,6 +136,17 @@ jobs:
         gcc -D_GNU_SOURCE -Wall example_ca.c -o example_ca $(pkg-config numcosmo --libs --cflags)
         ./example_simple
         ./example_ca
+    - name: Save data cache
+      # One writer per OS: every other Linux job restores this entry and never
+      # writes one, so a job that downloads only its own slice of the assets
+      # can never be what gets stored. Written only on success, since the key
+      # is exact and a partial entry would then stick until DATA_CACHE_VERSION
+      # is bumped.
+      if: success() && steps.data-cache.outputs.hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.data-cache.outputs.paths }}
+        key: ${{ steps.data-cache.outputs.key }}
 
   build-gcc-macos:
     name: (macos, brew, pip)
@@ -130,6 +160,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Restore data cache
+      id: data-cache
+      uses: ./.github/actions/data-cache
+      with:
+        version: ${{ env.DATA_CACHE_VERSION }}
     - name: Brew install pre-requisites
       run: |
         # The runner image carries both pkgconf and the older pkg-config@0.29.2
@@ -166,6 +201,12 @@ jobs:
     - name: Building NumCosmo
       run: |
         meson compile -C build
+    - name: Prefetch data files
+      # Writes the macOS data cache; see the same step in build-gcc-ubuntu.
+      if: steps.data-cache.outputs.hit != 'true'
+      run: |
+        source build/numcosmo_export.sh
+        python3 .github/scripts/prefetch_data.py
     - name: Test python examples
       run: |
         source build/numcosmo_export.sh
@@ -177,6 +218,13 @@ jobs:
     - name: Check NumCosmo
       run: |
         meson test -v -C build --num-processes=$(getconf _NPROCESSORS_ONLN) ${{ env.FAST_TEST_ARGS }} || (cat build/meson-logs/testlog.txt && exit 1)
+    - name: Save data cache
+      # The macOS writer; see the same step in build-gcc-ubuntu.
+      if: success() && steps.data-cache.outputs.hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.data-cache.outputs.paths }}
+        key: ${{ steps.data-cache.outputs.key }}
 
   build-miniforge:
     name: (${{ matrix.os }}, py${{ matrix.python-version }}, ${{ matrix.mpi }}, Miniforge)
@@ -194,6 +242,10 @@ jobs:
         shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
+      - name: Restore data cache
+        uses: ./.github/actions/data-cache
+        with:
+          version: ${{ env.DATA_CACHE_VERSION }}
       - uses: ./.github/actions/setup-miniforge
         with:
           python-version: ${{ matrix.python-version }}
@@ -281,6 +333,14 @@ jobs:
           key: test-durations-c-bundle-v${{ env.TEST_DURATION_CACHE_VERSION }}-${{ github.run_id }}
           restore-keys: |
             test-durations-c-bundle-v${{ env.TEST_DURATION_CACHE_VERSION }}-
+      - name: Restore data cache
+        # Only the shards whose tests reach a downloaded file: the marker-gated
+        # powspec/xcor/omp lanes touch none, and neither do the c-* slices, so
+        # restoring ~470 MB there would cost them time and buy nothing.
+        if: contains(fromJSON('["python", "py-acceptance", "py-app"]'), matrix.name)
+        uses: ./.github/actions/data-cache
+        with:
+          version: ${{ env.DATA_CACHE_VERSION }}
       - uses: ./.github/actions/setup-miniforge
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/weekly_flaky.yml
+++ b/.github/workflows/weekly_flaky.yml
@@ -15,6 +15,9 @@ on:
 
 env:
   CONDA_ENV: numcosmo_developer
+  # Kept in step with build_check.yml's knob of the same name, so both
+  # workflows share one stored copy of the data files.
+  DATA_CACHE_VERSION: 0
 
 jobs:
   flaky:
@@ -23,6 +26,13 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
     - uses: actions/checkout@v4
+    - name: Restore data cache
+      # Restore only: this lane repeats the python suite 20 times and would
+      # otherwise re-download every asset, but build_check.yml is what keeps
+      # the entry current.
+      uses: ./.github/actions/data-cache
+      with:
+        version: ${{ env.DATA_CACHE_VERSION }}
     - uses: actions/setup-python@v6
       with:
         python-version: '3.13'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,41 @@ environment forward — locks never drift on their own.
 Local development environments are unaffected: `conda env create -f
 environment.yml` still solves normally (see [docs/install.qmd](docs/install.qmd)).
 
+## CI data-file cache
+
+Several data sets are not in the repository: the Planck baseline (`plc_3.0`),
+the SNIa covariance catalogs, the curated weak-lensing catalogs and the native
+Planck likelihood objects. NumCosmo downloads each one from a tagged GitHub
+release the first time it is asked for and keeps it in `~/.numcosmo`. That is
+about 470 MB, and without a cache every CI job fetches its share of it on every
+run.
+
+`.github/actions/data-cache` restores that directory — only the downloaded
+files, never the FFTW wisdom and FFTLog tables the library writes alongside
+them. Two things make an entry stale, and nothing else does:
+
+- **The release tag.** The key embeds the `datafile-release-vX.Y.Z` tag read
+  back out of the sources that name it, so bumping the tag there is enough.
+- **`DATA_CACHE_VERSION`** in `.github/workflows/build_check.yml`. Bump it for
+  anything the tag does not catch — most importantly a file replaced in place
+  under an unchanged tag, which the library would otherwise never re-download.
+
+There are no `restore-keys`: a partial match would hand back a file whose name
+is unchanged but whose contents the new release replaced, and the library only
+downloads what is missing, so the stale copy would never be corrected.
+
+One job per OS writes the entry (`build-gcc-ubuntu` and `build-gcc-macos`);
+every other job restores it. That writer runs
+`.github/scripts/prefetch_data.py` first, which fetches *every* asset rather
+than the ones its own tests happen to touch — the key is exact, so whatever the
+writer stored is what the rest of the matrix gets until the key changes. The
+script enumerates the assets from the enums that define them, so a catalog
+added to `NcDataSNIAId`, `NcGalaxyWLObsCatalogId` or `PlanckReleaseId` is
+picked up without editing it.
+
+A cold cache is not a failure: every job simply downloads what it needs, as it
+did before, and the next run is warm.
+
 ## Submitting contributions
 
 1. Fork the repository (skip if you are on the development team).


### PR DESCRIPTION
NumCosmo downloads the Planck baseline (`plc_3.0`), the SNIa covariance catalogs, the curated weak-lensing catalogs and the native Planck likelihood objects from the `datafile-release-v1.0.0` GitHub release on first use, into `~/.numcosmo`. That is ~470 MB raw / ~254 MB compressed, fetched by every job on every run. This caches it.

## Staleness

Two triggers, and nothing else:

- **The release tag.** The key embeds the `datafile-release-vX.Y.Z` tag grepped back out of the sources that name it (three C files plus `planck_native_release.py`), so bumping it there is the whole change.
- **`DATA_CACHE_VERSION`** in `build_check.yml`, for anything the tag does not catch — most importantly a file replaced in place under an unchanged tag, which the library would otherwise never re-download.

No `restore-keys`: a partial match would hand back a file whose name is unchanged but whose content a new release replaced, and the library only downloads what is *missing*, so the stale copy would never be corrected.

## What is cached

Three explicit globs — `baseline`, `*.fits`, `*.gvar`. The FFTW wisdom (`*.fftw3`, `*.fftw3f`) and the ~1400 `ncm_fftlog_*` tables the library writes into the same directory are deliberately left out: they record what one machine measured to be fastest, and restoring them would hand a later run plans that were never timed on it. Verified against a populated `~/.numcosmo` that neither matches any of the three.

## One writer per OS

The key is exact, so whatever the writing job stored is what every other job gets until the key changes. A job that downloads only its own slice of the assets must therefore not be the writer — otherwise the rest would be re-downloaded forever, silently.

So `build-gcc-ubuntu` and `build-gcc-macos` run `.github/scripts/prefetch_data.py` on a miss (fetching *everything*) and save, `if: success()` so a failed run cannot pin a partial entry. Every other job restores only. Restore is skipped where no test reaches a downloaded file — the marker-gated `py-powspec` / `py-xcor` / `py-omp` lanes and the `c-1..3` slices — since pulling 254 MB there buys nothing.

`prefetch_data.py` enumerates the assets from `NcDataSNIAId` (`COV_*`), `NcGalaxyWLObsCatalogId` and `PlanckReleaseId`, so a catalog added to any of them is picked up without editing the script.

A cold cache is not a failure: every job downloads what it needs, exactly as before, and the next run is warm. The first run of this PR is that cold run.

## Noticed, not touched

`nc_galaxy_wl_obs_catalog_id_get_filename()` (`nc_galaxy_wl_obs.c:314`) `wget`s straight to the final path with no lock — the same race `_nc_data_download_lock` was added to fix for the Planck and SNIa paths in #344. Concurrent xdist workers can read a half-written `.gvar`. Caching makes it rarer, not gone.

`docs_artifacts_upload.yml` gets no cache, and does not need one: no docs page reaches a download. `snia.qmd` uses `SIMPLE_UNION2_1` (built in, not a `COV_*` catalog) and `galaxy_wl_mock.qmd` builds its catalog with `GalaxyWLObs.new`, not `new_from_catalog_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
