### PR TITLE
Collect coverage from unoptimized code

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -347,6 +347,14 @@ jobs:
       - name: Setting up NumCosmo
         run: |
           conda activate numcosmo_developer
+          # conda's compiler activation injects -O2 into CFLAGS and CPPFLAGS, both of
+          # which meson places after the buildtype flags, so -Dbuildtype=debug alone
+          # left this build optimized. gcc's inlining then detaches a function's line
+          # counts from its own record, which lcov 2.x rejects, and erases inlined
+          # functions from the report entirely. Append -O0 so it actually wins.
+          export CFLAGS="$CFLAGS -O0"
+          export CPPFLAGS="$CPPFLAGS -O0"
+          export FFLAGS="$FFLAGS -O0"
           meson setup build -Dbuildtype=debug -Db_coverage=true -Dnumcosmo_py=true -Dfftw-planner=estimate -Dnumcosmo_debug=disabled --libdir=$CONDA_PREFIX/lib --prefix=$CONDA_PREFIX || (cat build/meson-logs/meson-log.txt && exit 1)
       - name: Building NumCosmo
         run: |

--- a/numcosmo/external/class/meson.build
+++ b/numcosmo/external/class/meson.build
@@ -85,4 +85,5 @@ libclass = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: class_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/levmar/meson.build
+++ b/numcosmo/external/levmar/meson.build
@@ -33,4 +33,5 @@ liblevmar = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: levmar_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/libcuba/meson.build
+++ b/numcosmo/external/libcuba/meson.build
@@ -37,6 +37,7 @@ libcuba_cuhre = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: cuba_c_args,
+    override_options: ['b_coverage=false'],
 )
 
 divonne_sources = files(
@@ -54,6 +55,7 @@ libcuba_divonne = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: cuba_c_args,
+    override_options: ['b_coverage=false'],
 )
 
 suave_sources = files(
@@ -71,6 +73,7 @@ libcuba_suave = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: cuba_c_args,
+    override_options: ['b_coverage=false'],
 )
 
 vegas_sources = files(
@@ -88,6 +91,7 @@ libcuba_vegas = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: cuba_c_args,
+    override_options: ['b_coverage=false'],
 )
 
 libcuba_sources = files(
@@ -113,4 +117,5 @@ libcuba = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: cuba_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/libfyaml/meson.build
+++ b/numcosmo/external/libfyaml/meson.build
@@ -117,5 +117,5 @@ libfyaml = static_library(
     # atomics header and use of DBL_DECIMAL_DIG depend on C11-or-later
     # features. Pinned explicitly so it keeps building C17 regardless of
     # NumCosmo's own project-wide c_std default.
-    override_options: ['c_std=gnu17'],
+    override_options: ['c_std=gnu17', 'b_coverage=false'],
 )

--- a/numcosmo/external/lintegrate/meson.build
+++ b/numcosmo/external/lintegrate/meson.build
@@ -26,4 +26,5 @@ liblintegrate = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: lintegrate_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/misc/meson.build
+++ b/numcosmo/external/misc/meson.build
@@ -43,4 +43,5 @@ libmisc = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: misc_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/plc/meson.build
+++ b/numcosmo/external/plc/meson.build
@@ -267,4 +267,5 @@ libplc = static_library(
     gnu_symbol_visibility: 'default',
     c_args: plc_c_args,
     fortran_args: plc_fc_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/sundials/meson.build
+++ b/numcosmo/external/sundials/meson.build
@@ -233,4 +233,5 @@ libsundials = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: sundials_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/external/toeplitz/meson.build
+++ b/numcosmo/external/toeplitz/meson.build
@@ -44,4 +44,5 @@ libtoeplitz = static_library(
     install: false,
     gnu_symbol_visibility: 'hidden',
     c_args: toeplitz_c_args,
+    override_options: ['b_coverage=false'],
 )

--- a/numcosmo/nc/perturbations/nc_hipert_two_fluids.c
+++ b/numcosmo/nc/perturbations/nc_hipert_two_fluids.c
@@ -665,6 +665,8 @@ nc_hipert_two_fluids_wkb (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alph
 void
 nc_hipert_two_fluids_get_init_cond_QP (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alpha, guint main_mode, const gdouble beta_R, NcmVector *init_cond)
 {
+  g_return_if_fail (ncm_vector_len (init_cond) == NC_HIPERT_ITWO_FLUIDS_VARS_LEN);
+
   NcHIPert *pert             = NC_HIPERT (ptf);
   NcHIPertITwoFluidsEOM *eom = nc_hipert_itwo_fluids_eom_eval (NC_HIPERT_ITWO_FLUIDS (cosmo), alpha, nc_hipert_get_mode_k (pert));
   const gdouble beta_I       = beta_R + 0.5 * M_PI;
@@ -756,6 +758,8 @@ nc_hipert_two_fluids_get_init_cond_QP (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo,
 void
 nc_hipert_two_fluids_get_init_cond_zetaS (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alpha, guint main_mode, const gdouble beta_R, NcmVector *init_cond)
 {
+  g_return_if_fail (ncm_vector_len (init_cond) == NC_HIPERT_ITWO_FLUIDS_VARS_LEN);
+
   NcHIPert *pert                = NC_HIPERT (ptf);
   NcHIPertITwoFluidsWKB *tf_wkb = nc_hipert_itwo_fluids_wkb_eval (NC_HIPERT_ITWO_FLUIDS (cosmo), alpha, nc_hipert_get_mode_k (pert));
 
@@ -1106,6 +1110,8 @@ _nc_hipert_two_fluids_J_QP (sunrealtype alpha, N_Vector y, N_Vector fy, SUNMatri
 void
 nc_hipert_two_fluids_set_init_cond (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alpha, guint main_mode, gboolean useQP, NcmVector *init_cond)
 {
+  g_return_if_fail (ncm_vector_len (init_cond) == NC_HIPERT_ITWO_FLUIDS_VARS_LEN);
+
   NcHIPertTwoFluidsPrivate * const self = ptf->priv;
   NcHIPert *pert                        = NC_HIPERT (ptf);
   NcHIPertPrivate * const pself         = nc_hipert_get_private (pert);

--- a/tests/python/nc/perturbations/test_hipert_two_fluids.py
+++ b/tests/python/nc/perturbations/test_hipert_two_fluids.py
@@ -133,7 +133,7 @@ def test_compute_full_spectrum(
 
 def test_evolve_array(two_fluids: Nc.HIPertTwoFluids, cosmo_qgrw: Nc.HICosmo):
     """Test NcHIPertTwoFluids evolve_array."""
-    init_cond = Ncm.Vector.new_array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    init_cond = Ncm.Vector.new(8)
     two_fluids.props.reltol = 1.0e-9
 
     alpha_i = two_fluids.get_wkb_limit(cosmo_qgrw, 1, -90.0, 1.0e-8)


### PR DESCRIPTION
## Summary

* Stop instrumenting the 13 bundled static libraries under `numcosmo/external`, whose coverage was captured and then discarded by the `--remove` step anyway
* Size `test_evolve_array`'s initial-condition vector correctly and guard the functions that take one
* Build the coverage job unoptimized, by appending `-O0` after the flags conda injects

Unblocks #347, which only refreshes the conda locks but in doing so moves `lcov`
1.16 -> 2.5. lcov 2.x added `check_data_consistency`, which rejects a tracefile it
just wrote:

```
lcov: ERROR: (corrupt) unable to read trace file 'numcosmo-coverage-tests.info':
lcov: ERROR: (inconsistent) "numcosmo/nc/primordial/nc_hiprim.h":124:
      function 'nc_hiprim_lnSA_powspec_lnk' is not hit but line 124 is.
```

The real finding is underneath that. `conda activate` runs `gcc_linux-64`'s activation
script, which exports `-O2` inside both `CFLAGS` and `CPPFLAGS`; meson places those
after the buildtype flags, so the coverage job has always compiled `-O2` while its
summary printed `Optimization level : 0`. gcc then inlined `static` functions, which
detaches a function's line counts from its own record — what lcov 2.x rejects — and
erased roughly 1100 functions from the report (12198 counted at `-O2` versus 13332
at `-O0`).

`-Dc_args=-O0` is the wrong lever: meson treats `CFLAGS` as that option's default, so
passing it explicitly replaces conda's flags and drops `-isystem $CONDA_PREFIX/include`.
Appending to the environment is the safe form, and it has to reach `CPPFLAGS` too,
which meson places last. It is applied there rather than per target so the test
executables get it as well, not just the library.

The unoptimized build immediately exposed a real defect, included here because it
otherwise blocks the change: `test_evolve_array` passed a 6-element initial-condition
vector for an 8-component state, so `get_init_cond_zetaS` wrote past the end of the
buffer. It passed only because of what happened to follow the allocation — nonzero at
`-O2`, zero at `-O0`, which makes CVODE's error-weight vector illegal.

## Test plan

Full coverage matrix on #351, which stacks these commits on the new locks so lcov 2.5
is actually exercised. **All 9 slices pass with stock `.lcovrc`** — no `ignore_errors`,
nothing suppressed. Codecov moves 83.43% -> 82.76% (-0.68%), with misses up only 361:
lines that `-O2` reported as hit through inlined and optimized-away code stop being
counted.

Cost, against a green master run:

| slice | before | after | |
|---|---|---|---|
| Cov-py-xcor | 18m51s | 30m04s | +60% |
| Cov-py-acceptance | 15m37s | 24m31s | +57% |
| Cov-c-3 | 8m45s | 11m16s | +29% |
| Cov-py-omp | 8m46s | 9m42s | +11% |
| Cov-c-1 | 9m38s | 9m51s | +2% |
| Cov-py-app | 7m29s | 7m24s | -1% |
| Cov-python | 21m11s | 19m43s | -7% |
| Cov-py-powspec | 7m26s | 6m22s | -14% |
| Cov-c-2 | 8m07s | 6m40s | -18% |
| **total** | **105m50s** | **125m33s** | **+19%** |

The slowest job sets the wall clock, which moves from 21m11s to 30m04s. Unoptimized
builds compile roughly twice as fast and the external libraries no longer carry
instrumentation, which is why the lighter slices get quicker; the heavy numerical lanes
have no build time to reclaim and pay for `-O0` outright. Some of the `c-*` spread is
the duration-aware slicer still balancing against durations recorded under `-O2`.

Rebalancing or splitting the slow lanes is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)