### PR TITLE
Reject undersized two-fluids initial-condition vectors

### DIFF
--- a/numcosmo/nc/perturbations/nc_hipert_two_fluids.c
+++ b/numcosmo/nc/perturbations/nc_hipert_two_fluids.c
@@ -665,6 +665,8 @@ nc_hipert_two_fluids_wkb (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alph
 void
 nc_hipert_two_fluids_get_init_cond_QP (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alpha, guint main_mode, const gdouble beta_R, NcmVector *init_cond)
 {
+  g_return_if_fail (ncm_vector_len (init_cond) == NC_HIPERT_ITWO_FLUIDS_VARS_LEN);
+
   NcHIPert *pert             = NC_HIPERT (ptf);
   NcHIPertITwoFluidsEOM *eom = nc_hipert_itwo_fluids_eom_eval (NC_HIPERT_ITWO_FLUIDS (cosmo), alpha, nc_hipert_get_mode_k (pert));
   const gdouble beta_I       = beta_R + 0.5 * M_PI;
@@ -756,6 +758,8 @@ nc_hipert_two_fluids_get_init_cond_QP (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo,
 void
 nc_hipert_two_fluids_get_init_cond_zetaS (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alpha, guint main_mode, const gdouble beta_R, NcmVector *init_cond)
 {
+  g_return_if_fail (ncm_vector_len (init_cond) == NC_HIPERT_ITWO_FLUIDS_VARS_LEN);
+
   NcHIPert *pert                = NC_HIPERT (ptf);
   NcHIPertITwoFluidsWKB *tf_wkb = nc_hipert_itwo_fluids_wkb_eval (NC_HIPERT_ITWO_FLUIDS (cosmo), alpha, nc_hipert_get_mode_k (pert));
 
@@ -1106,6 +1110,8 @@ _nc_hipert_two_fluids_J_QP (sunrealtype alpha, N_Vector y, N_Vector fy, SUNMatri
 void
 nc_hipert_two_fluids_set_init_cond (NcHIPertTwoFluids *ptf, NcHICosmo *cosmo, gdouble alpha, guint main_mode, gboolean useQP, NcmVector *init_cond)
 {
+  g_return_if_fail (ncm_vector_len (init_cond) == NC_HIPERT_ITWO_FLUIDS_VARS_LEN);
+
   NcHIPertTwoFluidsPrivate * const self = ptf->priv;
   NcHIPert *pert                        = NC_HIPERT (ptf);
   NcHIPertPrivate * const pself         = nc_hipert_get_private (pert);

--- a/tests/python/nc/perturbations/test_hipert_two_fluids.py
+++ b/tests/python/nc/perturbations/test_hipert_two_fluids.py
@@ -133,7 +133,7 @@ def test_compute_full_spectrum(
 
 def test_evolve_array(two_fluids: Nc.HIPertTwoFluids, cosmo_qgrw: Nc.HICosmo):
     """Test NcHIPertTwoFluids evolve_array."""
-    init_cond = Ncm.Vector.new_array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    init_cond = Ncm.Vector.new(8)
     two_fluids.props.reltol = 1.0e-9
 
     alpha_i = two_fluids.get_wkb_limit(cosmo_qgrw, 1, -90.0, 1.0e-8)


### PR DESCRIPTION
## Summary

* Size `test_evolve_array`'s initial-condition vector to the 8 components the two-fluids state actually has, as `examples/twofluids_wkb_*.py` already do
* Add a length precondition to the three public functions that take an `init_cond` vector

The two-fluids state is `NC_HIPERT_ITWO_FLUIDS_VARS_LEN` = 8 (real and imaginary
parts of zeta, S, Pzeta, Ps), but `test_evolve_array` passed a 6-element vector.
`nc_hipert_two_fluids_get_init_cond_zetaS` therefore wrote two doubles past the end
of the buffer and `set_init_cond` read them back into the solver state.
`ncm_vector_set` does not range check, so nothing reported it.

The test passed only because of what happened to sit after the allocation. At `-O2`
those bytes were nonzero and CVODE ran; at `-O0` they were zero, which makes the
error-weight vector `1/(reltol*|y| + abstol)` illegal, so `cvInitialSetup` failed with
`CV_ILL_INPUT` and `evolve_array` returned NULL:

```
[cvInitialSetup] Initial ewt has component(s) equal to zero (illegal).
SUNDIALS_ERROR: CVode[nc_hipert_two_fluids_evolve_array]() failed with flag = -22
```

Found while testing an unoptimized coverage build; the overflow itself is unrelated to
that work and predates it.

## Test plan

* `pytest tests/python/nc/perturbations/test_hipert_two_fluids.py`: 7 passed against a
  `-O0` build and against a `-O3` build
* Passing the old 6-element vector now aborts on the precondition instead of
  overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)