### PR TITLE
Close the RSD follow-ups from the post-merge review

### DIFF
--- a/numcosmo/nc/powspec/nc_growth_func.c
+++ b/numcosmo/nc/powspec/nc_growth_func.c
@@ -648,17 +648,17 @@ nc_growth_func_prepare_if_needed (NcGrowthFunc *gf, NcHICosmo *cosmo)
  * @z: redshift $z$
  *
  * This function evaluates the derivative of the normalized growth
- * function $\mathrm{d}D/\mathrm{d}a$ at redshift $z$, also called as linear growth rate.
- * Where $a$ is the scale factor.
+ * function with respect to redshift, $\mathrm{d}D/\mathrm{d}z = -a^2\, \mathrm{d}D/\mathrm{d}a$,
+ * where $a = 1/(1+z)$ is the scale factor.
  *
- * Note that this  definition is different from the one normally applied in redshift-space distortion studies.
- * These studies use the parameter given by,
+ * This is not the linear growth rate used in redshift-space distortion studies,
  * \begin{equation*}
- * f(z) = \left. \frac{\mathrm{d}\ln D}{\mathrm{d} \ln a} \right|_{z} = -\frac{(1 + z)}{D(z)} \left. \frac{\mathrm{d} D}{\mathrm{d} a} \right|_{z} \,\, .
+ * f(z) = \left. \frac{\mathrm{d}\ln D}{\mathrm{d} \ln a} \right|_{z} = -\frac{(1 + z)}{D(z)} \left. \frac{\mathrm{d} D}{\mathrm{d} z} \right|_{z} \,\, ,
  * \end{equation*}
+ * which follows from this derivative and nc_growth_func_eval().
  * For more details see e.g. [Zarrouk et al. (2018)][X2018MNRAS.477.1639Z] [[arXiv](https://arxiv.org/abs/1801.03062)].
  *
- * Returns: the derivative of the normalized growth function $\left. \frac{\mathrm{d} D}{\mathrm{d} a} \right|_z$.
+ * Returns: the derivative of the normalized growth function $\left. \frac{\mathrm{d} D}{\mathrm{d} z} \right|_z$.
  */
 
 /**
@@ -667,9 +667,11 @@ nc_growth_func_prepare_if_needed (NcGrowthFunc *gf, NcHICosmo *cosmo)
  * @cosmo: a #NcHICosmo
  * @z: redshift $z$
  * @d: (out): Growth function $D(z)$
- * @f: (out): Growth function derivative $\left. \mathrm{d}D/\mathrm{d}a \right|_{z}$
+ * @f: (out): Growth function derivative $\left. \mathrm{d}D/\mathrm{d}z \right|_{z}$
  *
- * This function evaluates the normalized growth function $D$ and its derivative $\mathrm{d}D/\mathrm{d}a$ at redshift $z$.
+ * This function evaluates the normalized growth function $D$ and its derivative
+ * with respect to redshift, $\mathrm{d}D/\mathrm{d}z$, at redshift $z$. See
+ * nc_growth_func_eval_deriv() for the relation to the linear growth rate.
  *
  */
 

--- a/numcosmo/nc/xcor/nc_xcor_kernel_gal.c
+++ b/numcosmo/nc/xcor/nc_xcor_kernel_gal.c
@@ -516,7 +516,11 @@ nc_xcor_kernel_gal_class_init (NcXcorKernelGalClass *klass)
    * Whether to include the linear redshift-space distortion (Kaiser) term.
    * Adds a component with kernel $-f(z)\, \mathrm{d}n/\mathrm{d}z$ weighted by
    * $j_\ell''(k\chi)$, where $f$ is the linear growth rate. Supported by the
-   * kernel-space methods only.
+   * kernel-space methods only (%NC_XCOR_METHOD_KERNEL_EXACT,
+   * %NC_XCOR_METHOD_KERNEL_CUBATURE, %NC_XCOR_METHOD_KERNEL_GSL): the
+   * redshift-space Limber methods, including the #NcXcor:meth default
+   * %NC_XCOR_METHOD_LIMBER_Z_GSL, stop with an error on a kernel with this
+   * property set.
    */
   g_object_class_install_property (object_class,
                                    PROP_DORSD,

--- a/numcosmo/ncm/specfunc/ncm_sbessel_integrator.c
+++ b/numcosmo/ncm/specfunc/ncm_sbessel_integrator.c
@@ -374,7 +374,8 @@ ncm_sbessel_integrator_integrate (NcmSBesselIntegrator *sbi, NcmSBesselIntegrato
 void
 ncm_sbessel_integrator_integrate_deriv (NcmSBesselIntegrator *sbi, NcmSBesselIntegratorF F, gdouble a, gdouble b, gdouble k, guint deriv, NcmVector *result, gpointer user_data)
 {
-  g_return_if_fail (deriv <= 2);
+  if (deriv > 2)
+    g_error ("ncm_sbessel_integrator_integrate_deriv: derivative order %u not supported (up to 2)", deriv);
 
   if (deriv == 0)
     NCM_SBESSEL_INTEGRATOR_GET_CLASS (sbi)->integrate (sbi, F, a, b, k, result, user_data);

--- a/numcosmo/ncm/specfunc/ncm_sbessel_integrator_levin.c
+++ b/numcosmo/ncm/specfunc/ncm_sbessel_integrator_levin.c
@@ -1547,6 +1547,11 @@ _ncm_sbessel_integrator_levin_integrate_levin (NcmSBesselIntegratorLevin *sbilv,
   gint first_knot_idx         = -1;
   gint last_knot_idx          = -1;
   const guint n_ell           = ell_max - ell_min + 1;
+
+  /* Lowest order read from the Bessel array in a panel: the deriv > 0
+   * boundary terms use j_{ell-1}, so the panel-skip gate must match
+   * _ncm_sbessel_integrator_levin_panel_is_null and look one order down. */
+  const guint ell_gate = ((sbilv->deriv > 0) && (ell_min > 0)) ? ell_min - 1 : ell_min;
   gdouble first_knot, last_knot;
   guint i;
 
@@ -1581,7 +1586,7 @@ _ncm_sbessel_integrator_levin_integrate_levin (NcmSBesselIntegratorLevin *sbilv,
       const gdouble a_p = y_min;
       const gdouble b_p = g_array_index (sbilv->knots, gdouble, first_knot_idx);
 
-      if (ell_min <= ncm_sf_sbessel_array_eval_ell_cutoff (sbilv->sba, b_p))
+      if (ell_gate <= ncm_sf_sbessel_array_eval_ell_cutoff (sbilv->sba, b_p))
       {
         if (first_knot_idx > 0)
         {
@@ -1617,7 +1622,7 @@ _ncm_sbessel_integrator_levin_integrate_levin (NcmSBesselIntegratorLevin *sbilv,
       const gdouble a_p = g_array_index (sbilv->knots, gdouble, i);
       const gdouble b_p = g_array_index (sbilv->knots, gdouble, i + 1);
 
-      if (ell_min <= ncm_sf_sbessel_array_eval_ell_cutoff (sbilv->sba, b_p))
+      if (ell_gate <= ncm_sf_sbessel_array_eval_ell_cutoff (sbilv->sba, b_p))
         _ncm_sbessel_integrator_levin_integrate_panel (sbilv, i, i + 1,
                                                        a_p, b_p, spectral, F, k,
                                                        ell_min, ell_max, result_data, user_data, FALSE);
@@ -1628,7 +1633,7 @@ _ncm_sbessel_integrator_levin_integrate_levin (NcmSBesselIntegratorLevin *sbilv,
       const gdouble a_p = g_array_index (sbilv->knots, gdouble, last_knot_idx);
       const gdouble b_p = y_max;
 
-      if (ell_min <= ncm_sf_sbessel_array_eval_ell_cutoff (sbilv->sba, b_p))
+      if (ell_gate <= ncm_sf_sbessel_array_eval_ell_cutoff (sbilv->sba, b_p))
       {
         if ((guint) last_knot_idx + 1 < sbilv->knots->len)
         {

--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -23,6 +23,8 @@
 
 """Two-point correlation functions."""
 
+from typing import Callable
+
 import numpy as np
 import pyccl
 
@@ -73,7 +75,8 @@ def compute_kernel(
             case 0:
                 bessel_factors_list.append(1.0)
             case -1:
-                # j_l(x)/x^2, folded into the kernel as CCL does.
+                # j_l(x)/x^2 at the Limber point x = nu. A single-ell kernel
+                # cannot carry the exact 1/(k chi)^2; angular_cl does.
                 bessel_factors_list.append(1.0 / nu**2)
             case 1 | 2:
                 raise NotImplementedError(
@@ -148,6 +151,33 @@ def tracer_components(
     return chi_a[1:-1], [c[1:-1] for c in comps], der_bessel
 
 
+def _kernel_callback(sp: Ncm.Spline) -> Callable[[object, float, float], float]:
+    """Radial kernel callback for the integrator: the resampled table itself."""
+
+    def kernel_cb(_p: object, chi: float, _k: float) -> float:
+        return sp.eval(chi)
+
+    return kernel_cb
+
+
+def _spin2_kernel_callback(
+    sp: Ncm.Spline, slope: float, chi0: float
+) -> Callable[[object, float, float], float]:
+    """Radial kernel callback carrying the spin-2 weight 1 / chi^2.
+
+    Below the table's first sample ``chi0`` the kernel is continued linearly,
+    ``W = slope * chi``, so the callback returns ``slope / chi`` there.
+    """
+
+    def kernel_cb(_p: object, chi: float, _k: float) -> float:
+        if chi < chi0:
+            return slope / chi
+
+        return sp.eval(chi) / chi**2
+
+    return kernel_cb
+
+
 def bessel_transform_block(
     tracer: pyccl.Tracer,
     cosmology: Cosmology,
@@ -185,7 +215,6 @@ def bessel_transform_block(
     out = np.zeros((n_ell, len(k_a)))
 
     ells = np.arange(ell_min, ell_max + 1)
-    nu = ells + 0.5
 
     for comp, der in zip(comps, der_bessel):
         sp = Ncm.SplineBSpline.new_tol(reltol, 0.0)
@@ -194,26 +223,44 @@ def bessel_transform_block(
         f_ell = np.array([tracer.get_f_ell(float(ell)) for ell in ells]).reshape(
             len(ells), -1
         )
-        f_c = f_ell[:, 0] if f_ell.shape[1] == 1 else f_ell[:, 0]
-        bes = 1.0 / nu**2 if der == -1 else np.ones_like(nu, dtype=float)
+        f_c = f_ell[:, 0]
+        # der_bessel = -1 is CCL's spin-2 weight j_l(k chi) / (k chi)^2. It is
+        # separable: 1/chi^2 multiplies the radial kernel inside the solve and
+        # 1/k^2 comes out of the transform, so it is integrated exactly.
+        # Replacing it by 1/nu^2 (its Limber value, x = nu) is 6% off at
+        # ell = 2 on a lensing kernel. The weight is applied in the callback,
+        # not to the table: W ~ chi near the origin, so W / chi^2 ~ 1 / chi
+        # cannot be tabulated to the requested tolerance, while the solver's
+        # panel fits in y = k chi handle it (NumCosmo's own lensing kernel
+        # carries the same 1 / chi).
+        if der == -1:
+            # CCL's kernel table starts a few Mpc from the observer, where a
+            # lensing kernel is already linear in chi. The 1 / chi left of the
+            # first sample still contributes: at the ell = 2 peak the
+            # transform is oscillation-suppressed and the omitted piece is
+            # 0.2% of it (0.4% of C_2). Continue W linearly to the origin and
+            # integrate from far inside the first cell.
+            chi_from = 1.0e-3 * chi_min
+            kernel_cb = _spin2_kernel_callback(sp, float(comp[0]) / chi_min, chi_min)
+        else:
+            chi_from = chi_min
+            kernel_cb = _kernel_callback(sp)
+
         # positive orders are the Bessel-derivative weights (2 is CCL's RSD)
         deriv = der if der > 0 else 0
 
         block = np.zeros((n_ell, len(k_a)))
         for ik, k in enumerate(k_a):
             integ.integrate_deriv(
-                lambda _p, chi, _k, _s=sp: _s.eval(chi),
-                chi_min,
-                chi_max,
-                float(k),
-                deriv,
-                res,
-                None,
+                kernel_cb, chi_from, chi_max, float(k), deriv, res, None
             )
             for j in range(n_ell):
                 block[j, ik] = res.get(j)
 
-        out += block * (f_c * bes)[:, None]
+        if der == -1:
+            block /= k_a[None, :] ** 2
+
+        out += block * f_c[:, None]
 
     return out
 

--- a/numcosmo_py/ccl/two_point.py
+++ b/numcosmo_py/ccl/two_point.py
@@ -178,22 +178,22 @@ def _spin2_kernel_callback(
     return kernel_cb
 
 
-def bessel_transform_block(
+def block_transformer(
     tracer: pyccl.Tracer,
     cosmology: Cosmology,
     ell_min: int,
     ell_max: int,
-    k_a: np.ndarray,
     *,
     reltol: float = 1.0e-8,
-) -> np.ndarray:
-    r"""Batched :math:`\Delta_\ell(k)` for every multipole in ``[ell_min, ell_max]``.
+) -> Callable[[np.ndarray], np.ndarray]:
+    r"""Build the batched :math:`\Delta_\ell(k)` evaluator for one multipole block.
 
-    One operator factorisation serves the whole block, and one call per wavenumber
-    returns every multipole in it. This is the reuse structure the method is designed
-    around; solving multipole by multipole discards it.
+    The kernel splines and the integrator (one operator factorisation for the whole
+    block) are set up once; the returned callable evaluates every multipole of the
+    block on any wavenumber array, so an outer integral can grow its grid in pieces
+    without paying the setup again.
 
-    :returns: array of shape ``(ell_max - ell_min + 1, len(k_a))``.
+    :returns: ``f(k_a) -> array`` of shape ``(ell_max - ell_min + 1, len(k_a))``.
     """
     n_ell = ell_max - ell_min + 1
     chi_a, comps, der_bessel = tracer_components(tracer, cosmology, reltol=reltol)
@@ -212,10 +212,9 @@ def bessel_transform_block(
         reltol,
     )
     res = Ncm.Vector.new(n_ell)
-    out = np.zeros((n_ell, len(k_a)))
-
     ells = np.arange(ell_min, ell_max + 1)
 
+    pieces: list[tuple[Callable, int, np.ndarray, float]] = []
     for comp, der in zip(comps, der_bessel):
         sp = Ncm.SplineBSpline.new_tol(reltol, 0.0)
         sp.set_array(chi_a.tolist(), comp.tolist(), True)
@@ -247,22 +246,48 @@ def bessel_transform_block(
             kernel_cb = _kernel_callback(sp)
 
         # positive orders are the Bessel-derivative weights (2 is CCL's RSD)
-        deriv = der if der > 0 else 0
+        pieces.append((kernel_cb, der, f_c, chi_from))
 
-        block = np.zeros((n_ell, len(k_a)))
-        for ik, k in enumerate(k_a):
-            integ.integrate_deriv(
-                kernel_cb, chi_from, chi_max, float(k), deriv, res, None
-            )
-            for j in range(n_ell):
-                block[j, ik] = res.get(j)
+    def evaluate(k_a: np.ndarray) -> np.ndarray:
+        out = np.zeros((n_ell, len(k_a)))
+        for kernel_cb, der, f_c, chi_from in pieces:
+            deriv = der if der > 0 else 0
+            block = np.zeros((n_ell, len(k_a)))
+            for ik, k in enumerate(k_a):
+                integ.integrate_deriv(
+                    kernel_cb, chi_from, chi_max, float(k), deriv, res, None
+                )
+                for j in range(n_ell):
+                    block[j, ik] = res.get(j)
 
-        if der == -1:
-            block /= k_a[None, :] ** 2
+            if der == -1:
+                block /= k_a[None, :] ** 2
 
-        out += block * f_c[:, None]
+            out += block * f_c[:, None]
 
-    return out
+        return out
+
+    return evaluate
+
+
+def bessel_transform_block(
+    tracer: pyccl.Tracer,
+    cosmology: Cosmology,
+    ell_min: int,
+    ell_max: int,
+    k_a: np.ndarray,
+    *,
+    reltol: float = 1.0e-8,
+) -> np.ndarray:
+    r"""Batched :math:`\Delta_\ell(k)` for every multipole in ``[ell_min, ell_max]``.
+
+    One operator factorisation serves the whole block, and one call per wavenumber
+    returns every multipole in it. This is the reuse structure the method is designed
+    around; solving multipole by multipole discards it.
+
+    :returns: array of shape ``(ell_max - ell_min + 1, len(k_a))``.
+    """
+    return block_transformer(tracer, cosmology, ell_min, ell_max, reltol=reltol)(k_a)
 
 
 def bessel_transform(
@@ -285,6 +310,71 @@ def bessel_transform(
             "k-dependent transfers need one kernel per k; use tracer_components(lk=...)"
         )
     return bessel_transform_block(tracer, cosmology, ell, ell, k_a, reltol=reltol)[0]
+
+
+_OUTER_CHUNK = 512
+
+
+def _grow_outer_grid(
+    integrand_of: Callable[[np.ndarray], np.ndarray],
+    k_lo: float,
+    k_hi: float,
+    dk: float,
+    *,
+    chunk: int,
+    tol: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Sample the outer integrand on a step-``dk`` grid whose ends the integrand sets.
+
+    Both ends are placed by a bound on the *integrated* tail left outside,
+    relative to the integral accumulated so far, per multipole. Upward from
+    ``k_lo`` in chunks: past the peak the integrand falls at least as fast as
+    ``k^-3`` (``P(k)/k^2`` for a spin-2 pair, faster for density kernels), so
+    the tail beyond ``k_end`` is at most ``|I(k_end)| k_end / 2``; stop once that
+    is below ``tol`` of the integral for every multipole, or at ``k_hi``.
+    Downward from ``k_lo`` by halving: the integrand rises at least as
+    ``k^(2 + n_s)``, so the piece below ``k_0`` is at most ``|I(k_0)| k_0 / 3``.
+    A pointwise cut at ``tol`` of the peak is not enough here: on a lensing
+    pair it left a tail worth 2e-4 of C_10.
+
+    :returns: ``(k_a, vals)`` with ``vals`` of shape ``(n_ell, len(k_a))``.
+    """
+
+    def accumulated(k_a: np.ndarray, vals: np.ndarray) -> np.ndarray:
+        return np.trapezoid(np.abs(vals), k_a, axis=1)
+
+    k_a = np.empty(0)
+    vals = np.empty((0, 0))
+    k_start = k_lo
+    while k_start < k_hi:
+        k_stop = min(k_start + chunk * dk, k_hi)
+        n_pts = max(2, int(np.round((k_stop - k_start) / dk)) + 1)
+        k_c = np.linspace(k_start, k_stop, n_pts)
+        if k_a.size:
+            k_c = k_c[1:]  # shared endpoint
+        v_c = integrand_of(k_c)
+        k_a = np.concatenate([k_a, k_c])
+        vals = v_c if vals.size == 0 else np.concatenate([vals, v_c], axis=1)
+        k_start = k_stop
+
+        peaked = np.all(np.argmax(np.abs(vals), axis=1) < vals.shape[1] - v_c.shape[1])
+        tail = 0.5 * np.abs(vals[:, -1]) * k_a[-1]
+        if peaked and np.all(tail < tol * accumulated(k_a, vals)):
+            break
+
+    # Downward the integrand is smooth (no oscillation below the first peak),
+    # so each halving adds a handful of points rather than a step-dk chunk.
+    k_floor = 1.0e-4 * k_lo
+    while k_a[0] > k_floor:
+        head = np.abs(vals[:, 0]) * k_a[0] / 3.0
+        if np.all(head < tol * accumulated(k_a, vals)):
+            break
+        k_c = np.linspace(0.5 * k_a[0], k_a[0], 9)[:-1]
+        v_c = integrand_of(k_c)
+        k_a = np.concatenate([k_c, k_a])
+        vals = np.concatenate([v_c, vals], axis=1)
+
+    return k_a, vals
 
 
 def angular_cl(
@@ -317,13 +407,17 @@ def angular_cl(
     :param n_k: floor on the number of wavenumbers in the outer integral.
     :param n_osc: samples per oscillation of Delta_l(k) in the outer integral.
     :param support_tol: fraction of the kernel's peak below which its tail is
-        treated as outside the support. This is the dominant cost control, not a
-        safety margin: the grid's upper end is ``k_hi = 8 nu / chi_lo``, so
-        shrinking ``chi_lo`` raises ``k_hi`` and the point count with it. On the
-        Gaussian test tracer at ell = 32, 1e-10 (the old value) admits tail down
-        to chi = 16.7 Mpc and needs 180,720 wavenumbers for 293 s; 1e-6 needs
-        3,945 for 2.4 s, and the two C_ell agree to 2.6e-9. Tighten it only with
-        a measurement in hand.
+        treated as outside the support, and the fraction of the outer integral
+        allowed outside the k grid. This is the dominant cost control, not a
+        safety margin: the sampling step and the starting window come from
+        ``chi_lo`` and ``chi_hi``, so shrinking ``chi_lo`` raises the point
+        count. On the Gaussian test tracer at ell = 32, 1e-10 (the old value)
+        admits tail down to chi = 16.7 Mpc and needs 180,720 wavenumbers for
+        293 s; 1e-6 needs 3,945 for 2.4 s, and the two C_ell agree to 2.6e-9.
+        The grid then grows on the integrand itself, so a spin-2 tracer, whose
+        transform tends to a constant at small k and to 1/k^2 at large k, is
+        integrated to the same fraction (see :func:`_grow_outer_grid`).
+        Tighten it only with a measurement in hand.
     :param block_size: number of consecutive multipoles sharing a factorisation.
         Clamped to what the solver will honour: NC_XCOR_KERNEL_MAX_ELL_BLOCK and the
         integrator's ell_cache_max. Wider is not better -- the truncation order is a
@@ -343,40 +437,49 @@ def angular_cl(
 
     chi_a, comps, _ = tracer_components(tracer1, cosmology, reltol=reltol)
     w_abs = np.abs(sum(comps))
-    # See support_tol: chi_lo sets k_hi, so this threshold sets the grid size.
+    # See support_tol: chi_lo sets the sampling step and the starting window.
     keep = np.nonzero(w_abs > support_tol * w_abs.max())[0]
     chi_lo, chi_hi = float(chi_a[keep[0]]), float(chi_a[keep[-1]])
+
+    def pk_of(k_a: np.ndarray) -> np.ndarray:
+        # NumCosmo's power spectrum already takes k in Mpc^-1 and returns Mpc^3.
+        return np.array([ps_lin.eval(cosmo, 0.0, float(k)) for k in k_a])
 
     for start_i in range(0, len(ells), block_size):
         sel = np.arange(start_i, min(start_i + block_size, len(ells)))
         ell_min, ell_max = int(ells[sel[0]]), int(ells[sel[-1]])
 
-        # One k-grid serves the block, so it must cover the largest multipole in it.
+        d1_of = block_transformer(tracer1, cosmology, ell_min, ell_max, reltol=reltol)
+        d2_of = (
+            d1_of
+            if tracer2 is tracer1
+            else block_transformer(tracer2, cosmology, ell_min, ell_max, reltol=reltol)
+        )
+
+        def integrand_of(k_a: np.ndarray) -> np.ndarray:
+            return k_a[None, :] ** 2 * pk_of(k_a)[None, :] * d1_of(k_a) * d2_of(k_a)
+
+        # The window a density kernel needs: Delta_l ~ (k chi_hi)^l below k_lo
+        # and averaged out above k_hi. A spin-2 (der_bessel = -1) transform
+        # tends to a constant at small k and falls as 1/k^2 at large k, so
+        # neither bound holds for it; the grid is therefore grown on the
+        # integrand itself from this window, downward until its low end is
+        # below support_tol of the peak and upward until it stays there.
         nu_lo, nu_hi = ell_min + 0.5, ell_max + 0.5
         k_lo = 0.2 * nu_lo / chi_hi
         k_hi = 8.0 * nu_hi / chi_lo
+        # sampling step from the fastest oscillation in k, period 2 pi / chi_hi
         n_k_min = int(np.ceil(n_osc * (k_hi - k_lo) * chi_hi / np.pi))
-        k_a = np.linspace(k_lo, k_hi, max(n_k, n_k_min))
+        dk = (k_hi - k_lo) / max(n_k, n_k_min)
 
-        d1 = bessel_transform_block(
-            tracer1, cosmology, ell_min, ell_max, k_a, reltol=reltol
+        k_a, vals = _grow_outer_grid(
+            integrand_of, k_lo, k_hi, dk, chunk=_OUTER_CHUNK, tol=support_tol
         )
-        d2 = (
-            d1
-            if tracer2 is tracer1
-            else bessel_transform_block(
-                tracer2, cosmology, ell_min, ell_max, k_a, reltol=reltol
-            )
-        )
-
-        # NumCosmo's power spectrum already takes k in Mpc^-1 and returns Mpc^3.
-        pk = np.array([ps_lin.eval(cosmo, 0.0, float(k)) for k in k_a])
 
         for j, i in enumerate(sel):
             row = int(ells[i]) - ell_min
-            integrand = k_a**2 * pk * d1[row] * d2[row]
             sp = Ncm.SplineCubicNotaknot.new()
-            sp.set_array(k_a.tolist(), integrand.tolist(), True)
-            out[i] = (2.0 / np.pi) * sp.eval_integ(k_lo, k_hi)
+            sp.set_array(k_a.tolist(), vals[row].tolist(), True)
+            out[i] = (2.0 / np.pi) * sp.eval_integ(float(k_a[0]), float(k_a[-1]))
 
     return out

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -121,6 +121,46 @@ def test_der_bessel_unsupported_is_explicit(cosmology, ccl_cosmo):
         compute_kernel(wl, cosmology, 32.0)
 
 
+def test_angular_cl_spin2_weight_matches_the_lensing_kernel(cosmology, ccl_cosmo):
+    """der_bessel = -1 is integrated as the exact j_l(k chi) / (k chi)^2.
+
+    NumCosmo's own weak-lensing kernel carries that weight exactly (1 / chi^2 in
+    the component, 1 / k^2 in the transform), so a CCL WeakLensingTracer run
+    through the bridge must reproduce it at low ell, where the Limber value
+    1 / nu^2 of the same weight is 6% off at ell = 2. The tolerance is set by
+    the bridge's support cut, not by the transform.
+    """
+    ells = np.array([2, 5, 10])
+    z = np.linspace(0.0, 2.5, 1000)
+    nz = np.exp(-0.5 * ((z - 1.0) / 0.2) ** 2)
+
+    wl_ccl = pyccl.WeakLensingTracer(ccl_cosmo, dndz=(z, nz), n_samples=len(z))
+    dndz = Ncm.Spline.new_array(
+        Ncm.SplineCubicNotaknot.new(), z.tolist(), nz.tolist(), True
+    )
+    wl_nc = Nc.XcorKernelWeakLensing(
+        dist=cosmology.dist,
+        powspec=cosmology.ps_ml,
+        dndz=dndz,
+        nbar=1.0,
+        intr_shear=0.0,
+        integrator=Ncm.SBesselIntegratorLevin.new(2, int(ells[-1])),
+    )
+    wl_nc.set_l_limber(-1)
+    wl_nc.prepare(cosmology.cosmo)
+
+    lmin, lmax = int(ells[0]), int(ells[-1])
+    res = Ncm.Vector.new(lmax - lmin + 1)
+    xcor = Nc.Xcor.new(cosmology.dist, cosmology.ps_ml, Nc.XcorMethod.KERNEL_EXACT)
+    xcor.prepare(cosmology.cosmo)
+    xcor.compute(wl_nc, wl_nc, cosmology.cosmo, lmin, lmax, res)
+    expected = np.array(res.dup_array())[ells - lmin]
+
+    got = angular_cl(cosmology, wl_ccl, wl_ccl, ells, support_tol=1.0e-4)
+
+    assert_allclose(got, expected, rtol=1.0e-4)
+
+
 def test_batching_agrees_within_the_error_budget(cosmology, tracer):
     """A multipole's transform is the same alone or inside a block, to within the bound.
 

--- a/tests/python/nc/xcor/test_ccl_angular_cl.py
+++ b/tests/python/nc/xcor/test_ccl_angular_cl.py
@@ -127,8 +127,10 @@ def test_angular_cl_spin2_weight_matches_the_lensing_kernel(cosmology, ccl_cosmo
     NumCosmo's own weak-lensing kernel carries that weight exactly (1 / chi^2 in
     the component, 1 / k^2 in the transform), so a CCL WeakLensingTracer run
     through the bridge must reproduce it at low ell, where the Limber value
-    1 / nu^2 of the same weight is 6% off at ell = 2. The tolerance is set by
-    the bridge's support cut, not by the transform.
+    1 / nu^2 of the same weight is 6% off at ell = 2. Measured deviations at
+    ell 2, 5, 10 with the support cut at 1e-4: 2.4e-5, 2.9e-5, 6.0e-5 (at 1e-6
+    they fall to 1.8e-6, 2.4e-6, 5e-7, for 6x the run time); the tolerance is
+    set by the cut, not by the transform.
     """
     ells = np.array([2, 5, 10])
     z = np.linspace(0.0, 2.5, 1000)

--- a/tests/python/nc/xcor/test_kernel_gal_rsd.py
+++ b/tests/python/nc/xcor/test_kernel_gal_rsd.py
@@ -44,6 +44,7 @@ import pyccl
 
 from numcosmo_py import Nc, Ncm
 from numcosmo_py.ccl.nc_ccl import create_nc_obj, CCLParams
+from numcosmo_py.ccl import two_point
 
 pytestmark = [pytest.mark.ccl, pytest.mark.xcor, pytest.mark.xdist_group("ccl_rsd")]
 
@@ -112,14 +113,16 @@ def _ccl_gal_tracer(ccl_cosmo, dndz_arrays, *, has_rsd: bool):
     )
 
 
-def _nc_cl(cosmology, kernel, ells, l_limber):
-    kernel.set_l_limber(l_limber)
-    kernel.prepare(cosmology.cosmo)
+def _nc_cl(cosmology, kernel, ells, l_limber, kernel_2=None):
+    kernel_2 = kernel if kernel_2 is None else kernel_2
+    for k in (kernel, kernel_2):
+        k.set_l_limber(l_limber)
+        k.prepare(cosmology.cosmo)
     lmin, lmax = int(ells[0]), int(ells[-1])
     res = Ncm.Vector.new(lmax - lmin + 1)
     xcor = Nc.Xcor.new(cosmology.dist, cosmology.ps_ml, Nc.XcorMethod.KERNEL_EXACT)
     xcor.prepare(cosmology.cosmo)
-    xcor.compute(kernel, kernel, cosmology.cosmo, lmin, lmax, res)
+    xcor.compute(kernel, kernel_2, cosmology.cosmo, lmin, lmax, res)
     return np.array(res.dup_array())[np.asarray(ells) - lmin]
 
 
@@ -148,6 +151,63 @@ def test_rsd_auto_exact_matches_ccl_limber_at_high_ell(
     )
 
     assert_allclose(got, ref, rtol=2.0e-3)
+
+
+def test_rsd_auto_exact_matches_ccl_kernel_bridge_at_low_ell(
+    ccl_cosmo, cosmology, dndz_arrays
+) -> None:
+    """Exact-tier C_ell with RSD against the CCL-kernel bridge where RSD matters.
+
+    numcosmo_py.ccl.two_point.angular_cl integrates CCL's own tracer kernels,
+    transfer (-f for the RSD piece, der_bessel = 2) and growth with the
+    derivative-weighted Levin solve, so the two sides share the solver and
+    nothing else: NumCosmo's dn/dz, bias, distances and growth on one side,
+    CCL's tables on the other. The bridge's support cut at 1e-4 of the kernel
+    peak keeps it at a few seconds; measured deviation 3.5e-6 at ell = 2
+    (2.1e-6 with the cut at 1e-5), so the tolerance below is the cut, not
+    the solve.
+    """
+    ells = np.array([2, 5, 10])
+
+    kernel = _nc_gal_kernel(cosmology, dndz_arrays, dorsd=True, lmax=int(ells[-1]))
+    got = _nc_cl(cosmology, kernel, ells, l_limber=-1)
+
+    tracer = _ccl_gal_tracer(ccl_cosmo, dndz_arrays, has_rsd=True)
+    ref = two_point.angular_cl(cosmology, tracer, tracer, ells, support_tol=1.0e-4)
+
+    assert_allclose(got, ref, rtol=2.0e-5)
+
+
+def test_rsd_cross_spectrum_matches_ccl_kernel_bridge(
+    ccl_cosmo, cosmology, dndz_arrays
+) -> None:
+    """Cross spectrum of an RSD bin with a second, non-overlapping bin.
+
+    The cross of a density-plus-RSD kernel with a plain density kernel is
+    negative here (the bins do not overlap), so the sign and the mixed
+    j_l x j_l'' term are both checked; a second case switches RSD on in
+    both bins. Measured deviations vs the bridge are at or below 1.3e-5.
+    """
+    ells = np.array([2, 5, 10])
+    z2 = np.linspace(0.0, 2.0, Z_LEN)
+    nz2 = np.exp(-0.5 * ((z2 - 0.9) / SIGMA) ** 2)
+
+    kernel_1 = _nc_gal_kernel(cosmology, dndz_arrays, dorsd=True, lmax=int(ells[-1]))
+    tracer_1 = _ccl_gal_tracer(ccl_cosmo, dndz_arrays, has_rsd=True)
+
+    for has_rsd in (False, True):
+        kernel_2 = _nc_gal_kernel(
+            cosmology, (z2, nz2), dorsd=has_rsd, lmax=int(ells[-1])
+        )
+        tracer_2 = _ccl_gal_tracer(ccl_cosmo, (z2, nz2), has_rsd=has_rsd)
+
+        got = _nc_cl(cosmology, kernel_1, ells, l_limber=-1, kernel_2=kernel_2)
+        ref = two_point.angular_cl(
+            cosmology, tracer_1, tracer_2, ells, support_tol=1.0e-4
+        )
+
+        assert np.all(ref < 0.0)
+        assert_allclose(got, ref, rtol=5.0e-5)
 
 
 def test_rsd_auto_limber_matches_ccl(ccl_cosmo, cosmology, dndz_arrays) -> None:
@@ -228,6 +288,56 @@ def test_rsd_component_list_and_properties(cosmology, dndz_arrays) -> None:
     # dropping the kernel disposes the RSD component and its data
     del comps, rsd, kernel
     gc.collect()
+
+
+def test_rsd_kernel_survives_serialization(cosmology, dndz_arrays) -> None:
+    """A serialized copy keeps dorsd, rebuilds the RSD component and gives the same C_ell.
+
+    NcXcorSolver hands each OpenMP thread NcmSerialize-duplicated objects, so
+    a construct-only property that did not survive the round trip would
+    silently drop the Kaiser term there.
+    """
+    ells = np.array([2, 5, 10])
+    kernel = _nc_gal_kernel(cosmology, dndz_arrays, dorsd=True, lmax=int(ells[-1]))
+
+    ser = Ncm.Serialize.new(Ncm.SerializeOpt.CLEAN_DUP)
+    copy = ser.dup_obj(kernel)
+
+    assert copy.get_property("dorsd") is True
+    assert sorted(c.get_bessel_deriv() for c in copy.get_component_list()) == [0, 2]
+
+    original = _nc_cl(cosmology, kernel, ells, l_limber=-1)
+    duplicate = _nc_cl(cosmology, copy, ells, l_limber=-1)
+
+    assert_allclose(duplicate, original, rtol=1.0e-12)
+
+
+def test_rsd_through_solver_matches_compute(cosmology, dndz_arrays) -> None:
+    """NcXcorSolver's block path reproduces nc_xcor_compute() with the RSD component.
+
+    One 8-ell block, exact tier; the solver runs its OpenMP team over blocks
+    with per-block integrator clones, so this covers the deriv state living on
+    the integrator rather than on the shared kernel.
+    """
+    lmin, lmax = 2, 9
+    kernel = _nc_gal_kernel(cosmology, dndz_arrays, dorsd=True, lmax=lmax)
+    kernel.set_l_limber(-1)
+    kernel.prepare(cosmology.cosmo)
+
+    xcor = Nc.Xcor.new(cosmology.dist, cosmology.ps_ml, Nc.XcorMethod.KERNEL_EXACT)
+    xcor.prepare(cosmology.cosmo)
+
+    expected = Ncm.Vector.new(lmax - lmin + 1)
+    xcor.compute(kernel, kernel, cosmology.cosmo, lmin, lmax, expected)
+
+    solver = Nc.XcorSolver.new()
+    kid = solver.register_kernel(kernel)
+    solver.request_cl(kid, kid, lmin, lmax)
+    solver.plan_blocks(8)
+    solver.solve(xcor, cosmology.cosmo)
+
+    got = np.array(solver.get_result(0).dup_array())
+    assert_allclose(got, np.array(expected.dup_array()), rtol=1.0e-10)
 
 
 def test_deriv_one_limber_matches_exact_at_high_ell(cosmology, dndz_arrays) -> None:

--- a/tests/python/nc/xcor/test_kernel_gal_rsd.py
+++ b/tests/python/nc/xcor/test_kernel_gal_rsd.py
@@ -163,9 +163,8 @@ def test_rsd_auto_exact_matches_ccl_kernel_bridge_at_low_ell(
     derivative-weighted Levin solve, so the two sides share the solver and
     nothing else: NumCosmo's dn/dz, bias, distances and growth on one side,
     CCL's tables on the other. The bridge's support cut at 1e-4 of the kernel
-    peak keeps it at a few seconds; measured deviation 3.5e-6 at ell = 2
-    (2.1e-6 with the cut at 1e-5), so the tolerance below is the cut, not
-    the solve.
+    peak keeps it at a few seconds; measured deviations 1.7e-6, 1.7e-6, 6e-7
+    at ell 2, 5, 10, so the tolerance below is the cut, not the solve.
     """
     ells = np.array([2, 5, 10])
 

--- a/tests/python/ncm/specfunc/test_sbessel_integrator_fftl.py
+++ b/tests/python/ncm/specfunc/test_sbessel_integrator_fftl.py
@@ -28,6 +28,8 @@ import time
 from pathlib import Path
 import gzip
 import json
+import subprocess
+import sys
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -249,3 +251,45 @@ class TestSBesselIntegratorFFTL:
             if len(failures) > 10:
                 failure_msg += f"\n  ... and {len(failures) - 10} more"
             pytest.fail(failure_msg)
+
+
+class TestSBesselIntegratorFFTLDeriv:
+    """integrate_deriv on the FFTL integrator: order 0 is integrate, higher orders abort."""
+
+    def test_deriv_zero_matches_integrate(self) -> None:
+        """deriv = 0 must dispatch to the plain integrate path, bit for bit."""
+        integrator = Ncm.SBesselIntegratorFFTL.new(0, 8)
+        res_a = Ncm.Vector.new(9)
+        res_b = Ncm.Vector.new(9)
+
+        def f_gauss(x: float, _k: float) -> float:
+            return np.exp(-0.5 * ((x - 40.0) / 10.0) ** 2)
+
+        integrator.integrate_deriv(f_gauss, 5.0, 80.0, 1.0, 0, res_a)
+        integrator.integrate(f_gauss, 5.0, 80.0, 1.0, res_b)
+
+        assert res_a.dup_array() == res_b.dup_array()
+
+    @pytest.mark.parametrize("deriv", [1, 2])
+    def test_positive_order_is_not_implemented(self, deriv: int) -> None:
+        """Only the Levin path implements the derivative weights; the base class must fail loudly.
+
+        Runs in a subprocess since g_error aborts rather than raises.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from numcosmo_py import Ncm\n"
+                "Ncm.cfg_init()\n"
+                "sbi = Ncm.SBesselIntegratorFFTL.new(0, 3)\n"
+                "res = Ncm.Vector.new(4)\n"
+                f"sbi.integrate_deriv(lambda x, k: 1.0, 1.0, 2.0, 1.0, {deriv}, res)\n",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert proc.returncode != 0
+        assert "not implemented" in proc.stderr

--- a/tests/python/ncm/specfunc/test_sbessel_integrator_gl.py
+++ b/tests/python/ncm/specfunc/test_sbessel_integrator_gl.py
@@ -25,6 +25,8 @@
 """Unit tests for spherical Bessel integrator."""
 
 from typing import Callable
+import subprocess
+import sys
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -1176,3 +1178,45 @@ class TestSBesselIntegratorGLAnalyticalLargeIntervals:
             ref = np.sqrt(np.pi / (2.0 * ell + 1.0)) * f(ell + 0.5, 1.0)
 
             assert_allclose(num, ref, rtol=rtol, err_msg=f"ell={ell}")
+
+
+class TestSBesselIntegratorGLDeriv:
+    """integrate_deriv on the GL integrator: order 0 is integrate, higher orders abort."""
+
+    def test_deriv_zero_matches_integrate(self) -> None:
+        """deriv = 0 must dispatch to the plain integrate path, bit for bit."""
+        integrator = Ncm.SBesselIntegratorGL.new(0, 8)
+        res_a = Ncm.Vector.new(9)
+        res_b = Ncm.Vector.new(9)
+
+        def f_gauss(x: float, _k: float) -> float:
+            return np.exp(-0.5 * ((x - 40.0) / 10.0) ** 2)
+
+        integrator.integrate_deriv(f_gauss, 5.0, 80.0, 1.0, 0, res_a)
+        integrator.integrate(f_gauss, 5.0, 80.0, 1.0, res_b)
+
+        assert res_a.dup_array() == res_b.dup_array()
+
+    @pytest.mark.parametrize("deriv", [1, 2])
+    def test_positive_order_is_not_implemented(self, deriv: int) -> None:
+        """Only the Levin path implements the derivative weights; the base class must fail loudly.
+
+        Runs in a subprocess since g_error aborts rather than raises.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from numcosmo_py import Ncm\n"
+                "Ncm.cfg_init()\n"
+                "sbi = Ncm.SBesselIntegratorGL.new(0, 3)\n"
+                "res = Ncm.Vector.new(4)\n"
+                f"sbi.integrate_deriv(lambda x, k: 1.0, 1.0, 2.0, 1.0, {deriv}, res)\n",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert proc.returncode != 0
+        assert "not implemented" in proc.stderr

--- a/tests/python/ncm/specfunc/test_sbessel_integrator_levin.py
+++ b/tests/python/ncm/specfunc/test_sbessel_integrator_levin.py
@@ -1051,6 +1051,29 @@ class TestSBesselIntegratorLevinDeriv:
         for i in range(n_ell):
             assert res_a.get(i) == res_b.get(i)
 
+    def test_order_above_two_is_rejected(self) -> None:
+        """Orders above 2 have no implementation anywhere and must fail loudly.
+
+        Runs in a subprocess since g_error aborts rather than raises.
+        """
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from numcosmo_py import Ncm\n"
+                "Ncm.cfg_init()\n"
+                "sbi = Ncm.SBesselIntegratorLevin.new(0, 3)\n"
+                "res = Ncm.Vector.new(4)\n"
+                "sbi.integrate_deriv(lambda x, k: 1.0, 1.0, 2.0, 1.0, 3, res)\n",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert proc.returncode != 0
+        assert "not supported" in proc.stderr
+
     def test_evanescent_region_keeps_relative_precision(self) -> None:
         """Deep small-argument tail: tiny values must stay relatively accurate."""
         l_val = 30


### PR DESCRIPTION
Follow-ups to #365, from a full read of its diff plus a bit-compare of every stored comparison baseline on the merged master (12 N5K variants, the kernel-chain validation at two tolerances, and the 344-row certified C_ell sweep all reproduce identically, so the merge changed no shared plumbing). No correctness bug was found; this PR closes the small items that came out of the review, then fixes two defects in the CCL bridge that the new RSD tests exposed. One commit per item.

## Commit 1: RSD review items

* **NcGrowthFunc docs.** `nc_growth_func_eval_deriv` and `eval_both` document their output as dD/da, but the body returns `-a^2 dD/da = dD/dz`. The RSD growth rate `f = -(1+z) (dD/dz)/D` in the gal kernel uses it correctly; the doc is what was wrong.
* **Loud failure for unsupported derivative orders.** `ncm_sbessel_integrator_integrate_deriv` used `g_return_if_fail (deriv <= 2)`, which returned with the result vector untouched. It now `g_error`s.
* **Panel gate consistency in the Levin driver.** `panel_is_null` was widened to `ell_min - 1` for `deriv > 0` (the boundary terms read `j_{ell-1}`), but the three panel-skip gates in the knot loop still tested `ell_min`. Same rule now; numerically irrelevant at the array threshold.
* **Doc on `NcXcorKernelGal:dorsd`.** States that the redshift-space Limber methods, including the `NcXcor:meth` default `LIMBER_Z_GSL`, stop with an error on an RSD kernel.
* **Tests.** Exact tier with RSD against the CCL-kernel bridge (`numcosmo_py.ccl.two_point.angular_cl`) at ell 2, 5, 10: auto spectrum and two cross cases with a non-overlapping second bin (RSD on one side and on both). `dorsd` survives an `NcmSerialize` round trip. `NcXcorSolver` block path reproduces `nc_xcor_compute` with an RSD kernel. GL and FFTL `integrate_deriv`: order 0 bit-identical to `integrate`, orders 1 and 2 abort; Levin order 3 aborts.

## Commit 2: exact spin-2 weight in the CCL bridge

Writing the cross tests showed the bridge's gal x shear spectrum 6% off NumCosmo's exact lensing kernel at ell 2 with or without RSD. The bridge replaced CCL's `der_bessel = -1` weight `j_l(k chi)/(k chi)^2` by its Limber value `1/nu^2`. CCL's own FKEM integrates it exactly (power-law index -2), so the shortcut was the bridge's alone. The weight is separable: `1/chi^2` now multiplies the kernel inside the Levin solve (in the callback, since `W/chi^2 ~ 1/chi` cannot be tabulated to tolerance) and `1/k^2` comes out of the transform. W is continued linearly below CCL's first sample (~10 Mpc), whose omission was worth 0.4% of C_2. New test: a CCL `WeakLensingTracer` through the bridge against NumCosmo's exact weak-lensing kernel.

## Commit 3: the bridge's outer k grid grows on the integrand

The fixed window `[0.2 nu/chi_hi, 8 nu/chi_lo]` assumes a density transform. For a spin-2 transform (constant at small k, `1/k^2` at large k) it missed low-k signal and, with a lensing tracer first, asked for 92,000 wavenumbers per block: five minutes for three multipoles. The per-block transform is now set up once (`block_transformer`) and the grid is grown in chunks upward and by halving downward, each end placed by a bound on the integrated tail relative to the accumulated integral, per multipole, at `support_tol`. A pointwise cut at `tol x peak` was tried first and left a `P(k)/k^2` tail worth 2e-4 of C_10.

Measured against NumCosmo's exact tiers with the support cut at 1e-4: lensing auto 2.4e-5 / 2.9e-5 / 6.0e-5 at ell 2 / 5 / 10 in 11 s (was 3.8e-3 at ell 2 in 314 s); galaxy RSD auto 1.7e-6 / 1.7e-6 / 6e-7. `test_ccl_angular_cl.py` runs in 37 s instead of 324 s.

## Not in this PR

* The closure default (Chebyshev non-Limber, spline Limber) and the mixed-pair handling in KERNEL_EXACT, per the plan for a following PR.
* `nc_xcor_kernel_gal_new()` still has no `dorsd` argument; Python constructs via properties, so no consumer needs it yet.
* `compute_kernel()` (single-ell kernel export) still folds `1/nu^2`; a single-ell kernel cannot carry `1/(k chi)^2`. Documented at the site.

Checks run locally after the master merge: 161 sbessel-integrator tests, 1728 xcor tests (serialization, solver, component, window truth table, k-integral, RSD), 118 bridge/CCL-comparison tests, the 8 C suites for sbessel and xcor, flake8 and mypy on the bridge module, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)