### PR TITLE
Compute the CBE characteristic redshifts from the backend's own splines

### DIFF
--- a/numcosmo/nc/cmb/nc_cbe.c
+++ b/numcosmo/nc/cmb/nc_cbe.c
@@ -2134,7 +2134,10 @@ nc_cbe_thermodyn_get_Xe (NcCBE *cbe)
  * nc_cbe_thermodyn_v_tau_max_z:
  * @cbe: a #NcCBE
  *
- * Gets the redshift of the maximum visibility function.
+ * Gets CLASS's $z_\mathrm{rec}$, the redshift where the visibility function per unit
+ * conformal time is maximum. This is not the same as
+ * [nc_recomb_get_v_tau_max_z()], which maximizes the visibility function per unit
+ * $\lambda = -\ln(1+z)$; the two differ by about 4 in $z$.
  *
  * Returns: $z_\mathrm{rec}$.
  */

--- a/numcosmo/nc/recomb/nc_recomb_cbe.c
+++ b/numcosmo/nc/recomb/nc_recomb_cbe.c
@@ -149,17 +149,14 @@ _nc_recomb_cbe_prepare (NcRecomb *recomb, NcHICosmo *cosmo)
 
   _nc_recomb_prepare_tau_splines (recomb, cosmo);
 
-  recomb->v_tau_max_z = nc_cbe_thermodyn_v_tau_max_z (recomb_cbe->cbe);
-  recomb->tau_drag_z  = nc_cbe_thermodyn_z_d (recomb_cbe->cbe);
-
-  recomb->v_tau_max_lambda = -log1p (recomb->v_tau_max_z);
-  recomb->tau_drag_lambda  = -log1p (recomb->tau_drag_z);
-
-  recomb->tau_lambda = GSL_NAN;
-  recomb->tau_z      = GSL_NAN;
-
-  recomb->tau_cutoff_lambda = GSL_NAN;
-  recomb->tau_cutoff_z      = GSL_NAN;
+  /*
+   * The characteristic redshifts come from the splines above, using the same code as
+   * every other backend. CLASS publishes z_rec and z_d, but z_rec is the maximum of
+   * the visibility function per unit conformal time, whereas NcRecomb:v_tau_max_z is
+   * the maximum per unit lambda -- the two differ by about 4 in z. CLASS publishes no
+   * counterpart for tau_z or tau_cutoff_z.
+   */
+  _nc_recomb_prepare_redshifts (recomb, cosmo);
 }
 
 static gdouble

--- a/numcosmo/numcosmo.h
+++ b/numcosmo/numcosmo.h
@@ -55,6 +55,7 @@
 
 /* Cosmic thermodynamics */
 #include <numcosmo/nc/recomb/nc_recomb.h>
+#include <numcosmo/nc/recomb/nc_recomb_cbe.h>
 #include <numcosmo/nc/recomb/nc_recomb_seager.h>
 #include <numcosmo/nc/reion/nc_hireion.h>
 #include <numcosmo/nc/reion/nc_hireion_camb.h>

--- a/tests/c/nc/recomb/test_nc_recomb.c
+++ b/tests/c/nc/recomb/test_nc_recomb.c
@@ -31,6 +31,7 @@
 void test_nc_recomb_seager_new (void);
 void test_nc_recomb_seager_wmap_zstar (void);
 void test_nc_recomb_seager_Xe_ini (void);
+void test_nc_recomb_cbe_seager_redshifts (void);
 
 gint
 main (gint argc, gchar *argv[])
@@ -42,6 +43,7 @@ main (gint argc, gchar *argv[])
   g_test_add_func ("/nc/recomb/seager/new", &test_nc_recomb_seager_new);
   g_test_add_func ("/nc/recomb/seager/wmap/zstar", &test_nc_recomb_seager_wmap_zstar);
   g_test_add_func ("/nc/recomb/seager/wmap/Xe_ini", &test_nc_recomb_seager_Xe_ini);
+  g_test_add_func ("/nc/recomb/cbe/seager/redshifts", &test_nc_recomb_cbe_seager_redshifts);
 
   g_test_run ();
 }
@@ -80,7 +82,6 @@ void
 test_nc_recomb_seager_wmap_zstar (void)
 {
   NcRecomb *recomb = NC_RECOMB (nc_recomb_seager_new ());
-  NcHIReion *reion = NC_HIREION (nc_hireion_camb_new ());
   NcHICosmo *cosmo = NC_HICOSMO (nc_hicosmo_de_xcdm_new ());
 
   nc_hicosmo_de_set_wmap5_params (NC_HICOSMO_DE (cosmo));
@@ -101,7 +102,6 @@ test_nc_recomb_seager_wmap_zstar (void)
     ncm_assert_cmpdouble_e (zstar, ==, 1325.06, 1.0e-4, 0.0);
   }
 
-  nc_hireion_free (reion);
   nc_hicosmo_free (cosmo);
   nc_recomb_free (recomb);
 }
@@ -110,7 +110,6 @@ void
 test_nc_recomb_seager_Xe_ini (void)
 {
   NcRecomb *recomb = NC_RECOMB (nc_recomb_seager_new ());
-  NcHIReion *reion = NC_HIREION (nc_hireion_camb_new ());
   NcHICosmo *cosmo = NC_HICOSMO (nc_hicosmo_de_xcdm_new ());
 
   nc_recomb_prepare_if_needed (recomb, cosmo);
@@ -121,8 +120,53 @@ test_nc_recomb_seager_Xe_ini (void)
     ncm_assert_cmpdouble_e (Xe_ini, ==, 1.0 + 2.0 * nc_hicosmo_XHe (cosmo), recomb->prec * 1.0e2, 0.0);
   }
 
-  nc_hireion_free (reion);
   nc_hicosmo_free (cosmo);
   nc_recomb_free (recomb);
+}
+
+void
+test_nc_recomb_cbe_seager_redshifts (void)
+{
+  NcHIReion *reion = NC_HIREION (nc_hireion_camb_new ());
+  NcHIPrim *prim   = NC_HIPRIM (nc_hiprim_power_law_new ());
+  NcHICosmo *cosmo = NC_HICOSMO (nc_hicosmo_de_xcdm_new_full (reion, prim, NULL));
+  NcRecomb *seager = NC_RECOMB (nc_recomb_seager_new ());
+  NcRecomb *cbe    = NC_RECOMB (nc_recomb_cbe_new ());
+
+  nc_recomb_prepare_if_needed (seager, cosmo);
+  nc_recomb_prepare_if_needed (cbe, cosmo);
+
+  /*
+   * Both backends compute the four characteristic redshifts from their own optical
+   * depth splines with the same definitions, so they agree to the accuracy of the two
+   * recombination histories. CLASS publishes z_rec and z_d, which the CBE backend does
+   * not use: z_rec maximizes the visibility function per unit conformal time, not per
+   * unit lambda, and differs from v_tau_max_z by about 4 in z.
+   */
+  g_assert_true (gsl_finite (nc_recomb_get_v_tau_max_z (cbe, cosmo)));
+  g_assert_true (gsl_finite (nc_recomb_get_tau_z (cbe, cosmo)));
+  g_assert_true (gsl_finite (nc_recomb_get_tau_drag_z (cbe, cosmo)));
+  g_assert_true (gsl_finite (nc_recomb_get_tau_cutoff_z (cbe, cosmo)));
+
+  ncm_assert_cmpdouble_e (nc_recomb_get_v_tau_max_z (cbe, cosmo), ==,
+                          nc_recomb_get_v_tau_max_z (seager, cosmo), 1.0e-4, 0.0);
+  ncm_assert_cmpdouble_e (nc_recomb_get_tau_z (cbe, cosmo), ==,
+                          nc_recomb_get_tau_z (seager, cosmo), 1.0e-4, 0.0);
+  ncm_assert_cmpdouble_e (nc_recomb_get_tau_drag_z (cbe, cosmo), ==,
+                          nc_recomb_get_tau_drag_z (seager, cosmo), 1.0e-4, 0.0);
+  ncm_assert_cmpdouble_e (nc_recomb_get_tau_cutoff_z (cbe, cosmo), ==,
+                          nc_recomb_get_tau_cutoff_z (seager, cosmo), 1.0e-3, 0.0);
+
+  /* The lambda fields must match the redshifts they are derived from. */
+  ncm_assert_cmpdouble_e (nc_recomb_get_v_tau_max_lambda (cbe, cosmo), ==,
+                          -log1p (nc_recomb_get_v_tau_max_z (cbe, cosmo)), 1.0e-14, 0.0);
+  ncm_assert_cmpdouble_e (nc_recomb_get_tau_lambda (cbe, cosmo), ==,
+                          -log1p (nc_recomb_get_tau_z (cbe, cosmo)), 1.0e-14, 0.0);
+
+  nc_hiprim_free (prim);
+  nc_hireion_free (reion);
+  nc_hicosmo_free (cosmo);
+  nc_recomb_free (seager);
+  nc_recomb_free (cbe);
 }
 


### PR DESCRIPTION
## Summary

`_nc_recomb_cbe_prepare()` set `v_tau_max_z` from CLASS's `pth.z_rec` and left `tau_z` and
`tau_cutoff_z` at `GSL_NAN`. Both parts are wrong for the fields being filled:

- CLASS's `z_rec` is the maximum of the visibility function per unit conformal time.
  `NcRecomb:v_tau_max_z` is documented as the maximum per unit $\lambda = -\ln(1+z)$
  ("the value of $z(\lambda_\text{max})$ where $dv_\tau(\lambda_\text{max})/d\lambda = 0$").
  The two differ by about 4 in $z$: at a WMAP-like cosmology the CBE backend reported
  1089.86 where the documented quantity is 1085.91.
- `tau_z` and `tau_cutoff_z` were reachable all along: the backend already calls
  `_nc_recomb_prepare_tau_splines()`, and `nc_recomb_tau()` is an evaluation of that spline.

All four characteristic redshifts now come from `_nc_recomb_prepare_redshifts()`, the same
call the Seager backend makes on its own splines.

## Agreement between backends

Same cosmology (`NcHICosmoDEXcdm` with `NcHIReionCamb`), after the change:

| | Seager | CBE | rel. diff |
| --- | --- | --- | --- |
| `v_tau_max_z` | 1085.9160 | 1085.9068 | 8.5e-6 |
| `tau_z` | 1081.1209 | 1081.1119 | 8.3e-6 |
| `tau_drag_z` | 1059.8579 | 1059.8497 | 7.7e-6 |
| `tau_cutoff_z` | 1641.5608 | 1641.6119 | 3.1e-5 |

`tau_drag_z` was already consistent (CLASS's `z_d` is the $\tau_d = 1$ root, the same
definition) and moves by 4e-5 relative from taking it locally instead.

## Also here

- `nc_cbe_thermodyn_v_tau_max_z()` said only "the redshift of the maximum visibility
  function", with no measure. That is how the mismatch went unnoticed; it now states which
  maximum CLASS reports and how it relates to `nc_recomb_get_v_tau_max_z()`.
- `nc_recomb_cbe.h` added to the `numcosmo.h` umbrella. `NcRecombCBE` was installed but not
  reachable from the umbrella header, which is what the new test needed.
- Two `NcHIReion` objects in `test_nc_recomb.c` created and freed without ever being
  attached to a cosmology, removed.

## Test

`/nc/recomb/cbe/seager/redshifts`: the four redshifts must agree across the two backends,
and the $\lambda$ fields must match the redshifts derived from them. It fails on the previous
code at the `tau_z` NaN. Unit tier, no new test binary; the CBE half is a thermodynamics-only
CLASS run, and the whole `nc_recomb` suite runs in 1.1 s.

## Context

`nc_distance_decoupling_redshift()` in #361 proposes to read the recombination history, which
is what surfaced both problems. This PR is independent of that one and does not touch
`NcDistance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
