### PR TITLE
Route the last two downloads through the shared fetcher

### DIFF
--- a/numcosmo/nc/lss/galaxy/nc_galaxy_wl_obs.c
+++ b/numcosmo/nc/lss/galaxy/nc_galaxy_wl_obs.c
@@ -52,6 +52,7 @@
 #include "nc/lss/halo/nc_halo_density_profile.h"
 #include "nc/lss/halo/nc_halo_position.h"
 #include "nc/lss/wl/nc_wl_surface_mass_density.h"
+#include "nc/data/nc_data_download_priv.h"
 #include "ncm/core/ncm_cfg.h"
 #include "ncm/core/ncm_serialize.h"
 
@@ -311,20 +312,18 @@ nc_galaxy_wl_obs_catalog_id_get_filename (NcGalaxyWLObsCatalogId id)
 
     if (!g_file_test (full_filename, G_FILE_TEST_EXISTS))
     {
-      gchar *url_str   = g_strdup_printf ("https://github.com/NumCosmo/NumCosmo/releases/download/datafile-release-v1.0.0/%s", filename);
-      const gchar *dir = ncm_cfg_get_fullpath_base ();
-      gchar *cmd[]     = {"wget", "--tries=3", "--timeout=30", "-O", full_filename, url_str, NULL };
-      GError *error    = NULL;
+      gchar *url_str = g_strdup_printf ("https://github.com/NumCosmo/NumCosmo/releases/download/datafile-release-v1.0.0/%s", filename);
+      gchar *lockdir = NULL;
 
-      ncm_message ("# Downloading file [%s]...\n", url_str);
-
-      if (!g_spawn_sync (dir, cmd, NULL,
-                         G_SPAWN_SEARCH_PATH | G_SPAWN_STDOUT_TO_DEV_NULL | G_SPAWN_STDERR_TO_DEV_NULL,
-                         NULL, NULL, NULL, NULL, NULL, &error))
-        g_error ("nc_galaxy_wl_obs_catalog_id_get_filename: cannot download file: %s. Error: %s. "
-                 "Please download the file manually from %s and extract it to %s.",
-                 filename, error->message,
-                 url_str, dir);
+      /* Serialize with any other process fetching the same catalog, and let it
+       * publish by rename: writing straight to full_filename let a concurrent
+       * reader open a half-written catalog, and an interrupted fetch left a
+       * truncated one that every later run took for complete. */
+      if (_nc_data_download_lock (full_filename, full_filename, 900, &lockdir))
+      {
+        _nc_data_download_file (url_str, full_filename, filename);
+        _nc_data_download_unlock (lockdir);
+      }
 
       g_free (url_str);
     }

--- a/numcosmo_py/experiments/planck_native_release.py
+++ b/numcosmo_py/experiments/planck_native_release.py
@@ -139,12 +139,18 @@ def _ensure_downloaded(rid: PlanckReleaseId, cache_dir: str | None = None) -> st
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path), exist_ok=True)
         url = f"{RELEASE_URL}/{release_filename(rid)}"
+        # Fetched under a private name and published by rename, so a reader
+        # never sees a partial file and an interrupted fetch leaves nothing
+        # that a later run would take for a complete download. The name carries
+        # the pid: several processes may fetch the same id at once.
+        tmp = f"{path}.{os.getpid()}.part"
         try:
             print(f"# Downloading file [{url}]...", flush=True)
-            urllib.request.urlretrieve(url, path)  # nosec B310 - fixed https host
+            urllib.request.urlretrieve(url, tmp)  # nosec B310 - fixed https host
+            os.replace(tmp, path)
         except Exception as exc:  # pylint: disable=broad-except
-            if os.path.exists(path):
-                os.remove(path)
+            if os.path.exists(tmp):
+                os.remove(tmp)
             raise RuntimeError(
                 f"cannot download {url}: {exc}. Download it manually to {path}, "
                 f"or rebuild the release with build_release()."

--- a/tests/python/nc/data/test_data_download.py
+++ b/tests/python/nc/data/test_data_download.py
@@ -60,6 +60,20 @@ Ncm.cfg_init()
 sys.stdout.write(Nc.DataSNIACov.get_fits(sys.argv[1], False))
 """
 
+_FETCH_WL = """
+import sys
+from numcosmo_py import Nc, Ncm
+
+Ncm.cfg_init()
+sys.stdout.write(
+    Nc.galaxy_wl_obs_catalog_id_get_filename(Nc.GalaxyWLObsCatalogId.HSC_PDR1_HWL16A_094)
+)
+"""
+
+# Smallest curated weak-lensing catalog, 3.1 MB. Neither test below fetches it:
+# each arranges for the file to be there, and asserts it was left alone.
+WL_ASSET = "wl_obs_HWL16a-094.gvar"
+
 
 def run_isolated(script: str, home, *args) -> subprocess.CompletedProcess:
     """Run @script with an empty HOME, so the data directory starts bare."""
@@ -218,3 +232,71 @@ def test_a_waiter_uses_what_the_holder_produced(tmp_path):
     # it -- which is the whole point of waiting.
     assert target.read_bytes() == b"SENTINEL"
     assert not list(tmp_path.rglob("*.part"))
+
+
+def test_wl_catalog_waits_for_the_holder(tmp_path):
+    """The WL catalogs must take the lock like every other download.
+
+    They did not: the fetch ran `wget` straight to the final name, ignoring a
+    held lock, so a concurrent reader could open the file half-written.
+
+    Holding the lock from outside and letting the data appear separates the
+    two: the old code writes the real catalog over the sentinel, the shared
+    path waits and returns what the holder produced. The lock and rename
+    machinery is raced four ways over the tiny asset above; what this checks is
+    that this caller goes through it.
+    """
+    base = tmp_path / ".numcosmo"
+    base.mkdir()
+    target = base / WL_ASSET
+
+    # Held by nobody, which is what a live download looks like from outside.
+    (base / f"{WL_ASSET}.lock").mkdir()
+
+    proc = subprocess.Popen(  # pylint: disable=consider-using-with
+        [sys.executable, "-c", _FETCH_WL],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=dict(os.environ, HOME=str(tmp_path)),
+    )
+
+    try:
+        # Same six seconds as the SNIa waiter above: long enough that the child
+        # is past its own existence check and sitting in the lock's wait loop.
+        time.sleep(6.0)
+        # The holder finishes: distinguishable from a real fetch by content.
+        target.write_bytes(b"SENTINEL")
+        out, err = proc.communicate(timeout=120)
+    finally:
+        if proc.poll() is None:  # pragma: no cover - only on a hang
+            proc.kill()
+
+    assert proc.returncode == 0, err
+
+    # The discriminator, asserted first so a regression names itself: 8 bytes,
+    # not 3.1 MB, and no transfer announced. The old code ignored the lock and
+    # wrote the real catalog over the holder's file.
+    assert "Downloading" not in out, "fetched the catalog despite the held lock"
+    assert target.read_bytes() == b"SENTINEL"
+
+    # Last line, not the whole of stdout: a fetch would have printed first, and
+    # that is the assertion above's job to report, not this one's.
+    assert out.strip().splitlines()[-1] == str(target)
+    assert not list(tmp_path.rglob("*.part"))
+
+
+def test_wl_catalog_already_there_is_not_refetched(tmp_path):
+    """A catalog already in the data directory is returned untouched."""
+    base = tmp_path / ".numcosmo"
+    base.mkdir()
+    target = base / WL_ASSET
+    target.write_bytes(b"ALREADY")
+
+    result = run_isolated(_FETCH_WL, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(target)
+    assert target.read_bytes() == b"ALREADY"
+    assert not list(tmp_path.rglob("*.part"))
+    assert not list(tmp_path.rglob("*.lock"))

--- a/tests/python/nc/data/test_planck_release.py
+++ b/tests/python/nc/data/test_planck_release.py
@@ -183,6 +183,44 @@ def test_download_populates_the_cache(tmp_path, monkeypatch):
     assert calls[0].startswith(pnr.RELEASE_URL)
 
 
+def test_download_publishes_by_rename(tmp_path, monkeypatch):
+    """The cached name must appear only once the artifact is complete.
+
+    urlretrieve wrote straight to it, so a concurrent reader could deserialize a
+    half-written .gvar, and an interrupted fetch left a truncated one that every
+    later run took for a complete download -- the existence check is all that
+    guards it. Fetching under a private name and renaming makes the final name
+    atomic: it is either absent or whole.
+    """
+    source = tmp_path / "source"
+    cache = tmp_path / "cache"
+    source.mkdir()
+    clik = make_commander_cldf(source)
+    _write_cached(source, PlanckReleaseId.PR3_COMMANDER, build_commander(clik))
+
+    final = cache / release_filename(PlanckReleaseId.PR3_COMMANDER)
+    observed = {}
+
+    def _fake_download(url, path):  # pylint: disable=unused-argument
+        # Mid-transfer: the destination the caller will read must not be here.
+        observed["final_exists"] = final.exists()
+        observed["wrote_to"] = path
+        shutil.copyfile(
+            os.path.join(str(source), release_filename(PlanckReleaseId.PR3_COMMANDER)),
+            path,
+        )
+
+    monkeypatch.setattr(pnr.urllib.request, "urlretrieve", _fake_download)
+
+    data = load_planck_release(PlanckReleaseId.PR3_COMMANDER, cache_dir=str(cache))
+
+    assert isinstance(data, Nc.DataPlanckCommander)
+    assert observed["final_exists"] is False, "the final name existed mid-download"
+    assert observed["wrote_to"] != str(final), "wrote straight to the final name"
+    assert final.exists()
+    assert not list(cache.glob("*.part"))
+
+
 def test_download_failure_is_reported_and_leaves_no_stub(tmp_path, monkeypatch):
     """A failed download raises with the URL and removes the partial file."""
 
@@ -199,6 +237,7 @@ def test_download_failure_is_reported_and_leaves_no_stub(tmp_path, monkeypatch):
     assert not os.path.exists(
         os.path.join(str(tmp_path), release_filename(PlanckReleaseId.PR3_LENSING))
     )
+    assert not list(tmp_path.glob("*.part"))
 
 
 def test_build_release_skips_ids_without_source_data(tmp_path, monkeypatch):


### PR DESCRIPTION
#344 built one correct place to download a data file — lock the destination, fetch under a private name, publish by rename — because the destination is shared by every NumCosmo process on the machine and pytest-xdist runs several at once. Two callers never moved onto it. This moves them.

| Site | Before | After |
|---|---|---|
| `nc_data_planck_lkl.c` | shared helper | unchanged |
| `nc_data_snia_cov.c` | shared helper | unchanged |
| `nc_galaxy_wl_obs.c:316` | raw `wget` to the final path, no lock | shared helper |
| `planck_native_release.py:144` | `urlretrieve` to the final path | temp + `os.replace` |

Both had the exact defect #344 fixed: a reader can open a half-written file, and an interrupted fetch leaves a truncated one that passes the `exists()` check forever after. The C one is the worse of the two — it wrote 3.1–46 MB `.gvar` catalogs straight to the destination.

## Scope

The C side needs no new API: `nc_data_download_priv.h` is in `ncm_headers_internal` and the cross-directory include already works (`nc_xcor_priv.h` is used that way from four files).

The Python side deliberately does **not** get a public `nc_data_download_*` C function to share the implementation. That would be new installed API surface for one caller. The temp-plus-rename gets the corruption safety; what it forgoes is the lock, so several xdist workers may each fetch the same small `.gvar` once. That trade is worth revisiting if it ever shows up, but it is not worth new public API today.

## Testing

Both new tests were checked in **both directions** — they pass with the fix and fail without it, with a message naming the defect rather than a symptom:

- `test_wl_catalog_waits_for_the_holder` — the lock is held from outside and the data appears while the caller waits. The old code ignores the lock and writes the real catalog over the sentinel; the new code waits and returns what the holder produced. Reverted, it fails with `fetched the catalog despite the held lock`.
- `test_download_publishes_by_rename` — the fake transfer asserts, mid-download, that the final name does not yet exist and that it is not being written to. Reverted, it fails with `wrote straight to the final name`.

Neither test touches the network: each arranges for the file to be present and asserts it was left alone. The waiter test also cannot flake in either direction — if the child is slow and finds the sentinel through its own existence check, it still returns the sentinel and prints nothing.

Also tightened the existing failure test to assert no `.part` debris, and added a regression guard that a catalog already present is returned untouched.

Run against this worktree's build (verified by `/proc/self/maps`, after one run silently picked up another checkout's library): `test_data_download.py` + `test_planck_release.py` + `test_planck18_native.py` = 24 passed / 2 skipped (both `--run-planck-data`-gated), and `test_wl_app.py --run-app` = 97 passed. uncrustify clean on the changed C file; black, flake8 and mypy clean.

## Unrelated, noticed while testing

The release asset `wl_obs_HWL16a-094.gvar` was **replaced in place** under the unchanged `datafile-release-v1.0.0` tag: a copy fetched Jul 21 and one fetched today have the same length and different bytes, and the current asset's Last-Modified is Aug 6. Nothing here depends on that, but it is a live instance of the case `DATA_CACHE_VERSION` (#345) exists for, and it means any long-lived `~/.numcosmo` may hold a superseded copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)