### PR TITLE
Revert the xcor lane to loadgroup with explicit pins

### DIFF
--- a/tests/python/meson.build
+++ b/tests/python/meson.build
@@ -59,15 +59,14 @@ if enable_gir and python_for_tests.found()
         required: false,
     )
     if py_xdist.found()
-        # worksteal: split the suite across workers up front, then let a worker
-        # that runs dry take work from one that has not. That keeps the tail
-        # short without pinning anything to a single worker. The xcor lane's
-        # heaviest file used to be pinned with xdist_group under loadgroup,
-        # because an xdist worker is its own session and its fixture cache is
-        # therefore paid per worker; bounding that cache is what actually fixed
-        # the memory, and measuring the two separately showed the pin cost 5.1x
-        # wall time (278 s vs 54 s for the lane) while saving no memory.
-        pytest_parallel_args = pytest_base_args + ['-n', 'auto', '--dist', 'worksteal']
+        # loadgroup, not the default load: tests marked with xdist_group go to
+        # one worker, everything else still distributes test by test. An xdist
+        # worker is its own session, so a module-scoped fixture is built once
+        # per *worker* -- for the xcor lane's heaviest files that is several GB
+        # replicated 12 or 24 times, which exhausted a 30 GB machine. Grouping
+        # those files costs them their internal parallelism and nothing else.
+        # Ungrouped tests behave exactly as under load.
+        pytest_parallel_args = pytest_base_args + ['-n', 'auto', '--dist', 'loadgroup']
     else
         pytest_parallel_args = pytest_base_args
     endif

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -20,7 +20,10 @@ from numcosmo_py.ccl.two_point import (
     compute_kernel,
 )
 
-pytestmark = [pytest.mark.ccl, pytest.mark.xcor]
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [pytest.mark.ccl, pytest.mark.xcor, pytest.mark.xdist_group("ccl_angular")]
 
 Ncm.cfg_init()
 

--- a/tests/python/nc/xcor/test_ccl_comparison.py
+++ b/tests/python/nc/xcor/test_ccl_comparison.py
@@ -45,9 +45,13 @@ from numcosmo_py.cosmology import Cosmology
 from numcosmo_py.ccl.two_point import compute_kernel
 import numcosmo_py.ccl.comparison as nc_cmp
 
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
 pytestmark = [
     pytest.mark.ccl,
     pytest.mark.xcor,
+    pytest.mark.xdist_group("ccl_comparison"),
 ]
 
 Ncm.cfg_init()

--- a/tests/python/nc/xcor/test_k_integral.py
+++ b/tests/python/nc/xcor/test_k_integral.py
@@ -59,13 +59,15 @@ from xcor import cases_k_integral as cases
 
 pytest_plugins = ["python.fixtures_xcor"]
 
-# An xdist worker is its own session, so the frozen fixture's cache below is paid per
-# worker; FROZEN_CACHE_MAXSIZE is what bounds it. Before that cap existed the fixture
-# held every Frozen object it built -- 3.5 GB by the end of the file -- and exhausted
-# memory at 12 workers. This file was additionally pinned to a single worker at the same
-# time; measuring the two separately afterwards showed the cap alone is sufficient and
-# the pin cost 5.1x wall time (278 s vs 54 s across the lane) for no memory saving.
-pytestmark = pytest.mark.xcor
+# xdist_group pins this whole file to one worker under --dist loadgroup.
+# The frozen fixture below caches up to 102 Frozen objects, each holding two
+# kernels, two closures and their references -- 3.5 GB by the end of the file.
+# That is per *worker*, since an xdist worker is its own session, so plain
+# --dist load builds one copy per worker and exhausts memory on a many-core
+# machine (measured: OOM at 12 workers, and every run at 24). Grouping costs
+# this file its internal parallelism and nothing else -- every other file still
+# distributes test by test.
+pytestmark = [pytest.mark.xcor, pytest.mark.xdist_group("k_integral")]
 
 CLOSURES = {
     "spline": Nc.XcorKernelClosure.SPLINE,

--- a/tests/python/nc/xcor/test_kernel.py
+++ b/tests/python/nc/xcor/test_kernel.py
@@ -34,7 +34,10 @@ import numpy as np
 from numcosmo_py import Ncm, Nc
 from numcosmo_py.cosmology import Cosmology
 
-pytestmark = pytest.mark.xcor
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [pytest.mark.xcor, pytest.mark.xdist_group("kernel")]
 
 Ncm.cfg_init()
 pytest_plugins = ["python.fixtures_xcor"]

--- a/tests/python/nc/xcor/test_xcor_window_truth_table.py
+++ b/tests/python/nc/xcor/test_xcor_window_truth_table.py
@@ -51,7 +51,10 @@ from numcosmo_py import Nc, Ncm
 
 Ncm.cfg_init()
 
-pytestmark = pytest.mark.xcor
+# Pinned to one worker under --dist loadgroup: this file is one of the
+# xcor lane's memory peaks, and an xdist worker is its own session, so
+# without this its cost is paid once per worker rather than once.
+pytestmark = [pytest.mark.xcor, pytest.mark.xdist_group("window_truth")]
 
 TRUTH_TABLE = "truth_tables/xcor/xcor_window_ilk.json.gz"
 


### PR DESCRIPTION
Reverts `cdb1c638` from #355. That change replaced `--dist loadgroup` plus five `xdist_group` pins with `--dist worksteal`, and the xcor coverage lane went from **30m46s to 47m** on CI.

The pins were doing more than bounding memory. Keeping `test_k_integral.py` on one worker also meant its `Frozen` cache was built **once**; under `worksteal` the file's cases spread across workers and each rebuilds whatever it receives, with the LRU bound at 8.

The decisive detail is worker count: **CI runs two workers, not four.** `pytest-xdist`'s `-n auto` uses the physical core count, and the runners are two physical cores behind four vCPUs (`created: 2/2 workers` in the job log). With two workers there is no spare parallelism to absorb the rebuild, so the pinned tail is the cheaper of the two costs.

Measurements, all with 2186 tests passing:

| configuration | mode | wall |
|---|---|---:|
| CI (2 workers, `-O0`+gcov) | `loadgroup` + pins | **30m46s** |
| CI (2 workers, `-O0`+gcov) | `worksteal` | 47m |
| local (4 workers, `-O0`+gcov) | `worksteal` | 729 s |
| local (4 workers, `-O0`+gcov) | `loadfile` | 1114 s |
| local (4 workers, `-O0`+gcov) | `loadgroup` + pins | 1118 s |
| local (12 workers, Optimized) | `worksteal` | 54 s |
| local (12 workers, Optimized) | `loadgroup` + pins | 278 s |

The original change was benchmarked at twelve workers on the Optimized build, which reverses the ordering: the more workers, the better `worksteal` looks, and CI sits at the opposite end.

`loadfile` was tried as a middle ground and is no better — it pins *every* file, creating a tail per large file rather than one.

The underlying cost is that `test_k_integral.py` computes its reference at runtime and needs the cache to be affordable; every distribution mode only rearranges who pays. Sourcing those references from the existing `data/truth_tables/xcor/xcor_kquad.json.gz` would remove the cache, the memory pressure and the scheduling sensitivity together, and is tracked separately.

The other three commits from #355 are unaffected and stay: the app lane fix, the abstol leftovers, and blocking `pytest-randomly`.